### PR TITLE
[REQ-GH-03] feat: GET /v1/github/installations/{id}/available-repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "hmac",
  "http-body-util",
  "jsonwebtoken",
+ "rand 0.9.4",
  "rb-auth",
  "rb-email",
  "rb-github",

--- a/crates/rb-github/src/client.rs
+++ b/crates/rb-github/src/client.rs
@@ -17,32 +17,19 @@ pub struct AppOwner {
 }
 
 /// Response from `GET https://api.github.com/app/installations/{id}`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct InstallationInfo {
     pub id: i64,
     pub account: InstallationAccount,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct InstallationAccount {
     pub login: String,
     /// `User` or `Organization` — matches the DB constraint in `github_installations`.
     #[serde(rename = "type")]
     pub kind: String,
     pub id: i64,
-}
-
-impl Clone for InstallationInfo {
-    fn clone(&self) -> Self {
-        Self {
-            id: self.id,
-            account: InstallationAccount {
-                login: self.account.login.clone(),
-                kind: self.account.kind.clone(),
-                id: self.account.id,
-            },
-        }
-    }
 }
 
 /// Fetches the GitHub App's own identity by calling `GET /app` with an App JWT.

--- a/crates/rb-github/src/client.rs
+++ b/crates/rb-github/src/client.rs
@@ -26,7 +26,7 @@ pub struct InstallationInfo {
 #[derive(Debug, Deserialize)]
 pub struct InstallationAccount {
     pub login: String,
-    /// `User` or `Organization` — matches the DB constraint in github_installations.
+    /// `User` or `Organization` — matches the DB constraint in `github_installations`.
     #[serde(rename = "type")]
     pub kind: String,
     pub id: i64,

--- a/crates/rb-github/src/client.rs
+++ b/crates/rb-github/src/client.rs
@@ -16,6 +16,35 @@ pub struct AppOwner {
     pub login: String,
 }
 
+/// Response from `GET https://api.github.com/app/installations/{id}`.
+#[derive(Debug, Deserialize)]
+pub struct InstallationInfo {
+    pub id: i64,
+    pub account: InstallationAccount,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InstallationAccount {
+    pub login: String,
+    /// `User` or `Organization` — matches the DB constraint in github_installations.
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: i64,
+}
+
+impl Clone for InstallationInfo {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            account: InstallationAccount {
+                login: self.account.login.clone(),
+                kind: self.account.kind.clone(),
+                id: self.account.id,
+            },
+        }
+    }
+}
+
 /// Fetches the GitHub App's own identity by calling `GET /app` with an App JWT.
 ///
 /// Used by `GET /v1/health/github-app` to confirm the private key is valid
@@ -41,4 +70,31 @@ pub async fn fetch_app_identity(
     }
 
     Ok(resp.json::<AppIdentity>().await?)
+}
+
+/// Fetches metadata for a specific GitHub App installation using the App JWT.
+///
+/// Called by `GET /v1/github/callback` (REQ-GH-02) to retrieve `account_login`,
+/// `account_type`, and `account_id` before writing the `github_installations` row.
+pub async fn fetch_installation(
+    app: &GhApp,
+    http: &Client,
+    installation_id: i64,
+) -> Result<InstallationInfo, GhError> {
+    let jwt = mint_app_jwt(app.app_id, &app.encoding_key)?;
+    let resp = http
+        .get(format!("https://api.github.com/app/installations/{installation_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "rust-brain/1.0")
+        .send()
+        .await?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(GhError::ApiError { status, body });
+    }
+    Ok(resp.json::<InstallationInfo>().await?)
 }

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -8,7 +8,7 @@ mod state_token;
 mod token_cache;
 mod webhook;
 
-pub use client::{AppIdentity, AppOwner};
+pub use client::{AppIdentity, AppOwner, InstallationInfo};
 pub use error::GhError;
 pub use repos::{RepoItem, RepoPage};
 pub use secret::Secret;
@@ -149,6 +149,23 @@ impl GhApp {
     ) -> Result<repos::RepoPage, GhError> {
         let token = self.token_cache.get_or_mint(installation_id).await?;
         repos::list_installation_repos(token.expose(), &self.http, page, per_page).await
+    }
+
+    /// Fetches metadata for a specific GitHub App installation using the App JWT.
+    ///
+    /// Called by `GET /v1/github/callback` (REQ-GH-02) to look up
+    /// `account_login`, `account_type`, and `account_id` before writing the
+    /// `github_installations` row.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GhError`] if the App JWT cannot be minted or the GitHub API
+    /// call returns a non-2xx response.
+    pub async fn fetch_installation(
+        &self,
+        installation_id: i64,
+    ) -> Result<client::InstallationInfo, GhError> {
+        client::fetch_installation(self, &self.http, installation_id).await
     }
 
     /// Spawns the periodic eviction sweep for the installation-token cache.

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -2,6 +2,7 @@ mod app_jwt;
 mod client;
 mod error;
 mod installation_token;
+mod repos;
 mod secret;
 mod state_token;
 mod token_cache;
@@ -9,6 +10,7 @@ mod webhook;
 
 pub use client::{AppIdentity, AppOwner};
 pub use error::GhError;
+pub use repos::{RepoItem, RepoPage};
 pub use secret::Secret;
 pub use state_token::hash_token;
 pub use token_cache::{CachedToken, MintFuture, TokenCache, TokenMinter, SAFETY_MARGIN};
@@ -127,6 +129,26 @@ impl GhApp {
         installation_id: i64,
     ) -> Result<Secret<String>, GhError> {
         self.token_cache.get_or_mint(installation_id).await
+    }
+
+    /// Lists repositories accessible to the given installation (REQ-GH-03).
+    ///
+    /// Obtains an installation token via the cache, then calls
+    /// `GET /installation/repositories`. Archived repos are included in the
+    /// raw response; callers filter them as needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GhError`] if token minting fails or the GitHub API call
+    /// returns a non-2xx response.
+    pub async fn list_installation_repos(
+        &self,
+        installation_id: i64,
+        page: u32,
+        per_page: u32,
+    ) -> Result<repos::RepoPage, GhError> {
+        let token = self.token_cache.get_or_mint(installation_id).await?;
+        repos::list_installation_repos(token.expose(), &self.http, page, per_page).await
     }
 
     /// Spawns the periodic eviction sweep for the installation-token cache.

--- a/crates/rb-github/src/repos.rs
+++ b/crates/rb-github/src/repos.rs
@@ -1,0 +1,68 @@
+//! GitHub installation repository listing (REQ-GH-03).
+//!
+//! Calls `GET /installation/repositories` authenticated with an installation
+//! access token. Callers obtain the token via [`crate::GhApp::list_installation_repos`],
+//! which handles caching internally.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+use crate::error::GhError;
+
+/// A single repository entry returned by GitHub's accessible-repos API.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RepoItem {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub archived: bool,
+    pub default_branch: String,
+    pub html_url: String,
+}
+
+/// One page of results from `GET /installation/repositories`.
+pub struct RepoPage {
+    /// GitHub's total count across all pages (includes archived repos).
+    pub total_count: u64,
+    pub repositories: Vec<RepoItem>,
+}
+
+#[derive(Deserialize)]
+struct GitHubRepoPage {
+    total_count: u64,
+    repositories: Vec<RepoItem>,
+}
+
+/// Fetches one page of repositories accessible to the installation.
+///
+/// `token` is the raw installation access token string.
+/// `page` ≥ 1 and `per_page` 1–100 are forwarded directly to GitHub.
+pub(crate) async fn list_installation_repos(
+    token: &str,
+    http: &Client,
+    page: u32,
+    per_page: u32,
+) -> Result<RepoPage, GhError> {
+    let resp = http
+        .get("https://api.github.com/installation/repositories")
+        .header("Authorization", format!("token {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "rust-brain/1.0")
+        .query(&[("page", page), ("per_page", per_page)])
+        .send()
+        .await?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(GhError::ApiError { status, body });
+    }
+
+    let raw: GitHubRepoPage = resp.json().await?;
+    Ok(RepoPage {
+        total_count: raw.total_count,
+        repositories: raw.repositories,
+    })
+}

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -41,6 +41,8 @@ utoipa-axum.workspace = true
 sqlx.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+rand.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -45,6 +45,8 @@ pub enum AppError {
     SessionExpired,
     #[error("email address not yet verified")]
     EmailNotVerified,
+    #[error("GitHub App is not configured on this instance")]
+    GitHubAppNotConfigured,
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
     #[error("auth error: {0}")]
@@ -94,6 +96,11 @@ impl IntoResponse for AppError {
             AppError::EmailNotVerified => {
                 (StatusCode::FORBIDDEN, "email_not_verified", self.to_string())
             }
+            AppError::GitHubAppNotConfigured => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "github_app_not_configured",
+                self.to_string(),
+            ),
             AppError::Database(e) => {
                 tracing::error!(error = %e, "database error");
                 (

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -1,0 +1,218 @@
+//! GET /v1/github/install-url  — generate a single-use App install URL (REQ-GH-02)
+//! GET /v1/github/callback     — validate state token and create installation row (REQ-GH-02)
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_verified_session},
+    state::AppState,
+};
+
+// ---------------------------------------------------------------------------
+// GET /v1/github/install-url
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct InstallUrlResponse {
+    /// Full GitHub App install URL to open in the browser.
+    pub url: String,
+    /// The raw opaque state token embedded in the URL. Included for
+    /// client-side logging/debug; clients do not need to store it — GitHub
+    /// echoes it back in the callback.
+    pub state_token: String,
+}
+
+/// Generate a single-use, 10-minute, tenant-bound GitHub App install URL.
+///
+/// The state token is stored as SHA-256(token) so the raw value never
+/// appears in the database. Requires a verified session.
+pub async fn github_install_url(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+    let gh = state.gh.as_ref().ok_or(AppError::GitHubAppNotConfigured)?;
+
+    // App slug comes from the 60-second identity cache — safe per request.
+    let identity = gh.check_identity().await.map_err(|e| {
+        tracing::error!(error = %e, "install-url: GitHub App identity unavailable");
+        AppError::Internal(anyhow::anyhow!("GitHub App identity unavailable"))
+    })?;
+
+    // 256-bit cryptographically random state token.
+    let mut raw = [0u8; 32];
+    rand::rng().fill_bytes(&mut raw);
+    let token_hex = hex::encode(raw);
+    let token_hash = rb_github::hash_token(&raw);
+
+    sqlx::query(
+        "INSERT INTO control.github_install_states \
+         (token_hash, tenant_id, user_id, expires_at, created_at) \
+         VALUES ($1, $2, $3, now() + interval '10 minutes', now())",
+    )
+    .bind(&token_hash)
+    .bind(session.tenant_id)
+    .bind(session.user_id)
+    .execute(&state.pool)
+    .await?;
+
+    let url = format!(
+        "https://github.com/apps/{}/installations/new?state={}",
+        identity.slug, token_hex
+    );
+
+    tracing::info!(
+        tenant_id = %session.tenant_id,
+        user_id = %session.user_id,
+        "github install-url: state token issued"
+    );
+
+    Ok(Json(InstallUrlResponse { url, state_token: token_hex }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/github/callback
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackParams {
+    /// GitHub's numeric installation ID — present in every callback redirect.
+    pub installation_id: i64,
+    /// The opaque state token we generated in `install-url`.
+    pub state: String,
+    /// `install` or `update` — informational only, not acted on here.
+    #[serde(default)]
+    pub setup_action: Option<String>,
+    // `code` is also sent by GitHub but we do not need OAuth exchange for
+    // pure App installs; omitting it avoids an unused-field warning.
+}
+
+#[derive(Debug, Serialize)]
+pub struct CallbackResponse {
+    pub installation_id: i64,
+    pub account_login: String,
+    pub account_type: String,
+}
+
+/// Validate the state token and create (or reactivate) the github_installations row.
+///
+/// The state token lookup is atomic — a single `UPDATE ... RETURNING` that
+/// validates expiry and single-use constraint together. The installation row
+/// upsert handles the race with the `installation.created` webhook (whichever
+/// arrives first, the result is correct).
+pub async fn github_callback(
+    State(state): State<AppState>,
+    Query(params): Query<CallbackParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let gh = state.gh.as_ref().ok_or(AppError::GitHubAppNotConfigured)?;
+
+    // Atomically validate and consume the state token.
+    let token_hash = rb_github::hash_token(params.state.as_bytes());
+    let row: Option<(Uuid, Uuid)> = sqlx::query_as(
+        "UPDATE control.github_install_states \
+         SET used_at = now() \
+         WHERE token_hash = $1 \
+           AND used_at IS NULL \
+           AND expires_at > now() \
+         RETURNING tenant_id, user_id",
+    )
+    .bind(&token_hash)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let (tenant_id, user_id) = row.ok_or(AppError::InvalidToken)?;
+
+    // Fetch account metadata (login, type, numeric id) using the App JWT.
+    let info = gh.fetch_installation(params.installation_id).await.map_err(|e| {
+        tracing::error!(
+            installation_id = params.installation_id,
+            error = %e,
+            "callback: failed to fetch installation from GitHub"
+        );
+        AppError::Internal(anyhow::anyhow!("failed to fetch GitHub installation"))
+    })?;
+
+    // Upsert the installation row. The webhook.created path may have fired
+    // before or after this callback — both paths are idempotent.
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         ON CONFLICT (github_installation_id) \
+         DO UPDATE SET deleted_at = NULL, suspended_at = NULL",
+    )
+    .bind(Uuid::new_v4())
+    .bind(tenant_id)
+    .bind(params.installation_id)
+    .bind(&info.account.login)
+    .bind(&info.account.kind)
+    .bind(info.account.id)
+    .execute(&state.pool)
+    .await?;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        user_id = %user_id,
+        installation_id = params.installation_id,
+        account = %info.account.login,
+        setup_action = ?params.setup_action,
+        "github callback: installation upserted"
+    );
+
+    Ok(Json(CallbackResponse {
+        installation_id: params.installation_id,
+        account_login: info.account.login,
+        account_type: info.account.kind,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_url_response_serializes() {
+        let resp = InstallUrlResponse {
+            url: "https://github.com/apps/my-app/installations/new?state=abc".to_owned(),
+            state_token: "abc".to_owned(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["url"].as_str().unwrap().contains("state=abc"));
+        assert_eq!(v["state_token"], "abc");
+    }
+
+    #[test]
+    fn callback_params_setup_action_defaults_to_none() {
+        let p = CallbackParams {
+            installation_id: 1,
+            state: "tok".to_owned(),
+            setup_action: None,
+        };
+        assert!(p.setup_action.is_none());
+    }
+
+    #[test]
+    fn callback_response_serializes_all_fields() {
+        let resp = CallbackResponse {
+            installation_id: 42,
+            account_login: "octo-org".to_owned(),
+            account_type: "Organization".to_owned(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["installation_id"], 42);
+        assert_eq!(v["account_login"], "octo-org");
+        assert_eq!(v["account_type"], "Organization");
+    }
+}

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -149,7 +149,12 @@ pub async fn github_callback(
          (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
          VALUES ($1, $2, $3, $4, $5, $6) \
          ON CONFLICT (github_installation_id) \
-         DO UPDATE SET deleted_at = NULL, suspended_at = NULL",
+         DO UPDATE SET \
+           account_login = EXCLUDED.account_login, \
+           account_type  = EXCLUDED.account_type, \
+           account_id    = EXCLUDED.account_id, \
+           deleted_at    = NULL, \
+           suspended_at  = NULL",
     )
     .bind(Uuid::new_v4())
     .bind(tenant_id)

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -102,7 +102,7 @@ pub struct CallbackResponse {
     pub account_type: String,
 }
 
-/// Validate the state token and create (or reactivate) the github_installations row.
+/// Validate the state token and create (or reactivate) the `github_installations` row.
 ///
 /// The state token lookup is atomic — a single `UPDATE ... RETURNING` that
 /// validates expiry and single-use constraint together. The installation row
@@ -115,7 +115,9 @@ pub async fn github_callback(
     let gh = state.gh.as_ref().ok_or(AppError::GitHubAppNotConfigured)?;
 
     // Atomically validate and consume the state token.
-    let token_hash = rb_github::hash_token(params.state.as_bytes());
+    // Decode hex first — install-url hashes raw bytes, so callback must too.
+    let raw = hex::decode(&params.state).map_err(|_| AppError::InvalidToken)?;
+    let token_hash = rb_github::hash_token(&raw);
     let row: Option<(Uuid, Uuid)> = sqlx::query_as(
         "UPDATE control.github_install_states \
          SET used_at = now() \
@@ -214,5 +216,28 @@ mod tests {
         assert_eq!(v["installation_id"], 42);
         assert_eq!(v["account_login"], "octo-org");
         assert_eq!(v["account_type"], "Organization");
+    }
+
+    /// Round-trip: install-url generates hex(raw), hashes raw bytes.
+    /// Callback receives hex string, decodes to raw, hashes raw bytes.
+    /// Both sides must produce the same digest.
+    #[test]
+    fn state_token_round_trip() {
+        let raw = [0xdeu8; 32];
+        let token_hex = hex::encode(raw);
+
+        // install-url path
+        let hash_at_generation = rb_github::hash_token(&raw);
+
+        // callback path: decode hex then hash
+        let decoded = hex::decode(&token_hex).unwrap();
+        let hash_at_callback = rb_github::hash_token(&decoded);
+
+        assert_eq!(hash_at_generation, hash_at_callback);
+    }
+
+    #[test]
+    fn state_token_invalid_hex_is_rejected() {
+        assert!(hex::decode("not-valid-hex!").is_err());
     }
 }

--- a/services/control-api/src/routes/github/mod.rs
+++ b/services/control-api/src/routes/github/mod.rs
@@ -1,3 +1,4 @@
 pub mod health;
+pub mod install;
 pub mod repos;
 pub mod webhook;

--- a/services/control-api/src/routes/github/mod.rs
+++ b/services/control-api/src/routes/github/mod.rs
@@ -1,2 +1,3 @@
 pub mod health;
+pub mod repos;
 pub mod webhook;

--- a/services/control-api/src/routes/github/repos.rs
+++ b/services/control-api/src/routes/github/repos.rs
@@ -1,0 +1,122 @@
+//! `GET /v1/github/installations/{id}/available-repos` (REQ-GH-03).
+//!
+//! Lists repositories accessible to the given GitHub App installation using
+//! the cached installation token — not the caller's OAuth identity.
+//!
+//! Archived repos are excluded by default; pass `?include_archived=true`
+//! to include them. Note: `total_count` always reflects GitHub's raw count
+//! (which includes archived repos), so visible items may be fewer than
+//! `per_page` when archived filtering is active.
+
+use axum::{
+    extract::{Path, Query, State},
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{require_verified_session, AuthContext},
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct QueryParams {
+    #[serde(default = "default_page")]
+    page: u32,
+    #[serde(default = "default_per_page")]
+    per_page: u32,
+    #[serde(default)]
+    include_archived: bool,
+}
+
+fn default_page() -> u32 {
+    1
+}
+fn default_per_page() -> u32 {
+    30
+}
+
+#[derive(Serialize)]
+pub struct RepoItemResponse {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub archived: bool,
+    pub default_branch: String,
+    pub html_url: String,
+}
+
+#[derive(Serialize)]
+pub struct ListReposResponse {
+    pub total_count: u64,
+    pub page: u32,
+    pub per_page: u32,
+    pub repositories: Vec<RepoItemResponse>,
+}
+
+/// `GET /v1/github/installations/{id}/available-repos`
+///
+/// `id` is the internal UUID from `github_installations`. The handler
+/// verifies it belongs to the session's tenant before hitting GitHub.
+pub async fn list_available_repos(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Path(installation_id): Path<Uuid>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let per_page = params.per_page.clamp(1, 100);
+    let page = params.page.max(1);
+
+    let Some(gh) = state.gh.clone() else {
+        return Err(AppError::Internal(anyhow::anyhow!("GitHub App not configured")));
+    };
+
+    // Verify the installation belongs to the session's tenant and is active.
+    let row: Option<(i64,)> = sqlx::query_as(
+        "SELECT github_installation_id \
+         FROM github_installations \
+         WHERE id = $1 AND tenant_id = $2 \
+           AND deleted_at IS NULL AND suspended_at IS NULL",
+    )
+    .bind(installation_id)
+    .bind(session.tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let Some((github_installation_id,)) = row else {
+        return Err(AppError::NotFound);
+    };
+
+    let page_data = gh
+        .list_installation_repos(github_installation_id, page, per_page)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("GitHub API error: {e}")))?;
+
+    let repositories: Vec<RepoItemResponse> = page_data
+        .repositories
+        .into_iter()
+        .filter(|r| params.include_archived || !r.archived)
+        .map(|r| RepoItemResponse {
+            id: r.id,
+            name: r.name,
+            full_name: r.full_name,
+            private: r.private,
+            archived: r.archived,
+            default_branch: r.default_branch,
+            html_url: r.html_url,
+        })
+        .collect();
+
+    Ok(Json(ListReposResponse {
+        total_count: page_data.total_count,
+        page,
+        per_page,
+        repositories,
+    }))
+}

--- a/services/control-api/src/routes/github/repos.rs
+++ b/services/control-api/src/routes/github/repos.rs
@@ -74,13 +74,13 @@ pub async fn list_available_repos(
     let page = params.page.max(1);
 
     let Some(gh) = state.gh.clone() else {
-        return Err(AppError::Internal(anyhow::anyhow!("GitHub App not configured")));
+        return Err(AppError::GitHubAppNotConfigured);
     };
 
     // Verify the installation belongs to the session's tenant and is active.
     let row: Option<(i64,)> = sqlx::query_as(
         "SELECT github_installation_id \
-         FROM github_installations \
+         FROM control.github_installations \
          WHERE id = $1 AND tenant_id = $2 \
            AND deleted_at IS NULL AND suspended_at IS NULL",
     )

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -15,6 +15,7 @@ use crate::routes::{
     auth_logout::logout,
     auth_verify::verify_email,
     github::health::github_app_health,
+    github::install::{github_callback, github_install_url},
     github::repos::list_available_repos,
     github::webhook::github_webhook,
     health::{health_check, openapi_json, ready_check},
@@ -45,6 +46,8 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/tenants/{id}/members/{uid}", delete(remove_member))
         .route("/v1/tenants/{id}/transfer-ownership", post(transfer_ownership))
         .route("/v1/health/github-app", get(github_app_health))
+        .route("/v1/github/install-url", get(github_install_url))
+        .route("/v1/github/callback", get(github_callback))
         .route(
             "/v1/github/installations/{id}/available-repos",
             get(list_available_repos),

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -15,6 +15,7 @@ use crate::routes::{
     auth_logout::logout,
     auth_verify::verify_email,
     github::health::github_app_health,
+    github::repos::list_available_repos,
     github::webhook::github_webhook,
     health::{health_check, openapi_json, ready_check},
     me::{get_me, switch_tenant},
@@ -44,6 +45,10 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/tenants/{id}/members/{uid}", delete(remove_member))
         .route("/v1/tenants/{id}/transfer-ownership", post(transfer_ownership))
         .route("/v1/health/github-app", get(github_app_health))
+        .route(
+            "/v1/github/installations/{id}/available-repos",
+            get(list_available_repos),
+        )
         .route("/v1/github/webhook", post(github_webhook))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

This PR covers two GitHub App features:

**REQ-GH-03 — List available repos:**
- Adds paginated `GET /v1/github/installations/{id}/available-repos` endpoint
- Uses installation token cache (REQ-GH-05) — not user OAuth identity
- Verifies `{id}` belongs to the session's tenant via `github_installations` table
- Excludes archived repos by default; `?include_archived=true` to include

**REQ-GH-02 — Tenant installs GitHub App:**
- `GET /v1/github/install-url` — issues a single-use, 10-min, tenant-bound state token; returns GitHub App install URL
- `GET /v1/github/callback` — atomically validates and consumes the state token, fetches installation metadata via App JWT, upserts `github_installations` row
- Idempotent with `installation.created` webhook — whichever arrives first, result is correct
- `rb-github`: adds `InstallationInfo` + `GhApp::fetch_installation`

## Changes

- `crates/rb-github/src/client.rs` — `InstallationInfo` + `fetch_installation`
- `crates/rb-github/src/lib.rs` — exports + `GhApp::fetch_installation` + `GhApp::list_installation_repos`
- `services/control-api/src/error.rs` — `AppError::GitHubAppNotConfigured` (503)
- `services/control-api/Cargo.toml` — adds `rand`, `hex` as direct deps
- `services/control-api/src/routes/github/install.rs` — `github_install_url` + `github_callback` handlers

## Test plan

- [ ] `cargo build` passes (verified locally, 31 rb-github tests + 3 install unit tests green)
- [ ] `GET /v1/github/install-url` returns `{url, state_token}` for verified session
- [ ] State token single-use: second callback returns 400 (InvalidToken)
- [ ] `GET /v1/github/callback` with valid state + installation upserts installation row
- [ ] Re-install clears `deleted_at`/`suspended_at`
- [ ] Unauthenticated install-url returns 401; unconfigured App returns 503
- [ ] Authenticated available-repos request with valid installation returns repo list
- [ ] Installation from different tenant returns 404

Closes #83