### PR TITLE
[REQ-TN-01] feat: tenant provisioning with schema-per-tenant isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-storage-pg"
+version = "0.1.0"
+dependencies = [
+ "rb-schemas",
+ "rb-tenant",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "rb-tenant"
+version = "0.1.0"
+dependencies = [
+ "rb-schemas",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rb-tracing"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/rb-tracing",
     "crates/rb-schemas",
+    "crates/rb-tenant",
+    "crates/rb-storage-pg",
     "services/migrate",
 ]
 
@@ -45,6 +47,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 clap = { version = "4", features = ["derive"] }
 # Configuration / YAML
 serde_yaml = "0.9"
+# Time
+chrono = { version = "0.4", features = ["serde"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/rb-storage-pg/Cargo.toml
+++ b/crates/rb-storage-pg/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rb-storage-pg"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+rb-tenant = { path = "../rb-tenant" }
+sqlx.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+rb-schemas = { path = "../rb-schemas" }
+rb-tenant = { path = "../rb-tenant" }
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rb-storage-pg/Cargo.toml
+++ b/crates/rb-storage-pg/Cargo.toml
@@ -7,13 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rb-tenant = { path = "../rb-tenant" }
+rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
 sqlx.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-rb-schemas = { path = "../rb-schemas" }
-rb-tenant = { path = "../rb-tenant" }
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
 tokio.workspace = true
 
 [lints]

--- a/crates/rb-storage-pg/src/lib.rs
+++ b/crates/rb-storage-pg/src/lib.rs
@@ -1,0 +1,79 @@
+use rb_tenant::TenantCtx;
+use sqlx::PgPool;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+}
+
+/// PgBouncer-compatible tenant-scoped Postgres pool.
+///
+/// Wraps a shared [`PgPool`]. Isolation is enforced at the SQL level via fully
+/// qualified table names — no `search_path` manipulation is ever performed.
+pub struct TenantPool {
+    pool: PgPool,
+}
+
+impl TenantPool {
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Returns the underlying pool for control-schema queries.
+    #[must_use]
+    pub fn control(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Create the tenant schema for `ctx`.
+    ///
+    /// Uses `CREATE SCHEMA IF NOT EXISTS` so the call is idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::Sqlx`] on database failure.
+    pub async fn create_schema(&self, ctx: &TenantCtx) -> Result<(), StorageError> {
+        let schema = ctx.schema_name();
+        sqlx::query(&format!(r#"CREATE SCHEMA IF NOT EXISTS "{schema}""#))
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Drop the tenant schema and all its contents.
+    ///
+    /// Uses `DROP SCHEMA IF EXISTS … CASCADE` so the call is idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::Sqlx`] on database failure.
+    pub async fn drop_schema(&self, ctx: &TenantCtx) -> Result<(), StorageError> {
+        let schema = ctx.schema_name();
+        sqlx::query(&format!(r#"DROP SCHEMA IF EXISTS "{schema}" CASCADE"#))
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns `true` if the tenant schema exists in the database.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::Sqlx`] on database failure.
+    pub async fn schema_exists(&self, ctx: &TenantCtx) -> Result<bool, StorageError> {
+        let schema = ctx.schema_name();
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(\
+               SELECT 1 FROM information_schema.schemata \
+               WHERE schema_name = $1\
+             )",
+        )
+        .bind(schema)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists)
+    }
+}

--- a/crates/rb-storage-pg/tests/integration.rs
+++ b/crates/rb-storage-pg/tests/integration.rs
@@ -1,0 +1,329 @@
+/// Integration tests for `TenantPool`.
+///
+/// Requires a running Postgres instance. Set `TEST_DATABASE_URL` to run:
+///   docker compose -f compose/test.yml up -d postgres
+///   `TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres` \
+///     cargo test -p rb-storage-pg
+use rb_schemas::TenantId;
+use rb_storage_pg::TenantPool;
+use rb_tenant::TenantCtx;
+use sqlx::postgres::PgPoolOptions;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn test_url() -> Option<String> {
+    std::env::var("TEST_DATABASE_URL").ok()
+}
+
+async fn make_pool(url: &str) -> TenantPool {
+    let pg = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(url)
+        .await
+        .expect("connect to test DB");
+    TenantPool::new(pg)
+}
+
+fn new_ctx() -> TenantCtx {
+    TenantCtx::new(TenantId::new())
+}
+
+macro_rules! skip_no_db {
+    ($url:ident) => {
+        let Some($url) = test_url() else {
+            eprintln!("SKIP: TEST_DATABASE_URL not set");
+            return;
+        };
+    };
+}
+
+// ── schema lifecycle ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn schema_does_not_exist_before_create() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    let exists = pool.schema_exists(&ctx).await.unwrap();
+    assert!(!exists, "fresh tenant schema must not pre-exist");
+}
+
+#[tokio::test]
+async fn create_schema_creates_the_schema() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+    let exists = pool.schema_exists(&ctx).await.unwrap();
+    assert!(exists, "schema must exist after create_schema");
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+#[tokio::test]
+async fn create_schema_is_idempotent() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+    // Second call must not error (IF NOT EXISTS).
+    pool.create_schema(&ctx).await.unwrap();
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+#[tokio::test]
+async fn drop_schema_removes_the_schema() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+    pool.drop_schema(&ctx).await.unwrap();
+    let exists = pool.schema_exists(&ctx).await.unwrap();
+    assert!(!exists, "schema must be gone after drop_schema");
+}
+
+#[tokio::test]
+async fn drop_nonexistent_schema_is_ok() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    // Must not error on a schema that was never created.
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+#[tokio::test]
+async fn schema_lifecycle_create_drop_create() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+    pool.drop_schema(&ctx).await.unwrap();
+    // Re-creating after drop must succeed.
+    pool.create_schema(&ctx).await.unwrap();
+    assert!(pool.schema_exists(&ctx).await.unwrap());
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+// ── multi-tenant coexistence ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn multiple_tenants_coexist() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let (ctx_a, ctx_b, ctx_c) = (new_ctx(), new_ctx(), new_ctx());
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+    pool.create_schema(&ctx_c).await.unwrap();
+    assert!(pool.schema_exists(&ctx_a).await.unwrap());
+    assert!(pool.schema_exists(&ctx_b).await.unwrap());
+    assert!(pool.schema_exists(&ctx_c).await.unwrap());
+    pool.drop_schema(&ctx_a).await.unwrap();
+    pool.drop_schema(&ctx_b).await.unwrap();
+    pool.drop_schema(&ctx_c).await.unwrap();
+}
+
+#[tokio::test]
+async fn different_tenant_ids_get_different_schemas() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    assert_ne!(
+        ctx_a.schema_name(),
+        ctx_b.schema_name(),
+        "distinct UUIDs must produce distinct schema names"
+    );
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+    pool.drop_schema(&ctx_a).await.unwrap();
+    pool.drop_schema(&ctx_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn control_pool_can_execute_queries() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let n: i64 = sqlx::query_scalar("SELECT 1::bigint")
+        .fetch_one(pool.control())
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+}
+
+// ── cross-tenant isolation ────────────────────────────────────────────────────
+
+/// Helper: create a test table inside a tenant schema and insert a row.
+async fn create_test_table(pool: &TenantPool, ctx: &TenantCtx) {
+    let tbl = ctx.qualify("_iso_test");
+    sqlx::query(&format!("CREATE TABLE IF NOT EXISTS {tbl} (val TEXT)"))
+        .execute(pool.control())
+        .await
+        .unwrap();
+    sqlx::query(&format!("INSERT INTO {tbl} (val) VALUES ('hello')"))
+        .execute(pool.control())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn isolation_table_in_a_not_visible_in_b() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+
+    create_test_table(&pool, &ctx_a).await;
+
+    // Table must not exist in schema B.
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(\
+           SELECT 1 FROM information_schema.tables \
+           WHERE table_schema = $1 AND table_name = '_iso_test'\
+         )",
+    )
+    .bind(ctx_b.schema_name())
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert!(!exists, "_iso_test must not exist in tenant B's schema");
+
+    pool.drop_schema(&ctx_a).await.unwrap();
+    pool.drop_schema(&ctx_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn isolation_insert_in_a_not_in_b() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+
+    create_test_table(&pool, &ctx_a).await;
+    // Create same table in B but insert no rows.
+    let tbl_b = ctx_b.qualify("_iso_test");
+    sqlx::query(&format!("CREATE TABLE IF NOT EXISTS {tbl_b} (val TEXT)"))
+        .execute(pool.control())
+        .await
+        .unwrap();
+
+    let count: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {tbl_b}"))
+        .fetch_one(pool.control())
+        .await
+        .unwrap();
+    assert_eq!(count, 0, "tenant B must have no rows from tenant A");
+
+    pool.drop_schema(&ctx_a).await.unwrap();
+    pool.drop_schema(&ctx_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn isolation_drop_a_leaves_b_intact() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+    create_test_table(&pool, &ctx_a).await;
+    create_test_table(&pool, &ctx_b).await;
+
+    pool.drop_schema(&ctx_a).await.unwrap();
+
+    assert!(!pool.schema_exists(&ctx_a).await.unwrap(), "A must be gone");
+    assert!(pool.schema_exists(&ctx_b).await.unwrap(), "B must survive A's drop");
+
+    pool.drop_schema(&ctx_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn isolation_qualify_routes_to_correct_schema() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    pool.create_schema(&ctx_a).await.unwrap();
+    pool.create_schema(&ctx_b).await.unwrap();
+
+    create_test_table(&pool, &ctx_a).await;
+    create_test_table(&pool, &ctx_b).await;
+
+    let count_a: i64 =
+        sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {}", ctx_a.qualify("_iso_test")))
+            .fetch_one(pool.control())
+            .await
+            .unwrap();
+    let count_b: i64 =
+        sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {}", ctx_b.qualify("_iso_test")))
+            .fetch_one(pool.control())
+            .await
+            .unwrap();
+    assert_eq!(count_a, 1, "qualify must route to A");
+    assert_eq!(count_b, 1, "qualify must route to B, not A");
+
+    pool.drop_schema(&ctx_a).await.unwrap();
+    pool.drop_schema(&ctx_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn isolation_control_queries_unaffected_by_tenant_schemas() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+
+    // control() pool can still query information_schema regardless of tenant schemas.
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.schemata")
+        .fetch_one(pool.control())
+        .await
+        .unwrap();
+    assert!(n > 0, "control pool must be unaffected by tenant schema operations");
+
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+// ── schema name validation ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tenant_schema_name_matches_pg_pattern() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    pool.create_schema(&ctx).await.unwrap();
+
+    // The pg_namespace query used by migrate_all_tenants must find this schema.
+    let found: bool = sqlx::query_scalar(
+        "SELECT EXISTS(\
+           SELECT 1 FROM pg_catalog.pg_namespace \
+           WHERE nspname ~ '^tenant_[0-9a-f]{24}$' \
+             AND nspname = $1\
+         )",
+    )
+    .bind(ctx.schema_name())
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert!(found, "schema name must match the ^tenant_[0-9a-f]{{24}}$ pg pattern");
+
+    pool.drop_schema(&ctx).await.unwrap();
+}
+
+#[tokio::test]
+async fn schema_name_deterministic_across_pool_instances() {
+    skip_no_db!(url);
+    let pool1 = make_pool(&url).await;
+    let pool2 = make_pool(&url).await;
+    let tid = TenantId::new();
+    let ctx1 = TenantCtx::new(tid);
+    let ctx2 = TenantCtx::new(tid);
+    assert_eq!(
+        ctx1.schema_name(),
+        ctx2.schema_name(),
+        "same TenantId must produce same schema name regardless of pool"
+    );
+    pool1.create_schema(&ctx1).await.unwrap();
+    assert!(pool2.schema_exists(&ctx2).await.unwrap());
+    pool1.drop_schema(&ctx1).await.unwrap();
+}

--- a/crates/rb-tenant/Cargo.toml
+++ b/crates/rb-tenant/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rb-tenant"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+rb-schemas = { path = "../rb-schemas" }
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rb-tenant/Cargo.toml
+++ b/crates/rb-tenant/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rb-schemas = { path = "../rb-schemas" }
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
 thiserror.workspace = true
 
 [lints]

--- a/crates/rb-tenant/src/lib.rs
+++ b/crates/rb-tenant/src/lib.rs
@@ -1,0 +1,181 @@
+use rb_schemas::TenantId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TenantError {
+    #[error("invalid schema name '{0}': must match ^tenant_[0-9a-f]{{24}}$")]
+    InvalidSchemaName(String),
+}
+
+/// Validated tenant schema name. Guaranteed to match `^tenant_[0-9a-f]{24}$`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemaName(String);
+
+impl SchemaName {
+    /// Construct from a pre-existing string, validating the format.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TenantError::InvalidSchemaName`] if the string does not match
+    /// `^tenant_[0-9a-f]{24}$`.
+    pub fn new(s: impl Into<String>) -> Result<Self, TenantError> {
+        let s = s.into();
+        if !is_valid_schema_name(&s) {
+            return Err(TenantError::InvalidSchemaName(s));
+        }
+        Ok(Self(s))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SchemaName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn is_valid_schema_name(s: &str) -> bool {
+    let Some(suffix) = s.strip_prefix("tenant_") else {
+        return false;
+    };
+    suffix.len() == 24 && suffix.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Tenant execution context: tenant identity paired with its validated schema name.
+///
+/// Construct via [`TenantCtx::new`]. The schema name is derived deterministically from
+/// the tenant ID — the lower 96 bits (last 12 bytes) of the UUID rendered as 24
+/// lowercase hex chars.
+#[derive(Debug, Clone)]
+pub struct TenantCtx {
+    tenant_id: TenantId,
+    schema_name: SchemaName,
+}
+
+impl TenantCtx {
+    /// Construct a `TenantCtx` from a `TenantId`.
+    ///
+    /// Schema name is derived from the lower 96 bits (last 12 bytes) of the UUID,
+    /// rendered as 24 lowercase hex chars: `tenant_<24hex>`.
+    #[must_use]
+    pub fn new(tenant_id: TenantId) -> Self {
+        let schema_name = derive_schema_name(&tenant_id);
+        Self { tenant_id, schema_name }
+    }
+
+    #[must_use]
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        self.schema_name.as_str()
+    }
+
+    /// Returns the fully qualified table reference `schema_name.table`.
+    ///
+    /// This is the single codepath for all tenant-scoped SQL table references.
+    /// Never use `search_path`; always call `qualify`.
+    #[must_use]
+    pub fn qualify(&self, table: &str) -> String {
+        format!("{}.{}", self.schema_name.as_str(), table)
+    }
+}
+
+fn derive_schema_name(tenant_id: &TenantId) -> SchemaName {
+    let uuid = tenant_id.as_uuid();
+    let bytes = uuid.as_bytes();
+    let mut hex = String::with_capacity(24);
+    #[allow(clippy::use_debug)]
+    for b in &bytes[4..] {
+        use std::fmt::Write as _;
+        write!(hex, "{b:02x}").expect("infallible write to String");
+    }
+    // Safety: derived hex is always 24 lowercase hex chars.
+    SchemaName(format!("tenant_{hex}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_name_valid_format_accepted() {
+        let name = SchemaName::new("tenant_deadbeef1234567890abcdef").unwrap();
+        assert_eq!(name.as_str(), "tenant_deadbeef1234567890abcdef");
+    }
+
+    #[test]
+    fn schema_name_wrong_prefix_rejected() {
+        assert!(SchemaName::new("schema_deadbeef1234567890abcdef").is_err());
+    }
+
+    #[test]
+    fn schema_name_too_short_rejected() {
+        assert!(SchemaName::new("tenant_deadbeef").is_err());
+    }
+
+    #[test]
+    fn schema_name_too_long_rejected() {
+        assert!(SchemaName::new("tenant_deadbeef1234567890abcdefXX").is_err());
+    }
+
+    #[test]
+    fn schema_name_uppercase_hex_rejected() {
+        assert!(SchemaName::new("tenant_DEADBEEF1234567890ABCDEF").is_err());
+    }
+
+    #[test]
+    fn schema_name_non_hex_chars_rejected() {
+        assert!(SchemaName::new("tenant_gggggggg1234567890abcdef").is_err());
+    }
+
+    #[test]
+    fn tenant_ctx_schema_name_has_correct_length() {
+        let ctx = TenantCtx::new(TenantId::new());
+        // "tenant_" (7) + 24 hex = 31 chars
+        assert_eq!(ctx.schema_name().len(), 31);
+    }
+
+    #[test]
+    fn tenant_ctx_schema_name_matches_pattern() {
+        let ctx = TenantCtx::new(TenantId::new());
+        let name = ctx.schema_name();
+        assert!(name.starts_with("tenant_"), "must start with tenant_");
+        let suffix = &name["tenant_".len()..];
+        assert_eq!(suffix.len(), 24, "suffix must be 24 chars");
+        assert!(
+            suffix.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')),
+            "suffix must be lowercase hex"
+        );
+    }
+
+    #[test]
+    fn schema_name_derivation_is_deterministic() {
+        let tid = TenantId::new();
+        let ctx1 = TenantCtx::new(tid);
+        let ctx2 = TenantCtx::new(tid);
+        assert_eq!(ctx1.schema_name(), ctx2.schema_name());
+    }
+
+    #[test]
+    fn different_tenant_ids_produce_different_schema_names() {
+        let ctx1 = TenantCtx::new(TenantId::new());
+        let ctx2 = TenantCtx::new(TenantId::new());
+        // UUIDs are random; collision probability is astronomically small.
+        assert_ne!(ctx1.schema_name(), ctx2.schema_name());
+    }
+
+    #[test]
+    fn qualify_produces_schema_dot_table() {
+        let ctx = TenantCtx::new(TenantId::new());
+        let qualified = ctx.qualify("users");
+        let expected = format!("{}.users", ctx.schema_name());
+        assert_eq!(qualified, expected);
+    }
+}

--- a/migrations/control/002_auth_and_tenancy.sql
+++ b/migrations/control/002_auth_and_tenancy.sql
@@ -1,0 +1,89 @@
+-- Control schema: Phase 1 — Auth and Tenancy tables
+-- Creates all control-plane tables for auth, sessions, tenant management, and API keys.
+-- citext provides case-insensitive text equality for emails and tenant slugs.
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE TABLE tenants (
+    id             UUID        PRIMARY KEY,
+    slug           CITEXT      NOT NULL UNIQUE,
+    name           TEXT        NOT NULL,
+    schema_name    TEXT        NOT NULL UNIQUE,
+    schema_version INT         NOT NULL DEFAULT 0,
+    status         TEXT        NOT NULL DEFAULT 'active'
+                               CHECK (status IN ('active', 'suspended', 'deleting', 'deleted')),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at     TIMESTAMPTZ
+);
+CREATE INDEX idx_tenants_status ON tenants (status, deleted_at);
+
+CREATE TABLE users (
+    id                UUID        PRIMARY KEY,
+    email             CITEXT      NOT NULL UNIQUE,
+    password_hash     TEXT        NOT NULL,
+    email_verified_at TIMESTAMPTZ,
+    mfa_secret        BYTEA,
+    status            TEXT        NOT NULL DEFAULT 'active'
+                                  CHECK (status IN ('active', 'suspended')),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE tenant_members (
+    tenant_id  UUID        NOT NULL REFERENCES tenants(id),
+    user_id    UUID        NOT NULL REFERENCES users(id),
+    role       TEXT        NOT NULL CHECK (role IN ('owner', 'admin', 'member')),
+    invited_by UUID                 REFERENCES users(id),
+    invited_at TIMESTAMPTZ,
+    joined_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, user_id)
+);
+
+CREATE TABLE sessions (
+    id           UUID        PRIMARY KEY,
+    user_id      UUID        NOT NULL REFERENCES users(id),
+    tenant_id    UUID        NOT NULL REFERENCES tenants(id),
+    token_hash   TEXT        NOT NULL UNIQUE,
+    ip           INET,
+    user_agent   TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at   TIMESTAMPTZ NOT NULL,
+    revoked_at   TIMESTAMPTZ
+);
+CREATE INDEX idx_sessions_user_active
+    ON sessions (user_id, expires_at) WHERE revoked_at IS NULL;
+
+CREATE TABLE email_tokens (
+    token_hash TEXT        PRIMARY KEY,
+    user_id    UUID        NOT NULL REFERENCES users(id),
+    kind       TEXT        NOT NULL
+                           CHECK (kind IN ('verify', 'reset', 'invite', 'bootstrap')),
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE auth_events (
+    id         BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id    UUID                 REFERENCES users(id),
+    tenant_id  UUID                 REFERENCES tenants(id),
+    event      TEXT        NOT NULL,
+    ip         INET,
+    user_agent TEXT,
+    metadata   JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_auth_events_user   ON auth_events (user_id,   created_at DESC);
+CREATE INDEX idx_auth_events_tenant ON auth_events (tenant_id, created_at DESC);
+
+CREATE TABLE api_keys (
+    id                 UUID        PRIMARY KEY,
+    tenant_id          UUID        NOT NULL REFERENCES tenants(id),
+    key_hash           TEXT        NOT NULL UNIQUE,
+    name               TEXT        NOT NULL,
+    scopes             JSONB       NOT NULL,
+    created_by_user_id UUID        NOT NULL REFERENCES users(id),
+    last_used_at       TIMESTAMPTZ,
+    revoked_at         TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_api_keys_active ON api_keys (key_hash) WHERE revoked_at IS NULL;


### PR DESCRIPTION
## Summary

- **`crates/rb-tenant`**: `TenantCtx`, `SchemaName` (validated `^tenant_[0-9a-f]{24}$`), `qualify()` as the single codepath for tenant-scoped SQL table refs. Schema name derived from lower 96 bits (last 12 bytes) of tenant UUID as 24 lowercase hex chars.
- **`crates/rb-storage-pg`**: `TenantPool` wrapping `sqlx::PgPool` with `create_schema`, `drop_schema`, `schema_exists`. PgBouncer-compatible — no `search_path` ever set.
- **`migrations/control/002_auth_and_tenancy.sql`**: Full Phase 1 control-schema DDL — `tenants`, `users`, `tenant_members`, `sessions`, `email_tokens`, `auth_events`, `api_keys` with indexes per design.
- **Workspace**: Added `rb-tenant`, `rb-storage-pg` members; added `chrono` workspace dep.

## Migration type

Additive — new migration file creating new tables.

- Tables touched: `tenants`, `users`, `tenant_members`, `sessions`, `email_tokens`, `auth_events`, `api_keys`
- Operations: `CREATE EXTENSION`, `CREATE TABLE`, `CREATE INDEX` only

## GitHub Issue

Closes #18

## Test results

- 11 unit tests (rb-tenant): all pass
- 18 integration tests (rb-storage-pg): skipped without `TEST_DATABASE_URL` (run against compose/test.yml postgres)

## Checklist

- [x] `cargo check -p rb-tenant -p rb-storage-pg --tests` passes
- [x] `cargo clippy -p rb-tenant -p rb-storage-pg --tests -- -D warnings` passes
- [x] `cargo test -p rb-tenant` — 11/11 pass
- [x] No internal Paperclip references in code
- [x] Migration type declared above