### PR TITLE
[REQ-AU-07] feat: tenant switching for multi-tenant users

### DIFF
--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -5,7 +5,7 @@
 
 use utoipa::OpenApi;
 
-use crate::routes::{auth, health, tenants};
+use crate::routes::{auth, health, me, tenants};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -15,6 +15,7 @@ use crate::routes::{auth, health, tenants};
         auth::signup,
         auth::forgot_password,
         auth::reset_password,
+        me::switch_tenant,
         tenants::invite_member,
         tenants::update_member_role,
         tenants::remove_member,
@@ -27,6 +28,9 @@ use crate::routes::{auth, health, tenants};
             auth::SignupResponse,
             auth::ForgotPasswordRequest,
             auth::ResetPasswordRequest,
+            me::SwitchTenantRequest,
+            me::SwitchTenantResponse,
+            me::CurrentTenant,
             tenants::InviteMemberRequest,
             tenants::InviteMemberResponse,
             tenants::UpdateRoleRequest,
@@ -46,6 +50,7 @@ use crate::routes::{auth, health, tenants};
     tags(
         (name = "health", description = "Liveness and readiness probes"),
         (name = "auth", description = "Authentication and session management"),
+        (name = "me", description = "Current-user and session endpoints"),
         (name = "tenants", description = "Tenant membership and role management"),
     ),
 )]

--- a/services/control-api/src/routes/me.rs
+++ b/services/control-api/src/routes/me.rs
@@ -1,0 +1,175 @@
+use axum::{Json, extract::State, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{error::AppError, middleware::auth::AuthContext, state::AppState};
+
+// ---------------------------------------------------------------------------
+// POST /v1/me/switch-tenant
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SwitchTenantRequest {
+    /// UUID of the tenant to switch to.
+    pub tenant_id: Uuid,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CurrentTenant {
+    pub id: Uuid,
+    pub name: String,
+    pub slug: String,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SwitchTenantResponse {
+    pub current_tenant: CurrentTenant,
+}
+
+/// Switch the active tenant for the current session.
+///
+/// The caller must already be a member of the target tenant. The session's
+/// `tenant_id` is updated in place and a `tenant_switched` auth event is
+/// written. Returns the new active tenant with the caller's role.
+#[utoipa::path(
+    post,
+    path = "/v1/me/switch-tenant",
+    request_body = SwitchTenantRequest,
+    responses(
+        (status = 200, description = "Tenant switched", body = SwitchTenantResponse),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Not a member of the target tenant (not_a_member)"),
+        (status = 404, description = "Target tenant not found or inactive"),
+    ),
+    tag = "me"
+)]
+pub async fn switch_tenant(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Json(body): Json<SwitchTenantRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = match auth {
+        AuthContext::Session(info) => info,
+        AuthContext::Anonymous => return Err(AppError::Unauthorized),
+    };
+
+    let member: Option<(String,)> = sqlx::query_as(
+        "SELECT role FROM control.tenant_members \
+         WHERE tenant_id = $1 AND user_id = $2",
+    )
+    .bind(body.tenant_id)
+    .bind(session.user_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let (role,) = member.ok_or(AppError::NotAMember)?;
+
+    let tenant: Option<(String, String)> = sqlx::query_as(
+        "SELECT name, slug FROM control.tenants WHERE id = $1 AND status = 'active'",
+    )
+    .bind(body.tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let (name, slug) = tenant.ok_or(AppError::NotFound)?;
+
+    let mut tx = state.pool.begin().await?;
+
+    sqlx::query("UPDATE control.sessions SET tenant_id = $1 WHERE id = $2")
+        .bind(body.tenant_id)
+        .bind(session.session_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query(
+        "INSERT INTO control.auth_events (user_id, tenant_id, event, metadata) \
+         VALUES ($1, $2, 'tenant_switched', $3)",
+    )
+    .bind(session.user_id)
+    .bind(body.tenant_id)
+    .bind(serde_json::json!({
+        "from_tenant": session.tenant_id,
+        "to_tenant": body.tenant_id,
+        "session_id": session.session_id,
+    }))
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    Ok(Json(SwitchTenantResponse {
+        current_tenant: CurrentTenant { id: body.tenant_id, name, slug, role },
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{AuthContext, SessionInfo};
+
+    fn make_session() -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+        }
+    }
+
+    #[test]
+    fn switch_tenant_request_deserializes() {
+        let json = r#"{"tenant_id":"550e8400-e29b-41d4-a716-446655440000"}"#;
+        let req: SwitchTenantRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.tenant_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn switch_tenant_response_serializes_all_fields() {
+        let resp = SwitchTenantResponse {
+            current_tenant: CurrentTenant {
+                id: Uuid::new_v4(),
+                name: "Test Corp".to_owned(),
+                slug: "test-corp-abc123".to_owned(),
+                role: "admin".to_owned(),
+            },
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        let ct = &json["current_tenant"];
+        assert!(ct.get("id").is_some());
+        assert_eq!(ct["name"], "Test Corp");
+        assert_eq!(ct["slug"], "test-corp-abc123");
+        assert_eq!(ct["role"], "admin");
+    }
+
+    #[test]
+    fn anonymous_auth_returns_unauthorized() {
+        let result: Result<SessionInfo, AppError> = match AuthContext::Anonymous {
+            AuthContext::Session(info) => Ok(info),
+            AuthContext::Anonymous => Err(AppError::Unauthorized),
+        };
+        assert!(matches!(result, Err(AppError::Unauthorized)));
+    }
+
+    #[test]
+    fn session_auth_returns_info() {
+        let info = make_session();
+        let auth = AuthContext::Session(info.clone());
+        let result: Result<SessionInfo, AppError> = match auth {
+            AuthContext::Session(s) => Ok(s),
+            AuthContext::Anonymous => Err(AppError::Unauthorized),
+        };
+        let extracted = result.unwrap();
+        assert_eq!(extracted.user_id, info.user_id);
+        assert_eq!(extracted.session_id, info.session_id);
+    }
+
+    #[test]
+    fn not_a_member_error_message() {
+        assert_eq!(AppError::NotAMember.to_string(), "user is not a member of this tenant");
+    }
+}

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod health;
+pub mod me;
 pub mod tenants;
 
 use axum::{Router, routing::{delete, get, post, put}};
@@ -7,6 +8,7 @@ use axum::{Router, routing::{delete, get, post, put}};
 use crate::routes::{
     auth::{forgot_password, reset_password, signup},
     health::{health_check, openapi_json, ready_check},
+    me::switch_tenant,
     tenants::{invite_member, remove_member, transfer_ownership, update_member_role},
 };
 use crate::state::AppState;
@@ -20,6 +22,7 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/auth/signup", post(signup))
         .route("/v1/auth/forgot-password", post(forgot_password))
         .route("/v1/auth/reset-password", post(reset_password))
+        .route("/v1/me/switch-tenant", post(switch_tenant))
         .route("/v1/tenants/{id}/members", post(invite_member))
         .route("/v1/tenants/{id}/members/{uid}/role", put(update_member_role))
         .route("/v1/tenants/{id}/members/{uid}", delete(remove_member))


### PR DESCRIPTION
## Summary

- Adds `POST /v1/me/switch-tenant` endpoint per  ([REQ-AU-07])
- Verifies the caller is a member of the target tenant before switching
- Updates `sessions.tenant_id` in-place and writes a `tenant_switched` auth event
- Returns `{ current_tenant: { id, name, slug, role } }` on success; `403 not_a_member` when not a member

## Test plan

- [x] `cargo test -p control-api` — 35 tests pass (5 new in `routes::me`)
- [x] `cargo clippy -p control-api -- -D warnings` — clean
- [x] OpenAPI spec updated: `POST /v1/me/switch-tenant` path + `SwitchTenantRequest`, `SwitchTenantResponse`, `CurrentTenant` schemas + `me` tag
- [ ] Integration test: create user in two tenants → switch → verify session reflects new tenant (DB required)

Closes 

🤖 Generated with [Claude Code](https://claude.com/claude-code)