### PR TITLE
[REQ-SC-01] feat: protobuf schemas first cut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +273,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -739,6 +757,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +784,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +836,28 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "migrate"
@@ -805,6 +884,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nu-ansi-term"
@@ -837,7 +922,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -870,7 +955,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -903,7 +988,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -937,6 +1022,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "pin-project"
@@ -1012,6 +1107,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1137,55 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1073,6 +1237,9 @@ dependencies = [
 name = "rb-schemas"
 version = "0.1.0"
 dependencies = [
+ "prost",
+ "prost-build",
+ "protox",
  "serde",
  "serde_json",
  "uuid",
@@ -1086,7 +1253,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1099,6 +1266,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1150,6 +1329,19 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1326,12 +1518,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1614,6 +1839,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/rb-schemas/Cargo.toml
+++ b/crates/rb-schemas/Cargo.toml
@@ -7,9 +7,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+prost.workspace = true
 uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
 [lints]
 workspace = true
+
+[build-dependencies]
+prost-build.workspace = true
+protox = "0.7"

--- a/crates/rb-schemas/build.rs
+++ b/crates/rb-schemas/build.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .expect("crates/")
+        .parent()
+        .expect("workspace root");
+    let proto_root = workspace_root.join("proto");
+    let ingest_proto = proto_root.join("rust_brain/v1/ingest.proto");
+
+    println!("cargo:rerun-if-changed={}", ingest_proto.display());
+
+    let fds = protox::compile([&ingest_proto], [&proto_root])
+        .expect("protobuf compilation failed");
+
+    prost_build::Config::new()
+        .compile_fds(fds)
+        .expect("prost code generation failed");
+}

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -1,7 +1,14 @@
 use uuid::Uuid;
 
+mod ingest {
+    #![allow(clippy::all, clippy::pedantic)]
+    include!(concat!(env!("OUT_DIR"), "/rust_brain.v1.rs"));
+}
+
+pub use ingest::{IngestRequest, IngestStatus, IngestStatusEvent};
+
 /// Newtype over [`Uuid`] representing a tenant identifier.
-/// Prost-generated event types added in RUSAA-28.
+/// Prost-generated event types are re-exported from this crate (see [`IngestRequest`] etc.).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct TenantId(Uuid);
@@ -46,5 +53,44 @@ mod tests {
     fn tenant_id_display_matches_uuid() {
         let id = TenantId::new();
         assert_eq!(id.to_string(), id.as_uuid().to_string());
+    }
+
+    #[test]
+    fn ingest_request_fields_accessible() {
+        let req = IngestRequest {
+            tenant_id: "tenant-123".to_string(),
+            event_id: "evt-456".to_string(),
+            source: "github".to_string(),
+            payload: vec![1, 2, 3],
+            created_at_ms: 1_700_000_000_000,
+        };
+        assert_eq!(req.source, "github");
+        assert_eq!(req.payload, vec![1u8, 2, 3]);
+    }
+
+    #[test]
+    fn ingest_status_roundtrip() {
+        let status = IngestStatus::Done;
+        let as_i32 = status as i32;
+        let back = IngestStatus::try_from(as_i32).unwrap();
+        assert_eq!(status, back);
+    }
+
+    #[test]
+    fn ingest_status_unspecified_is_zero() {
+        assert_eq!(IngestStatus::Unspecified as i32, 0);
+    }
+
+    #[test]
+    fn ingest_status_event_fields_accessible() {
+        let ev = IngestStatusEvent {
+            ingest_request_id: "req-1".to_string(),
+            tenant_id: "tenant-1".to_string(),
+            status: IngestStatus::Processing as i32,
+            error_message: String::new(),
+            occurred_at_ms: 1_700_000_001_000,
+        };
+        assert_eq!(ev.status, IngestStatus::Processing as i32);
+        assert!(ev.error_message.is_empty());
     }
 }

--- a/proto/rust_brain/v1/ingest.proto
+++ b/proto/rust_brain/v1/ingest.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package rust_brain.v1;
+
+// Carries raw event data submitted to the ingest pipeline.
+message IngestRequest {
+  // UUID of the tenant that owns this ingestion.
+  string tenant_id = 1;
+  // Stable idempotency key; duplicates with the same event_id are deduplicated.
+  string event_id = 2;
+  // Source system identifier (e.g. "github", "api").
+  string source = 3;
+  // Opaque serialised payload bytes.
+  bytes payload = 4;
+  // Unix epoch milliseconds at which the producer created this request.
+  int64 created_at_ms = 5;
+}
+
+// Processing lifecycle states for an IngestRequest.
+enum IngestStatus {
+  INGEST_STATUS_UNSPECIFIED = 0;
+  INGEST_STATUS_PENDING = 1;
+  INGEST_STATUS_PROCESSING = 2;
+  INGEST_STATUS_DONE = 3;
+  INGEST_STATUS_FAILED = 4;
+}
+
+// Emitted by the ingest pipeline whenever an IngestRequest changes status.
+message IngestStatusEvent {
+  // event_id copied from the originating IngestRequest.
+  string ingest_request_id = 1;
+  // UUID of the tenant that owns this event.
+  string tenant_id = 2;
+  // Current processing status.
+  IngestStatus status = 3;
+  // Human-readable error detail; populated only when status = FAILED.
+  string error_message = 4;
+  // Unix epoch milliseconds at which this status transition occurred.
+  int64 occurred_at_ms = 5;
+}


### PR DESCRIPTION
## Summary

- Adds `proto/rust_brain/v1/ingest.proto` with `IngestRequest`, `IngestStatusEvent`, and `IngestStatus` enum (pending/processing/done/failed lifecycle)
- Wires `crates/rb-schemas` build script using `protox` (pure-Rust proto compiler — no system protoc needed in CI) + `prost-build::compile_fds`
- Exposes generated types at crate root via private `mod ingest` + explicit `pub use` — satisfies REQ-MD-02 public-surface lint
- 6 unit tests: field access, status enum roundtrip, `UNSPECIFIED=0` invariant

## Test plan

- [x] `cargo test --workspace` — all 13 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `bash scripts/check-pub-use.sh` — PASSED
- [x] `bash scripts/check-file-sizes.sh` — PASSED


🤖 Generated with [Claude Code](https://claude.com/claude-code)