### PR TITLE
feat: [REQ-DV-06] CI pipeline — 12-job GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,145 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ── Real Rust jobs ─────────────────────────────────────────────────────────
+
+  cargo-check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace
+
+  cargo-test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace -- -D warnings
+
+  # ── Script-backed jobs ─────────────────────────────────────────────────────
+
+  file-size:
+    name: file size (600-line cap)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-file-sizes.sh
+
+  public-surface:
+    name: public surface lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: bash scripts/check-pub-use.sh
+
+  openapi-sync:
+    name: openapi sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-openapi-sync.sh
+
+  # ── Dependency graph & policy ──────────────────────────────────────────────
+
+  crate-cycle:
+    name: crate cycle check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Validate workspace dependency graph (cycles = cargo-check fail)
+        run: cargo metadata --format-version 1 --no-deps > /dev/null
+      - name: Check license / ban / source policies
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+
+  # ── Security ───────────────────────────────────────────────────────────────
+
+  security-lint:
+    name: security lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo audit
+        uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Stub jobs (wired in later waves) ──────────────────────────────────────
+
+  docker-build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build service images
+        # Dockerfiles are added in a later wave; job scaffolded here per REQ-DV-06
+        run: echo "docker-build stub — no Dockerfiles yet"
+
+  playwright-e2e:
+    name: playwright e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Playwright suite
+        # Full wiring against compose/test.yml happens in Wave 8
+        run: echo "playwright-e2e stub — wired in Wave 8"
+
+  rb-feature-resolver-isolation:
+    name: rb-feature-resolver isolation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check zero rb-* imports in rb-feature-resolver
+        # Crate does not exist yet; stub ensures job slot exists in CI matrix
+        run: echo "rb-feature-resolver-isolation stub — crate not yet created"
+
+  tenant-isolation:
+    name: tenant isolation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cross-tenant row count must be zero
+        # Requires DB integration via compose/test.yml; implemented when migration runner lands
+        run: echo "tenant-isolation stub — DB integration pending"

--- a/scripts/check-file-sizes.sh
+++ b/scripts/check-file-sizes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# REQ-MD-01: Hard cap — no source file may exceed 600 lines.
+# Checks all .rs, .ts, .tsx, .py, and .go files outside of generated / vendor paths.
+# RUSAA-25 owns any refinements to scope or thresholds.
+set -euo pipefail
+
+MAX_LINES=600
+FAILED=0
+
+while IFS= read -r -d '' file; do
+    lines=$(wc -l < "$file")
+    if (( lines > MAX_LINES )); then
+        echo "FAIL: $file has $lines lines (limit: $MAX_LINES)" >&2
+        FAILED=1
+    fi
+done < <(find . -type f \( \
+    -name "*.rs" -o \
+    -name "*.ts" -o \
+    -name "*.tsx" -o \
+    -name "*.py"  -o \
+    -name "*.go" \
+  \) \
+  ! -path "*/target/*" \
+  ! -path "*/.git/*" \
+  ! -path "*/node_modules/*" \
+  ! -path "*/vendor/*" \
+  ! -path "*/generated/*" \
+  -print0)
+
+if (( FAILED == 1 )); then
+    echo "file-size check FAILED: one or more files exceed the ${MAX_LINES}-line limit" >&2
+    exit 1
+fi
+
+echo "file-size check PASSED: all files are within the ${MAX_LINES}-line limit"

--- a/scripts/check-openapi-sync.sh
+++ b/scripts/check-openapi-sync.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Verifies that generated OpenAPI specs match the source definitions.
+# Stub: exits 0 until openapi generation tooling is set up.
+set -euo pipefail
+
+echo "openapi-sync: stub — no OpenAPI specs generated yet"

--- a/scripts/check-pub-use.sh
+++ b/scripts/check-pub-use.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# REQ-MD-02: Lint that every public item is documented and re-exported correctly.
+# Implementation owned by RUSAA-26; this stub exits 0 until that issue lands.
+set -euo pipefail
+
+echo "public-surface: stub — full lint implemented in RUSAA-26"

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Update a Paperclip issue status and post a multiline markdown comment.
+#
+# Usage:
+#   scripts/paperclip-issue-update.sh --issue-id <id> --status <status> <<'MD'
+#   ## Update
+#   - did the thing
+#   MD
+#
+# Required env: PAPERCLIP_API_KEY, PAPERCLIP_API_URL
+# Optional env: PAPERCLIP_RUN_ID (included as X-Paperclip-Run-Id when set)
+set -euo pipefail
+
+ISSUE_ID=""
+STATUS=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --issue-id) ISSUE_ID="$2"; shift 2 ;;
+        --status)   STATUS="$2";   shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$ISSUE_ID" || -z "$STATUS" ]]; then
+    echo "Usage: $0 --issue-id <id> --status <status> < comment-body" >&2
+    exit 1
+fi
+
+COMMENT=$(cat)
+
+PAYLOAD=$(jq -n \
+    --arg status  "$STATUS" \
+    --arg comment "$COMMENT" \
+    '{"status": $status, "comment": $comment}')
+
+CURL_ARGS=(
+    -sf -X PATCH
+    -H "Authorization: Bearer ${PAPERCLIP_API_KEY}"
+    -H "Content-Type: application/json"
+    -d "$PAYLOAD"
+)
+
+if [[ -n "${PAPERCLIP_RUN_ID:-}" ]]; then
+    CURL_ARGS+=(-H "X-Paperclip-Run-Id: ${PAPERCLIP_RUN_ID}")
+fi
+
+curl "${CURL_ARGS[@]}" "${PAPERCLIP_API_URL}/api/issues/${ISSUE_ID}"


### PR DESCRIPTION
## Summary

Implements [REQ-DV-06] initial CI pipeline with all 12 required jobs scaffolded. Triggered on every push to `main` and every pull request, with per-branch concurrency cancellation.

**4 fully wired jobs:**
- `cargo-check` — `cargo check --workspace`
- `cargo-test` — `cargo test --workspace`
- `clippy` — `cargo clippy --workspace -- -D warnings`
- `file-size` — 600-line hard cap via `scripts/check-file-sizes.sh`

**2 jobs with stubs (owned by downstream issues):**
- `public-surface` — stub,  implements the lint
- `openapi-sync` — stub, no OpenAPI specs yet

**3 jobs wired structurally (Wave 8+):**
- `docker-build`, `playwright-e2e` — stubs, Dockerfiles/Playwright suite added later
- `rb-feature-resolver-isolation`, `tenant-isolation` — stubs, require crate/DB

**2 security/policy jobs:**
- `security-lint` — `cargo audit` (rustsec/audit-check) + gitleaks secret scan
- `crate-cycle` — `cargo metadata` graph validation + `cargo-deny` (licenses/bans/sources using existing `deny.toml`)

Also adds `scripts/paperclip-issue-update.sh` — agent helper for multiline issue updates.

## GitHub Issue

Part of  — CI pipeline (initial).

Unblocks  and .

## Migration type

N/A — no database changes.

## Checklist

- [x] All 12 CI job slots scaffolded
- [x] `cargo check --workspace` and `cargo test --workspace` run clean
- [x] `file-size` script tested locally against current codebase (passes)
- [x] Stub scripts exit 0 and print clear intent messages
- [x] CI triggers on push to main and pull_request
- [x] Concurrency group cancels stale runs on same ref