### PR TITLE
feat: port conflict audit + Tailscale access + auto-restart 

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     networks:
       - rb-net
     healthcheck:
@@ -28,8 +28,8 @@ services:
     volumes:
       - neo4j_data:/data
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "${NEO4J_HTTP_HOST_PORT:-7474}:7474"
+      - "${NEO4J_BOLT_HOST_PORT:-7687}:7687"
     networks:
       - rb-net
     deploy:
@@ -48,8 +48,8 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
     ports:
-      - "6333:6333"
-      - "6334:6334"
+      - "${QDRANT_REST_HOST_PORT:-6333}:6333"
+      - "${QDRANT_GRPC_HOST_PORT:-6334}:6334"
     networks:
       - rb-net
     deploy:
@@ -68,7 +68,7 @@ services:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_ADVERTISED_HOST:-localhost}:${KAFKA_HOST_PORT:-9094}"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT"
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
@@ -82,7 +82,7 @@ services:
     volumes:
       - kafka_data:/var/lib/kafka/data
     ports:
-      - "9094:9094"
+      - "${KAFKA_HOST_PORT:-9094}:9094"
     networks:
       - rb-net
     healthcheck:
@@ -118,8 +118,8 @@ services:
     volumes:
       - ./infra/otel-collector/config.yaml:/etc/otel-collector/config.yaml:ro
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "${OTEL_GRPC_HOST_PORT:-4317}:4317"
+      - "${OTEL_HTTP_HOST_PORT:-4318}:4318"
     networks:
       - rb-net
     depends_on:
@@ -133,7 +133,7 @@ services:
       - ./infra/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
       - tempo_data:/var/tempo
     ports:
-      - "3200:3200"
+      - "${TEMPO_HOST_PORT:-3200}:3200"
     networks:
       - rb-net
     healthcheck:
@@ -152,7 +152,7 @@ services:
       - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
     networks:
       - rb-net
     healthcheck:
@@ -172,7 +172,7 @@ services:
       - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - "3000:3000"
+      - "${GRAFANA_HOST_PORT:-3000}:3000"
     networks:
       - rb-net
     depends_on:
@@ -190,7 +190,7 @@ services:
     volumes:
       - ollama_data:/root/.ollama
     ports:
-      - "11434:11434"
+      - "${OLLAMA_HOST_PORT:-11434}:11434"
     networks:
       - rb-net
 
@@ -202,14 +202,14 @@ services:
     environment:
       RB_DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       RB_LISTEN_ADDR: "0.0.0.0:8080"
-      RB_CORS_ORIGINS: "http://localhost:5173"
-      RB_BASE_URL: "http://localhost:8080"
+      RB_CORS_ORIGINS: "${RB_CORS_ORIGINS:-http://localhost:5173}"
+      RB_BASE_URL: "${RB_BASE_URL:-http://localhost:8080}"
       RB_EMAIL_TRANSPORT: console
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: control-api
       RUST_LOG: "info,control_api=debug"
     ports:
-      - "8080:8080"
+      - "${CONTROL_API_HOST_PORT:-8080}:8080"
     networks:
       - rb-net
     depends_on:
@@ -230,8 +230,8 @@ services:
       - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
     ports:
-      - "80:80"
-      - "443:443"
+      - "${CADDY_HTTP_HOST_PORT:-80}:80"
+      - "${CADDY_HTTPS_HOST_PORT:-443}:443"
     networks:
       - rb-net
     depends_on:
@@ -243,7 +243,7 @@ services:
     environment:
       DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain?sslmode=disable
     ports:
-      - "8081:8081"
+      - "${PGWEB_HOST_PORT:-8081}:8081"
     networks:
       - rb-net
     depends_on:
@@ -257,7 +257,7 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
       SERVER_PORT: 8082
     ports:
-      - "8082:8082"
+      - "${KAFKA_UI_HOST_PORT:-8082}:8082"
     networks:
       - rb-net
     depends_on:

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -1,0 +1,44 @@
+# compose/tailscale.env — Port remapping for mars (Tailscale IP: 100.87.157.74)
+#
+# All dev ports are remapped to the 1XXXX range (dev port + 10000) to avoid
+# conflicts with existing containers on mars. No listed existing port is reused.
+#
+# Usage:
+#   docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml up -d
+
+# --- Infrastructure services ---
+POSTGRES_HOST_PORT=15432
+NEO4J_HTTP_HOST_PORT=17474
+NEO4J_BOLT_HOST_PORT=17687
+QDRANT_REST_HOST_PORT=16333
+QDRANT_GRPC_HOST_PORT=16334
+
+# --- Kafka ---
+# KAFKA_ADVERTISED_HOST tells external clients which host:port to connect to.
+# Without this, Kafka advertises "localhost:KAFKA_HOST_PORT" which only works
+# from the same machine. Set to the Tailscale IP for cross-machine access.
+KAFKA_HOST_PORT=19094
+KAFKA_ADVERTISED_HOST=100.87.157.74
+
+# --- Observability ---
+OTEL_GRPC_HOST_PORT=14317
+OTEL_HTTP_HOST_PORT=14318
+TEMPO_HOST_PORT=13200
+PROMETHEUS_HOST_PORT=19090
+GRAFANA_HOST_PORT=13000
+
+# --- AI ---
+OLLAMA_HOST_PORT=21434
+
+# --- Application ---
+CONTROL_API_HOST_PORT=18080
+RB_BASE_URL=http://100.87.157.74:18080
+RB_CORS_ORIGINS=http://100.87.157.74:10080
+
+# --- Reverse proxy ---
+CADDY_HTTP_HOST_PORT=10080
+CADDY_HTTPS_HOST_PORT=10443
+
+# --- Dev tools ---
+PGWEB_HOST_PORT=18081
+KAFKA_UI_HOST_PORT=18082

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -1,7 +1,7 @@
 # compose/tailscale.env — Port remapping for mars (Tailscale IP: 100.87.157.74)
 #
-# All dev ports are remapped to the 1XXXX range (dev port + 10000) to avoid
-# conflicts with existing containers on mars. No listed existing port is reused.
+# All dev ports are remapped by adding 10000 (e.g. 5432 → 15432, 11434 → 21434)
+# to avoid conflicts with existing containers on mars. No listed existing port is reused.
 #
 # Usage:
 #   docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml up -d

--- a/compose/tailscale.yml
+++ b/compose/tailscale.yml
@@ -1,0 +1,51 @@
+# compose/tailscale.yml — Overlay for Tailscale deployment on mars (100.87.157.74)
+#
+# Usage:
+#   docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml up -d
+#
+# What this overlay adds:
+#   - restart: unless-stopped on all long-running services (survives reboots)
+#   - Port remapping is handled by tailscale.env via env-var substitution in dev.yml
+#   - kafka-init is intentionally excluded (one-shot container, must not restart)
+
+name: rustbrain-dev
+
+services:
+  postgres:
+    restart: unless-stopped
+
+  neo4j:
+    restart: unless-stopped
+
+  qdrant:
+    restart: unless-stopped
+
+  kafka:
+    restart: unless-stopped
+
+  otel-collector:
+    restart: unless-stopped
+
+  tempo:
+    restart: unless-stopped
+
+  prometheus:
+    restart: unless-stopped
+
+  grafana:
+    restart: unless-stopped
+
+  ollama:
+    restart: unless-stopped
+
+  control-api:
+    restart: unless-stopped
+
+  caddy:
+    restart: unless-stopped
+
+  pgweb:
+    restart: unless-stopped
+
+  kafka-ui:
+    restart: unless-stopped

--- a/docs/PORT_MAP.md
+++ b/docs/PORT_MAP.md
@@ -1,0 +1,100 @@
+# Port Map — mars (100.87.157.74)
+
+This document is the authoritative reference for all ports on the `mars` host.
+
+**Rule:** Never bind a new service to a port already listed here. If a port is taken, pick a free one and update this table.
+
+---
+
+## Rustbrain Dev Stack (compose/dev.yml)
+
+Deployed via:
+```bash
+docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml up -d
+```
+
+| Host Port | Dev Default | Service | Protocol | Notes |
+|-----------|-------------|---------|----------|-------|
+| 15432 | 5432 | postgres | TCP | PostgreSQL — rustbrain DB |
+| 17474 | 7474 | neo4j | HTTP | Neo4j browser UI |
+| 17687 | 7687 | neo4j | Bolt | Neo4j bolt driver |
+| 16333 | 6333 | qdrant | HTTP | Qdrant REST API |
+| 16334 | 6334 | qdrant | gRPC | Qdrant gRPC |
+| 19094 | 9094 | kafka | TCP | Kafka external listener (KRaft) |
+| 14317 | 4317 | otel-collector | gRPC | OTLP gRPC receiver |
+| 14318 | 4318 | otel-collector | HTTP | OTLP HTTP receiver |
+| 13200 | 3200 | tempo | HTTP | Grafana Tempo |
+| 19090 | 9090 | prometheus | HTTP | Prometheus scrape + query |
+| 13000 | 3000 | grafana | HTTP | Grafana dashboards |
+| 21434 | 11434 | ollama | HTTP | Ollama LLM API |
+| 18080 | 8080 | control-api | HTTP | Rustbrain control plane API |
+| 10080 | 80 | caddy | HTTP | Reverse proxy HTTP |
+| 10443 | 443 | caddy | HTTPS | Reverse proxy HTTPS |
+| 18081 | 8081 | pgweb | HTTP | pgweb DB browser (read-only) |
+| 18082 | 8082 | kafka-ui | HTTP | Kafka UI |
+
+### Quick access via Tailscale
+
+| Service | URL |
+|---------|-----|
+| Control API | http://100.87.157.74:18080 |
+| Grafana | http://100.87.157.74:13000 |
+| Prometheus | http://100.87.157.74:19090 |
+| pgweb | http://100.87.157.74:18081 |
+| Kafka UI | http://100.87.157.74:18082 |
+| Neo4j browser | http://100.87.157.74:17474 |
+
+---
+
+## Existing mars Containers (pre-existing, do not reuse)
+
+| Host Port | Container | Notes |
+|-----------|-----------|-------|
+| 443 | vcs | Gitea HTTPS |
+| 2424 | vcs | Gitea SSH |
+| 3001 | rustbrain-mcp-sse | MCP SSE |
+| 3010 | mars-grafana | Mars monitoring Grafana |
+| 3100 | paperclip | Paperclip server |
+| 3103 | extensions-server | Governance extensions |
+| 4096 | rustbrain-opencode | OpenCode |
+| 5432 | rustbrain-postgres | Shared Postgres (pre-existing stack) |
+| 6333–6334 | rustbrain-qdrant | Qdrant (pre-existing stack) |
+| 7474, 7687 | rustbrain-neo4j | Neo4j (pre-existing stack) |
+| 8000 | portainer | Container management |
+| 8081 | vcs | Gitea HTTP |
+| 8085 | rustbrain-pgweb | pgweb (remapped from 8081) |
+| 8088 | rustbrain-api | Control API (remapped from 8080) |
+| 8092 | rustbrain-playground-ui | Playground |
+| 8096 | mars-alert-webhook | Mars alerting |
+| 9000, 9443 | portainer | Container management HTTPS |
+| 9090 | rustbrain-prometheus | Prometheus (pre-existing stack) |
+| 9098 | mars-alertmanager | Mars alertmanager |
+| 9099 | mars-prometheus | Mars Prometheus |
+| 9100 | rustbrain-node-exporter | Node exporter |
+| 9115 | rustbrain-blackbox-exporter | Blackbox exporter |
+| 9400 | mars-nvidia-dcgm-exporter | GPU monitoring |
+| 11434 | rustbrain-ollama | Ollama LLM (pre-existing stack) |
+| 54329 | paperclip-pg | Paperclip embedded PostgreSQL |
+
+---
+
+## Notes
+
+### Kafka external connectivity
+When connecting to Kafka from outside the Docker network (e.g., from a laptop via Tailscale), use:
+- Bootstrap server: `100.87.157.74:19094`
+
+Kafka advertises `100.87.157.74:19094` to external clients (set via `KAFKA_ADVERTISED_HOST` in `tailscale.env`). Internal services within the compose network use `kafka:9092` (PLAINTEXT listener, unaffected).
+
+### Pre-existing rustbrain-* containers
+The containers listed under "pre-existing" with `rustbrain-*` names may be from a previous or parallel deployment. Before redeploying, confirm whether they are managed by this repo's compose files:
+```bash
+docker inspect <container-name> --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}'
+```
+If they are from this repo, the new deployment will update them in-place (ports will shift to the 1XXXX range).
+
+### Adding new services
+1. Check both tables above for port conflicts.
+2. Pick a port in the `1XXXX` range (or another free range).
+3. Add an env-var default in `compose/dev.yml` and the remapped value in `compose/tailscale.env`.
+4. Update this table.


### PR DESCRIPTION
## Summary

- Parameterizes all host port bindings in `compose/dev.yml` via `${VAR:-default}` substitution — local dev behavior unchanged
- Adds `compose/tailscale.env` mapping every service to the `1XXXX` port range (dev port + 10000) — no collisions with any existing mars container
- Adds `compose/tailscale.yml` overlay setting `restart: unless-stopped` on all long-running services (`kafka-init` excluded — one-shot)
- Adds `docs/PORT_MAP.md` as the authoritative port reference for the mars host; covers rustbrain-dev ports and all pre-existing containers

## Deploy on mars

```bash
docker compose --env-file compose/tailscale.env \
  -f compose/dev.yml -f compose/tailscale.yml up -d
```

## Migration type

Not applicable — no schema changes.

## GitHub Issue

Closes #53

## Checklist

- [x] All port defaults preserved — local `docker compose -f compose/dev.yml up -d` unchanged
- [x] Kafka `ADVERTISED_LISTENERS` parameterized for correct external-client routing via Tailscale
- [x] `restart: unless-stopped` on all daemons; `kafka-init` (one-shot) intentionally excluded
- [x] `docs/PORT_MAP.md` documents both rustbrain-dev ports and all pre-existing mars ports
- [x] No internal tracking references in PR title or body