### PR TITLE
docs: crate READMEs for rb-tracing and rb-schemas (REQ-MD-03)

### DIFF
--- a/crates/rb-schemas/README.md
+++ b/crates/rb-schemas/README.md
@@ -1,0 +1,48 @@
+# rb-schemas
+
+Protobuf-generated message types for the rust-brain v1 ingest pipeline, plus the `TenantId` newtype.
+
+## Public API
+
+| Type | Description |
+|------|-------------|
+| `struct TenantId` | UUID newtype identifying a tenant; serialises transparently as a UUID string |
+| `struct IngestRequest` | Carries raw event data submitted to the ingest pipeline (`tenant_id`, `event_id`, `source`, `payload`, `created_at_ms`) |
+| `enum IngestStatus` | Processing lifecycle states: `Unspecified`, `Pending`, `Processing`, `Done`, `Failed` |
+| `struct IngestStatusEvent` | Emitted by the ingest pipeline whenever an `IngestRequest` changes status |
+
+Types generated from `proto/rust_brain/v1/ingest.proto` via `prost`; source of truth is the `.proto` file.
+
+## Usage
+
+```rust
+use rb_schemas::{IngestRequest, IngestStatus, TenantId};
+
+let tenant = TenantId::new();
+
+let req = IngestRequest {
+    tenant_id: tenant.to_string(),
+    event_id: "evt-abc123".to_string(),
+    source: "github".to_string(),
+    payload: serde_json::to_vec(&my_payload).unwrap(),
+    created_at_ms: 1_700_000_000_000,
+};
+
+assert_eq!(req.source, "github");
+assert_eq!(IngestStatus::Done as i32, 3);
+```
+
+## Proto source
+
+The messages are compiled from:
+
+```
+proto/rust_brain/v1/ingest.proto   (package rust_brain.v1)
+```
+
+To regenerate after editing the `.proto` file, simply run `cargo build -p rb-schemas`; the `build.rs` script re-runs `protox` + `prost-build` automatically when the file changes.
+
+## Dependencies
+
+- Depends on: *(no other rb-\* crates)*
+- Used by: ingest pipeline services (none wired up yet)

--- a/crates/rb-tracing/README.md
+++ b/crates/rb-tracing/README.md
@@ -1,0 +1,57 @@
+# rb-tracing
+
+Structured JSON logging and OpenTelemetry tracing initialization for rust-brain services.
+
+## Public API
+
+| Type | Description |
+|------|-------------|
+| `fn init` | Initializes OTLP span export and a `tracing-subscriber` registry; returns a `TracingGuard` |
+| `struct TracingGuard` | Flushes pending spans on drop — hold for the process lifetime inside `main()` |
+| `struct StructuredJsonLayer` | `tracing-subscriber` layer that emits one compact JSON line per event |
+| `enum TracingError` | Error variants for OTLP exporter init (`OtlpInit`) and subscriber registration (`Subscriber`) |
+
+## Usage
+
+```rust
+use rb_tracing::init;
+
+#[tokio::main]
+async fn main() {
+    let _guard = init("my-service").expect("tracing init failed");
+    // _guard is held for the process lifetime; dropping it flushes pending spans
+    tracing::info!(version = "1.0", "service started");
+}
+```
+
+### JSON log line shape
+
+Each line written by `StructuredJsonLayer` contains:
+
+```json
+{
+  "timestamp": "2024-06-01T12:34:56.123456789Z",
+  "level": "INFO",
+  "target": "my_service::handler",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "span": "handle_request",
+  "spans": ["serve", "handle_request"],
+  "fields": { "message": "service started", "version": "1.0" }
+}
+```
+
+`trace_id` and `span_id` are non-empty only when the event is emitted inside an active OpenTelemetry span. `span` / `spans` are omitted when no `tracing` span is active.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | gRPC endpoint for the OTLP span exporter |
+| `RUST_LOG` | `info` | Log filter passed to `EnvFilter` |
+| `RB_LOG_FORMAT` | `json` | Set to `pretty` for human-readable output in development |
+
+## Dependencies
+
+- Depends on: *(no other rb-\* crates)*
+- Used by: all rust-brain services (none wired up yet)


### PR DESCRIPTION
## Summary

- Adds `crates/rb-tracing/README.md`: purpose, public API table (`init`, `TracingGuard`, `StructuredJsonLayer`, `TracingError`), minimal usage example, JSON log line shape, env-var reference
- Adds `crates/rb-schemas/README.md`: purpose, public API table (`TenantId`, `IngestRequest`, `IngestStatus`, `IngestStatusEvent`), minimal usage example, proto source note, regeneration instructions

Both follow the template defined in AGENTS.md (REQ-MD-03).

## Test plan

- [ ] `cargo doc --workspace --no-deps` renders without warnings
- [ ] Reviewers verify accuracy of public API tables against source code in `crates/rb-tracing/src/lib.rs` and `crates/rb-schemas/src/lib.rs`
- [ ] No legacy references or broken links in either README

🤖 Generated with [Claude Code](https://claude.com/claude-code)