### PR TITLE
fix: grant security-events: write to security-lint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
   security-lint:
     name: security lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Adds `permissions: security-events: write` (plus `contents: read`) to the `security-lint` job
- Both `rustsec/audit-check@v1.4.1` and `gitleaks/gitleaks-action@v2` upload SARIF results to the GitHub Security tab — this requires the `security-events: write` token permission
- Without it every run fails with `##[error]Resource not accessible by integration` regardless of actual vulnerabilities

## GitHub Issue

Closes #the internal tracking issue (internal)

## Root cause

The workflow had no job-level `permissions` block on `security-lint`. GitHub Actions tokens default to `contents: read` only; SARIF uploads are gated on `security-events: write`.

## Checklist

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No functional logic changed — permissions only
- [x] No internal references