### PR TITLE
[REQ-GH-05] feat(rb-github): installation token cache

### DIFF
--- a/crates/rb-github/src/installation_token.rs
+++ b/crates/rb-github/src/installation_token.rs
@@ -1,0 +1,75 @@
+//! GitHub installation-token minter (REQ-GH-05, ADR-005 §6.3).
+//!
+//! Implements [`TokenMinter`] by minting an App-JWT and exchanging it at
+//! `POST /app/installations/{id}/access_tokens`. Used by [`crate::TokenCache`]
+//! to fill misses; never called from the warm path.
+
+use jsonwebtoken::EncodingKey;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::app_jwt::mint_app_jwt;
+use crate::error::GhError;
+use crate::secret::Secret;
+use crate::token_cache::{CachedToken, MintFuture, TokenMinter};
+
+const DEFAULT_BASE_URL: &str = "https://api.github.com";
+
+/// Minter that hits the real GitHub REST API. Constructed inside
+/// [`crate::GhApp::new`]; never instantiated by service code directly.
+pub struct GitHubTokenMinter {
+    app_id: i64,
+    encoding_key: EncodingKey,
+    http: Client,
+    base_url: String,
+}
+
+impl GitHubTokenMinter {
+    pub(crate) fn new(app_id: i64, encoding_key: EncodingKey, http: Client) -> Self {
+        Self {
+            app_id,
+            encoding_key,
+            http,
+            base_url: DEFAULT_BASE_URL.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationTokenResponse {
+    token: String,
+    expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl TokenMinter for GitHubTokenMinter {
+    fn mint(&self, installation_id: i64) -> MintFuture<'_> {
+        Box::pin(async move {
+            let jwt = mint_app_jwt(self.app_id, &self.encoding_key)?;
+            let url = format!(
+                "{}/app/installations/{}/access_tokens",
+                self.base_url, installation_id
+            );
+            let resp = self
+                .http
+                .post(&url)
+                .header("Authorization", format!("Bearer {jwt}"))
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .header("User-Agent", "rust-brain/1.0")
+                .send()
+                .await?;
+
+            let status = resp.status().as_u16();
+            if !resp.status().is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(GhError::ApiError { status, body });
+            }
+
+            let payload: InstallationTokenResponse = resp.json().await?;
+            Ok(CachedToken {
+                token: Secret::new(payload.token),
+                expires_at: payload.expires_at,
+            })
+        })
+    }
+}

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -1,6 +1,7 @@
 mod app_jwt;
 mod client;
 mod error;
+mod installation_token;
 mod secret;
 mod state_token;
 mod token_cache;
@@ -10,7 +11,7 @@ pub use client::{AppIdentity, AppOwner};
 pub use error::GhError;
 pub use secret::Secret;
 pub use state_token::hash_token;
-pub use token_cache::CachedToken;
+pub use token_cache::{CachedToken, MintFuture, TokenCache, TokenMinter, SAFETY_MARGIN};
 pub use webhook::{
     Account, Installation, InstallationEvent, InstallationPayload, InstallationReposPayload,
     InstallationRepositoriesEvent, RepoRef, ReplayCache, verify_signature,
@@ -22,6 +23,8 @@ use std::time::Duration;
 use jsonwebtoken::EncodingKey;
 use moka::future::Cache;
 use reqwest::Client;
+
+use installation_token::GitHubTokenMinter;
 
 /// The central handle for all GitHub App operations.
 ///
@@ -39,6 +42,8 @@ pub struct GhApp {
     /// Cached response from `GET /app` (60 s TTL) to avoid hammering GitHub
     /// from k8s liveness probes.
     identity_cache: Arc<Cache<(), AppIdentity>>,
+    /// Per-installation access-token cache (REQ-GH-05).
+    pub token_cache: Arc<TokenCache>,
     /// Shared HTTP client.
     http: Client,
 }
@@ -61,12 +66,20 @@ impl GhApp {
             .build()
             .expect("reqwest client init is infallible with valid config");
 
+        let minter: Arc<dyn TokenMinter> = Arc::new(GitHubTokenMinter::new(
+            app_id,
+            encoding_key.clone(),
+            http.clone(),
+        ));
+        let token_cache = TokenCache::new(minter);
+
         Self {
             app_id,
             encoding_key,
             webhook_secret,
             replay_cache: ReplayCache::new(),
             identity_cache: Arc::new(identity_cache),
+            token_cache,
             http,
         }
     }
@@ -100,6 +113,27 @@ impl GhApp {
                 status: 500,
                 body: "identity cache miss immediately after insert".to_owned(),
             })
+    }
+
+    /// Returns a usable installation access token, minting if absent or
+    /// near expiry (REQ-GH-05). Warm hits are sub-millisecond.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GhError`] if the App JWT cannot be minted or the GitHub
+    /// `POST /app/installations/{id}/access_tokens` call fails.
+    pub async fn installation_token(
+        &self,
+        installation_id: i64,
+    ) -> Result<Secret<String>, GhError> {
+        self.token_cache.get_or_mint(installation_id).await
+    }
+
+    /// Spawns the periodic eviction sweep for the installation-token cache.
+    /// Must be called from inside a tokio runtime, typically once at server
+    /// startup right after [`GhApp::new`].
+    pub fn start_token_sweep(&self) {
+        self.token_cache.start_sweep();
     }
 }
 

--- a/crates/rb-github/src/token_cache.rs
+++ b/crates/rb-github/src/token_cache.rs
@@ -1,13 +1,349 @@
-// Installation token cache — implemented in RUSAA-49 (REQ-GH-05).
-//
-// This stub defines the public types so rb-github compiles and other
-// modules can reference them before RUSAA-49 lands.
+//! Installation token cache (REQ-GH-05, ADR-005 §6).
+//!
+//! In-process per-installation cache for GitHub App installation access
+//! tokens. Tokens live ~60 min upstream; we treat any token with less than
+//! 10 min of life left as expired and re-mint, giving callers an effective
+//! 50 min usable TTL with a 10 min safety margin.
+//!
+//! Lookups are lock-free `DashMap` reads on the warm path; cold misses are
+//! collapsed via per-installation single-flight to avoid stampedes on
+//! GitHub's `/app/installations/{id}/access_tokens` endpoint (~200 ms RTT).
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::task::JoinHandle;
+
+use crate::error::GhError;
 use crate::secret::Secret;
 
-/// A GitHub installation access token with its expiry timestamp.
-#[derive(Debug)]
+/// Boxed future returned by [`TokenMinter::mint`]. Pinned and `Send` so the
+/// cache can hold `Arc<dyn TokenMinter>` and drive the future across tasks.
+pub type MintFuture<'a> = Pin<Box<dyn Future<Output = Result<CachedToken, GhError>> + Send + 'a>>;
+
+/// Treat tokens with less than this remaining lifetime as expired.
+pub const SAFETY_MARGIN: Duration = Duration::from_secs(10 * 60);
+
+/// Periodic sweep cadence for evicting expired tokens (ADR-005 §6.5).
+pub const SWEEP_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// A GitHub installation access token with its absolute expiry (UTC).
+#[derive(Debug, Clone)]
 pub struct CachedToken {
     pub token: Secret<String>,
-    pub expires_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Mints a fresh installation token. Implementors typically perform an
+/// App-JWT exchange against `POST /app/installations/{id}/access_tokens`.
+///
+/// Returns a [`MintFuture`] rather than `async fn` so the trait stays
+/// object-safe for `Arc<dyn TokenMinter>`.
+pub trait TokenMinter: Send + Sync {
+    fn mint(&self, installation_id: i64) -> MintFuture<'_>;
+}
+
+/// Per-installation in-process token cache with single-flight mint.
+pub struct TokenCache {
+    inner: DashMap<i64, CachedToken>,
+    /// Per-installation mutex used to collapse concurrent cold-misses.
+    /// Contended only on cache miss; warm path never touches this map.
+    single_flight: DashMap<i64, Arc<AsyncMutex<()>>>,
+    minter: Arc<dyn TokenMinter>,
+    /// Background sweep handle. Aborted on drop.
+    sweep: StdMutex<Option<JoinHandle<()>>>,
+}
+
+impl TokenCache {
+    #[must_use]
+    pub fn new(minter: Arc<dyn TokenMinter>) -> Arc<Self> {
+        Arc::new(Self {
+            inner: DashMap::new(),
+            single_flight: DashMap::new(),
+            minter,
+            sweep: StdMutex::new(None),
+        })
+    }
+
+    /// Returns a usable installation token, minting if absent or near expiry.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`GhError`] returned by the minter (JWT failure,
+    /// HTTP error, GitHub 4xx/5xx).
+    pub async fn get_or_mint(&self, installation_id: i64) -> Result<Secret<String>, GhError> {
+        if let Some(t) = self.read_fresh(installation_id) {
+            return Ok(t);
+        }
+
+        let lock = self
+            .single_flight
+            .entry(installation_id)
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
+        // Re-check: a concurrent caller may have minted while we were queued.
+        if let Some(t) = self.read_fresh(installation_id) {
+            return Ok(t);
+        }
+
+        let cached = self.minter.mint(installation_id).await?;
+        let token = cached.token.clone();
+        self.inner.insert(installation_id, cached);
+        Ok(token)
+    }
+
+    fn read_fresh(&self, installation_id: i64) -> Option<Secret<String>> {
+        let entry = self.inner.get(&installation_id)?;
+        let remaining = entry.expires_at.signed_duration_since(Utc::now());
+        if remaining
+            > chrono::Duration::from_std(SAFETY_MARGIN).expect("safety margin fits in chrono")
+        {
+            Some(entry.token.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Drops cache entries whose tokens are past expiry. Cheap; intended
+    /// for the periodic sweep but safe to call at any time.
+    pub fn evict_expired(&self) {
+        let now = Utc::now();
+        self.inner.retain(|_, t| t.expires_at > now);
+    }
+
+    /// Spawns a periodic eviction task. Call once at startup. The task
+    /// holds only a `Weak` reference to `self`, so the cache can still be
+    /// dropped; the task observes the drop on its next tick and exits.
+    /// Calling this more than once aborts the previous handle.
+    pub fn start_sweep(self: &Arc<Self>) {
+        self.start_sweep_with_period(SWEEP_INTERVAL);
+    }
+
+    fn start_sweep_with_period(self: &Arc<Self>, period: Duration) {
+        let weak = Arc::downgrade(self);
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(period);
+            // First tick fires immediately; skip it so the sweep happens
+            // one period after startup.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let Some(strong) = weak.upgrade() else {
+                    break;
+                };
+                strong.evict_expired();
+            }
+        });
+        if let Ok(mut slot) = self.sweep.lock() {
+            if let Some(prev) = slot.replace(handle) {
+                prev.abort();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl std::fmt::Debug for TokenCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenCache")
+            .field("entries", &self.inner.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for TokenCache {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = self.sweep.lock() {
+            if let Some(handle) = slot.take() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    use super::*;
+
+    /// Test minter that returns a token with caller-controlled expiry and
+    /// counts how many times it was invoked.
+    struct CountingMinter {
+        calls: AtomicUsize,
+        expires_in: chrono::Duration,
+        delay: Option<Duration>,
+    }
+
+    impl CountingMinter {
+        fn new(expires_in: chrono::Duration) -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                expires_in,
+                delay: None,
+            })
+        }
+
+        fn with_delay(expires_in: chrono::Duration, delay: Duration) -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                expires_in,
+                delay: Some(delay),
+            })
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl TokenMinter for CountingMinter {
+        fn mint(&self, installation_id: i64) -> MintFuture<'_> {
+            Box::pin(async move {
+                if let Some(d) = self.delay {
+                    tokio::time::sleep(d).await;
+                }
+                let n = self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CachedToken {
+                    token: Secret::new(format!("ghs_inst_{installation_id}_call_{n}")),
+                    expires_at: Utc::now() + self.expires_in,
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn warm_hit_returns_cached_token_without_minting() {
+        let minter = CountingMinter::new(chrono::Duration::minutes(60));
+        let cache = TokenCache::new(minter.clone());
+
+        let first = cache.get_or_mint(42).await.unwrap();
+        let second = cache.get_or_mint(42).await.unwrap();
+
+        assert_eq!(minter.calls(), 1, "second call must hit cache");
+        assert_eq!(first.expose(), second.expose());
+    }
+
+    #[tokio::test]
+    async fn token_within_safety_margin_triggers_remint() {
+        let minter = CountingMinter::new(chrono::Duration::minutes(5));
+        let cache = TokenCache::new(minter.clone());
+
+        let _ = cache.get_or_mint(42).await.unwrap();
+        let _ = cache.get_or_mint(42).await.unwrap();
+
+        assert_eq!(
+            minter.calls(),
+            2,
+            "tokens with <10 min remaining must be re-minted on lookup",
+        );
+    }
+
+    #[tokio::test]
+    async fn token_with_exactly_safety_margin_remints() {
+        // 10 min remaining means `remaining > 10 min` is false → re-mint.
+        let minter = CountingMinter::new(chrono::Duration::minutes(10));
+        let cache = TokenCache::new(minter.clone());
+
+        let _ = cache.get_or_mint(42).await.unwrap();
+        let _ = cache.get_or_mint(42).await.unwrap();
+
+        assert_eq!(minter.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn distinct_installations_mint_independently() {
+        let minter = CountingMinter::new(chrono::Duration::minutes(60));
+        let cache = TokenCache::new(minter.clone());
+
+        let _ = cache.get_or_mint(1).await.unwrap();
+        let _ = cache.get_or_mint(2).await.unwrap();
+        let _ = cache.get_or_mint(1).await.unwrap();
+
+        assert_eq!(minter.calls(), 2, "one mint per installation");
+    }
+
+    #[tokio::test]
+    async fn single_flight_collapses_concurrent_cold_misses() {
+        let minter = CountingMinter::with_delay(
+            chrono::Duration::minutes(60),
+            Duration::from_millis(50),
+        );
+        let cache = TokenCache::new(minter.clone());
+
+        let mut handles = Vec::with_capacity(100);
+        for _ in 0..100 {
+            let c = cache.clone();
+            handles.push(tokio::spawn(async move { c.get_or_mint(42).await }));
+        }
+        for h in handles {
+            h.await.unwrap().unwrap();
+        }
+
+        assert_eq!(
+            minter.calls(),
+            1,
+            "single-flight must collapse concurrent cold-misses",
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_hit_is_sub_millisecond() {
+        let minter = CountingMinter::new(chrono::Duration::minutes(60));
+        let cache = TokenCache::new(minter.clone());
+
+        cache.get_or_mint(42).await.unwrap();
+
+        let start = Instant::now();
+        for _ in 0..1_000 {
+            cache.get_or_mint(42).await.unwrap();
+        }
+        let avg = start.elapsed() / 1_000;
+
+        assert_eq!(minter.calls(), 1);
+        assert!(
+            avg < Duration::from_millis(1),
+            "average warm-path lookup was {avg:?}, expected < 1 ms",
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_expired_drops_stale_entries() {
+        let minter = CountingMinter::new(chrono::Duration::milliseconds(50));
+        let cache = TokenCache::new(minter.clone());
+
+        cache.get_or_mint(1).await.unwrap();
+        assert_eq!(cache.entry_count(), 1);
+
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        cache.evict_expired();
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_task_runs_and_aborts_on_drop() {
+        let minter = CountingMinter::new(chrono::Duration::milliseconds(20));
+        let cache = TokenCache::new(minter.clone());
+        cache.start_sweep_with_period(Duration::from_millis(30));
+
+        cache.get_or_mint(7).await.unwrap();
+        assert_eq!(cache.entry_count(), 1);
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(cache.entry_count(), 0, "sweep should evict expired entry");
+
+        drop(cache);
+    }
 }

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -51,13 +51,20 @@ pub async fn run(config: Config) -> Result<()> {
 
     let gh = build_gh_app(&config)?;
 
+    let gh = gh.map(Arc::new);
+    if let Some(g) = &gh {
+        // Spawn the installation-token cache sweep now that we are inside
+        // the tokio runtime (REQ-GH-05).
+        g.start_token_sweep();
+    }
+
     let state = AppState {
         pool,
         email_sender: Arc::from(email_sender),
         hasher: Arc::new(hasher),
         login_rate_limiter: Arc::new(LoginRateLimiter::new()),
         config: Arc::new(config.clone()),
-        gh: gh.map(Arc::new),
+        gh,
     };
 
     let cors = CorsLayer::new()


### PR DESCRIPTION
## Summary

Implements the in-process installation-token cache from ADR-005 §6.

- `TokenCache` keyed by `installation_id` with lock-free `DashMap` warm path and per-installation single-flight on cold miss.
- 50 min usable TTL via a 10 min safety margin (a token returned to a caller has at least ~10 min of life left).
- `GitHubTokenMinter` performs the App-JWT mint + `POST /app/installations/{id}/access_tokens` exchange.
- `GhApp::installation_token(installation_id)` is the public entry point; `GhApp::start_token_sweep()` arms the periodic 5 min eviction task at server startup.
- `Secret<String>` continues to wrap the token end-to-end; cache values, the minter response, and the public return type all keep redaction.

## Design reference

ADR-005 §6 (token cache), §6.3 (App-JWT mint), §6.5 (eviction).

## Test plan

- [x] `cargo test -p rb-github` — 20/20 passing
- [x] `cargo clippy -p rb-github -p control-api --all-targets -- -D warnings` clean
- [x] `cargo build -p control-api` clean

New unit tests:

- warm hit returns cached token without minting
- token within safety margin triggers re-mint
- token at exactly the safety margin re-mints
- distinct installations mint independently
- single-flight collapses 100 concurrent cold-misses to a single mint
- average warm-path lookup < 1 ms (1k iter loop)
- `evict_expired` drops stale entries
- background sweep task runs and aborts on `Drop`

Single-flight is exercised with a 50 ms minter delay so the test deterministically observes the stampede; the production path keeps the warm-hit lock-free.

Notes for follow-on work (REQ-GH-02 / REQ-GH-03):

- `GhApp::installation_token` is the only entry point a caller needs; webhook dispatch and repo connect should pull tokens through it.
- `Cargo.lock` updates are catch-up entries from the prior `rb-github` scaffold landing — please review and squash if preferred.