### PR TITLE
fix: allow Unicode-3.0 in cargo-deny license check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "ISC",
     "Zlib",
     "OpenSSL",


### PR DESCRIPTION
## Summary

- Adds `Unicode-3.0` to the `[licenses] allow` list in `deny.toml`
- Unblocks the `security-lint` CI job (`cargo deny check licenses`) which was failing because one or more upstream crates carry this license
- Unicode-3.0 is a permissive, OSI-approved license compatible with the project's open-source stance

## Migration type

N/A — config-only change, no schema migration.

## Checklist

- [x] `deny.toml` syntax follows existing entry format
- [x] No other allowlist entries removed or altered
- [x] Branch from `main`, one task → one PR

Closes #the internal tracking issue