### PR TITLE
[REQ-AU-09] feat: rb-email crate with Smtp/Console/Noop transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1157,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lettre"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+dependencies = [
+ "async-trait",
+ "base64",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1405,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1797,6 +1865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1904,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rb-email"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "lettre",
+ "minijinja",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -2051,6 +2137,7 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2687,6 +2774,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/rb-tracing",
     "crates/rb-schemas",
+    "crates/rb-email",
     "crates/rb-tenant",
     "crates/rb-storage-pg",
     "crates/rb-secrets",
@@ -61,6 +62,10 @@ utoipa = { version = "5", features = ["axum_extras", "uuid"] }
 utoipa-axum = "0.2"
 # Secret management (REQ-DV-04 / rb-secrets)
 zeroize = { version = "1", features = ["derive"] }
+# Email (RUSAA-37 / rb-email)
+minijinja = "2"
+lettre = { version = "0.11", features = ["smtp-transport", "tokio1-rustls-tls", "builder"], default-features = false }
+async-trait = "0.1"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/rb-email/Cargo.toml
+++ b/crates/rb-email/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rb-email"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio.workspace = true
+minijinja.workspace = true
+lettre.workspace = true
+async-trait.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rb-email/README.md
+++ b/crates/rb-email/README.md
@@ -1,0 +1,52 @@
+# rb-email
+
+Transactional email for rust-brain. Provides an `EmailSender` trait with three transports and minijinja-powered HTML + plain-text templates.
+
+## Transports
+
+| Transport | Env value | Behaviour |
+|-----------|-----------|-----------|
+| `SmtpSender` | `smtp` | Delivers via SMTP with rustls TLS |
+| `ConsoleSender` | `console` | Prints `[EMAIL]` banner to stdout (default for local dev) |
+| `NoopSender` | `noop` | Silently discards (useful in tests) |
+
+Select the transport via `RB_EMAIL_TRANSPORT` (default: `console`).
+
+## Quick start
+
+```rust
+use rb_email::{EmailTemplate, SmtpConfig, from_transport};
+
+let transport = std::env::var("RB_EMAIL_TRANSPORT")
+    .unwrap_or_else(|_| "console".to_string());
+
+let smtp = SmtpConfig {
+    host: "smtp.example.com".to_string(),
+    port: 587,
+    username: "user".to_string(),
+    password: "secret".to_string(),
+    from_address: "noreply@example.com".to_string(),
+};
+
+let sender = from_transport(&transport, &smtp)?;
+
+let email = EmailTemplate::VerifyEmail {
+    link: "https://app.example.com/verify/TOKEN".to_string(),
+}.to_email("new-user@example.com")?;
+
+sender.send(email).await?;
+```
+
+## Templates
+
+All templates live in `crates/rb-email/templates/` and are embedded at compile time.
+
+| Template | Variables |
+|----------|-----------|
+| `verify-email.{txt,html}` | `link` |
+| `reset-password.{txt,html}` | `link` |
+| `tenant-invite.{txt,html}` | `link`, `tenant_name` |
+
+## Dependencies
+
+Standalone — no other `rb-*` crates required.

--- a/crates/rb-email/src/email.rs
+++ b/crates/rb-email/src/email.rs
@@ -1,0 +1,18 @@
+/// A fully-rendered email ready for delivery.
+#[derive(Debug, Clone)]
+pub struct Email {
+    pub to: String,
+    pub subject: String,
+    pub text_body: String,
+    pub html_body: String,
+}
+
+/// SMTP connection parameters.
+#[derive(Debug, Clone)]
+pub struct SmtpConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub from_address: String,
+}

--- a/crates/rb-email/src/error.rs
+++ b/crates/rb-email/src/error.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, thiserror::Error)]
+pub enum EmailError {
+    #[error("SMTP transport error: {0}")]
+    Smtp(String),
+    #[error("template rendering failed: {0}")]
+    Template(String),
+    #[error("unknown email transport '{0}': expected smtp, console, or noop")]
+    UnknownTransport(String),
+}

--- a/crates/rb-email/src/lib.rs
+++ b/crates/rb-email/src/lib.rs
@@ -1,0 +1,130 @@
+mod email;
+mod error;
+mod sender;
+mod templates;
+
+pub use email::{Email, SmtpConfig};
+pub use error::EmailError;
+pub use sender::{ConsoleSender, EmailSender, NoopSender, SmtpSender, from_transport};
+pub use templates::EmailTemplate;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn smtp_config() -> SmtpConfig {
+        SmtpConfig {
+            host: "localhost".to_string(),
+            port: 587,
+            username: "user@example.com".to_string(),
+            password: "secret".to_string(),
+            from_address: "noreply@example.com".to_string(),
+        }
+    }
+
+    fn sample_email() -> Email {
+        Email {
+            to: "user@example.com".to_string(),
+            subject: "Test".to_string(),
+            text_body: "Hello".to_string(),
+            html_body: "<p>Hello</p>".to_string(),
+        }
+    }
+
+    // --- sender dispatch ---
+
+    #[tokio::test]
+    async fn noop_sender_returns_ok() {
+        let sender = NoopSender;
+        assert!(sender.send(sample_email()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn console_sender_returns_ok() {
+        let sender = ConsoleSender;
+        assert!(sender.send(sample_email()).await.is_ok());
+    }
+
+    #[test]
+    fn from_transport_noop_succeeds() {
+        let result = from_transport("noop", &smtp_config());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn from_transport_console_succeeds() {
+        let result = from_transport("console", &smtp_config());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn from_transport_smtp_succeeds() {
+        let result = from_transport("smtp", &smtp_config());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn from_transport_unknown_returns_err() {
+        let result = from_transport("fax", &smtp_config());
+        assert!(matches!(result, Err(EmailError::UnknownTransport(_))));
+    }
+
+    // --- template rendering ---
+
+    #[test]
+    fn verify_email_txt_contains_link() {
+        let tpl = EmailTemplate::VerifyEmail {
+            link: "https://example.com/verify/abc123".to_string(),
+        };
+        let (txt, _) = tpl.render().unwrap();
+        assert!(txt.contains("https://example.com/verify/abc123"));
+    }
+
+    #[test]
+    fn verify_email_html_contains_link() {
+        let tpl = EmailTemplate::VerifyEmail {
+            link: "https://example.com/verify/abc123".to_string(),
+        };
+        let (_, html) = tpl.render().unwrap();
+        assert!(html.contains("https://example.com/verify/abc123"));
+    }
+
+    #[test]
+    fn reset_password_txt_mentions_expiry() {
+        let tpl = EmailTemplate::ResetPassword {
+            link: "https://example.com/reset/tok".to_string(),
+        };
+        let (txt, _) = tpl.render().unwrap();
+        assert!(txt.contains("15 minutes"));
+    }
+
+    #[test]
+    fn reset_password_html_contains_link() {
+        let tpl = EmailTemplate::ResetPassword {
+            link: "https://example.com/reset/tok".to_string(),
+        };
+        let (_, html) = tpl.render().unwrap();
+        assert!(html.contains("https://example.com/reset/tok"));
+    }
+
+    #[test]
+    fn tenant_invite_txt_contains_tenant_name() {
+        let tpl = EmailTemplate::TenantInvite {
+            link: "https://example.com/invite/xyz".to_string(),
+            tenant_name: "Acme Corp".to_string(),
+        };
+        let (txt, _) = tpl.render().unwrap();
+        assert!(txt.contains("Acme Corp"));
+    }
+
+    #[test]
+    fn tenant_invite_html_contains_tenant_name_and_link() {
+        let tpl = EmailTemplate::TenantInvite {
+            link: "https://example.com/invite/xyz".to_string(),
+            tenant_name: "Acme Corp".to_string(),
+        };
+        let (_, html) = tpl.render().unwrap();
+        assert!(html.contains("Acme Corp"));
+        assert!(html.contains("https://example.com/invite/xyz"));
+    }
+}

--- a/crates/rb-email/src/sender.rs
+++ b/crates/rb-email/src/sender.rs
@@ -1,0 +1,124 @@
+use async_trait::async_trait;
+use lettre::{
+    AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+    message::{MultiPart, SinglePart, header::ContentType},
+    transport::smtp::{authentication::Credentials, Error as SmtpError},
+};
+
+use crate::{Email, EmailError, SmtpConfig};
+
+/// Abstraction over email delivery backends.
+#[async_trait]
+pub trait EmailSender: Send + Sync {
+    /// Send a fully-rendered email.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmailError`] on delivery failure.
+    async fn send(&self, email: Email) -> Result<(), EmailError>;
+}
+
+/// SMTP delivery via [`lettre`] with tokio + rustls.
+pub struct SmtpSender {
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+    from: String,
+}
+
+impl SmtpSender {
+    /// Build a sender from [`SmtpConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmailError::Smtp`] if the relay address is invalid.
+    pub fn new(config: &SmtpConfig) -> Result<Self, EmailError> {
+        let creds = Credentials::new(config.username.clone(), config.password.clone());
+        let transport = AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
+            .map_err(|e: SmtpError| EmailError::Smtp(e.to_string()))?
+            .port(config.port)
+            .credentials(creds)
+            .build();
+        Ok(Self { transport, from: config.from_address.clone() })
+    }
+}
+
+#[async_trait]
+impl EmailSender for SmtpSender {
+    async fn send(&self, email: Email) -> Result<(), EmailError> {
+        let from: lettre::message::Mailbox = self
+            .from
+            .parse()
+            .map_err(|e: lettre::address::AddressError| EmailError::Smtp(e.to_string()))?;
+        let to: lettre::message::Mailbox = email
+            .to
+            .parse()
+            .map_err(|e: lettre::address::AddressError| EmailError::Smtp(e.to_string()))?;
+
+        let message = Message::builder()
+            .from(from)
+            .to(to)
+            .subject(email.subject)
+            .multipart(
+                MultiPart::alternative()
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_PLAIN)
+                            .body(email.text_body),
+                    )
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_HTML)
+                            .body(email.html_body),
+                    ),
+            )
+            .map_err(|e| EmailError::Smtp(e.to_string()))?;
+
+        AsyncTransport::send(&self.transport, message)
+            .await
+            .map_err(|e: SmtpError| EmailError::Smtp(e.to_string()))?;
+        Ok(())
+    }
+}
+
+/// Prints a `[EMAIL]` banner to stdout. Safe for local development.
+pub struct ConsoleSender;
+
+#[async_trait]
+impl EmailSender for ConsoleSender {
+    async fn send(&self, email: Email) -> Result<(), EmailError> {
+        println!(
+            "[EMAIL] to={} subject={}\n{}\n---",
+            email.to, email.subject, email.text_body
+        );
+        Ok(())
+    }
+}
+
+/// Silently discards every email. Useful in tests.
+pub struct NoopSender;
+
+#[async_trait]
+impl EmailSender for NoopSender {
+    async fn send(&self, _email: Email) -> Result<(), EmailError> {
+        Ok(())
+    }
+}
+
+/// Create an [`EmailSender`] from the `RB_EMAIL_TRANSPORT` value.
+///
+/// `smtp` requires a valid `smtp` config; `console` and `noop` ignore it.
+///
+/// # Errors
+///
+/// Returns [`EmailError::UnknownTransport`] for unrecognised values.
+/// Returns [`EmailError::Smtp`] if the SMTP relay address is invalid.
+pub fn from_transport(
+    transport: &str,
+    smtp: &SmtpConfig,
+) -> Result<Box<dyn EmailSender>, EmailError> {
+    match transport {
+        "smtp" => Ok(Box::new(SmtpSender::new(smtp)?)),
+        "console" => Ok(Box::new(ConsoleSender)),
+        "noop" => Ok(Box::new(NoopSender)),
+        other => Err(EmailError::UnknownTransport(other.to_string())),
+    }
+}

--- a/crates/rb-email/src/templates.rs
+++ b/crates/rb-email/src/templates.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use minijinja::Environment;
+
+use crate::{Email, EmailError};
+
+const VERIFY_EMAIL_TXT: &str = include_str!("../templates/verify-email.txt");
+const VERIFY_EMAIL_HTML: &str = include_str!("../templates/verify-email.html");
+const RESET_PASSWORD_TXT: &str = include_str!("../templates/reset-password.txt");
+const RESET_PASSWORD_HTML: &str = include_str!("../templates/reset-password.html");
+const TENANT_INVITE_TXT: &str = include_str!("../templates/tenant-invite.txt");
+const TENANT_INVITE_HTML: &str = include_str!("../templates/tenant-invite.html");
+
+/// Pre-defined transactional email templates.
+#[derive(Debug, Clone)]
+pub enum EmailTemplate {
+    VerifyEmail { link: String },
+    ResetPassword { link: String },
+    TenantInvite { link: String, tenant_name: String },
+}
+
+impl EmailTemplate {
+    /// Subject line for this template variant.
+    #[must_use]
+    pub fn subject(&self) -> String {
+        match self {
+            Self::VerifyEmail { .. } => "Verify your email address".to_string(),
+            Self::ResetPassword { .. } => "Reset your password".to_string(),
+            Self::TenantInvite { tenant_name, .. } => {
+                format!("You're invited to join {tenant_name}")
+            }
+        }
+    }
+
+    /// Render the template into `(plain_text, html)` bodies.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmailError::Template`] if minijinja rendering fails.
+    pub fn render(&self) -> Result<(String, String), EmailError> {
+        match self {
+            Self::VerifyEmail { link } => {
+                let ctx: HashMap<&str, &str> =
+                    [("link", link.as_str())].into_iter().collect();
+                render_pair(VERIFY_EMAIL_TXT, VERIFY_EMAIL_HTML, &ctx)
+            }
+            Self::ResetPassword { link } => {
+                let ctx: HashMap<&str, &str> =
+                    [("link", link.as_str())].into_iter().collect();
+                render_pair(RESET_PASSWORD_TXT, RESET_PASSWORD_HTML, &ctx)
+            }
+            Self::TenantInvite { link, tenant_name } => {
+                let ctx: HashMap<&str, &str> =
+                    [("link", link.as_str()), ("tenant_name", tenant_name.as_str())]
+                        .into_iter()
+                        .collect();
+                render_pair(TENANT_INVITE_TXT, TENANT_INVITE_HTML, &ctx)
+            }
+        }
+    }
+
+    /// Render this template into a ready-to-send [`Email`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmailError::Template`] if rendering fails.
+    pub fn to_email(&self, to: impl Into<String>) -> Result<Email, EmailError> {
+        let subject = self.subject();
+        let (text_body, html_body) = self.render()?;
+        Ok(Email { to: to.into(), subject, text_body, html_body })
+    }
+}
+
+fn render_pair(
+    txt_src: &str,
+    html_src: &str,
+    ctx: &HashMap<&str, &str>,
+) -> Result<(String, String), EmailError> {
+    let mut env = Environment::new();
+    env.add_template("txt", txt_src)
+        .map_err(|e| EmailError::Template(e.to_string()))?;
+    env.add_template("html_body", html_src)
+        .map_err(|e| EmailError::Template(e.to_string()))?;
+
+    let txt = env
+        .get_template("txt")
+        .and_then(|t| t.render(ctx))
+        .map_err(|e| EmailError::Template(e.to_string()))?;
+
+    let html = env
+        .get_template("html_body")
+        .and_then(|t| t.render(ctx))
+        .map_err(|e| EmailError::Template(e.to_string()))?;
+
+    Ok((txt, html))
+}

--- a/crates/rb-email/templates/reset-password.html
+++ b/crates/rb-email/templates/reset-password.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Reset your password</title>
+</head>
+<body>
+  <h1>Reset your password</h1>
+  <p>Click the link below to reset your password:</p>
+  <p><a href="{{ link }}">Reset Password</a></p>
+  <p>This link expires in 15 minutes.</p>
+  <p>If you did not request a password reset, you can safely ignore this email.</p>
+</body>
+</html>

--- a/crates/rb-email/templates/reset-password.txt
+++ b/crates/rb-email/templates/reset-password.txt
@@ -1,0 +1,9 @@
+Reset your password
+
+Click the link below to reset your password:
+
+{{ link }}
+
+This link expires in 15 minutes.
+
+If you did not request a password reset, you can safely ignore this email.

--- a/crates/rb-email/templates/tenant-invite.html
+++ b/crates/rb-email/templates/tenant-invite.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>You're invited to join {{ tenant_name }}</title>
+</head>
+<body>
+  <h1>You're invited to join {{ tenant_name }}</h1>
+  <p>You have been invited to join <strong>{{ tenant_name }}</strong> on Rust Brain.</p>
+  <p><a href="{{ link }}">Accept Invitation</a></p>
+  <p>If you were not expecting this invitation, you can safely ignore this email.</p>
+</body>
+</html>

--- a/crates/rb-email/templates/tenant-invite.txt
+++ b/crates/rb-email/templates/tenant-invite.txt
@@ -1,0 +1,9 @@
+You're invited to join {{ tenant_name }}
+
+You have been invited to join {{ tenant_name }} on Rust Brain.
+
+Accept your invitation:
+
+{{ link }}
+
+If you were not expecting this invitation, you can safely ignore this email.

--- a/crates/rb-email/templates/verify-email.html
+++ b/crates/rb-email/templates/verify-email.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Verify your email address</title>
+</head>
+<body>
+  <h1>Verify your email address</h1>
+  <p>Please verify your email address by clicking the link below:</p>
+  <p><a href="{{ link }}">Verify Email</a></p>
+  <p>This link expires in 1 hour.</p>
+  <p>If you did not sign up for Rust Brain, you can safely ignore this email.</p>
+</body>
+</html>

--- a/crates/rb-email/templates/verify-email.txt
+++ b/crates/rb-email/templates/verify-email.txt
@@ -1,0 +1,9 @@
+Verify your email address
+
+Please verify your email address by clicking the link below:
+
+{{ link }}
+
+This link expires in 1 hour.
+
+If you did not sign up for Rust Brain, you can safely ignore this email.

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ allow = [
     "OpenSSL",
     # webpki-roots bundles Mozilla CA certificates under CDLA-Permissive-2.0
     "CDLA-Permissive-2.0",
+    # quoted_printable (dep of lettre email transport) uses zero-clause BSD
+    "0BSD",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary

- Implements `crates/rb-email/` per  and the approved design in 
- `EmailSender` trait (async, `dyn`-safe via `async-trait`) with three implementations: `SmtpSender` (lettre + tokio-rustls), `ConsoleSender` (`[EMAIL]` banner to stdout), `NoopSender` (silent discard)
- `from_transport(transport, smtp_config)` factory keyed on `RB_EMAIL_TRANSPORT=smtp|console|noop` (default: `console`)
- `EmailTemplate` enum with `render()` → `(text, html)` and `to_email(addr)` convenience for three transactional templates: verify-email, reset-password, tenant-invite
- All six minijinja templates (txt + HTML) embedded at compile time via `include_str!`
- 12 unit tests — all passing; `cargo clippy -p rb-email -- -D warnings` clean

## Test plan

- [x] `cargo test -p rb-email` — 12/12 pass
- [x] `cargo clippy -p rb-email -- -D warnings` — no warnings
- [ ] Jarnura merge review
- [ ] QA pass on the internal tracking issue

## Scope

Pure library crate — no service code. Integrated into `control-api` by AU-01 (the internal tracking issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)