### PR TITLE
[REQ-FE-09] fix(frontend): tenant-scope apiKeysQueryKey to avoid stale-flash on switch

### DIFF
--- a/frontend/src/api/hooks/useApiKeys.ts
+++ b/frontend/src/api/hooks/useApiKeys.ts
@@ -11,16 +11,20 @@ type ListApiKeysResponse = components["schemas"]["ListApiKeysResponse"];
 type CreateApiKeyRequest = components["schemas"]["CreateApiKeyRequest"];
 type CreateApiKeyResponse = components["schemas"]["CreateApiKeyResponse"];
 
-export const apiKeysQueryKey = ["api-keys"] as const;
+// Tenant-scoped key prevents stale rows from a previous tenant flashing
+// in `/api-keys` while the active tenant's refetch is in flight.
+export const apiKeysQueryKey = (tenantId: string) =>
+  ["tenants", tenantId, "api-keys"] as const;
 
 export function useApiKeys(
+  tenantId: string,
   options?: Omit<
     UseQueryOptions<ListApiKeysResponse, ApiError>,
     "queryKey" | "queryFn"
   >,
 ) {
   return useQuery<ListApiKeysResponse, ApiError>({
-    queryKey: apiKeysQueryKey,
+    queryKey: apiKeysQueryKey(tenantId),
     queryFn: async () => {
       const { data, error, response } = await apiClient.GET("/v1/api-keys");
       if (error || !data) {
@@ -28,11 +32,12 @@ export function useApiKeys(
       }
       return data;
     },
+    enabled: tenantId.length > 0,
     ...options,
   });
 }
 
-export function useCreateApiKey() {
+export function useCreateApiKey(tenantId: string) {
   const qc = useQueryClient();
   return useMutation<CreateApiKeyResponse, ApiError, CreateApiKeyRequest>({
     mutationFn: async (body) => {
@@ -46,12 +51,12 @@ export function useCreateApiKey() {
       return data;
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: apiKeysQueryKey });
+      void qc.invalidateQueries({ queryKey: apiKeysQueryKey(tenantId) });
     },
   });
 }
 
-export function useRevokeApiKey() {
+export function useRevokeApiKey(tenantId: string) {
   const qc = useQueryClient();
   return useMutation<void, ApiError, string>({
     mutationFn: async (id) => {
@@ -64,7 +69,7 @@ export function useRevokeApiKey() {
       }
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: apiKeysQueryKey });
+      void qc.invalidateQueries({ queryKey: apiKeysQueryKey(tenantId) });
     },
   });
 }

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -67,6 +67,7 @@ export function ApiKeysPage(): JSX.Element {
 
   return (
     <ApiKeysPageInner
+      tenantId={me.data.current_tenant.id}
       tenantName={me.data.current_tenant.name}
       callerRole={me.data.current_tenant.role}
     />
@@ -74,19 +75,21 @@ export function ApiKeysPage(): JSX.Element {
 }
 
 interface ApiKeysPageInnerProps {
+  readonly tenantId: string;
   readonly tenantName: string;
   readonly callerRole: string;
 }
 
 function ApiKeysPageInner({
+  tenantId,
   tenantName,
   callerRole,
 }: ApiKeysPageInnerProps): JSX.Element {
   const canManage = callerRole === "owner" || callerRole === "admin";
 
-  const keys = useApiKeys();
-  const createKey = useCreateApiKey();
-  const revokeKey = useRevokeApiKey();
+  const keys = useApiKeys(tenantId);
+  const createKey = useCreateApiKey(tenantId);
+  const revokeKey = useRevokeApiKey(tenantId);
 
   const [plaintext, setPlaintext] = useState<PlaintextKey | null>(null);
 


### PR DESCRIPTION
Closes #87

## Summary

- Tenant-scope `apiKeysQueryKey` to `["tenants", tenantId, "api-keys"]` so React Query no longer reuses the previous tenant's cache after a tenant switch (no stale-flash on `/api-keys`).
- `useApiKeys`, `useCreateApiKey`, `useRevokeApiKey` now take a `tenantId` argument and invalidate the tenant-scoped key. The query is gated with `enabled: tenantId.length > 0`, mirroring `useTenantMembers`.
- `ApiKeysPage` threads `me.current_tenant.id` into the hooks the same way `MembersPage` already does.

## Why

Follow-up flagged during [PR #73](https://github.com/jarnura/rustacean/pull/73) review. Static `["api-keys"]` kept the previous tenant's keys cached under one key, causing a brief stale row flash during tenant switch.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (max-warnings=0)
- [ ] Manual: switch tenants → `/api-keys` shows no rows from previous tenant during refetch (no Playwright e2e suite in repo yet)