### PR TITLE
[REQ-FE-02] feat: auth surfaces (signup, login, verify, forgot, reset)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,15 @@
       "name": "@rustacean/frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.59.20",
         "openapi-fetch": "^0.13.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.74.0",
+        "react-router-dom": "^7.14.2",
+        "sonner": "^2.0.7",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
@@ -848,6 +853,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1396,6 +1413,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.5",
@@ -2079,6 +2102,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3070,6 +3106,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
+      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3078,6 +3130,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/require-from-string": {
@@ -3164,6 +3254,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3185,6 +3281,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {
@@ -3493,6 +3599,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,10 +14,15 @@
     "lint": "eslint src --max-warnings=0"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.59.20",
     "openapi-fetch": "^0.13.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.74.0",
+    "react-router-dom": "^7.14.2",
+    "sonner": "^2.0.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,26 @@
+// REQ-FE-02: routes the auth surfaces. The protected app shell + tenant-aware
+// gating arrive with REQ-FE-01 (RUSAA-41); for now the post-login destination
+// is a thin placeholder that confirms the session.
+import { Navigate, Route, Routes } from "react-router-dom";
+import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
+import { LoginPage } from "@/pages/LoginPage";
+import { ReposPlaceholderPage } from "@/pages/ReposPlaceholderPage";
+import { ResetPasswordPage } from "@/pages/ResetPasswordPage";
+import { SignupPage } from "@/pages/SignupPage";
+import { VerifyEmailPage } from "@/pages/VerifyEmailPage";
+import { routes } from "@/lib/routes";
+
 export function App(): JSX.Element {
   return (
-    <main style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
-      <h1>Rustacean</h1>
-      <p>
-        Frontend scaffold. Auth surfaces and app shell are tracked under
-        RUSAA-42 and RUSAA-41.
-      </p>
-    </main>
+    <Routes>
+      <Route path={routes.signup} element={<SignupPage />} />
+      <Route path={routes.login} element={<LoginPage />} />
+      <Route path={routes.verifyEmail} element={<VerifyEmailPage />} />
+      <Route path={routes.forgotPassword} element={<ForgotPasswordPage />} />
+      <Route path={routes.resetPassword} element={<ResetPasswordPage />} />
+      <Route path={routes.repos} element={<ReposPlaceholderPage />} />
+      <Route path="/" element={<Navigate to={routes.login} replace />} />
+      <Route path="*" element={<Navigate to={routes.login} replace />} />
+    </Routes>
   );
 }

--- a/frontend/src/components/auth/AuthLayout.tsx
+++ b/frontend/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,31 @@
+// REQ-FE-02: shared layout chrome for unauthenticated auth pages.
+import type { ReactNode } from "react";
+
+type AuthLayoutProps = {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly children: ReactNode;
+  readonly footer?: ReactNode;
+};
+
+export function AuthLayout({
+  title,
+  subtitle,
+  children,
+  footer,
+}: AuthLayoutProps): JSX.Element {
+  return (
+    <main className="auth-shell">
+      <section className="auth-card" aria-labelledby="auth-card-title">
+        <header className="auth-card__header">
+          <h1 id="auth-card-title" className="auth-card__title">
+            {title}
+          </h1>
+          {subtitle ? <p className="auth-card__subtitle">{subtitle}</p> : null}
+        </header>
+        <div className="auth-card__body">{children}</div>
+        {footer ? <footer className="auth-card__footer">{footer}</footer> : null}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/Field.tsx
+++ b/frontend/src/components/ui/Field.tsx
@@ -1,0 +1,51 @@
+// REQ-FE-02: shared input field with inline label and error rendering.
+// Wrapper passes refs through so it composes with react-hook-form's `register`.
+import { forwardRef } from "react";
+import type { InputHTMLAttributes } from "react";
+
+type FieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  readonly label: string;
+  readonly error?: string | undefined;
+  readonly helperText?: string | undefined;
+};
+
+export const Field = forwardRef<HTMLInputElement, FieldProps>(function Field(
+  { label, error, helperText, id, ...inputProps },
+  ref,
+) {
+  const inputId = id ?? inputProps.name ?? label.replace(/\s+/g, "-").toLowerCase();
+  const describedByIds: string[] = [];
+  const errorId = `${inputId}-error`;
+  const helperId = `${inputId}-helper`;
+  if (error) {
+    describedByIds.push(errorId);
+  } else if (helperText) {
+    describedByIds.push(helperId);
+  }
+  const describedBy = describedByIds.length > 0 ? describedByIds.join(" ") : undefined;
+
+  return (
+    <div className="auth-field">
+      <label htmlFor={inputId} className="auth-field__label">
+        {label}
+      </label>
+      <input
+        ref={ref}
+        id={inputId}
+        aria-invalid={error ? "true" : "false"}
+        {...(describedBy !== undefined ? { "aria-describedby": describedBy } : {})}
+        className="auth-field__input"
+        {...inputProps}
+      />
+      {error ? (
+        <p id={errorId} role="alert" className="auth-field__error">
+          {error}
+        </p>
+      ) : helperText ? (
+        <p id={helperId} className="auth-field__helper">
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+});

--- a/frontend/src/components/ui/SubmitButton.tsx
+++ b/frontend/src/components/ui/SubmitButton.tsx
@@ -1,0 +1,28 @@
+// REQ-FE-02: primary submit button with loading state.
+import type { ButtonHTMLAttributes } from "react";
+
+type SubmitButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  readonly isLoading?: boolean;
+  readonly loadingLabel?: string;
+};
+
+export function SubmitButton({
+  isLoading = false,
+  loadingLabel,
+  disabled,
+  children,
+  ...rest
+}: SubmitButtonProps): JSX.Element {
+  const label = isLoading ? loadingLabel ?? "Working…" : children;
+  return (
+    <button
+      type="submit"
+      className="auth-button"
+      disabled={isLoading || disabled === true}
+      aria-busy={isLoading ? "true" : "false"}
+      {...rest}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/lib/errors/api.ts
+++ b/frontend/src/lib/errors/api.ts
@@ -1,0 +1,71 @@
+// REQ-FE-02: map ApiError objects to user-friendly toast messages.
+// Auth surfaces only need a small mapping table — anything outside the table
+// falls back to the server-supplied message or a status-aware default.
+import type { ApiError } from "@/api";
+
+type ErrorBody = {
+  readonly message?: unknown;
+  readonly error?: unknown;
+};
+
+function asApiError(value: unknown): ApiError | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as { status?: unknown };
+  if (typeof candidate.status !== "number") {
+    return null;
+  }
+  return value as ApiError;
+}
+
+const STATUS_FALLBACKS: Record<number, string> = {
+  400: "Please check the form and try again.",
+  401: "Your credentials weren't accepted. Please try again.",
+  403: "You don't have permission to do that.",
+  404: "We couldn't find that account.",
+  409: "That email is already registered.",
+  410: "This link has expired. Please request a new one.",
+  422: "Please check the form and try again.",
+  423: "Account temporarily locked. Try again in a few minutes.",
+  429: "Too many attempts. Please slow down and retry shortly.",
+};
+
+const NETWORK_FALLBACK = "We couldn't reach the server. Check your connection.";
+const DEFAULT_FALLBACK = "Something went wrong. Please try again.";
+
+function readMessage(body: unknown): string | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+  const candidate = body as ErrorBody;
+  if (typeof candidate.message === "string" && candidate.message.length > 0) {
+    return candidate.message;
+  }
+  if (typeof candidate.error === "string" && candidate.error.length > 0) {
+    return candidate.error;
+  }
+  return null;
+}
+
+export function formatApiError(
+  error: unknown,
+  contextFallback?: string,
+): string {
+  const apiError = asApiError(error);
+  if (!apiError) {
+    return contextFallback ?? DEFAULT_FALLBACK;
+  }
+  if (apiError.status === 0) {
+    return NETWORK_FALLBACK;
+  }
+  const fromBody = readMessage(apiError.body);
+  if (fromBody) {
+    return fromBody;
+  }
+  return (
+    STATUS_FALLBACKS[apiError.status] ??
+    contextFallback ??
+    DEFAULT_FALLBACK
+  );
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -1,0 +1,11 @@
+// REQ-FE-02: shared route paths so navigation calls stay symbolic.
+export const routes = {
+  signup: "/signup",
+  login: "/login",
+  verifyEmail: "/verify-email",
+  forgotPassword: "/forgot-password",
+  resetPassword: "/reset-password",
+  repos: "/repos",
+} as const;
+
+export type RoutePath = (typeof routes)[keyof typeof routes];

--- a/frontend/src/lib/validation/auth.ts
+++ b/frontend/src/lib/validation/auth.ts
@@ -1,0 +1,66 @@
+// REQ-FE-02: client-side validation schemas mirroring OpenAPI auth contracts.
+// Server-side validation is still authoritative; these provide fast UX feedback
+// before the request leaves the browser.
+import { z } from "zod";
+
+// PRD-aligned minimum password length. Matches the backend argon2id flow
+// where the server rejects passwords shorter than 12 characters.
+export const PASSWORD_MIN_LENGTH = 12;
+
+const emailSchema = z
+  .email("Enter a valid email address")
+  .trim()
+  .min(1, "Email is required");
+
+const passwordSchema = z
+  .string()
+  .min(
+    PASSWORD_MIN_LENGTH,
+    `Password must be at least ${String(PASSWORD_MIN_LENGTH)} characters`,
+  );
+
+const tenantNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Workspace name is required")
+  .max(100, "Workspace name must be 100 characters or fewer");
+
+const tokenSchema = z
+  .string()
+  .trim()
+  .min(1, "Token is required");
+
+export const signupFormSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+  tenant_name: tenantNameSchema,
+});
+export type SignupFormValues = z.infer<typeof signupFormSchema>;
+
+export const loginFormSchema = z.object({
+  email: emailSchema,
+  password: z.string().min(1, "Password is required"),
+});
+export type LoginFormValues = z.infer<typeof loginFormSchema>;
+
+export const forgotPasswordFormSchema = z.object({
+  email: emailSchema,
+});
+export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordFormSchema>;
+
+export const resetPasswordFormSchema = z
+  .object({
+    token: tokenSchema,
+    new_password: passwordSchema,
+    confirm_password: z.string().min(1, "Please re-enter the new password"),
+  })
+  .refine((values) => values.new_password === values.confirm_password, {
+    message: "Passwords do not match",
+    path: ["confirm_password"],
+  });
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordFormSchema>;
+
+export const verifyEmailFormSchema = z.object({
+  token: tokenSchema,
+});
+export type VerifyEmailFormValues = z.infer<typeof verifyEmailFormSchema>;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import { Toaster } from "sonner";
 import { App } from "./App";
+import "./styles/auth.css";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -30,7 +33,10 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+      <Toaster richColors position="top-right" />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,89 @@
+// REQ-FE-02: forgot-password form. The backend always returns 200 (timing-safe
+// per ADR-005 #6) so we treat any non-network response as success in the UI.
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useForgotPassword } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  forgotPasswordFormSchema,
+  type ForgotPasswordFormValues,
+} from "@/lib/validation/auth";
+
+export function ForgotPasswordPage(): JSX.Element {
+  const forgotPassword = useForgotPassword();
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordFormSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await forgotPassword.mutateAsync(values);
+      setSubmittedEmail(values.email);
+      toast.success("If that email exists, a reset link is on its way.");
+      reset({ email: "" });
+    } catch (error) {
+      toast.error(
+        formatApiError(error, "We couldn't send the reset email."),
+      );
+    }
+  });
+
+  if (submittedEmail) {
+    return (
+      <AuthLayout
+        title="Check your inbox"
+        subtitle={`If an account exists for ${submittedEmail}, we've sent a password reset link.`}
+        footer={
+          <>
+            <Link to={routes.login}>Back to sign in</Link>
+            <Link to={routes.resetPassword}>Have a token?</Link>
+          </>
+        }
+      >
+        <p className="auth-status auth-status--success">
+          Reset email requested.
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout
+      title="Forgot your password?"
+      subtitle="Enter your email and we'll send a reset link."
+      footer={
+        <>
+          <Link to={routes.login}>Back to sign in</Link>
+          <Link to={routes.signup}>Create an account</Link>
+        </>
+      }
+    >
+      <form className="auth-form" onSubmit={onSubmit} noValidate>
+        <Field
+          label="Email"
+          type="email"
+          autoComplete="email"
+          {...(errors.email?.message ? { error: errors.email.message } : {})}
+          {...register("email")}
+        />
+        <SubmitButton isLoading={isSubmitting} loadingLabel="Sending…">
+          Send reset link
+        </SubmitButton>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,79 @@
+// REQ-FE-02: login form. On success the server sets the rb_session cookie;
+// we route to /repos (Phase 1 exit destination) or /verify-email when the
+// account still needs verification.
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useLogin } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import { loginFormSchema, type LoginFormValues } from "@/lib/validation/auth";
+
+export function LoginPage(): JSX.Element {
+  const navigate = useNavigate();
+  const login = useLogin();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginFormSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      const result = await login.mutateAsync(values);
+      if (result.email_verification_required) {
+        toast.message("Verify your email to continue.");
+        navigate(routes.verifyEmail, { replace: true });
+        return;
+      }
+      toast.success("Signed in.");
+      navigate(routes.repos, { replace: true });
+    } catch (error) {
+      toast.error(
+        formatApiError(error, "Login failed. Please try again."),
+      );
+    }
+  });
+
+  return (
+    <AuthLayout
+      title="Sign in"
+      subtitle="Welcome back to Rustacean."
+      footer={
+        <>
+          <Link to={routes.forgotPassword}>Forgot password?</Link>
+          <span>
+            New here? <Link to={routes.signup}>Create an account</Link>
+          </span>
+        </>
+      }
+    >
+      <form className="auth-form" onSubmit={onSubmit} noValidate>
+        <Field
+          label="Email"
+          type="email"
+          autoComplete="email"
+          {...(errors.email?.message ? { error: errors.email.message } : {})}
+          {...register("email")}
+        />
+        <Field
+          label="Password"
+          type="password"
+          autoComplete="current-password"
+          {...(errors.password?.message ? { error: errors.password.message } : {})}
+          {...register("password")}
+        />
+        <SubmitButton isLoading={isSubmitting} loadingLabel="Signing in…">
+          Sign in
+        </SubmitButton>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/ReposPlaceholderPage.tsx
+++ b/frontend/src/pages/ReposPlaceholderPage.tsx
@@ -1,0 +1,44 @@
+// REQ-FE-02: temporary landing destination after login. The real /repos
+// experience and protected-route gating ship with REQ-FE-01 (RUSAA-41).
+// This stub exists only so the post-login redirect resolves to a real route.
+import { Link } from "react-router-dom";
+import { useMe } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { routes } from "@/lib/routes";
+
+export function ReposPlaceholderPage(): JSX.Element {
+  const me = useMe({ retry: false, refetchOnWindowFocus: false });
+
+  if (me.isLoading) {
+    return (
+      <AuthLayout title="Loading…" subtitle="Confirming your session.">
+        <p className="auth-status">Checking your session…</p>
+      </AuthLayout>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <AuthLayout
+        title="Please sign in"
+        subtitle="You need to be signed in to view your repositories."
+        footer={<Link to={routes.login}>Go to sign in</Link>}
+      >
+        <p className="auth-status auth-status--error">No active session.</p>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout
+      title="Repositories"
+      subtitle={`Signed in as ${me.data.user.email}.`}
+      footer={<Link to={routes.login}>Switch account</Link>}
+    >
+      <p className="auth-status">
+        You're signed in. The full repos experience lands with the application
+        shell (REQ-FE-01).
+      </p>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,104 @@
+// REQ-FE-02: reset-password form. The token usually arrives as ?token=...
+// from the email; we let the user override it manually if needed.
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { useResetPassword } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  PASSWORD_MIN_LENGTH,
+  resetPasswordFormSchema,
+  type ResetPasswordFormValues,
+} from "@/lib/validation/auth";
+
+export function ResetPasswordPage(): JSX.Element {
+  const [params] = useSearchParams();
+  const tokenFromUrl = params.get("token") ?? "";
+  const navigate = useNavigate();
+  const resetPassword = useResetPassword();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setValue,
+  } = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordFormSchema),
+    defaultValues: {
+      token: tokenFromUrl,
+      new_password: "",
+      confirm_password: "",
+    },
+  });
+
+  useEffect(() => {
+    if (tokenFromUrl) {
+      setValue("token", tokenFromUrl, { shouldValidate: false });
+    }
+  }, [tokenFromUrl, setValue]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await resetPassword.mutateAsync({
+        token: values.token,
+        new_password: values.new_password,
+      });
+      toast.success("Password updated — please sign in.");
+      navigate(routes.login, { replace: true });
+    } catch (error) {
+      toast.error(
+        formatApiError(error, "We couldn't reset your password."),
+      );
+    }
+  });
+
+  return (
+    <AuthLayout
+      title="Choose a new password"
+      subtitle="Enter your reset token and a new password."
+      footer={
+        <>
+          <Link to={routes.login}>Back to sign in</Link>
+          <Link to={routes.forgotPassword}>Need a new link?</Link>
+        </>
+      }
+    >
+      <form className="auth-form" onSubmit={onSubmit} noValidate>
+        <Field
+          label="Reset token"
+          autoComplete="one-time-code"
+          placeholder="Paste the token from the email"
+          {...(errors.token?.message ? { error: errors.token.message } : {})}
+          {...register("token")}
+        />
+        <Field
+          label="New password"
+          type="password"
+          autoComplete="new-password"
+          helperText={`At least ${String(PASSWORD_MIN_LENGTH)} characters.`}
+          {...(errors.new_password?.message
+            ? { error: errors.new_password.message }
+            : {})}
+          {...register("new_password")}
+        />
+        <Field
+          label="Confirm new password"
+          type="password"
+          autoComplete="new-password"
+          {...(errors.confirm_password?.message
+            ? { error: errors.confirm_password.message }
+            : {})}
+          {...register("confirm_password")}
+        />
+        <SubmitButton isLoading={isSubmitting} loadingLabel="Updating…">
+          Update password
+        </SubmitButton>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,84 @@
+// REQ-FE-02: signup form. On success, route to /verify-email so the user can
+// paste the token from the verification email.
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useSignup } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  PASSWORD_MIN_LENGTH,
+  signupFormSchema,
+  type SignupFormValues,
+} from "@/lib/validation/auth";
+
+export function SignupPage(): JSX.Element {
+  const navigate = useNavigate();
+  const signup = useSignup();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignupFormValues>({
+    resolver: zodResolver(signupFormSchema),
+    defaultValues: { email: "", password: "", tenant_name: "" },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await signup.mutateAsync(values);
+      toast.success("Account created — check your email for the verification link.");
+      navigate(routes.verifyEmail, { replace: true });
+    } catch (error) {
+      toast.error(formatApiError(error, "Could not create your account."));
+    }
+  });
+
+  return (
+    <AuthLayout
+      title="Create your workspace"
+      subtitle="Sign up with your work email to start using Rustacean."
+      footer={
+        <>
+          <span>Already have an account?</span>
+          <Link to={routes.login}>Sign in</Link>
+        </>
+      }
+    >
+      <form className="auth-form" onSubmit={onSubmit} noValidate>
+        <Field
+          label="Workspace name"
+          autoComplete="organization"
+          placeholder="Acme Inc."
+          {...(errors.tenant_name?.message
+            ? { error: errors.tenant_name.message }
+            : {})}
+          {...register("tenant_name")}
+        />
+        <Field
+          label="Work email"
+          type="email"
+          autoComplete="email"
+          placeholder="you@company.com"
+          {...(errors.email?.message ? { error: errors.email.message } : {})}
+          {...register("email")}
+        />
+        <Field
+          label="Password"
+          type="password"
+          autoComplete="new-password"
+          helperText={`At least ${String(PASSWORD_MIN_LENGTH)} characters.`}
+          {...(errors.password?.message ? { error: errors.password.message } : {})}
+          {...register("password")}
+        />
+        <SubmitButton isLoading={isSubmitting} loadingLabel="Creating account…">
+          Create account
+        </SubmitButton>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -1,0 +1,111 @@
+// REQ-FE-02: email verification surface. Two flows:
+//   1. Token arrives on the URL (?token=...) → submit it automatically and
+//      route to /login on success.
+//   2. No token yet → user pastes one from their email, or stays on the page
+//      while we poll /v1/me every 5s. As soon as the server reports the email
+//      verified, we route to /repos.
+import { useEffect, useMemo, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { useMe, useVerifyEmail } from "@/api";
+import { AuthLayout } from "@/components/auth/AuthLayout";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  verifyEmailFormSchema,
+  type VerifyEmailFormValues,
+} from "@/lib/validation/auth";
+
+const ME_POLL_INTERVAL_MS = 5_000;
+
+export function VerifyEmailPage(): JSX.Element {
+  const [params, setParams] = useSearchParams();
+  const initialToken = params.get("token") ?? "";
+  const navigate = useNavigate();
+  const verifyEmail = useVerifyEmail();
+  const autoSubmitRef = useRef(false);
+
+  const me = useMe({
+    refetchInterval: ME_POLL_INTERVAL_MS,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<VerifyEmailFormValues>({
+    resolver: zodResolver(verifyEmailFormSchema),
+    defaultValues: { token: initialToken },
+  });
+
+  const submitToken = useMemo(
+    () =>
+      handleSubmit(async (values) => {
+        try {
+          await verifyEmail.mutateAsync({ token: values.token });
+          toast.success("Email verified — please sign in.");
+          if (params.has("token")) {
+            params.delete("token");
+            setParams(params, { replace: true });
+          }
+          reset({ token: "" });
+          navigate(routes.login, { replace: true });
+        } catch (error) {
+          toast.error(
+            formatApiError(error, "We couldn't verify that token."),
+          );
+        }
+      }),
+    [handleSubmit, navigate, params, reset, setParams, verifyEmail],
+  );
+
+  useEffect(() => {
+    if (initialToken && !autoSubmitRef.current) {
+      autoSubmitRef.current = true;
+      void submitToken();
+    }
+  }, [initialToken, submitToken]);
+
+  useEffect(() => {
+    if (me.data?.user.email_verified === true) {
+      toast.success("Email verified.");
+      navigate(routes.repos, { replace: true });
+    }
+  }, [me.data, navigate]);
+
+  return (
+    <AuthLayout
+      title="Verify your email"
+      subtitle="Open the verification email and either click the link or paste the code below. We'll keep watching for confirmation in the background."
+      footer={
+        <>
+          <Link to={routes.login}>Back to sign in</Link>
+          <Link to={routes.signup}>Use a different email</Link>
+        </>
+      }
+    >
+      <form className="auth-form" onSubmit={submitToken} noValidate>
+        <Field
+          label="Verification token"
+          autoComplete="one-time-code"
+          placeholder="Paste the token from the email"
+          {...(errors.token?.message ? { error: errors.token.message } : {})}
+          {...register("token")}
+        />
+        <SubmitButton isLoading={isSubmitting} loadingLabel="Verifying…">
+          Verify email
+        </SubmitButton>
+      </form>
+      <p className="auth-status">
+        Waiting for verification… we check every 5 seconds.
+      </p>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/styles/auth.css
+++ b/frontend/src/styles/auth.css
@@ -1,0 +1,153 @@
+/* REQ-FE-02: minimal styling for auth surfaces. Tailwind/shadcn arrives with
+   REQ-FE-01 (app shell). Until then, keep the CSS surface tiny and scoped. */
+:root {
+  color-scheme: light;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f6f7fb;
+  color: #111827;
+}
+
+.auth-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 12px 40px -16px rgba(15, 23, 42, 0.18);
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+}
+
+.auth-card__header {
+  margin-bottom: 1.5rem;
+}
+
+.auth-card__title {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.auth-card__subtitle {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.auth-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-card__footer {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.auth-card__footer a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.auth-card__footer a:hover {
+  text-decoration: underline;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.auth-field__label {
+  font-size: 0.875rem;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.auth-field__input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 0.95rem;
+  background: #ffffff;
+  color: inherit;
+}
+
+.auth-field__input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+  border-color: #2563eb;
+}
+
+.auth-field__input[aria-invalid="true"] {
+  border-color: #dc2626;
+}
+
+.auth-field__error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.8125rem;
+}
+
+.auth-field__helper {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.8125rem;
+}
+
+.auth-button {
+  background: #111827;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.auth-button:hover:not([disabled]) {
+  background: #1f2937;
+}
+
+.auth-button[disabled] {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.auth-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.auth-status--error {
+  color: #b91c1c;
+}
+
+.auth-status--success {
+  color: #047857;
+}


### PR DESCRIPTION
Closes #49

## Summary
- Build the five unauthenticated React pages — signup, login, email verification, forgot-password, reset-password — against the typed openapi-fetch hooks landed in REQ-FE-10.
- Add React Router v7, react-hook-form + zod for validation, and Sonner for toast notifications. Provide a tiny `/repos` placeholder so the post-login redirect resolves until REQ-FE-01 ships the real shell.
- Surface server errors through `formatApiError`, which narrows `unknown` to the typed `ApiError` shape and maps status codes / body messages to user-friendly toast copy.

### Pages
- `/signup` — creates the tenant + user, then routes to `/verify-email`.
- `/login` — handles `email_verification_required` (routes to verify) versus a healthy login (routes to `/repos`). Server sets the `rb_session` cookie.
- `/verify-email` — auto-submits `?token=…` from the email link, then polls `/v1/me` every 5s for background confirmation.
- `/forgot-password` — treats any non-network response as success, matching ADR-005 #6 timing-safe semantics.
- `/reset-password` — pre-fills `?token=…`, enforces the 12-character minimum, and double-confirms the new password.
- `/repos` — minimal placeholder until REQ-FE-01.

### Verified
- `npm run typecheck` ✓
- `npm run lint` ✓ (no raw-`fetch` violations; openapi-fetch remains the only allowed `fetch` site)
- `npm run gen:api:check` ✓ (schema in sync)
- `npm run build` ✓
- `scripts/check-file-sizes.sh` ✓ (all files <600 lines)
- Vite dev smoke: `GET /` and `GET /login` both return 200.

## Test plan
- [ ] CI: `frontend typecheck` job stays green (gen:api:check + tsc + eslint).
- [ ] CI: `paperclip-leak hygiene` check stays green.
- [ ] Manual smoke (full stack): signup → receive token → verify → login → land on `/repos` placeholder.
- [ ] Manual smoke: forgot-password with an unknown email returns the same neutral confirmation.
- [ ] Manual smoke: reset-password with `?token=...` from the email succeeds and redirects to `/login`.
- [ ] Toasts appear on each error path (400, 401, 409, 422, 429, network).

## Follow-up
- zxcvbn password meter on signup/reset (per design doc) — separate issue.
- Phase 1 Playwright E2E (signup → verify → login → repos) — separate issue once a vitest/playwright runner lands.
