### PR TITLE
feat: public surface lint (REQ-MD-02)

### DIFF
--- a/scripts/check-pub-use.sh
+++ b/scripts/check-pub-use.sh
@@ -1,6 +1,55 @@
 #!/usr/bin/env bash
-# REQ-MD-02: Lint that every public item is documented and re-exported correctly.
-# Implementation owned by RUSAA-26; this stub exits 0 until that issue lands.
+# REQ-MD-02: Public surface lint for workspace library crates.
+#
+# Every src/lib.rs in the workspace must satisfy two rules:
+#
+#   Rule 1 — No bare `pub mod name;`
+#     Using `pub mod` makes an entire internal module part of the public API,
+#     leaking implementation structure.  Use private `mod name;` declarations
+#     and re-export only the specific items callers need via explicit `pub use`.
+#     Note: `pub(crate) mod` and `pub(super) mod` are allowed.
+#
+#   Rule 2 — No wildcard re-exports (`pub use path::*;`)
+#     Wildcard re-exports silently pull in every public item from a module,
+#     making the crate's public surface opaque and hard to audit.  Name each
+#     re-exported item explicitly.
+#
+# When a new lib.rs is added it is checked automatically — no allowlist needed.
 set -euo pipefail
 
-echo "public-surface: stub — full lint implemented in RUSAA-26"
+FAILED=0
+
+while IFS= read -r -d '' file; do
+    # Rule 1: bare `pub mod name;` (pub(crate)/pub(super)/etc. are permitted)
+    # Regex: optional whitespace, then literally `pub mod`, then identifier and semicolon.
+    # A parenthesised qualifier like `pub(crate)` contains `(` immediately after `pub`,
+    # so the negative lookahead `(?!\s*\()` excludes those forms.
+    if grep -Pn '^\s*pub(?!\s*\()\s+mod\s+\w+\s*;' "$file" 2>/dev/null | grep -q .; then
+        echo "FAIL [$file]: bare 'pub mod' declaration(s) found:" >&2
+        grep -Pn '^\s*pub(?!\s*\()\s+mod\s+\w+\s*;' "$file" >&2
+        echo "  Fix: change to 'mod name;' and add 'pub use name::Item;' for each public item." >&2
+        FAILED=1
+    fi
+
+    # Rule 2: wildcard re-exports — `pub use path::*;` (any pub visibility modifier)
+    # Plain `use path::*;` inside test modules is permitted; only public re-exports are flagged.
+    if grep -Pn '^\s*pub(\([^)]+\))?\s+use\s+\S+::\*\s*;' "$file" 2>/dev/null | grep -q .; then
+        echo "FAIL [$file]: wildcard re-export(s) found:" >&2
+        grep -Pn '^\s*pub(\([^)]+\))?\s+use\s+\S+::\*\s*;' "$file" >&2
+        echo "  Fix: replace 'pub use foo::*;' with named re-exports, e.g. 'pub use foo::{A, B};'." >&2
+        FAILED=1
+    fi
+done < <(find . -name "lib.rs" \
+    ! -path "*/target/*" \
+    ! -path "*/.git/*" \
+    ! -path "*/vendor/*" \
+    ! -path "*/node_modules/*" \
+    -print0)
+
+if (( FAILED == 1 )); then
+    echo "" >&2
+    echo "public-surface lint FAILED." >&2
+    exit 1
+fi
+
+echo "public-surface lint PASSED"


### PR DESCRIPTION
## Summary

Implements the `check-pub-use.sh` script that was stubbed in  (CI pipeline, PR #6). Replaces the stub exit-0 with a real lint enforcing two rules on every `src/lib.rs` in the workspace.

**Rules enforced:**

- **Rule 1 — No bare `pub mod name;`**  
  Forces private `mod name;` + explicit `pub use name::Item;` so each crate's public API is declared intentionally. `pub(crate)` / `pub(super)` qualifiers are permitted.

- **Rule 2 — No wildcard re-exports (`pub use path::*;`)**  
  Forces naming every re-exported item. Plain `use path::*;` inside `#[cfg(test)]` modules (e.g. `use super::*;`) is unaffected — only public-visibility wildcards are flagged.

**Scope:** Finds all `lib.rs` files via `find`, skipping `target/`, `.git/`, `vendor/`, `node_modules/`. Both existing library crates (`rb-tracing`, `rb-schemas`) already comply — no changes needed to crate code.

**Note for unmerged PRs (the internal tracking issue, the internal tracking issue):** `services/migrate/src/lib.rs` uses `pub mod error; pub mod kafka; pub mod pg;` — these will fail CI when those branches are rebased onto `main`. The fix is to change to private `mod` + explicit `pub use` in that file and update integration test import paths accordingly.

## Test plan

- [x] `bash scripts/check-pub-use.sh` passes locally on current codebase
- [x] Verified `pub mod foo;` is detected (Rule 1)
- [x] Verified `pub(crate) mod foo;` is NOT flagged (allowed)
- [x] Verified `pub use foo::*;` is detected (Rule 2)
- [x] Verified `use super::*;` inside test modules is NOT flagged
- [ ] CI `public-surface` job passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)