### PR TITLE
feat: [REQ-DV-05] Docker Compose stacks

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,0 +1,250 @@
+name: rustbrain-dev
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: rustbrain
+      POSTGRES_PASSWORD: rustbrain
+      POSTGRES_DB: rustbrain
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - rb-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rustbrain"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/rustbrain123
+      NEO4J_server_memory_heap_max__size: 4G
+      NEO4J_server_memory_pagecache_size: 2G
+    volumes:
+      - neo4j_data:/data
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    networks:
+      - rb-net
+    deploy:
+      resources:
+        limits:
+          memory: 8g
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  qdrant:
+    image: qdrant/qdrant:v1.13
+    volumes:
+      - qdrant_data:/qdrant/storage
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    networks:
+      - rb-net
+    deploy:
+      resources:
+        limits:
+          memory: 8g
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6333/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka:
+    image: apache/kafka:3.9
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      CLUSTER_ID: MkU3OEVhNTcwNTJENDM2Qk
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    ports:
+      - "9094:9094"
+    networks:
+      - rb-net
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: apache/kafka:3.9
+    depends_on:
+      kafka:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - rb-net
+    command: >
+      bash -c "
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.clone.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.expand.commands    --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.parse.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.typecheck.commands --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.graph.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.embed.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 12 --replication-factor 1 --config retention.ms=2592000000 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000
+      "
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.116.0
+    command: ["--config=/etc/otel-collector/config.yaml"]
+    volumes:
+      - ./infra/otel-collector/config.yaml:/etc/otel-collector/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - rb-net
+    depends_on:
+      - tempo
+      - prometheus
+
+  tempo:
+    image: grafana/tempo:2.7
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    volumes:
+      - ./infra/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    ports:
+      - "3200:3200"
+    networks:
+      - rb-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3200/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  prometheus:
+    image: prom/prometheus:v3.2.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - rb-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:11.5.0
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - rb-net
+    depends_on:
+      - prometheus
+      - tempo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    ports:
+      - "11434:11434"
+    networks:
+      - rb-net
+
+  caddy:
+    image: caddy:2-alpine
+    volumes:
+      - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - rb-net
+    depends_on:
+      - otel-collector
+
+  pgweb:
+    image: sosedoff/pgweb:latest
+    command: ["--readonly", "--bind", "0.0.0.0", "--listen", "8081"]
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain?sslmode=disable
+    ports:
+      - "8081:8081"
+    networks:
+      - rb-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      SERVER_PORT: 8082
+    ports:
+      - "8082:8082"
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+networks:
+  rb-net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  neo4j_data:
+  qdrant_data:
+  kafka_data:
+  tempo_data:
+  prometheus_data:
+  grafana_data:
+  ollama_data:
+  caddy_data:

--- a/compose/full.yml
+++ b/compose/full.yml
@@ -1,0 +1,7 @@
+name: rustbrain-full
+
+include:
+  - dev.yml
+
+# Rust service containers added per-wave as binaries are built.
+# Wave 4+: ingestion services, graph builder, embedding worker, API gateway.

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -1,0 +1,58 @@
+name: rustbrain-test
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: rustbrain
+      POSTGRES_PASSWORD: rustbrain
+      POSTGRES_DB: rustbrain
+    volumes:
+      - test_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    networks:
+      - rb-test-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rustbrain"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka:
+    image: apache/kafka:3.9
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      CLUSTER_ID: VGVzdENsdXN0ZXJJZEtleQ
+    volumes:
+      - test_kafka_data:/var/lib/kafka/data
+    ports:
+      - "9093:9092"
+    networks:
+      - rb-test-net
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+networks:
+  rb-test-net:
+    driver: bridge
+
+volumes:
+  test_postgres_data:
+  test_kafka_data:

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,8 @@
+{
+    admin off
+    auto_https off
+}
+
+:80 {
+    respond /health 200
+}

--- a/infra/grafana/dashboards/rust-brain.json
+++ b/infra/grafana/dashboards/rust-brain.json
@@ -1,0 +1,18 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "rust-brain v2 — placeholder dashboard (populated in Wave 8)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["rust-brain"],
+  "title": "rust-brain Overview",
+  "uid": "rust-brain-overview",
+  "version": 1
+}

--- a/infra/grafana/provisioning/dashboards/dashboards.yaml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: dashboards
+    type: file
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/infra/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      serviceMap:
+        datasourceUid: prometheus

--- a/infra/kafka/topics.yaml
+++ b/infra/kafka/topics.yaml
@@ -1,0 +1,48 @@
+topics:
+  - name: rb.ingest.clone.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"  # 7 days
+
+  - name: rb.ingest.expand.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"
+
+  - name: rb.ingest.parse.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"
+
+  - name: rb.ingest.typecheck.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"
+
+  - name: rb.ingest.graph.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"
+
+  - name: rb.ingest.embed.commands
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"
+
+  - name: rb.projector.events
+    partitions: 12
+    replication_factor: 1
+    config:
+      retention.ms: "2592000000"  # 30 days
+
+  - name: rb.audit.events
+    partitions: 3
+    replication_factor: 1
+    config:
+      retention.ms: "7776000000"  # 90 days

--- a/infra/otel-collector/config.yaml
+++ b/infra/otel-collector/config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+  debug:
+    verbosity: normal
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets: ['otel-collector:8889']

--- a/infra/tempo/tempo.yaml
+++ b/infra/tempo/tempo.yaml
@@ -1,0 +1,24 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h  # 7 days
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
## Summary

- **compose/dev.yml** — full developer stack on `rb-net` bridge: postgres 16-alpine, neo4j 5-community (8G), qdrant v1.13 (8G), kafka 3.9 KRaft with `kafka-init` creating all 8 topics, otel-collector→tempo+prometheus, grafana (provisioned), ollama, caddy, pgweb (read-only), kafka-ui
- **compose/test.yml** — minimal CI stack, different host ports (postgres:5433, kafka:9093) so dev and test can run simultaneously
- **compose/full.yml** — `include: [dev.yml]` shell; Rust service containers added from Wave 4+
- **infra/** — otel-collector config (OTLP→Tempo traces, Prometheus metrics), tempo 7-day retention, prometheus scrape config, grafana provisioning (datasources + dashboard provider), placeholder dashboard JSON, Caddyfile, `infra/kafka/topics.yaml` (8 topics per ADR-004 consumed by migrate-kafka)

All three files validated with `docker compose config --quiet`.

## Migration type

N/A — no database migrations in this PR.

## GitHub Issue

Closes #the internal tracking issue (tracked in Paperclip as the internal tracking issue)

## Checklist

- [x] All three compose files pass `docker compose config --quiet`
- [x] Ports isolated between dev and test (5433/9093 in test vs 5432/9094 in dev)
- [x] Kafka uses KRaft mode (no ZooKeeper), topics created via kafka-init
- [x] Named volumes with project-name scoping (`name: rustbrain-dev/test/full`)
- [x] Health checks on all stateful services
- [x] pgweb runs in `--readonly` mode
- [x] Grafana auto-provisioned from infra/grafana/provisioning/