### PR TITLE
[REQ-TN-02] fix(control-api): cast citext email::text in list_members query

### DIFF
--- a/services/control-api/src/routes/tenants/mod.rs
+++ b/services/control-api/src/routes/tenants/mod.rs
@@ -61,7 +61,7 @@ pub async fn list_members(
     require_role(&state.pool, session.user_id, tenant_id, TenantRole::Member).await?;
 
     let rows: Vec<(Uuid, String, String, Option<DateTime<Utc>>)> = sqlx::query_as(
-        "SELECT tm.user_id, u.email, tm.role, tm.invited_at \
+        "SELECT tm.user_id, u.email::text, tm.role, tm.invited_at \
          FROM control.tenant_members tm \
          JOIN control.users u ON u.id = tm.user_id \
          WHERE tm.tenant_id = $1 \


### PR DESCRIPTION
## Summary

`control.users.email` is declared `CITEXT` in the database schema. The `list_members` handler in `services/control-api/src/routes/tenants/mod.rs` selected `u.email` without a `::text` cast. SQLx maps `String` to SQL `TEXT`, which PostgreSQL rejects for a `citext` column at runtime, producing a 500 on every call to `GET /v1/tenants/{id}/members`.

**Fix**: cast `u.email::text` in the SELECT — same pattern as the prior switch-tenant citext fix (PR #59).

Closes #64

## Files changed

- `services/control-api/src/routes/tenants/mod.rs` — 1 line: `u.email` → `u.email::text`

## Test plan

- [x] `cargo check -p control-api` — clean
- [x] `cargo test -p control-api --lib routes::tenants` — 18/18 passed
- [ ] Integration: `GET /v1/tenants/{id}/members` returns 200 after rebuild + restart