### PR TITLE
fix: make Secure cookie flag configurable via RB_SECURE_COOKIES

### DIFF
--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -15,6 +15,9 @@ pub struct Config {
     pub argon2_parallelism: u32,
     pub email_transport: String,
     pub service_name: String,
+    /// Whether to set the `Secure` flag on `rb_session` cookies.
+    /// Set `RB_SECURE_COOKIES=false` when running behind an HTTP proxy in development.
+    pub secure_cookies: bool,
 }
 
 impl Config {
@@ -57,6 +60,9 @@ impl Config {
                 .unwrap_or_else(|_| "console".to_owned()),
             service_name: env::var("OTEL_SERVICE_NAME")
                 .unwrap_or_else(|_| "control-api".to_owned()),
+            secure_cookies: env::var("RB_SECURE_COOKIES")
+                .map(|v| v.to_ascii_lowercase() != "false")
+                .unwrap_or(true),
         })
     }
 
@@ -77,6 +83,7 @@ impl Config {
             argon2_parallelism: 1,
             email_transport: "noop".to_owned(),
             service_name: "control-api-test".to_owned(),
+            secure_cookies: true,
         }
     }
 }

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -61,8 +61,7 @@ impl Config {
             service_name: env::var("OTEL_SERVICE_NAME")
                 .unwrap_or_else(|_| "control-api".to_owned()),
             secure_cookies: env::var("RB_SECURE_COOKIES")
-                .map(|v| v.to_ascii_lowercase() != "false")
-                .unwrap_or(true),
+                .map_or(true, |v| !v.eq_ignore_ascii_case("false")),
         })
     }
 

--- a/services/control-api/src/routes/auth.rs
+++ b/services/control-api/src/routes/auth.rs
@@ -71,10 +71,7 @@ pub async fn signup(
         tracing::warn!(user_id = %result.user_id, error = %e, "verification email delivery failed");
     }
 
-    let cookie = format!(
-        "rb_session={}; HttpOnly; SameSite=Lax; Path=/; Secure",
-        result.session_token.as_str()
-    );
+    let cookie = build_session_cookie(result.session_token.as_str(), state.config.secure_cookies);
     Ok((
         StatusCode::CREATED,
         [("Set-Cookie", cookie)],
@@ -172,6 +169,11 @@ async fn execute_signup_transaction(
     .await?;
 
     Ok(SignupTransactionResult { user_id, session_token, email_token })
+}
+
+fn build_session_cookie(token: &str, secure: bool) -> String {
+    let secure_attr = if secure { "; Secure" } else { "" };
+    format!("rb_session={token}; HttpOnly; SameSite=Lax; Path=/{secure_attr}")
 }
 
 fn validate_email(email: &str) -> Result<(), AppError> {
@@ -473,10 +475,7 @@ pub async fn login(
 
     tx.commit().await?;
 
-    let cookie = format!(
-        "rb_session={}; HttpOnly; SameSite=Lax; Path=/; Secure",
-        session_token.as_str()
-    );
+    let cookie = build_session_cookie(session_token.as_str(), state.config.secure_cookies);
     Ok((
         StatusCode::OK,
         [("Set-Cookie", cookie)],

--- a/services/control-api/src/routes/auth_logout.rs
+++ b/services/control-api/src/routes/auth_logout.rs
@@ -65,19 +65,20 @@ pub async fn logout(
 
     Ok((
         StatusCode::NO_CONTENT,
-        [("Set-Cookie", clear_session_cookie())],
+        [("Set-Cookie", clear_session_cookie(state.config.secure_cookies))],
     ))
 }
 
 /// Build the `Set-Cookie` value that clears `rb_session`.
 ///
-/// Attributes mirror the login cookie (`HttpOnly; SameSite=Lax; Path=/;
-/// Secure`) so browsers replace the existing cookie. `Max-Age=0` plus the
-/// unix-epoch `Expires` covers both modern and legacy clients.
-fn clear_session_cookie() -> String {
-    "rb_session=; HttpOnly; SameSite=Lax; Path=/; Secure; Max-Age=0; \
-     Expires=Thu, 01 Jan 1970 00:00:00 GMT"
-        .to_owned()
+/// Attributes mirror the login cookie so browsers replace the existing cookie.
+/// `Max-Age=0` plus the unix-epoch `Expires` covers both modern and legacy clients.
+fn clear_session_cookie(secure: bool) -> String {
+    let secure_attr = if secure { " Secure;" } else { "" };
+    format!(
+        "rb_session=; HttpOnly; SameSite=Lax; Path=/;{secure_attr} Max-Age=0; \
+         Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    )
 }
 
 #[cfg(test)]
@@ -86,13 +87,13 @@ mod tests {
 
     #[test]
     fn clear_session_cookie_targets_rb_session() {
-        let cookie = clear_session_cookie();
+        let cookie = clear_session_cookie(true);
         assert!(cookie.starts_with("rb_session=;"), "cookie was: {cookie}");
     }
 
     #[test]
     fn clear_session_cookie_expires_immediately() {
-        let cookie = clear_session_cookie();
+        let cookie = clear_session_cookie(true);
         assert!(cookie.contains("Max-Age=0"), "cookie was: {cookie}");
         assert!(
             cookie.contains("Expires=Thu, 01 Jan 1970 00:00:00 GMT"),
@@ -101,14 +102,23 @@ mod tests {
     }
 
     #[test]
-    fn clear_session_cookie_preserves_login_attributes() {
-        let cookie = clear_session_cookie();
+    fn clear_session_cookie_with_secure_true_has_secure_attr() {
+        let cookie = clear_session_cookie(true);
         // Browsers only overwrite a cookie when Path/SameSite/Secure match the
-        // original Set-Cookie. Login emits all four — mirror them here.
+        // original Set-Cookie. Mirror login attributes here.
         assert!(cookie.contains("HttpOnly"), "cookie was: {cookie}");
         assert!(cookie.contains("SameSite=Lax"), "cookie was: {cookie}");
         assert!(cookie.contains("Path=/"), "cookie was: {cookie}");
         assert!(cookie.contains("Secure"), "cookie was: {cookie}");
+    }
+
+    #[test]
+    fn clear_session_cookie_with_secure_false_omits_secure_attr() {
+        let cookie = clear_session_cookie(false);
+        assert!(cookie.contains("HttpOnly"), "cookie was: {cookie}");
+        assert!(cookie.contains("SameSite=Lax"), "cookie was: {cookie}");
+        assert!(cookie.contains("Path=/"), "cookie was: {cookie}");
+        assert!(!cookie.contains("Secure"), "Secure must be absent: {cookie}");
     }
 
     #[test]

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -40,6 +40,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         argon2_parallelism: 1,
         email_transport: "noop".to_owned(),
         service_name: "control-api-test".to_owned(),
+        secure_cookies: true,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -53,6 +53,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         argon2_parallelism: 1,
         email_transport: "noop".to_owned(),
         service_name: "control-api-test".to_owned(),
+        secure_cookies: true,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -309,6 +309,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         argon2_parallelism: 1,
         email_transport: "noop".to_owned(),
         service_name: "control-api-test".to_owned(),
+        secure_cookies: true,
     };
     let state = AppState {
         pool: pool.clone(),


### PR DESCRIPTION
## Summary

- Adds `secure_cookies: bool` to `Config`, read from `RB_SECURE_COOKIES` env var (default `true`)
- `login`, `signup`, and `logout` all gate the `; Secure` cookie attribute on this flag
- Extracts a `build_session_cookie(token, secure)` helper in `auth.rs` to centralise the logic
- `clear_session_cookie(secure)` in `auth_logout.rs` now takes a `bool` parameter
- Adds unit test `clear_session_cookie_with_secure_false_omits_secure_attr` to verify the HTTP-proxy path
- All three integration-test harnesses updated with `secure_cookies: true` to keep existing assertions green

## Migration type
Additive — no schema changes

## How to use in dev
```
RB_SECURE_COOKIES=false cargo run -p control-api
```
Or in compose:
```yaml
environment:
  RB_SECURE_COOKIES: "false"
```

## GitHub Issue
Closes #58

## Checklist
- [x] All unit tests pass (`cargo test -p control-api --lib`)
- [x] No Paperclip issue IDs in commit or PR body
- [x] Existing integration test assertions for `Secure` flag preserved (tests use `secure_cookies: true`)