### PR TITLE
feat(frontend): members and API keys UI [REQ-FE-09]

### DIFF
--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -14,6 +14,7 @@ export {
 } from "./useApiKeys";
 export {
   tenantMembersQueryKey,
+  useTenantMembers,
   useInviteMember,
   useUpdateMemberRole,
   useRemoveMember,

--- a/frontend/src/api/hooks/useTenantMembers.ts
+++ b/frontend/src/api/hooks/useTenantMembers.ts
@@ -1,8 +1,14 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
 import { apiClient, toApiError, type ApiError } from "../client";
 import type { components } from "../generated/schema";
 import { meQueryKey } from "./useMe";
 
+type ListMembersResponse = components["schemas"]["ListMembersResponse"];
 type InviteMemberRequest = components["schemas"]["InviteMemberRequest"];
 type InviteMemberResponse = components["schemas"]["InviteMemberResponse"];
 type UpdateRoleRequest = components["schemas"]["UpdateRoleRequest"];
@@ -12,6 +18,30 @@ type TransferOwnershipRequest =
 
 export const tenantMembersQueryKey = (tenantId: string) =>
   ["tenants", tenantId, "members"] as const;
+
+export function useTenantMembers(
+  tenantId: string,
+  options?: Omit<
+    UseQueryOptions<ListMembersResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<ListMembersResponse, ApiError>({
+    queryKey: tenantMembersQueryKey(tenantId),
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET(
+        "/v1/tenants/{id}/members",
+        { params: { path: { id: tenantId } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0,
+    ...options,
+  });
+}
 
 export function useInviteMember(tenantId: string) {
   const qc = useQueryClient();

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -18,6 +18,41 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
           >
             Rustacean
           </Link>
+          <nav
+            aria-label="Primary"
+            className="hidden items-center gap-1 sm:flex"
+          >
+            <Link
+              to={routes.repos}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              activeProps={{
+                className:
+                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
+              }}
+            >
+              Repos
+            </Link>
+            <Link
+              to={routes.members}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              activeProps={{
+                className:
+                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
+              }}
+            >
+              Members
+            </Link>
+            <Link
+              to={routes.apiKeys}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              activeProps={{
+                className:
+                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
+              }}
+            >
+              API keys
+            </Link>
+          </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />
           </div>

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -6,6 +6,8 @@ export const routes = {
   forgotPassword: "/forgot-password",
   resetPassword: "/reset-password",
   repos: "/repos",
+  members: "/members",
+  apiKeys: "/api-keys",
 } as const;
 
 export type RoutePath = (typeof routes)[keyof typeof routes];

--- a/frontend/src/lib/validation/members.ts
+++ b/frontend/src/lib/validation/members.ts
@@ -1,0 +1,34 @@
+// REQ-FE-09: validation schemas for the members and API keys management forms.
+// Server-side validation is still authoritative; these only catch obvious
+// mistakes before the request leaves the browser.
+import { z } from "zod";
+
+const emailSchema = z
+  .email("Enter a valid email address")
+  .trim()
+  .min(1, "Email is required");
+
+export const inviteMemberFormSchema = z.object({
+  email: emailSchema,
+});
+export type InviteMemberFormValues = z.infer<typeof inviteMemberFormSchema>;
+
+export const API_KEY_NAME_MAX = 100;
+
+const apiKeyScopes = ["read", "write", "admin"] as const;
+export type ApiKeyScope = (typeof apiKeyScopes)[number];
+
+export const createApiKeyFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(
+      API_KEY_NAME_MAX,
+      `Name must be ${String(API_KEY_NAME_MAX)} characters or fewer`,
+    ),
+  scopes: z
+    .array(z.enum(apiKeyScopes))
+    .min(1, "Select at least one scope"),
+});
+export type CreateApiKeyFormValues = z.infer<typeof createApiKeyFormSchema>;

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1,0 +1,378 @@
+// REQ-FE-09: API key management. Lists API keys for the active tenant and
+// supports create (key shown exactly once) and revoke. Backed by /v1/api-keys
+// (RUSAA-36 wave 2). Plaintext key is never re-fetchable from the server, so
+// the create response is surfaced in a one-shot panel with a copy action.
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  useApiKeys,
+  useCreateApiKey,
+  useMe,
+  useRevokeApiKey,
+} from "@/api";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  createApiKeyFormSchema,
+  type ApiKeyScope,
+  type CreateApiKeyFormValues,
+} from "@/lib/validation/members";
+
+const ALL_SCOPES: ReadonlyArray<ApiKeyScope> = ["read", "write", "admin"];
+
+interface PlaintextKey {
+  readonly id: string;
+  readonly name: string;
+  readonly key: string;
+  readonly scopes: ReadonlyArray<ApiKeyScope>;
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}
+
+export function ApiKeysPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading your session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">API keys</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need to be signed in to manage API keys.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <ApiKeysPageInner
+      tenantName={me.data.current_tenant.name}
+      callerRole={me.data.current_tenant.role}
+    />
+  );
+}
+
+interface ApiKeysPageInnerProps {
+  readonly tenantName: string;
+  readonly callerRole: string;
+}
+
+function ApiKeysPageInner({
+  tenantName,
+  callerRole,
+}: ApiKeysPageInnerProps): JSX.Element {
+  const canManage = callerRole === "owner" || callerRole === "admin";
+
+  const keys = useApiKeys();
+  const createKey = useCreateApiKey();
+  const revokeKey = useRevokeApiKey();
+
+  const [plaintext, setPlaintext] = useState<PlaintextKey | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateApiKeyFormValues>({
+    resolver: zodResolver(createApiKeyFormSchema),
+    defaultValues: { name: "", scopes: ["read"] },
+  });
+
+  const selectedScopes = watch("scopes");
+
+  const onCreate = handleSubmit(async (values) => {
+    try {
+      const result = await createKey.mutateAsync({
+        name: values.name,
+        scopes: values.scopes,
+      });
+      setPlaintext({
+        id: result.id,
+        name: result.name,
+        key: result.key,
+        scopes: result.scopes as ReadonlyArray<ApiKeyScope>,
+      });
+      reset({ name: "", scopes: ["read"] });
+      toast.success(`Created “${result.name}”. Copy the key now.`);
+    } catch (error) {
+      toast.error(formatApiError(error, "Could not create API key."));
+    }
+  });
+
+  const sortedKeys = useMemo(() => {
+    if (!keys.data) return [];
+    return [...keys.data.keys].sort((a, b) => {
+      return (
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      );
+    });
+  }, [keys.data]);
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">API keys</h1>
+        <p className="text-sm text-muted-foreground">
+          Programmatic access to{" "}
+          <span className="font-medium">{tenantName}</span>. Use the{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            Authorization: Bearer
+          </code>{" "}
+          header.
+        </p>
+      </header>
+
+      {plaintext ? (
+        <PlaintextKeyPanel
+          plaintext={plaintext}
+          onDismiss={() => {
+            setPlaintext(null);
+          }}
+        />
+      ) : null}
+
+      {canManage ? (
+        <section
+          aria-labelledby="create-key-heading"
+          className="mb-8 rounded-lg border border-border bg-card p-4"
+        >
+          <h2 id="create-key-heading" className="text-sm font-medium">
+            Create an API key
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            The plaintext key is shown <strong>only once</strong>. Store it in
+            your secret manager immediately — we cannot recover it for you
+            later.
+          </p>
+          <form onSubmit={onCreate} noValidate className="mt-3 flex flex-col gap-4">
+            <Field
+              label="Name"
+              type="text"
+              placeholder="ci-deploy"
+              {...(errors.name?.message ? { error: errors.name.message } : {})}
+              {...register("name")}
+            />
+
+            <fieldset className="flex flex-col gap-2">
+              <legend className="text-sm font-medium">Scopes</legend>
+              <p className="text-xs text-muted-foreground">
+                Pick the smallest set of scopes you need.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                {ALL_SCOPES.map((scope) => (
+                  <label
+                    key={scope}
+                    className="flex items-center gap-2 rounded-md border border-input px-3 py-2 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      value={scope}
+                      defaultChecked={scope === "read"}
+                      {...register("scopes")}
+                    />
+                    <span>{scope}</span>
+                  </label>
+                ))}
+              </div>
+              {errors.scopes?.message ? (
+                <p role="alert" className="text-xs text-destructive">
+                  {errors.scopes.message}
+                </p>
+              ) : null}
+              <p className="text-xs text-muted-foreground">
+                Selected: {selectedScopes && selectedScopes.length > 0
+                  ? selectedScopes.join(", ")
+                  : "none"}
+              </p>
+            </fieldset>
+
+            <div>
+              <SubmitButton
+                isLoading={isSubmitting || createKey.isPending}
+                loadingLabel="Creating…"
+              >
+                Create key
+              </SubmitButton>
+            </div>
+          </form>
+        </section>
+      ) : (
+        <p className="mb-8 text-sm text-muted-foreground">
+          Your role ({callerRole}) cannot create or revoke API keys. Ask an
+          admin or owner of {tenantName}.
+        </p>
+      )}
+
+      <section aria-labelledby="keys-heading">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 id="keys-heading" className="text-sm font-medium">
+            Existing keys
+          </h2>
+          {keys.data ? (
+            <span className="text-xs text-muted-foreground">
+              {String(keys.data.keys.length)} total
+            </span>
+          ) : null}
+        </div>
+
+        {keys.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading keys…</p>
+        ) : keys.isError ? (
+          <p className="text-sm text-destructive">
+            {formatApiError(keys.error, "Could not load API keys.")}
+          </p>
+        ) : sortedKeys.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No API keys yet. Create one above.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+            {sortedKeys.map((k) => (
+              <li
+                key={k.id}
+                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium">{k.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    Scopes: {k.scopes.join(", ") || "—"}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Created {formatTimestamp(k.created_at)}
+                    {" · "}
+                    Last used {formatTimestamp(k.last_used_at ?? null)}
+                  </span>
+                </div>
+                {canManage ? (
+                  <button
+                    type="button"
+                    disabled={revokeKey.isPending}
+                    onClick={async () => {
+                      if (
+                        !window.confirm(
+                          `Revoke API key “${k.name}”? Any service using it will stop working immediately.`,
+                        )
+                      ) {
+                        return;
+                      }
+                      try {
+                        await revokeKey.mutateAsync(k.id);
+                        toast.success(`Revoked “${k.name}”.`);
+                      } catch (error) {
+                        toast.error(
+                          formatApiError(error, "Could not revoke key."),
+                        );
+                      }
+                    }}
+                    className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Revoke
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </PageContainer>
+  );
+}
+
+interface PlaintextKeyPanelProps {
+  readonly plaintext: PlaintextKey;
+  readonly onDismiss: () => void;
+}
+
+function PlaintextKeyPanel({
+  plaintext,
+  onDismiss,
+}: PlaintextKeyPanelProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(plaintext.key);
+      setCopied(true);
+      toast.success("Copied to clipboard.");
+      window.setTimeout(() => {
+        setCopied(false);
+      }, 2_000);
+    } catch {
+      toast.error("Copy failed — select the key and copy manually.");
+    }
+  };
+
+  return (
+    <section
+      role="alert"
+      aria-live="polite"
+      aria-labelledby="plaintext-key-heading"
+      className="mb-8 rounded-lg border border-amber-500/60 bg-amber-50 p-4 text-amber-950 shadow-sm dark:bg-amber-900/20 dark:text-amber-100"
+    >
+      <h2 id="plaintext-key-heading" className="text-sm font-semibold">
+        New API key — shown only once
+      </h2>
+      <p className="mt-1 text-xs">
+        Copy <strong>{plaintext.name}</strong> now and store it somewhere safe.
+        We cannot recover it for you later.
+      </p>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <code className="flex-1 break-all rounded-md border border-amber-500/40 bg-white px-3 py-2 font-mono text-sm text-foreground dark:bg-amber-950/40 dark:text-amber-50">
+          {plaintext.key}
+        </code>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCopy}
+            className="rounded-md border border-amber-500/40 bg-amber-500 px-3 py-2 text-xs font-medium text-amber-950 hover:bg-amber-400"
+          >
+            {copied ? "Copied!" : "Copy key"}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md border border-amber-500/40 px-3 py-2 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/40"
+          >
+            I&apos;ve saved it
+          </button>
+        </div>
+      </div>
+      <p className="mt-2 text-xs">
+        Scopes: {plaintext.scopes.join(", ") || "—"}
+      </p>
+    </section>
+  );
+}
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -1,0 +1,441 @@
+// REQ-FE-09: tenant member management. Lists every member of the active
+// tenant and exposes invite / role-change / remove / transfer-ownership for
+// admins and owners. Backed by /v1/tenants/{id}/members and
+// /v1/tenants/{id}/transfer-ownership (RUSAA-36 wave 2).
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  useInviteMember,
+  useMe,
+  useRemoveMember,
+  useTenantMembers,
+  useTransferOwnership,
+  useUpdateMemberRole,
+} from "@/api";
+import { Field } from "@/components/ui/Field";
+import { SubmitButton } from "@/components/ui/SubmitButton";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+import {
+  inviteMemberFormSchema,
+  type InviteMemberFormValues,
+} from "@/lib/validation/members";
+
+type Role = "owner" | "admin" | "member";
+
+const ASSIGNABLE_ROLES: ReadonlyArray<Exclude<Role, "owner">> = [
+  "member",
+  "admin",
+];
+
+function isManagerRole(role: string | undefined): role is "owner" | "admin" {
+  return role === "owner" || role === "admin";
+}
+
+function formatInvitedAt(invitedAt: string | null | undefined): string {
+  if (!invitedAt) {
+    return "—";
+  }
+  const date = new Date(invitedAt);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleString();
+}
+
+export function MembersPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading your session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">Members</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need to be signed in to manage members.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <MembersPageInner
+      tenantId={me.data.current_tenant.id}
+      tenantName={me.data.current_tenant.name}
+      callerRole={me.data.current_tenant.role as Role}
+      callerUserId={me.data.user.id}
+    />
+  );
+}
+
+interface MembersPageInnerProps {
+  readonly tenantId: string;
+  readonly tenantName: string;
+  readonly callerRole: Role;
+  readonly callerUserId: string;
+}
+
+function MembersPageInner({
+  tenantId,
+  tenantName,
+  callerRole,
+  callerUserId,
+}: MembersPageInnerProps): JSX.Element {
+  const canManage = isManagerRole(callerRole);
+  const isOwner = callerRole === "owner";
+
+  const members = useTenantMembers(tenantId);
+  const invite = useInviteMember(tenantId);
+  const updateRole = useUpdateMemberRole(tenantId);
+  const removeMember = useRemoveMember(tenantId);
+  const transferOwnership = useTransferOwnership(tenantId);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<InviteMemberFormValues>({
+    resolver: zodResolver(inviteMemberFormSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onInvite = handleSubmit(async (values) => {
+    try {
+      const result = await invite.mutateAsync(values);
+      toast.success(
+        result.invited
+          ? `Invitation sent to ${result.email}.`
+          : `${result.email} added to ${tenantName}.`,
+      );
+      reset({ email: "" });
+    } catch (error) {
+      toast.error(formatApiError(error, "Could not send invite."));
+    }
+  });
+
+  const sortedMembers = useMemo(() => {
+    if (!members.data) {
+      return [];
+    }
+    const roleOrder: Record<string, number> = {
+      owner: 0,
+      admin: 1,
+      member: 2,
+    };
+    return [...members.data.members].sort((a, b) => {
+      const ra = roleOrder[a.role] ?? 99;
+      const rb = roleOrder[b.role] ?? 99;
+      if (ra !== rb) return ra - rb;
+      return a.email.localeCompare(b.email);
+    });
+  }, [members.data]);
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Members</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage who can access <span className="font-medium">{tenantName}</span>.
+        </p>
+      </header>
+
+      {canManage ? (
+        <section
+          aria-labelledby="invite-heading"
+          className="mb-8 rounded-lg border border-border bg-card p-4"
+        >
+          <h2 id="invite-heading" className="text-sm font-medium">
+            Invite a member
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            We&apos;ll send an invitation email if they don&apos;t have an account
+            yet, or add them directly if they do.
+          </p>
+          <form
+            onSubmit={onInvite}
+            noValidate
+            className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-end"
+          >
+            <div className="flex-1">
+              <Field
+                label="Email"
+                type="email"
+                autoComplete="email"
+                placeholder="teammate@example.com"
+                {...(errors.email?.message
+                  ? { error: errors.email.message }
+                  : {})}
+                {...register("email")}
+              />
+            </div>
+            <SubmitButton
+              isLoading={isSubmitting || invite.isPending}
+              loadingLabel="Sending…"
+            >
+              Send invite
+            </SubmitButton>
+          </form>
+        </section>
+      ) : null}
+
+      <section aria-labelledby="members-heading">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 id="members-heading" className="text-sm font-medium">
+            All members
+          </h2>
+          {members.data ? (
+            <span className="text-xs text-muted-foreground">
+              {String(members.data.members.length)} total
+            </span>
+          ) : null}
+        </div>
+
+        {members.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading members…</p>
+        ) : members.isError ? (
+          <p className="text-sm text-destructive">
+            {formatApiError(members.error, "Could not load members.")}
+          </p>
+        ) : sortedMembers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No members yet — invite someone above.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+            {sortedMembers.map((m) => {
+              const isSelf = m.user_id === callerUserId;
+              return (
+                <MemberRow
+                  key={m.user_id}
+                  email={m.email}
+                  role={m.role as Role}
+                  invitedAt={m.invited_at ?? null}
+                  userId={m.user_id}
+                  isSelf={isSelf}
+                  canManage={canManage}
+                  isOwner={isOwner}
+                  onChangeRole={async (nextRole) => {
+                    try {
+                      await updateRole.mutateAsync({
+                        uid: m.user_id,
+                        body: { role: nextRole },
+                      });
+                      toast.success(`Updated ${m.email} to ${nextRole}.`);
+                    } catch (error) {
+                      toast.error(
+                        formatApiError(error, "Could not update role."),
+                      );
+                    }
+                  }}
+                  onRemove={async () => {
+                    if (
+                      !window.confirm(
+                        `Remove ${m.email} from ${tenantName}? They will lose access immediately.`,
+                      )
+                    ) {
+                      return;
+                    }
+                    try {
+                      await removeMember.mutateAsync(m.user_id);
+                      toast.success(`${m.email} removed.`);
+                    } catch (error) {
+                      toast.error(
+                        formatApiError(error, "Could not remove member."),
+                      );
+                    }
+                  }}
+                  onTransferOwnership={async () => {
+                    if (
+                      !window.confirm(
+                        `Transfer ownership of ${tenantName} to ${m.email}? You will become an admin.`,
+                      )
+                    ) {
+                      return;
+                    }
+                    try {
+                      await transferOwnership.mutateAsync({
+                        user_id: m.user_id,
+                      });
+                      toast.success(`${m.email} is now the owner.`);
+                    } catch (error) {
+                      toast.error(
+                        formatApiError(
+                          error,
+                          "Could not transfer ownership.",
+                        ),
+                      );
+                    }
+                  }}
+                />
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </PageContainer>
+  );
+}
+
+interface MemberRowProps {
+  readonly email: string;
+  readonly role: Role;
+  readonly invitedAt: string | null;
+  readonly userId: string;
+  readonly isSelf: boolean;
+  readonly canManage: boolean;
+  readonly isOwner: boolean;
+  readonly onChangeRole: (nextRole: Exclude<Role, "owner">) => Promise<void>;
+  readonly onRemove: () => Promise<void>;
+  readonly onTransferOwnership: () => Promise<void>;
+}
+
+function MemberRow({
+  email,
+  role,
+  invitedAt,
+  isSelf,
+  canManage,
+  isOwner,
+  onChangeRole,
+  onRemove,
+  onTransferOwnership,
+}: MemberRowProps): JSX.Element {
+  const [pendingRole, setPendingRole] = useState<Role>(role);
+  const [busy, setBusy] = useState(false);
+
+  // Keep the local select in sync with refetched data.
+  useEffect(() => {
+    setPendingRole(role);
+  }, [role]);
+
+  const isOwnerRow = role === "owner";
+  // Admins cannot manage other admins or the owner; only the owner can.
+  const canActOnRow =
+    canManage &&
+    !isOwnerRow &&
+    !isSelf &&
+    (isOwner || role !== "admin");
+
+  const canTransferOwnership = isOwner && !isOwnerRow;
+
+  return (
+    <li className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">
+          {email}
+          {isSelf ? (
+            <span className="ml-2 text-xs text-muted-foreground">(you)</span>
+          ) : null}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Joined {formatInvitedAt(invitedAt)}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {isOwnerRow ? (
+          <span className="rounded-md border border-border bg-secondary px-2 py-1 text-xs font-medium text-secondary-foreground">
+            owner
+          </span>
+        ) : canActOnRow ? (
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="sr-only">Role for {email}</span>
+            <select
+              value={pendingRole}
+              disabled={busy}
+              onChange={async (event) => {
+                const next = event.target.value as Exclude<Role, "owner">;
+                setPendingRole(next);
+                if (next === role) {
+                  return;
+                }
+                setBusy(true);
+                try {
+                  await onChangeRole(next);
+                } finally {
+                  setBusy(false);
+                }
+              }}
+              className="rounded-md border border-input bg-background px-2 py-1 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {ASSIGNABLE_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <span className="rounded-md border border-border bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
+            {role}
+          </span>
+        )}
+
+        {canTransferOwnership ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true);
+              try {
+                await onTransferOwnership();
+              } finally {
+                setBusy(false);
+              }
+            }}
+            className="rounded-md border border-border px-2 py-1 text-xs text-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Make owner
+          </button>
+        ) : null}
+
+        {canActOnRow ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true);
+              try {
+                await onRemove();
+              } finally {
+                setBusy(false);
+              }
+            }}
+            className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Remove
+          </button>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div className="container max-w-3xl py-8">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,8 +8,10 @@ import {
 } from "@tanstack/react-router";
 import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
+import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
 import { LoginPage } from "@/pages/LoginPage";
+import { MembersPage } from "@/pages/MembersPage";
 import { ReposPlaceholderPage } from "@/pages/ReposPlaceholderPage";
 import { ResetPasswordPage } from "@/pages/ResetPasswordPage";
 import { SignupPage } from "@/pages/SignupPage";
@@ -81,6 +83,18 @@ const reposRoute = createRoute({
   component: ReposPlaceholderPage,
 });
 
+const membersRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.members,
+  component: MembersPage,
+});
+
+const apiKeysRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.apiKeys,
+  component: ApiKeysPage,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -98,6 +112,8 @@ const routeTree = rootRoute.addChildren([
   forgotPasswordRoute,
   resetPasswordRoute,
   reposRoute,
+  membersRoute,
+  apiKeysRoute,
   catchAllRoute,
 ]);
 


### PR DESCRIPTION
## Summary

Implements [REQ-FE-09] — two new authenticated pages plus header navigation, backed by the Wave 2 membership and API key endpoints already shipped.

### MembersPage (`/members`)
- Lists tenant members sorted by role (owner → admin → member).
- Invite by email (admin/owner only). Toast distinguishes "invite sent" vs "added directly".
- Inline role select (`member`/`admin`); admins can manage members but not other admins or the owner.
- Remove member with `window.confirm` guard.
- "Make owner" action visible only to the owner; calls `/v1/tenants/{id}/transfer-ownership` and refetches `/v1/me` so the role badge in the AppShell updates.

### ApiKeysPage (`/api-keys`)
- Lists existing keys (name, scopes, created, last used) sorted newest-first.
- Create form with read/write/admin scope checkboxes.
- One-shot plaintext key panel with copy + dismiss. Server cannot return the plaintext again, so we surface that explicitly.
- Revoke with `window.confirm` guard.

### Plumbing
- New `useTenantMembers(tenantId)` query hook over `GET /v1/tenants/{id}/members`. The mutation hooks (`useInviteMember`, `useUpdateMemberRole`, `useRemoveMember`, `useTransferOwnership`, `useCreateApiKey`, `useRevokeApiKey`) were already shipped — they just needed a list query and pages to call them.
- Routes added: `/members`, `/api-keys`. Nav links added to `AppShell` with active-state styling.
- Validation schemas: `inviteMemberFormSchema`, `createApiKeyFormSchema` (`zod`).

## Test plan
- [ ] `npm run typecheck` (clean)
- [ ] `npm run lint` (clean, `--max-warnings=0`)
- [ ] `npm run build` (clean)
- [ ] Manual: invite a teammate → toast confirms, list refreshes
- [ ] Manual: change a member's role → toast + select state stays in sync after refetch
- [ ] Manual: remove a member → confirm dialog → list refreshes
- [ ] Manual (owner only): "Make owner" → `/v1/me` re-fetches, AppShell role badge / permissions update
- [ ] Manual: create API key → plaintext panel appears with copy button → key disappears once dismissed and is not in the list response
- [ ] Manual: revoke an API key → confirm dialog → row disappears
- [ ] Manual: member-role caller sees no invite/create/revoke controls (read-only)
