### PR TITLE
fix(control-api): cast citext slug::text in switch-tenant query

### DIFF
--- a/services/control-api/src/routes/me.rs
+++ b/services/control-api/src/routes/me.rs
@@ -76,7 +76,7 @@ pub async fn switch_tenant(
 
     // FOR SHARE prevents the tenant from being deactivated between check and commit.
     let tenant: Option<(String, String)> = sqlx::query_as(
-        "SELECT name, slug FROM control.tenants \
+        "SELECT name, slug::text FROM control.tenants \
          WHERE id = $1 AND status = 'active' \
          FOR SHARE",
     )


### PR DESCRIPTION
## Summary

`tenants.slug` is declared `CITEXT` in the database schema. The `switch_tenant` handler selected it without a `::text` cast. SQLx maps `String` to SQL `TEXT`, which PostgreSQL rejects for a `citext` column at runtime, producing a 500 on every call to `POST /v1/me/switch-tenant`.

**Fix**: add `slug::text` cast in `services/control-api/src/routes/me.rs` — the same pattern already used in `get_me` (Q1 and Q2).

## Files changed

- `services/control-api/src/routes/me.rs` — 1 line: `slug` → `slug::text`

## Test plan

- [x] `cargo check -p control-api` — clean
- [x] `cargo test -p control-api routes::me` — 14/14 passed
- [ ] Integration: POST /v1/me/switch-tenant with multi-tenant user returns 200