### PR TITLE
chore(deploy): add RB_SECURE_COOKIES to dev compose + fix Dockerfile rust version

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -205,6 +205,7 @@ services:
       RB_CORS_ORIGINS: "${RB_CORS_ORIGINS:-http://localhost:5173}"
       RB_BASE_URL: "${RB_BASE_URL:-http://localhost:8080}"
       RB_EMAIL_TRANSPORT: console
+      RB_SECURE_COOKIES: "${RB_SECURE_COOKIES:-false}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: control-api
       RUST_LOG: "info,control_api=debug"

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1.85-slim AS builder
+FROM rust:latest AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- `compose/dev.yml`: add `RB_SECURE_COOKIES=${RB_SECURE_COOKIES:-false}` to the `control-api` environment block. Dev deployments over plain HTTP will no longer set the `Secure` cookie attribute, so browsers accept the session cookie.
- `docker/control-api/Dockerfile`: bump builder from `rust:1.85-slim` → `rust:latest`. The `icu_*` and `home` crates in Cargo.lock require rustc ≥1.86/1.88; the old pin broke `docker build`.

## Deployment verification

Tested against the live service (already rebuilt from `da537f8`):

```
set-cookie: rb_session=…; HttpOnly; SameSite=Lax; Path=/
```

No `Secure` flag — browsers on plain HTTP will keep the session cookie.

## Migration type

None — no schema changes.

## Checklist
- [x] Compose config validated (`docker compose config --quiet`)
- [x] Docker image builds successfully with `rust:latest`
- [x] Live endpoint verified: signup + login cookies lack `Secure` flag
- [x] No internal tracking references in PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)