### PR TITLE
fix: exclude *.generated.rs files by name in file-size check

### DIFF
--- a/scripts/check-file-sizes.sh
+++ b/scripts/check-file-sizes.sh
@@ -25,6 +25,7 @@ done < <(find . -type f \( \
   ! -path "*/node_modules/*" \
   ! -path "*/vendor/*" \
   ! -path "*/generated/*" \
+  ! -name "*.generated.rs" \
   -print0)
 
 if (( FAILED == 1 )); then


### PR DESCRIPTION
## Summary

Implements REQ-MD-01 (the internal tracking issue): add `*.generated.rs` filename exclusion to `scripts/check-file-sizes.sh`.

The existing script excluded files inside `generated/` directories via `! -path "*/generated/*"`, but files named `foo.generated.rs` located outside such directories would still be subject to the 600-line cap. This PR adds `! -name "*.generated.rs"` so the exclusion is file-name-based, matching the spec exactly.

## Change

```diff
+  ! -name "*.generated.rs" \
```

## Verification

- `bash scripts/check-file-sizes.sh` → PASSED on current workspace
- Tested with a synthetic 650-line `test.generated.rs` — correctly excluded (script still passes)

## GitHub Issue

Closes #9

## Checklist

- [x] `bash scripts/check-file-sizes.sh` passes
- [x] `*.generated.rs` files over 600 lines are correctly excluded by name
- [x] `target/` still excluded via `! -path "*/target/*"`
- [x] No internal Paperclip references in commit or PR