### PR TITLE
fix(compose): rb-migrations init container repairs control-api DB wiring

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,90 @@
+# compose/ — Docker Compose stacks
+
+## Which Postgres does the compose stack use?
+
+**The compose stack runs its own Postgres** (`rustbrain-dev-postgres-1`, image `postgres:16-alpine`).
+It does **not** connect to any pre-existing `rustbrain-postgres` container or the host Postgres on port 5432.
+
+| Stack | DB host (inside compose network) | Host port |
+|-------|----------------------------------|-----------|
+| `dev.yml` (default) | `postgres:5432` | 5432 (or `$POSTGRES_HOST_PORT`) |
+| `dev.yml` + `tailscale.env` (mars) | `postgres:5432` | 15432 |
+
+Connection string used by `control-api` inside the compose network:
+```
+postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+```
+
+## How migrations work
+
+A `rb-migrations` init container runs **before** `control-api` starts:
+
+1. Waits for the `postgres` service to be healthy.
+2. Creates the `control` schema and a `control.schema_migrations` tracking table if they do not exist.
+3. Applies each `.sql` file under `migrations/control/` in version order (idempotent — already-applied versions are skipped).
+4. Exits 0 on success. `control-api` starts only after `rb-migrations` exits successfully
+   (`depends_on: rb-migrations: condition: service_completed_successfully`).
+
+The script is `compose/scripts/migrate-control.sh`. It mirrors the logic of the
+`services/migrate` Rust binary so checksums match and future `migrate` invocations
+recognise already-applied versions.
+
+Adding a new control migration: drop a `.sql` file in `migrations/control/` with the next
+version prefix (`003_...`). The next `docker compose up` will pick it up automatically.
+
+## Start the stack
+
+```bash
+# Local dev (default ports)
+docker compose -f compose/dev.yml up -d
+
+# mars / Tailscale (remapped ports, see docs/PORT_MAP.md)
+docker compose --env-file compose/tailscale.env \
+  -f compose/dev.yml -f compose/tailscale.yml up -d
+
+# Infra only — skip control-api (e.g. running it with `cargo run`)
+docker compose -f compose/dev.yml up -d \
+  postgres kafka neo4j qdrant otel-collector tempo prometheus grafana ollama
+```
+
+## Smoke test after `docker compose up -d control-api`
+
+Run these to confirm the stack is healthy and migrations applied correctly.
+
+```bash
+# 1. Health check — expects {"status":"ok"}
+PORT=${CONTROL_API_HOST_PORT:-8080}
+curl -fsS http://localhost:${PORT}/health | jq .
+
+# 2. Login endpoint — expects 401 (Unauthorized), NOT 500
+#    A 401 proves the handler reached the DB and found no matching user.
+#    A 500 with "relation does not exist" means migrations did not apply.
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:${PORT}/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"smoke@test.local","password":"irrelevant"}'
+# → 401
+
+# 3. Check logs for migration errors
+docker logs rustbrain-dev-control-api-1 2>&1 | grep -i "relation\|error" | head -20
+# → (no output expected)
+
+# 4. Verify migration tracking table
+docker compose -f compose/dev.yml exec postgres \
+  psql -U rustbrain rustbrain \
+  -c "SELECT version, description, applied_at FROM control.schema_migrations ORDER BY version;"
+```
+
+## Port reference
+
+See `docs/PORT_MAP.md` for the full port table, including Tailscale remapping for mars.
+
+## Tear down
+
+```bash
+# Stop (preserves volumes — migrations stay applied)
+docker compose -f compose/dev.yml down
+
+# Full reset (drops volumes — migrations will re-run on next up)
+docker compose -f compose/dev.yml down -v
+```

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -194,6 +194,21 @@ services:
     networks:
       - rb-net
 
+  rb-migrations:
+    image: postgres:16-alpine
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+    volumes:
+      - ../migrations:/migrations:ro
+      - ./scripts/migrate-control.sh:/usr/local/bin/migrate-control.sh:ro
+    command: ["sh", "/usr/local/bin/migrate-control.sh"]
+    restart: "no"
+    networks:
+      - rb-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   control-api:
     build:
       context: ..
@@ -216,6 +231,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
       otel-collector:
         condition: service_started
     healthcheck:

--- a/compose/scripts/migrate-control.sh
+++ b/compose/scripts/migrate-control.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Applies control-plane migrations idempotently via psql.
+# Run by the rb-migrations init container in compose/dev.yml before control-api starts.
+# Mirrors the logic of services/migrate (Runner::bootstrap + Runner::apply_all).
+set -e
+
+echo "rb-migrations: waiting for postgres..."
+until psql "$DATABASE_URL" -c '\q' 2>/dev/null; do
+  sleep 1
+done
+
+echo "rb-migrations: bootstrapping control schema..."
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+CREATE SCHEMA IF NOT EXISTS control;
+CREATE TABLE IF NOT EXISTS control.schema_migrations (
+    version     INTEGER     PRIMARY KEY,
+    description TEXT        NOT NULL,
+    checksum    TEXT        NOT NULL,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+SQL
+
+for f in $(ls /migrations/control/*.sql 2>/dev/null | sort); do
+    # Strip leading zeros so the value works as a SQL integer literal.
+    ver=$(basename "$f" | sed 's/^\([0-9]*\)_.*/\1/' | sed 's/^0*//')
+    : "${ver:=0}"
+
+    applied=$(psql "$DATABASE_URL" -t -A \
+      -c "SELECT count(*) FROM control.schema_migrations WHERE version = ${ver};")
+
+    if [ "$applied" = "1" ]; then
+        printf "  v%03d already applied, skipping\n" "$ver"
+        continue
+    fi
+
+    printf "  applying v%03d: %s\n" "$ver" "$(basename "$f")"
+    cksum=$(sha256sum "$f" | awk '{print $1}')
+    desc=$(basename "$f" | sed 's/^[0-9]*_//' | sed 's/\.sql$//' | tr '_' ' ')
+
+    # Apply with search_path=control,public so SQL in the file lands in the
+    # right schema without needing explicit schema prefixes.
+    PGOPTIONS='-c search_path=control,public' \
+      psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+
+    # Record using dollar-quoting to avoid single-quote escaping issues.
+    psql "$DATABASE_URL" \
+      -c "INSERT INTO control.schema_migrations (version, description, checksum)
+          VALUES (${ver}, \$\$${desc}\$\$, \$\$${cksum}\$\$)
+          ON CONFLICT (version) DO NOTHING;"
+done
+
+echo "rb-migrations: all control migrations applied."


### PR DESCRIPTION
## Summary

- Adds `rb-migrations` init container to `compose/dev.yml` that applies `migrations/control/*.sql` against the in-compose Postgres before `control-api` starts
- `control-api` now has `depends_on: rb-migrations: condition: service_completed_successfully`, blocking startup until schema is ready
- Migration script (`compose/scripts/migrate-control.sh`) is idempotent — already-applied versions are skipped by checking `control.schema_migrations`; checksums are compatible with the `services/migrate` Rust binary
- Documents the Postgres wiring and smoke test in `compose/README.md`

## Root cause

`control-api` pointed at the in-compose Postgres (`postgres:5432`) which had no `control` schema. On every fresh volume or restart, the app returned 500 `relation "control.users" does not exist` on any DB-touching endpoint.

## Migration type

Additive — no schema changes. Init container only applies existing SQL files.

## Smoke test

```bash
# Bring up the stack (on mars: add --env-file compose/tailscale.env)
docker compose -f compose/dev.yml up -d control-api

# Health check → {"status":"ok"}
curl -fsS http://localhost:18080/health | jq .

# Login → 401 (not 500) proves control.users exists and was reached
curl -s -o /dev/null -w "%{http_code}" \
  -X POST http://localhost:18080/v1/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"smoke@test.local","password":"irrelevant"}'

# Zero "relation" errors in logs
docker logs rustbrain-dev-control-api-1 2>&1 | grep -i "relation\|does not exist"
```

Closes #69