### PR TITLE
chore(compose): pin grafana/tempo to 2.7.2

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -127,7 +127,7 @@ services:
       - prometheus
 
   tempo:
-    image: grafana/tempo:2.7
+    image: grafana/tempo:2.7.2
     command: ["-config.file=/etc/tempo/tempo.yaml"]
     volumes:
       - ./infra/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro


### PR DESCRIPTION
## Summary

- Pin `grafana/tempo` image tag from loose `2.7` to explicit `2.7.2` in `compose/dev.yml`
- Eliminates tag drift between the declared pin and the actually installed image identified during QA smoke testing

## Migration type

N/A — no schema changes.

## Healthcheck

The `/ready` endpoint used by the existing healthcheck is unchanged between patch versions; no config update needed.

## Checklist

- [x] Single-line change, no logic affected
- [x] Healthcheck verified compatible with 2.7.x patch line
- [x] No internal issue tracker references in PR body