### PR TITLE
[REQ-AU-07] fix: move membership/tenant checks inside switch-tenant transaction

### DIFF
--- a/services/control-api/src/routes/me.rs
+++ b/services/control-api/src/routes/me.rs
@@ -55,27 +55,33 @@ pub async fn switch_tenant(
         AuthContext::Anonymous => return Err(AppError::Unauthorized),
     };
 
+    let mut tx = state.pool.begin().await?;
+
+    // FOR SHARE prevents a concurrent revocation from deleting/updating this row
+    // between our membership check and the session UPDATE that follows.
     let member: Option<(String,)> = sqlx::query_as(
         "SELECT role FROM control.tenant_members \
-         WHERE tenant_id = $1 AND user_id = $2",
+         WHERE tenant_id = $1 AND user_id = $2 \
+         FOR SHARE",
     )
     .bind(body.tenant_id)
     .bind(session.user_id)
-    .fetch_optional(&state.pool)
+    .fetch_optional(&mut *tx)
     .await?;
 
     let (role,) = member.ok_or(AppError::NotAMember)?;
 
+    // FOR SHARE prevents the tenant from being deactivated between check and commit.
     let tenant: Option<(String, String)> = sqlx::query_as(
-        "SELECT name, slug FROM control.tenants WHERE id = $1 AND status = 'active'",
+        "SELECT name, slug FROM control.tenants \
+         WHERE id = $1 AND status = 'active' \
+         FOR SHARE",
     )
     .bind(body.tenant_id)
-    .fetch_optional(&state.pool)
+    .fetch_optional(&mut *tx)
     .await?;
 
     let (name, slug) = tenant.ok_or(AppError::NotFound)?;
-
-    let mut tx = state.pool.begin().await?;
 
     sqlx::query("UPDATE control.sessions SET tenant_id = $1 WHERE id = $2")
         .bind(body.tenant_id)


### PR DESCRIPTION
## Summary

- Move `SELECT role FROM control.tenant_members` and `SELECT name, slug FROM control.tenants` inside the database transaction in `switch_tenant`
- Add `FOR SHARE` to both SELECTs so concurrent revocations/deactivations are serialized against our commit
- Eliminates the TOCTOU race window where membership could be revoked between check and session UPDATE

## Root cause

Previously the two read queries ran against the connection pool before `pool.begin()`, leaving a window where:
1. User's membership is checked → passes
2. Admin concurrently revokes membership (DELETE from `tenant_members`)
3. `UPDATE sessions SET tenant_id = ...` succeeds — user gets access they should not have

## Fix

All four queries (membership check, tenant-status check, session update, auth event) now execute within the same transaction. `FOR SHARE` on the two SELECT queries prevents the rows from being deleted or updated until the transaction commits.

## GitHub Issue

Closes #32

## Migration type

No schema migration — this is a query-logic-only change.

## Checklist

- [x] All tests pass (`cargo test -p control-api`)
- [x] No internal Paperclip references leaked
- [x] Docs unchanged (no API surface change)