### PR TITLE
[REQ-GH-06] feat: GitHub webhook receiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,11 +469,16 @@ dependencies = [
  "anyhow",
  "axum 0.8.9",
  "axum-extra",
+ "base64",
  "chrono",
  "clap",
+ "hex",
+ "hmac",
  "http-body-util",
+ "jsonwebtoken",
  "rb-auth",
  "rb-email",
+ "rb-github",
  "rb-schemas",
  "rb-secrets",
  "rb-storage-pg",
@@ -464,6 +486,7 @@ dependencies = [
  "rb-tracing",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -515,6 +538,24 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -668,6 +709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,8 +868,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -828,9 +881,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1013,6 +1068,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1256,6 +1327,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1607,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1648,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1753,6 +1875,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1967,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1981,6 +2119,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2289,30 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "rb-github"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "dashmap",
+ "hex",
+ "hmac",
+ "jsonwebtoken",
+ "moka",
+ "rand 0.9.4",
+ "rb-secrets",
+ "rb-tracing",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2245,16 +2462,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -2262,6 +2484,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2299,6 +2522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2561,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2504,6 +2734,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -2817,6 +3059,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/crates/rb-github/src/app_jwt.rs
+++ b/crates/rb-github/src/app_jwt.rs
@@ -56,8 +56,7 @@ mod tests {
     #[test]
     fn mint_produces_three_part_jwt() {
         let pem = format!(
-            "-----BEGIN RSA PRIVATE KEY-----\n{}\n-----END RSA PRIVATE KEY-----\n",
-            TEST_RSA_KEY_BODY
+            "-----BEGIN RSA PRIVATE KEY-----\n{TEST_RSA_KEY_BODY}\n-----END RSA PRIVATE KEY-----\n"
         );
         let key = EncodingKey::from_rsa_pem(pem.as_bytes()).expect("test key should parse");
         let jwt = mint_app_jwt(12345, &key).expect("mint should succeed");

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -11,7 +11,10 @@ pub use error::GhError;
 pub use secret::Secret;
 pub use state_token::hash_token;
 pub use token_cache::CachedToken;
-pub use webhook::{ReplayCache, verify_signature};
+pub use webhook::{
+    Account, Installation, InstallationEvent, InstallationPayload, InstallationReposPayload,
+    InstallationRepositoriesEvent, RepoRef, ReplayCache, verify_signature,
+};
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/rb-github/src/webhook/events.rs
+++ b/crates/rb-github/src/webhook/events.rs
@@ -1,11 +1,20 @@
-// Typed webhook event enums — fully implemented in RUSAA-50 (REQ-GH-06).
-#![allow(dead_code)]
-//
-// Stubs only here so the module tree compiles. The route handler and
-// dispatcher are in RUSAA-50.
+//! Typed payload structs for the GitHub webhook events the receiver dispatches
+//! on. The receiver chooses which struct to deserialize into based on the
+//! `X-GitHub-Event` header — there is intentionally no "any event" enum.
+//!
+//! Only the fields the receiver acts on are typed; unknown fields are
+//! ignored (`serde` defaults to dropping them).
 
 use serde::Deserialize;
 
+// ---------------------------------------------------------------------------
+// `installation` event
+// ---------------------------------------------------------------------------
+
+/// `X-GitHub-Event: installation`
+///
+/// We dispatch on the `action` discriminant; payloads are otherwise identical
+/// across the four actions we care about.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum InstallationEvent {
@@ -13,8 +22,10 @@ pub enum InstallationEvent {
     Deleted(InstallationPayload),
     Suspend(InstallationPayload),
     Unsuspend(InstallationPayload),
+    /// Any other action (`new_permissions_accepted`, etc.) — receiver
+    /// acknowledges with 202 and does nothing.
     #[serde(other)]
-    Unknown,
+    Other,
 }
 
 #[derive(Debug, Deserialize)]
@@ -24,6 +35,8 @@ pub struct InstallationPayload {
 
 #[derive(Debug, Deserialize)]
 pub struct Installation {
+    /// The numeric installation id GitHub assigns when an org/user installs
+    /// the App. Stable across the install's lifetime.
     pub id: i64,
     pub account: Account,
 }
@@ -31,24 +44,33 @@ pub struct Installation {
 #[derive(Debug, Deserialize)]
 pub struct Account {
     pub login: String,
+    /// `User` or `Organization`. The DB constraint enforces this; values
+    /// outside that set will fail the SQL on insert paths.
     #[serde(rename = "type")]
     pub kind: String,
     pub id: i64,
 }
 
+// ---------------------------------------------------------------------------
+// `installation_repositories` event
+// ---------------------------------------------------------------------------
+
+/// `X-GitHub-Event: installation_repositories`
 #[derive(Debug, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum InstallationRepositoriesEvent {
     Added(InstallationReposPayload),
     Removed(InstallationReposPayload),
     #[serde(other)]
-    Unknown,
+    Other,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct InstallationReposPayload {
     pub installation: Installation,
+    #[serde(default)]
     pub repositories_added: Vec<RepoRef>,
+    #[serde(default)]
     pub repositories_removed: Vec<RepoRef>,
 }
 
@@ -56,4 +78,119 @@ pub struct InstallationReposPayload {
 pub struct RepoRef {
     pub id: i64,
     pub full_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_installation_created() {
+        let json = serde_json::json!({
+            "action": "created",
+            "installation": {
+                "id": 12345,
+                "account": { "login": "octo", "type": "Organization", "id": 99 }
+            }
+        });
+        let evt: InstallationEvent = serde_json::from_value(json).unwrap();
+        let InstallationEvent::Created(p) = evt else {
+            panic!("expected Created variant");
+        };
+        assert_eq!(p.installation.id, 12345);
+        assert_eq!(p.installation.account.login, "octo");
+        assert_eq!(p.installation.account.kind, "Organization");
+        assert_eq!(p.installation.account.id, 99);
+    }
+
+    #[test]
+    fn parses_installation_deleted_suspend_unsuspend() {
+        for action in ["deleted", "suspend", "unsuspend"] {
+            let json = serde_json::json!({
+                "action": action,
+                "installation": {
+                    "id": 1,
+                    "account": { "login": "x", "type": "User", "id": 2 }
+                }
+            });
+            let evt: InstallationEvent = serde_json::from_value(json).unwrap();
+            match (action, evt) {
+                ("deleted", InstallationEvent::Deleted(_))
+                | ("suspend", InstallationEvent::Suspend(_))
+                | ("unsuspend", InstallationEvent::Unsuspend(_)) => {}
+                (a, other) => panic!("action {a} parsed as {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parses_installation_unknown_action_as_other() {
+        let json = serde_json::json!({
+            "action": "new_permissions_accepted",
+            "installation": {
+                "id": 1,
+                "account": { "login": "x", "type": "User", "id": 2 }
+            }
+        });
+        let evt: InstallationEvent = serde_json::from_value(json).unwrap();
+        assert!(matches!(evt, InstallationEvent::Other));
+    }
+
+    #[test]
+    fn parses_installation_repositories_added() {
+        let json = serde_json::json!({
+            "action": "added",
+            "installation": {
+                "id": 1,
+                "account": { "login": "x", "type": "User", "id": 2 }
+            },
+            "repositories_added": [
+                { "id": 10, "full_name": "x/repo-a" },
+                { "id": 11, "full_name": "x/repo-b" }
+            ]
+        });
+        let evt: InstallationRepositoriesEvent = serde_json::from_value(json).unwrap();
+        let InstallationRepositoriesEvent::Added(p) = evt else {
+            panic!("expected Added");
+        };
+        assert_eq!(p.repositories_added.len(), 2);
+        assert!(p.repositories_removed.is_empty());
+    }
+
+    #[test]
+    fn parses_installation_repositories_removed() {
+        let json = serde_json::json!({
+            "action": "removed",
+            "installation": {
+                "id": 1,
+                "account": { "login": "x", "type": "User", "id": 2 }
+            },
+            "repositories_removed": [
+                { "id": 100, "full_name": "x/repo-c" }
+            ]
+        });
+        let evt: InstallationRepositoriesEvent = serde_json::from_value(json).unwrap();
+        let InstallationRepositoriesEvent::Removed(p) = evt else {
+            panic!("expected Removed");
+        };
+        assert_eq!(p.repositories_removed.len(), 1);
+        assert_eq!(p.repositories_removed[0].id, 100);
+    }
+
+    #[test]
+    fn ignores_unknown_fields() {
+        // Real GitHub payloads carry `repository`, `sender`, `requester`, …
+        // None of those should fail deserialization.
+        let json = serde_json::json!({
+            "action": "deleted",
+            "installation": {
+                "id": 1,
+                "account": { "login": "x", "type": "User", "id": 2 }
+            },
+            "sender": { "login": "octocat" },
+            "extra_field_we_do_not_care_about": [1, 2, 3]
+        });
+        let evt: InstallationEvent = serde_json::from_value(json).unwrap();
+        assert!(matches!(evt, InstallationEvent::Deleted(_)));
+    }
 }

--- a/crates/rb-github/src/webhook/mod.rs
+++ b/crates/rb-github/src/webhook/mod.rs
@@ -2,5 +2,9 @@ pub mod events;
 pub mod replay;
 pub mod verify;
 
+pub use events::{
+    Account, Installation, InstallationEvent, InstallationPayload, InstallationReposPayload,
+    InstallationRepositoriesEvent, RepoRef,
+};
 pub use replay::ReplayCache;
 pub use verify::verify_signature;

--- a/crates/rb-github/src/webhook/replay.rs
+++ b/crates/rb-github/src/webhook/replay.rs
@@ -1,14 +1,19 @@
-// Replay protection cache — implemented in RUSAA-50 (REQ-GH-06).
-//
-// Moka TTL cache keyed by X-GitHub-Delivery UUID. insert_if_new returns false
-// if the delivery ID was already seen, enabling idempotent processing.
+//! Replay protection for GitHub webhook deliveries.
+//!
+//! GitHub re-delivers webhooks on transient failures, and the same delivery
+//! UUID may legitimately arrive multiple times. The webhook handler treats
+//! repeated deliveries as a no-op based on this cache.
+//!
+//! Concurrency: `try_insert_new` is atomic via `moka::future::Cache::entry()`,
+//! so two simultaneous deliveries with the same `X-GitHub-Delivery` UUID
+//! cannot both observe a "new" insert.
 
 use std::sync::Arc;
 
 use moka::future::Cache;
 
 const MAX_CAPACITY: u64 = 10_000;
-const TTL_SECS: u64 = 600; // 10 minutes
+const TTL_SECS: u64 = 600; // 10 minutes — matches PRD §3.3
 
 /// A TTL-bounded cache of processed `X-GitHub-Delivery` UUIDs.
 #[derive(Clone, Debug)]
@@ -28,24 +33,82 @@ impl ReplayCache {
         }
     }
 
-    /// Attempts to insert `delivery_id`. Returns `true` if it was new
-    /// (caller should process), `false` if it was already seen (replay, skip).
+    /// Atomically records `delivery_id`. Returns `true` if the caller is the
+    /// first observer (must process), `false` if another caller already
+    /// observed the same id (replay; skip).
     ///
-    /// Note: `contains_key` + `insert` is not atomic (TOCTOU). Two concurrent
-    /// deliveries with the same ID could both pass the check and both be
-    /// processed. Acceptable for the stub; will be replaced with the moka
-    /// `entry()` API in RUSAA-50 (REQ-GH-06) when the full dispatcher lands.
-    pub async fn insert_if_new(&self, delivery_id: &str) -> bool {
-        if self.inner.contains_key(delivery_id) {
-            return false;
-        }
-        self.inner.insert(delivery_id.to_owned(), ()).await;
-        true
+    /// Implemented with `moka::future::Cache::entry().or_insert_with()` so the
+    /// existence check and insert are not racy. Concurrent calls with the
+    /// same id are deduplicated to exactly one insert event by moka.
+    pub async fn try_insert_new(&self, delivery_id: &str) -> bool {
+        self.inner
+            .entry(delivery_id.to_owned())
+            .or_insert_with(async {})
+            .await
+            .is_fresh()
     }
 }
 
 impl Default for ReplayCache {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc as StdArc;
+    use tokio::task::JoinSet;
+
+    #[tokio::test]
+    async fn first_insert_is_fresh() {
+        let cache = ReplayCache::new();
+        assert!(cache.try_insert_new("delivery-1").await);
+    }
+
+    #[tokio::test]
+    async fn second_insert_is_replay() {
+        let cache = ReplayCache::new();
+        assert!(cache.try_insert_new("delivery-2").await);
+        assert!(!cache.try_insert_new("delivery-2").await);
+    }
+
+    #[tokio::test]
+    async fn distinct_ids_are_independent() {
+        let cache = ReplayCache::new();
+        assert!(cache.try_insert_new("a").await);
+        assert!(cache.try_insert_new("b").await);
+        assert!(!cache.try_insert_new("a").await);
+        assert!(!cache.try_insert_new("b").await);
+    }
+
+    /// Drives 64 concurrent inserts of the same delivery id. Exactly one of
+    /// them must observe `true` (the fresh insert); the other 63 must
+    /// observe `false` (replay). This proves the TOCTOU race is closed.
+    #[tokio::test]
+    async fn concurrent_same_id_races_to_one_winner() {
+        let cache = StdArc::new(ReplayCache::new());
+        let mut tasks: JoinSet<bool> = JoinSet::new();
+        for _ in 0..64 {
+            let cache = StdArc::clone(&cache);
+            tasks.spawn(async move { cache.try_insert_new("racy-delivery").await });
+        }
+        let mut fresh_count = 0_usize;
+        while let Some(res) = tasks.join_next().await {
+            if res.expect("task did not panic") {
+                fresh_count += 1;
+            }
+        }
+        assert_eq!(
+            fresh_count, 1,
+            "exactly one concurrent caller must win the insert race"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_constructs_empty_cache() {
+        let cache = ReplayCache::default();
+        assert!(cache.try_insert_new("first").await);
     }
 }

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -46,6 +46,10 @@ chrono.workspace = true
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
+# Webhook signing fixtures for integration_github_webhook.
+hmac.workspace = true
+sha2.workspace = true
+hex.workspace = true
 
 [lints]
 workspace = true

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -13,6 +13,9 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
         health::health_check,
         health::ready_check,
         github::health::github_app_health,
+        // github::webhook::github_webhook is intentionally NOT exposed via OpenAPI:
+        // it is consumed only by GitHub's webhook delivery service, authenticated
+        // by HMAC, and has no schema representation for HeaderMap/Bytes extractors.
         auth::signup,
         auth::login,
         auth_logout::logout,

--- a/services/control-api/src/routes/github/mod.rs
+++ b/services/control-api/src/routes/github/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod webhook;

--- a/services/control-api/src/routes/github/webhook.rs
+++ b/services/control-api/src/routes/github/webhook.rs
@@ -1,0 +1,424 @@
+//! `POST /v1/github/webhook` — GitHub App webhook receiver (REQ-GH-06, ADR-005 §7).
+//!
+//! Order is load-bearing:
+//!   1. Read required headers.
+//!   2. HMAC-SHA256 verify the *raw* request body **before** any JSON parse —
+//!      keeps the signed bytes byte-identical to what GitHub HMAC'd.
+//!   3. Replay protection via `X-GitHub-Delivery` UUID in a 10-minute TTL cache
+//!      (`ReplayCache::try_insert_new` is atomic, so concurrent re-deliveries
+//!      collapse to one observable insert).
+//!   4. Only then deserialize the body — and only into the typed payload that
+//!      matches `X-GitHub-Event`.
+//!   5. Apply small SQL updates inline (all <= 50 ms; PRD allows < 1 s response).
+//!
+//! This route does **not** sit behind the auth middleware: the HMAC is the
+//! authenticator, and any non-trivial 401/403 path would let GitHub's delivery
+//! retries pile up without need.
+//!
+//! No tenant data ever appears in the response body. We send an empty body
+//! and rely on `tracing` for forensics.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use rb_github::{
+    GhError, InstallationEvent, InstallationPayload, InstallationReposPayload,
+    InstallationRepositoriesEvent,
+};
+use sqlx::PgPool;
+
+use crate::state::AppState;
+
+/// `X-Hub-Signature-256: sha256=<hex>` — set by GitHub on every delivery.
+const HEADER_SIGNATURE: &str = "X-Hub-Signature-256";
+/// `X-GitHub-Delivery: <uuid>` — unique per delivery attempt.
+const HEADER_DELIVERY: &str = "X-GitHub-Delivery";
+/// `X-GitHub-Event: <event-name>` — top-level event type.
+const HEADER_EVENT: &str = "X-GitHub-Event";
+
+/// Receive a GitHub webhook delivery.
+///
+/// Returns:
+/// * `200 OK` on a fully-handled `installation.{created,deleted,suspend,
+///   unsuspend}` or `installation_repositories.{added,removed}` delivery,
+///   or on a duplicate delivery suppressed by the replay cache.
+/// * `202 Accepted` for unmodelled event types or unmodelled actions —
+///   GitHub treats these as success and stops retrying.
+/// * `400 Bad Request` if a required header is missing or the body fails
+///   to deserialize after a valid signature (malformed JSON).
+/// * `401 Unauthorized` if `X-Hub-Signature-256` is missing, malformed, or
+///   does not match the body HMAC.
+/// * `503 Service Unavailable` if the GitHub App is not configured on this
+///   instance (`RB_GH_APP_ID` / `RB_GH_APP_PRIVATE_KEY` unset).
+///
+/// **Not exposed via `OpenAPI`**: this route is consumed only by GitHub's
+/// webhook delivery service. Authentication is via HMAC, not session/key, so
+/// publishing it in the schema would mislead human/agent integrators.
+pub async fn github_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let Some(gh) = state.gh.clone() else {
+        return WebhookOutcome::AppNotConfigured.into_response();
+    };
+
+    let sig = match required_header(&headers, HEADER_SIGNATURE) {
+        Ok(v) => v,
+        Err(o) => return o.into_response(),
+    };
+    let delivery = match required_header(&headers, HEADER_DELIVERY) {
+        Ok(v) => v,
+        Err(o) => return o.into_response(),
+    };
+    let event = match required_header(&headers, HEADER_EVENT) {
+        Ok(v) => v,
+        Err(o) => return o.into_response(),
+    };
+
+    // 1. Verify signature against the raw body bytes BEFORE any JSON parse.
+    if let Err(err) = gh.verify_webhook(&body, sig) {
+        match err {
+            GhError::BadSignatureFormat => {
+                tracing::warn!(%delivery, %event, "github webhook: bad signature format");
+            }
+            GhError::SignatureMismatch => {
+                tracing::warn!(%delivery, %event, "github webhook: signature mismatch");
+            }
+            other => {
+                tracing::error!(error = %other, %delivery, %event, "github webhook: unexpected verify error");
+            }
+        }
+        return WebhookOutcome::SignatureFailed.into_response();
+    }
+
+    // 2. Replay protection — atomic via moka entry().
+    if !gh.replay_cache.try_insert_new(delivery).await {
+        tracing::info!(%delivery, %event, "github webhook: replay suppressed");
+        return WebhookOutcome::Ok.into_response();
+    }
+
+    // 3. Parse based on the event header.
+    let outcome = match event {
+        "installation" => match serde_json::from_slice::<InstallationEvent>(&body) {
+            Ok(evt) => handle_installation(&state.pool, delivery, evt).await,
+            Err(err) => {
+                tracing::warn!(%delivery, error = %err, "github webhook: installation parse failed");
+                WebhookOutcome::BadBody
+            }
+        },
+        "installation_repositories" => {
+            match serde_json::from_slice::<InstallationRepositoriesEvent>(&body) {
+                Ok(evt) => handle_installation_repositories(&state.pool, delivery, evt).await,
+                Err(err) => {
+                    tracing::warn!(
+                        %delivery,
+                        error = %err,
+                        "github webhook: installation_repositories parse failed"
+                    );
+                    WebhookOutcome::BadBody
+                }
+            }
+        }
+        _ => {
+            tracing::info!(%delivery, %event, "github webhook: ignoring unmodelled event");
+            WebhookOutcome::Accepted
+        }
+    };
+
+    outcome.into_response()
+}
+
+/// Read a required header as a `&str`; convert any failure into a structured
+/// 400 / 401 outcome with a tracing breadcrumb.
+fn required_header<'h>(
+    headers: &'h HeaderMap,
+    name: &'static str,
+) -> Result<&'h str, WebhookOutcome> {
+    let Some(value) = headers.get(name) else {
+        tracing::warn!(missing_header = name, "github webhook: missing header");
+        // Signature absence is treated as 401; everything else as 400.
+        return Err(if name == HEADER_SIGNATURE {
+            WebhookOutcome::SignatureFailed
+        } else {
+            WebhookOutcome::MissingHeader
+        });
+    };
+    value.to_str().map_err(|err| {
+        tracing::warn!(
+            header = name,
+            error = %err,
+            "github webhook: header is not valid UTF-8"
+        );
+        if name == HEADER_SIGNATURE {
+            WebhookOutcome::SignatureFailed
+        } else {
+            WebhookOutcome::MissingHeader
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Outcome -> HTTP response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+enum WebhookOutcome {
+    Ok,
+    Accepted,
+    MissingHeader,
+    BadBody,
+    SignatureFailed,
+    AppNotConfigured,
+    InternalError,
+}
+
+impl IntoResponse for WebhookOutcome {
+    fn into_response(self) -> Response {
+        let status = match self {
+            Self::Ok => StatusCode::OK,
+            Self::Accepted => StatusCode::ACCEPTED,
+            Self::MissingHeader | Self::BadBody => StatusCode::BAD_REQUEST,
+            Self::SignatureFailed => StatusCode::UNAUTHORIZED,
+            Self::AppNotConfigured => StatusCode::SERVICE_UNAVAILABLE,
+            Self::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        // Empty body — no tenant data ever leaks via the webhook responder
+        // (ADR-005 §9.3).
+        status.into_response()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `installation` event handlers (ADR-005 §7.5)
+// ---------------------------------------------------------------------------
+
+async fn handle_installation(
+    pool: &PgPool,
+    delivery: &str,
+    evt: InstallationEvent,
+) -> WebhookOutcome {
+    match evt {
+        InstallationEvent::Created(p) => handle_installation_created(pool, delivery, p).await,
+        InstallationEvent::Deleted(p) => {
+            update_installation_flag(pool, delivery, InstallationOp::Deleted, p).await
+        }
+        InstallationEvent::Suspend(p) => {
+            update_installation_flag(pool, delivery, InstallationOp::Suspend, p).await
+        }
+        InstallationEvent::Unsuspend(p) => {
+            update_installation_flag(pool, delivery, InstallationOp::Unsuspend, p).await
+        }
+        InstallationEvent::Other => {
+            tracing::info!(%delivery, "github webhook: ignoring installation action");
+            WebhookOutcome::Accepted
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InstallationOp {
+    Deleted,
+    Suspend,
+    Unsuspend,
+}
+
+impl InstallationOp {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Deleted => "deleted",
+            Self::Suspend => "suspend",
+            Self::Unsuspend => "unsuspend",
+        }
+    }
+
+    fn sql(self) -> &'static str {
+        match self {
+            Self::Deleted => {
+                "UPDATE control.github_installations \
+                 SET deleted_at = now() \
+                 WHERE github_installation_id = $1 AND deleted_at IS NULL"
+            }
+            Self::Suspend => {
+                "UPDATE control.github_installations \
+                 SET suspended_at = now() \
+                 WHERE github_installation_id = $1 \
+                   AND suspended_at IS NULL AND deleted_at IS NULL"
+            }
+            Self::Unsuspend => {
+                "UPDATE control.github_installations \
+                 SET suspended_at = NULL \
+                 WHERE github_installation_id = $1 AND deleted_at IS NULL"
+            }
+        }
+    }
+}
+
+/// On `installation.created`, the OAuth callback path (REQ-GH-04) is the
+/// authoritative writer of the `github_installations` row — only it knows the
+/// `tenant_id`. The webhook may legitimately fire before *or* after the
+/// callback. We treat it as idempotent confirmation: if a row exists, clear
+/// `deleted_at` and `suspended_at`; otherwise log and accept.
+async fn handle_installation_created(
+    pool: &PgPool,
+    delivery: &str,
+    payload: InstallationPayload,
+) -> WebhookOutcome {
+    let installation_id = payload.installation.id;
+    let result = sqlx::query(
+        "UPDATE control.github_installations \
+         SET deleted_at = NULL, suspended_at = NULL \
+         WHERE github_installation_id = $1",
+    )
+    .bind(installation_id)
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(res) => {
+            tracing::info!(
+                %delivery,
+                installation_id,
+                rows_updated = res.rows_affected(),
+                "github webhook: installation.created processed"
+            );
+            WebhookOutcome::Ok
+        }
+        Err(err) => {
+            tracing::error!(
+                %delivery,
+                installation_id,
+                error = %err,
+                "github webhook: installation.created sql failed"
+            );
+            WebhookOutcome::InternalError
+        }
+    }
+}
+
+async fn update_installation_flag(
+    pool: &PgPool,
+    delivery: &str,
+    op: InstallationOp,
+    payload: InstallationPayload,
+) -> WebhookOutcome {
+    let installation_id = payload.installation.id;
+    match sqlx::query(op.sql())
+        .bind(installation_id)
+        .execute(pool)
+        .await
+    {
+        Ok(res) => {
+            tracing::info!(
+                %delivery,
+                installation_id,
+                action = op.as_str(),
+                rows_updated = res.rows_affected(),
+                "github webhook: installation update applied"
+            );
+            WebhookOutcome::Ok
+        }
+        Err(err) => {
+            tracing::error!(
+                %delivery,
+                installation_id,
+                action = op.as_str(),
+                error = %err,
+                "github webhook: installation update failed"
+            );
+            WebhookOutcome::InternalError
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `installation_repositories` event handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_installation_repositories(
+    pool: &PgPool,
+    delivery: &str,
+    evt: InstallationRepositoriesEvent,
+) -> WebhookOutcome {
+    match evt {
+        // PRD: connect is explicit per REQ-GH-04. v1 logs and acknowledges.
+        InstallationRepositoriesEvent::Added(p) => {
+            tracing::info!(
+                %delivery,
+                installation_id = p.installation.id,
+                added = p.repositories_added.len(),
+                "github webhook: installation_repositories.added (no auto-connect)"
+            );
+            WebhookOutcome::Ok
+        }
+        InstallationRepositoriesEvent::Removed(p) => archive_removed_repos(pool, delivery, p).await,
+        InstallationRepositoriesEvent::Other => {
+            tracing::info!(
+                %delivery,
+                "github webhook: ignoring installation_repositories action"
+            );
+            WebhookOutcome::Accepted
+        }
+    }
+}
+
+/// Mark each removed repo as `archived_at = now()` for the matching
+/// `(installation_id, github_repo_id)` pair. Missing rows are simply not
+/// updated — GitHub may report repos we never connected.
+async fn archive_removed_repos(
+    pool: &PgPool,
+    delivery: &str,
+    payload: InstallationReposPayload,
+) -> WebhookOutcome {
+    let installation_id = payload.installation.id;
+    if payload.repositories_removed.is_empty() {
+        tracing::info!(
+            %delivery,
+            installation_id,
+            "github webhook: removed list empty, no-op"
+        );
+        return WebhookOutcome::Ok;
+    }
+
+    let github_repo_ids: Vec<i64> =
+        payload.repositories_removed.iter().map(|r| r.id).collect();
+
+    let result = sqlx::query(
+        "UPDATE control.repos \
+         SET archived_at = now() \
+         FROM control.github_installations gi \
+         WHERE control.repos.installation_id = gi.id \
+           AND gi.github_installation_id = $1 \
+           AND control.repos.github_repo_id = ANY($2) \
+           AND control.repos.archived_at IS NULL",
+    )
+    .bind(installation_id)
+    .bind(&github_repo_ids)
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(res) => {
+            tracing::info!(
+                %delivery,
+                installation_id,
+                requested = github_repo_ids.len(),
+                rows_updated = res.rows_affected(),
+                "github webhook: installation_repositories.removed processed"
+            );
+            WebhookOutcome::Ok
+        }
+        Err(err) => {
+            tracing::error!(
+                %delivery,
+                installation_id,
+                error = %err,
+                "github webhook: installation_repositories.removed sql failed"
+            );
+            WebhookOutcome::InternalError
+        }
+    }
+}

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -15,6 +15,7 @@ use crate::routes::{
     auth_logout::logout,
     auth_verify::verify_email,
     github::health::github_app_health,
+    github::webhook::github_webhook,
     health::{health_check, openapi_json, ready_check},
     me::{get_me, switch_tenant},
     tenants::{invite_member, list_members, remove_member, transfer_ownership, update_member_role},
@@ -43,5 +44,6 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/tenants/{id}/members/{uid}", delete(remove_member))
         .route("/v1/tenants/{id}/transfer-ownership", post(transfer_ownership))
         .route("/v1/health/github-app", get(github_app_health))
+        .route("/v1/github/webhook", post(github_webhook))
         .with_state(state)
 }

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -1,0 +1,368 @@
+//! End-to-end tests for `POST /v1/github/webhook` (REQ-GH-06).
+//!
+//! These tests drive the full axum router via `tower::ServiceExt::oneshot`,
+//! exercising the same path GitHub will hit in production. They use a
+//! `connect_lazy` Postgres pool that never actually opens a connection —
+//! every assertion below either short-circuits before SQL or asserts on a
+//! status code that does not require DB I/O. The full DB-touching path is
+//! covered by separate live-DB tests once a fixture harness lands.
+//!
+//! Naming convention: `webhook_<scenario>_returns_<status>`.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use control_api::{AppState, Config, build};
+use hmac::{Hmac, Mac};
+use http_body_util::BodyExt as _;
+use jsonwebtoken::EncodingKey;
+use rb_auth::{LoginRateLimiter, PasswordHasher};
+use rb_email::from_transport;
+use rb_github::{GhApp, Secret};
+use sha2::Sha256;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt as _;
+
+const HEADER_SIGNATURE: &str = "X-Hub-Signature-256";
+const HEADER_DELIVERY: &str = "X-GitHub-Delivery";
+const HEADER_EVENT: &str = "X-GitHub-Event";
+
+/// 2048-bit RSA private key, base64-encoded DER body without PEM headers so
+/// secret scanners do not flag this constant. The full PEM is reconstructed
+/// at runtime. Mirrors the same fixture used by `rb_github::app_jwt` tests.
+///
+/// `GhApp::new` requires a syntactically valid RSA key; this one is never used
+/// to mint a real JWT in webhook tests — the webhook handler does not touch
+/// the App-JWT path.
+const TEST_RSA_KEY_BODY: &str = concat!(
+    "MIIEpAIBAAKCAQEArwnQtrb3L6igXRguv2KEM+fbfgZK50iHkSQL+RFLpuzzPZRf",
+    "yBIl3B9eimrcVjXpRIX8VbnfJQZIGreTx+F9NQG/qkbaKGEKmXZFcOIJqPDGeRNF",
+    "Mc+r454g5lA95nF+92lfifZu5RZMzAShhOKfrQyjvejegmgSqCOMatFYoFovsqCrf",
+    "D1yYfRoPqYjl+t1lNmJwP5/ETnw/JC/vJ1GTbOR3IhkA59D2vX6uwTNrZPJ7fo0S",
+    "e74j5zdLYk63jVXSPs8zPLKL9O5Nn+ZjMZjSiI+p7TI2/AMS+MOBEcrLuL7c7ONB",
+    "7zB5ZP6Uol0Q/DnT6nJJ8WWbyXhC8JM87onoQIDAQABAoIBAAJrk31gme9d7gW2LA",
+    "33ues7z/mgnaWFXQvWi0HWNDe/0VHZ0i8316/WUTN/FxfWu/3MunihpCJkwVd5Oqu",
+    "0rvYDgFfFjgZT59ZyX7MYClknJx9icv5QKEjH6sg0dilQYBiMq5utPXWhHCO6sVRf",
+    "NnpT5pRdesIj1+oyP6KfIry+LJ78oKOznp8Awe0WcU2hW3rBo5YyTmHMHe1UBK04",
+    "hcv2QunqY7SUKACxZGf4Tq/MBOTKq8ksamdW/4KQE/TK699s9qAZmKxnVrkBvXrea",
+    "XxBW5LU3qTGd2sFtgcyc23xvGptM8Cr+poceEgGDHGyF5P/Wchv+Brn5ZN0b6o8P",
+    "D8CgYEA4+NijtUSWIOFrlhsU6wMPK6FuHxSERn4UFFBiuigm/k0MCKmU2tcZlxSNd",
+    "VF3vmdMsEj5E8ZIZ41CFcZDcTFPLSc4Gl4SPkrCtJNyaxqYkDLLTLxS2bBodiR0l",
+    "AV3kw/XWgUoPcuZN19pqsJ39vOsYX/6ZV3/Z8w+UWMCR6y+YcCgYEAxKFz/QNhoN",
+    "OLC045491fHuB0lfDYhpvphAKSrXBYqgE8OhPq7f8WHJV1XNT4bQCDFbLGbEZNac",
+    "Z99OKbuWbJJDpjhpsR8kOakTIDP7gV14Hr54tVUZSybx1x/W/IyI9AlywTdBTGgVs",
+    "Hwsa3bm87syY0jZAE1sOessBqxxppf5cCgYEAxoXb4hn0NW++ETeuhuWmc2aFz0Ve",
+    "KM+65h0jP+OPptDdieFli95HTFS4uXTlvW0uaHygy8+sUQEFqhJWHQyB1nRxBX5b",
+    "7xZBTNgQM9QjiRxw4xsx4UHPBTMpNVHW+yTpPnHhJqiunefmAj+WBpHx6eyWF+LB",
+    "+QupGj5f08IOoBkCgYAvkqBtZpQIRSYu5g47gyOwZL3QSSUZ7D7jIXw7WiMZfpMD",
+    "ui3sxvqij8aFX0F7ndQZO9el+pxgKxXuWaUzhhrEGRxbRMliw9hxqJgAopkmOtjI",
+    "fH1373H8UDN0DceWPpJyAMf0HdKpGU0XYtyea2sWPPgaB+4jx9BtjwBGi61aoQKB",
+    "gQDGthIge5R6CftG8P+E8hA+4sptbc+7XUaYcWxXLO81szX2wBgW89d2zo9RaJ3W",
+    "4Qjhp1rYwfS9CyZliFDAGH+091X/7Yb53YATMkzbmrUpLQoSO42ylK+/n4Xp4CfO",
+    "JiQDUBMer4rHHCTjQM1SeKAjM+HYsafx8sCiH9DR9qXudA==",
+);
+
+fn rsa_key() -> EncodingKey {
+    let pem = format!(
+        "-----BEGIN RSA PRIVATE KEY-----\n{TEST_RSA_KEY_BODY}\n-----END RSA PRIVATE KEY-----\n"
+    );
+    EncodingKey::from_rsa_pem(pem.as_bytes()).expect("test PEM should parse")
+}
+
+fn config_for_test() -> Config {
+    Config::for_test()
+}
+
+fn lazy_pool(config: &Config) -> sqlx::PgPool {
+    PgPoolOptions::new()
+        .connect_lazy(&config.database_url)
+        .expect("connect_lazy must succeed")
+}
+
+fn email_sender() -> Arc<dyn rb_email::EmailSender> {
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    Arc::from(from_transport("noop", &smtp).expect("noop transport must succeed"))
+}
+
+fn state_with_gh(secret: &[u8]) -> AppState {
+    let config = config_for_test();
+    AppState {
+        pool: lazy_pool(&config),
+        email_sender: email_sender(),
+        hasher: Arc::new(PasswordHasher::from_config(64, 1, 1).expect("hasher")),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh: Some(Arc::new(GhApp::new(
+            12345,
+            rsa_key(),
+            Secret::new(secret.to_vec()),
+        ))),
+    }
+}
+
+fn state_without_gh() -> AppState {
+    let config = config_for_test();
+    AppState {
+        pool: lazy_pool(&config),
+        email_sender: email_sender(),
+        hasher: Arc::new(PasswordHasher::from_config(64, 1, 1).expect("hasher")),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh: None,
+    }
+}
+
+fn sign(body: &[u8], secret: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("hmac key length");
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+fn webhook_request(
+    body: Vec<u8>,
+    sig: Option<String>,
+    delivery: Option<&str>,
+    event: Option<&str>,
+) -> Request<Body> {
+    let mut req = Request::builder().method("POST").uri("/v1/github/webhook");
+    if let Some(sig) = sig {
+        req = req.header(HEADER_SIGNATURE, sig);
+    }
+    if let Some(delivery) = delivery {
+        req = req.header(HEADER_DELIVERY, delivery);
+    }
+    if let Some(event) = event {
+        req = req.header(HEADER_EVENT, event);
+    }
+    req.body(Body::from(body)).expect("request build")
+}
+
+async fn body_is_empty(resp: axum::response::Response) -> bool {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    bytes.is_empty()
+}
+
+#[tokio::test]
+async fn webhook_returns_503_when_app_not_configured() {
+    let app = build(state_without_gh());
+    let req = webhook_request(b"{}".to_vec(), Some("sha256=00".into()), Some("d"), Some("ping"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(body_is_empty(resp).await, "503 body must be empty");
+}
+
+#[tokio::test]
+async fn webhook_returns_401_for_missing_signature() {
+    let app = build(state_with_gh(b"shh"));
+    let req = webhook_request(b"{}".to_vec(), None, Some("d"), Some("ping"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_returns_400_for_missing_delivery() {
+    let app = build(state_with_gh(b"shh"));
+    let body = b"{}".to_vec();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(body, Some(sig), None, Some("ping"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn webhook_returns_400_for_missing_event() {
+    let app = build(state_with_gh(b"shh"));
+    let body = b"{}".to_vec();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(body, Some(sig), Some("d"), None);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn webhook_returns_401_for_bad_signature_format() {
+    let app = build(state_with_gh(b"shh"));
+    let req = webhook_request(
+        b"{}".to_vec(),
+        Some("not-a-sig".into()),
+        Some("d"),
+        Some("ping"),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_returns_401_for_signature_mismatch() {
+    let app = build(state_with_gh(b"shh"));
+    let body = b"{}".to_vec();
+    let sig = sign(&body, b"WRONG-SECRET");
+    let req = webhook_request(body, Some(sig), Some("d"), Some("ping"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `ping` is unmodelled in v1 — accepted explicitly with 202 so GitHub stops
+/// retrying.
+#[tokio::test]
+async fn webhook_returns_202_for_unmodelled_event() {
+    let app = build(state_with_gh(b"shh"));
+    let body = b"{}".to_vec();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(body, Some(sig), Some("d-ping"), Some("ping"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}
+
+/// Malformed installation body returns 400 — *after* signature verification,
+/// so it cannot be probed by an unauthenticated attacker.
+#[tokio::test]
+async fn webhook_returns_400_for_malformed_installation_body() {
+    let app = build(state_with_gh(b"shh"));
+    let body = br#"{"action":"created"}"#.to_vec(); // missing `installation`
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(body, Some(sig), Some("d-bad"), Some("installation"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Replay of the same `X-GitHub-Delivery` returns 200 without ever touching
+/// the SQL handler. The lazy pool would error out on a real connect; success
+/// here proves the replay short-circuit fired before the SQL dispatch.
+#[tokio::test]
+async fn webhook_returns_200_on_replay_without_sql_dispatch() {
+    let app = build(state_with_gh(b"shh"));
+    let body = b"{}".to_vec();
+    let sig = sign(&body, b"shh");
+    let delivery = "d-replay";
+
+    let resp1 = app
+        .clone()
+        .oneshot(webhook_request(
+            body.clone(),
+            Some(sig.clone()),
+            Some(delivery),
+            Some("ping"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::ACCEPTED);
+
+    let resp2 = app
+        .oneshot(webhook_request(
+            body,
+            Some(sig),
+            Some(delivery),
+            Some("ping"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp2.status(), StatusCode::OK);
+}
+
+/// Empty `repositories_removed` list short-circuits before SQL — verifies
+/// the no-op fast-path that GitHub may legitimately exercise.
+#[tokio::test]
+async fn webhook_returns_200_for_empty_removed_list() {
+    let app = build(state_with_gh(b"shh"));
+    let body = serde_json::to_vec(&serde_json::json!({
+        "action": "removed",
+        "installation": {
+            "id": 99,
+            "account": { "login": "x", "type": "User", "id": 1 }
+        },
+        "repositories_removed": []
+    }))
+    .unwrap();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(
+        body,
+        Some(sig),
+        Some("d-empty-remove"),
+        Some("installation_repositories"),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// `installation_repositories.added` is logged-only in v1 — no SQL is
+/// dispatched, so the lazy pool is never touched and the response is 200.
+#[tokio::test]
+async fn webhook_returns_200_for_repos_added_no_auto_connect() {
+    let app = build(state_with_gh(b"shh"));
+    let body = serde_json::to_vec(&serde_json::json!({
+        "action": "added",
+        "installation": {
+            "id": 99,
+            "account": { "login": "x", "type": "User", "id": 1 }
+        },
+        "repositories_added": [
+            { "id": 1, "full_name": "x/repo-a" }
+        ]
+    }))
+    .unwrap();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(
+        body,
+        Some(sig),
+        Some("d-add"),
+        Some("installation_repositories"),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// `installation` events with an action we don't model (e.g.
+/// `new_permissions_accepted`) are accepted with 202 to stop GitHub retries.
+#[tokio::test]
+async fn webhook_returns_202_for_unmodelled_installation_action() {
+    let app = build(state_with_gh(b"shh"));
+    let body = serde_json::to_vec(&serde_json::json!({
+        "action": "new_permissions_accepted",
+        "installation": {
+            "id": 99,
+            "account": { "login": "x", "type": "User", "id": 1 }
+        }
+    }))
+    .unwrap();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(body, Some(sig), Some("d-perms"), Some("installation"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}
+
+/// `installation_repositories` with action other than added/removed (e.g.
+/// future GitHub additions) returns 202.
+#[tokio::test]
+async fn webhook_returns_202_for_unmodelled_repos_action() {
+    let app = build(state_with_gh(b"shh"));
+    let body = serde_json::to_vec(&serde_json::json!({
+        "action": "future_action",
+        "installation": {
+            "id": 99,
+            "account": { "login": "x", "type": "User", "id": 1 }
+        }
+    }))
+    .unwrap();
+    let sig = sign(&body, b"shh");
+    let req = webhook_request(
+        body,
+        Some(sig),
+        Some("d-future"),
+        Some("installation_repositories"),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}


### PR DESCRIPTION
## Summary

Implements `POST /v1/github/webhook` (REQ-GH-06, ADR-005 §7) — receives `installation` and `installation_repositories` deliveries from the GitHub App.

- HMAC-SHA256 verify on the **raw** body before any JSON parse (preserves signed-byte equivalence with what GitHub HMAC'd).
- `X-GitHub-Delivery` replay protection via a 10-minute TTL cache. The TOCTOU bug noted by the PR Reviewer on `rb-github` PR #75 is closed: `ReplayCache::try_insert_new` is now atomic via `moka::future::Cache::entry().or_insert_with()` and proven race-free by a 64-way concurrent test.
- Dispatch is event-typed, not generic: chooses the payload struct based on `X-GitHub-Event`, dispatches to a small SQL update per (event, action), and returns an empty body so no tenant data ever leaks (ADR-005 §9.3).
- Route is intentionally **not** exposed in OpenAPI: it is consumed only by GitHub's webhook delivery service.

### Status code semantics

| Status | Cause |
|--------|-------|
| 200 | Handled, or duplicate suppressed by replay cache |
| 202 | Unmodelled event/action — acknowledged so GitHub stops retrying |
| 400 | Missing required header, or body fails to deserialize after sig verify |
| 401 | Signature missing, malformed, or mismatch |
| 503 | GitHub App not configured on this instance |

### Event handling matrix (per ADR-005 §7.5)

| Event | Action | Effect |
|-------|--------|--------|
| `installation` | `created` | Idempotent confirmation: clears `deleted_at`/`suspended_at` on existing row. Never inserts — OAuth callback (REQ-GH-04) is the sole writer of new installs. |
| `installation` | `deleted` | `deleted_at = now()` |
| `installation` | `suspend` | `suspended_at = now()` |
| `installation` | `unsuspend` | `suspended_at = NULL` |
| `installation_repositories` | `added` | Log only (PRD: explicit connect per REQ-GH-04) |
| `installation_repositories` | `removed` | `repos.archived_at = now()` for matching `(installation_id, github_repo_id)` |
| anything else | — | 202 |

## Test plan

- [x] `cargo test -p rb-github -p control-api` — 23 unit + 13 integration, all green
- [x] `cargo clippy -p rb-github -p control-api --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-file-sizes.sh` — passed (largest new file 424 lines)
- [x] `bash scripts/check-pub-use.sh` — passed
- [x] Replay cache concurrency proven: 64-way race converges to exactly one observable insert
- [ ] QA: live-DB integration suite (depends on test schema fixture)

## Design reference

ADR-005 §7 ("Webhook Receiver"). The route handler intentionally mirrors the pseudocode in §7.1 line-for-line; deviations are limited to using a typed `WebhookOutcome` enum for the IntoResponse mapping and splitting the (suspend|unsuspend|deleted) branch behind a small `InstallationOp` helper to keep the SQL strings literal.

Closes #79