### PR TITLE
ci: add PR template and Paperclip-leak hygiene check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Test Plan
+
+- [ ] All CI jobs pass
+- [ ] Manual testing performed (describe below)
+
+<!-- Describe manual verification steps -->
+
+## Checklist
+
+- [ ] PR links a GitHub issue via `Closes #XX`
+- [ ] No internal tracking references (RUSAA-XX, RUSTBRAINBYGOV-XX) in title, body, or commit messages
+- [ ] Tests added or updated for changed behaviour
+- [ ] Docs updated if API or architecture changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,6 @@
 ## Checklist
 
 - [ ] PR links a GitHub issue via `Closes #XX`
-- [ ] No internal tracking references (RUSAA-XX, RUSTBRAINBYGOV-XX) in title, body, or commit messages
+- [ ] No internal board tracking references in title, body, or commit messages
 - [ ] Tests added or updated for changed behaviour
 - [ ] Docs updated if API or architecture changed

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,33 @@
+name: PR Hygiene
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  pr-hygiene:
+    name: pr hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for internal tracking references
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          FAILED=0
+
+          if echo "$PR_TITLE" | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
+            echo "::error::PR title contains an internal tracking reference (RUSAA-* or RUSTBRAINBYGOV-*). Remove it before merging."
+            FAILED=1
+          fi
+
+          if echo "$PR_BODY" | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
+            echo "::error::PR body contains an internal tracking reference (RUSAA-* or RUSTBRAINBYGOV-*). Remove it before merging."
+            FAILED=1
+          fi
+
+          if ! echo "$PR_BODY" | grep -qiE 'closes[[:space:]]+#[0-9]+'; then
+            echo "::warning::PR body does not contain a 'Closes #XX' link. Add one to auto-close the related GitHub issue."
+          fi
+
+          exit $FAILED


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` with Summary, Test Plan, and Checklist sections reminding contributors to link a GitHub issue and avoid internal tracking references
- Adds `.github/workflows/pr-hygiene.yml`: new `pr-hygiene` CI job that errors if PR title or body contain internal tracking identifiers and warns if no `Closes #XX` pattern is found

## Checklist

- [x] No internal tracking references in title or body
- [x] Internal tooling — no separate GitHub issue required
- [x] CI job triggers on `pull_request` events: opened, edited, synchronize