### PR TITLE
[REQ-CI-01] ci: harden pr-hygiene.yml with title format, Closes link, and diff scan

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+> **Title format**: `[REQ-XX-NN] type(scope): description` — CI will reject PRs without the bracket prefix.
+
 ## Summary
 
 <!-- What does this PR do and why? -->

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -9,10 +9,29 @@ jobs:
     name: pr hygiene
     runs-on: ubuntu-latest
     steps:
-      - name: Check for internal tracking references
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          FAILED=0
+
+          if ! echo "$PR_TITLE" | grep -qE '^\[REQ-[A-Z]+-[0-9]+\]'; then
+            echo "::error::PR title must start with [REQ-XX-NN] bracket prefix (e.g. [REQ-FE-09] feat: description). Got: $PR_TITLE"
+            FAILED=1
+          fi
+
+          exit $FAILED
+
+      - name: Check for internal tracking references and required links
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           FAILED=0
 
@@ -26,8 +45,14 @@ jobs:
             FAILED=1
           fi
 
-          if ! echo "$PR_BODY" | grep -qiE 'closes[[:space:]]+#[0-9]+'; then
-            echo "::warning::PR body does not contain a 'Closes #XX' link. Add one to auto-close the related GitHub issue."
+          if ! echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
+            echo "::error::PR body does not contain a 'Closes #XX', 'Fixes #XX', or 'Resolves #XX' link. Add one to auto-close the related GitHub issue."
+            FAILED=1
+          fi
+
+          if gh pr diff "$PR_NUMBER" -- | grep -E '^\+' | grep -v '^\+\+\+' | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
+            echo "::error::PR diff contains internal tracking references (RUSAA-* or RUSTBRAINBYGOV-*) in added lines. Remove them before merging."
+            FAILED=1
           fi
 
           exit $FAILED

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -35,13 +35,18 @@ jobs:
         run: |
           FAILED=0
 
-          if echo "$PR_TITLE" | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
-            echo "::error::PR title contains an internal tracking reference (RUSAA-* or RUSTBRAINBYGOV-*). Remove it before merging."
+          # Build pattern from fragments — literal strings must not appear in source
+          # so the diff scan does not flag this file itself.
+          _A="RUS"; _B="AA-"; _C="RUSTBRAIN"; _D="BYGOV-"
+          TRACKER_RE="(${_A}${_B}|${_C}${_D})"
+
+          if echo "$PR_TITLE" | grep -qiE "$TRACKER_RE"; then
+            echo "::error::PR title contains an internal tracking reference. Remove it before merging."
             FAILED=1
           fi
 
-          if echo "$PR_BODY" | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
-            echo "::error::PR body contains an internal tracking reference (RUSAA-* or RUSTBRAINBYGOV-*). Remove it before merging."
+          if echo "$PR_BODY" | grep -qiE "$TRACKER_RE"; then
+            echo "::error::PR body contains an internal tracking reference. Remove it before merging."
             FAILED=1
           fi
 
@@ -50,8 +55,8 @@ jobs:
             FAILED=1
           fi
 
-          if gh pr diff "$PR_NUMBER" -- | grep -E '^\+' | grep -v '^\+\+\+' | grep -qiE '(RUSAA-|RUSTBRAINBYGOV-)'; then
-            echo "::error::PR diff contains internal tracking references (RUSAA-* or RUSTBRAINBYGOV-*) in added lines. Remove them before merging."
+          if gh pr diff "$PR_NUMBER" -- | grep -E '^\+' | grep -v '^\+\+\+' | grep -qiE "$TRACKER_RE"; then
+            echo "::error::PR diff contains internal tracking references in added lines. Remove them before merging."
             FAILED=1
           fi
 


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/pr-hygiene.yml` and `.github/pull_request_template.md` to enforce three PR conventions that the PR reviewer was flagging manually on every PR:

- **REQ-ID title format**: PR titles must start with `[REQ-XX-NN]`; CI emits `::error::` and fails if missing
- **Closes/Fixes/Resolves link**: upgraded from `::warning::` to `::error::` with `FAILED=1`; extended to match all three GitHub close keywords (case-insensitive)
- **Diff scan for internal tracker IDs**: scans added lines in the PR diff for internal tracking references; tracker prefixes are built from concatenated string fragments so the workflow does not flag itself
- **PR template**: adds title format reminder at the top so contributors see it before CI runs

## Changes

- `.github/workflows/pr-hygiene.yml` — added `actions/checkout@v4`; split into title-format step and tracker/link check step; upgraded Closes warning to error; added diff scan; use fragment-concatenated regex to avoid self-referential match
- `.github/pull_request_template.md` — prepended title format instruction

## Closes

Closes #80

## Checklist

- [x] CI hygiene checks pass on this PR itself
- [x] No internal board tracking references in title, body, or added lines
- [x] PR template updated with title format guidance