### PR TITLE
[REQ-GH-02] feat(github): install-url + callback + available-repos endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "hmac",
  "http-body-util",
  "jsonwebtoken",
+ "rand 0.9.4",
  "rb-auth",
  "rb-email",
  "rb-github",

--- a/crates/rb-github/src/client.rs
+++ b/crates/rb-github/src/client.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 
 use crate::{app_jwt::mint_app_jwt, error::GhError, GhApp};
 
-/// Response from `GET https://api.github.com/app`.
 #[derive(Debug, Deserialize)]
 pub struct AppIdentity {
     pub id: i64,
@@ -16,7 +15,6 @@ pub struct AppOwner {
     pub login: String,
 }
 
-/// Repository details returned by `GET /repositories/{id}`.
 #[derive(Debug)]
 pub struct RepoInfo {
     pub full_name: String,
@@ -29,14 +27,21 @@ struct GhRepoResponse {
     default_branch: String,
 }
 
-/// Fetches the GitHub App's own identity by calling `GET /app` with an App JWT.
-///
-/// Used by `GET /v1/health/github-app` to confirm the private key is valid
-/// and the App ID matches what GitHub knows.
-pub async fn fetch_app_identity(
-    app: &GhApp,
-    http: &Client,
-) -> Result<AppIdentity, GhError> {
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstallationInfo {
+    pub id: i64,
+    pub account: InstallationAccount,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstallationAccount {
+    pub login: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: i64,
+}
+
+pub async fn fetch_app_identity(app: &GhApp, http: &Client) -> Result<AppIdentity, GhError> {
     let jwt = mint_app_jwt(app.app_id, &app.encoding_key)?;
     let resp = http
         .get("https://api.github.com/app")
@@ -46,20 +51,14 @@ pub async fn fetch_app_identity(
         .header("User-Agent", "rust-brain/1.0")
         .send()
         .await?;
-
     let status = resp.status().as_u16();
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         return Err(GhError::ApiError { status, body });
     }
-
     Ok(resp.json::<AppIdentity>().await?)
 }
 
-/// Fetches a repository by its GitHub numeric ID using an installation access token.
-///
-/// Returns `GhError::ApiError { status: 404, .. }` when the repo is not found or
-/// not accessible via this installation token.
 pub(crate) async fn fetch_repo_by_id(
     http: &Client,
     installation_token: &str,
@@ -74,16 +73,33 @@ pub(crate) async fn fetch_repo_by_id(
         .header("User-Agent", "rust-brain/1.0")
         .send()
         .await?;
-
     let status = resp.status().as_u16();
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         return Err(GhError::ApiError { status, body });
     }
-
     let raw = resp.json::<GhRepoResponse>().await?;
-    Ok(RepoInfo {
-        full_name: raw.full_name,
-        default_branch: raw.default_branch,
-    })
+    Ok(RepoInfo { full_name: raw.full_name, default_branch: raw.default_branch })
+}
+
+pub async fn fetch_installation(
+    app: &GhApp,
+    http: &Client,
+    installation_id: i64,
+) -> Result<InstallationInfo, GhError> {
+    let jwt = mint_app_jwt(app.app_id, &app.encoding_key)?;
+    let resp = http
+        .get(format!("https://api.github.com/app/installations/{installation_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "rust-brain/1.0")
+        .send()
+        .await?;
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(GhError::ApiError { status, body });
+    }
+    Ok(resp.json::<InstallationInfo>().await?)
 }

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -2,13 +2,15 @@ mod app_jwt;
 mod client;
 mod error;
 mod installation_token;
+mod repos;
 mod secret;
 mod state_token;
 mod token_cache;
 mod webhook;
 
-pub use client::{AppIdentity, AppOwner, RepoInfo};
+pub use client::{AppIdentity, AppOwner, InstallationInfo, RepoInfo};
 pub use error::GhError;
+pub use repos::{RepoItem, RepoPage};
 pub use secret::Secret;
 pub use state_token::hash_token;
 pub use token_cache::{CachedToken, MintFuture, TokenCache, TokenMinter, SAFETY_MARGIN};
@@ -60,19 +62,16 @@ impl GhApp {
             .max_capacity(1)
             .time_to_live(Duration::from_secs(60))
             .build();
-
         let http = Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
             .expect("reqwest client init is infallible with valid config");
-
         let minter: Arc<dyn TokenMinter> = Arc::new(GitHubTokenMinter::new(
             app_id,
             encoding_key.clone(),
             http.clone(),
         ));
         let token_cache = TokenCache::new(minter);
-
         Self {
             app_id,
             encoding_key,
@@ -106,13 +105,10 @@ impl GhApp {
         }
         let identity = client::fetch_app_identity(self, &self.http).await?;
         self.identity_cache.insert((), identity).await;
-        self.identity_cache
-            .get(&())
-            .await
-            .ok_or_else(|| GhError::ApiError {
-                status: 500,
-                body: "identity cache miss immediately after insert".to_owned(),
-            })
+        self.identity_cache.get(&()).await.ok_or_else(|| GhError::ApiError {
+            status: 500,
+            body: "identity cache miss immediately after insert".to_owned(),
+        })
     }
 
     /// Returns a usable installation access token, minting if absent or
@@ -122,31 +118,47 @@ impl GhApp {
     ///
     /// Returns [`GhError`] if the App JWT cannot be minted or the GitHub
     /// `POST /app/installations/{id}/access_tokens` call fails.
-    pub async fn installation_token(
-        &self,
-        installation_id: i64,
-    ) -> Result<Secret<String>, GhError> {
+    pub async fn installation_token(&self, installation_id: i64) -> Result<Secret<String>, GhError> {
         self.token_cache.get_or_mint(installation_id).await
     }
 
     /// Fetches a repository by GitHub numeric ID, confirming it is accessible
     /// via the given installation.
     ///
-    /// Mints (or reuses a cached) installation access token, then calls
-    /// `GET /repositories/{repo_id}` on GitHub's API.
-    ///
     /// # Errors
     ///
     /// Returns [`GhError::ApiError { status: 404, .. }`] when the repo does not
     /// exist or is not accessible through this installation. Other GitHub API
     /// errors and token-minting failures propagate as [`GhError`].
-    pub async fn fetch_repo(
-        &self,
-        installation_id: i64,
-        repo_id: i64,
-    ) -> Result<RepoInfo, GhError> {
+    pub async fn fetch_repo(&self, installation_id: i64, repo_id: i64) -> Result<RepoInfo, GhError> {
         let token = self.installation_token(installation_id).await?;
         client::fetch_repo_by_id(&self.http, token.expose(), repo_id).await
+    }
+
+    /// Returns the paginated list of repositories accessible to an installation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GhError`] if the installation token cannot be minted or the
+    /// GitHub API call fails.
+    pub async fn list_installation_repos(
+        &self,
+        installation_id: i64,
+        page: u32,
+        per_page: u32,
+    ) -> Result<repos::RepoPage, GhError> {
+        let token = self.token_cache.get_or_mint(installation_id).await?;
+        repos::list_installation_repos(token.expose(), &self.http, page, per_page).await
+    }
+
+    /// Fetches metadata for a GitHub App installation by installation ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GhError`] if the App JWT cannot be minted or the GitHub API
+    /// call fails.
+    pub async fn fetch_installation(&self, installation_id: i64) -> Result<client::InstallationInfo, GhError> {
+        client::fetch_installation(self, &self.http, installation_id).await
     }
 
     /// Spawns the periodic eviction sweep for the installation-token cache.
@@ -167,15 +179,12 @@ impl std::fmt::Debug for GhApp {
     }
 }
 
-// AppIdentity must be Clone for the moka cache to store it.
 impl Clone for AppIdentity {
     fn clone(&self) -> Self {
         Self {
             id: self.id,
             slug: self.slug.clone(),
-            owner: AppOwner {
-                login: self.owner.login.clone(),
-            },
+            owner: AppOwner { login: self.owner.login.clone() },
         }
     }
 }

--- a/crates/rb-github/src/repos.rs
+++ b/crates/rb-github/src/repos.rs
@@ -1,0 +1,68 @@
+//! GitHub installation repository listing (REQ-GH-03).
+//!
+//! Calls `GET /installation/repositories` authenticated with an installation
+//! access token. Callers obtain the token via [`crate::GhApp::list_installation_repos`],
+//! which handles caching internally.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+use crate::error::GhError;
+
+/// A single repository entry returned by GitHub's accessible-repos API.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RepoItem {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub archived: bool,
+    pub default_branch: String,
+    pub html_url: String,
+}
+
+/// One page of results from `GET /installation/repositories`.
+pub struct RepoPage {
+    /// GitHub's total count across all pages (includes archived repos).
+    pub total_count: u64,
+    pub repositories: Vec<RepoItem>,
+}
+
+#[derive(Deserialize)]
+struct GitHubRepoPage {
+    total_count: u64,
+    repositories: Vec<RepoItem>,
+}
+
+/// Fetches one page of repositories accessible to the installation.
+///
+/// `token` is the raw installation access token string.
+/// `page` ≥ 1 and `per_page` 1–100 are forwarded directly to GitHub.
+pub(crate) async fn list_installation_repos(
+    token: &str,
+    http: &Client,
+    page: u32,
+    per_page: u32,
+) -> Result<RepoPage, GhError> {
+    let resp = http
+        .get("https://api.github.com/installation/repositories")
+        .header("Authorization", format!("token {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "rust-brain/1.0")
+        .query(&[("page", page), ("per_page", per_page)])
+        .send()
+        .await?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(GhError::ApiError { status, body });
+    }
+
+    let raw: GitHubRepoPage = resp.json().await?;
+    Ok(RepoPage {
+        total_count: raw.total_count,
+        repositories: raw.repositories,
+    })
+}

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -221,6 +221,54 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/github/callback": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["github_callback"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/github/install-url": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["github_install_url"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/github/installations/{id}/available-repos": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["list_available_repos"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/health/github-app": {
         readonly parameters: {
             readonly query?: never;
@@ -418,6 +466,12 @@ export interface components {
             readonly name: string;
             readonly scopes: readonly components["schemas"]["Scope"][];
         };
+        readonly CallbackResponse: {
+            readonly account_login: string;
+            readonly account_type: string;
+            /** Format: int64 */
+            readonly installation_id: number;
+        };
         readonly ConnectRepoRequest: {
             /** @description Default branch override. If omitted, the value is fetched from GitHub. */
             readonly default_branch?: string | null;
@@ -471,6 +525,12 @@ export interface components {
             readonly owner: string;
             readonly slug: string;
         };
+        readonly InstallUrlResponse: {
+            /** @description The raw opaque state token embedded in the URL. */
+            readonly state_token: string;
+            /** @description Full GitHub App install URL to open in the browser. */
+            readonly url: string;
+        };
         readonly InviteMemberRequest: {
             /** @description Email address of the user to invite or add. */
             readonly email: string;
@@ -491,6 +551,15 @@ export interface components {
         };
         readonly ListMembersResponse: {
             readonly members: readonly components["schemas"]["MemberItem"][];
+        };
+        readonly ListReposResponse: {
+            /** Format: int32 */
+            readonly page: number;
+            /** Format: int32 */
+            readonly per_page: number;
+            readonly repositories: readonly components["schemas"]["RepoItemResponse"][];
+            /** Format: int64 */
+            readonly total_count: number;
         };
         readonly LoginRequest: {
             /** @description RFC 5322 email address. */
@@ -525,6 +594,16 @@ export interface components {
         };
         readonly ProbeResponse: {
             readonly status: string;
+        };
+        readonly RepoItemResponse: {
+            readonly archived: boolean;
+            readonly default_branch: string;
+            readonly full_name: string;
+            readonly html_url: string;
+            /** Format: int64 */
+            readonly id: number;
+            readonly name: string;
+            readonly private: boolean;
         };
         readonly ResetPasswordRequest: {
             /** @description New password; minimum 12 characters. */
@@ -936,6 +1015,146 @@ export interface operations {
             };
             /** @description Token expired, already used, or not found (invalid_token) */
             readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly github_callback: {
+        readonly parameters: {
+            readonly query: {
+                /** @description GitHub numeric installation ID */
+                readonly installation_id: number;
+                /** @description Opaque state token from install-url */
+                readonly state: string;
+                /** @description install or update */
+                readonly setup_action?: string;
+            };
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Installation created or updated */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["CallbackResponse"];
+                };
+            };
+            /** @description Invalid or expired state token */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description GitHub App not configured on this instance */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly github_install_url: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Install URL generated */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["InstallUrlResponse"];
+                };
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description GitHub App not configured on this instance */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly list_available_repos: {
+        readonly parameters: {
+            readonly query?: {
+                /** @description Page number (default 1) */
+                readonly page?: number;
+                /** @description Results per page 1-100 (default 30) */
+                readonly per_page?: number;
+                /** @description Include archived repos (default false) */
+                readonly include_archived?: boolean;
+            };
+            readonly header?: never;
+            readonly path: {
+                /** @description Internal installation UUID (from github_installations) */
+                readonly id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Paginated list of repositories */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ListReposResponse"];
+                };
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Installation not found or not owned by this tenant */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description GitHub App not configured on this instance */
+            readonly 503: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1048,7 +1048,7 @@ export interface operations {
                 };
             };
             /** @description Invalid or expired state token */
-            readonly 401: {
+            readonly 400: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -331,6 +331,166 @@
         }
       }
     },
+    "/v1/github/callback": {
+      "get": {
+        "tags": [
+          "github"
+        ],
+        "operationId": "github_callback",
+        "parameters": [
+          {
+            "name": "installation_id",
+            "in": "query",
+            "description": "GitHub numeric installation ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Opaque state token from install-url",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "setup_action",
+            "in": "query",
+            "description": "install or update",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Installation created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallbackResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or expired state token"
+          },
+          "503": {
+            "description": "GitHub App not configured on this instance"
+          }
+        }
+      }
+    },
+    "/v1/github/install-url": {
+      "get": {
+        "tags": [
+          "github"
+        ],
+        "operationId": "github_install_url",
+        "responses": {
+          "200": {
+            "description": "Install URL generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallUrlResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified"
+          },
+          "503": {
+            "description": "GitHub App not configured on this instance"
+          }
+        }
+      }
+    },
+    "/v1/github/installations/{id}/available-repos": {
+      "get": {
+        "tags": [
+          "github"
+        ],
+        "operationId": "list_available_repos",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Internal installation UUID (from github_installations)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default 1)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Results per page 1-100 (default 30)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "include_archived",
+            "in": "query",
+            "description": "Include archived repos (default false)",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of repositories",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListReposResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified"
+          },
+          "404": {
+            "description": "Installation not found or not owned by this tenant"
+          },
+          "503": {
+            "description": "GitHub App not configured on this instance"
+          }
+        }
+      }
+    },
     "/v1/health/github-app": {
       "get": {
         "tags": [
@@ -774,6 +934,26 @@
           }
         }
       },
+      "CallbackResponse": {
+        "type": "object",
+        "required": [
+          "installation_id",
+          "account_login",
+          "account_type"
+        ],
+        "properties": {
+          "account_login": {
+            "type": "string"
+          },
+          "account_type": {
+            "type": "string"
+          },
+          "installation_id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
       "ConnectRepoRequest": {
         "type": "object",
         "required": [
@@ -929,6 +1109,23 @@
           }
         }
       },
+      "InstallUrlResponse": {
+        "type": "object",
+        "required": [
+          "url",
+          "state_token"
+        ],
+        "properties": {
+          "state_token": {
+            "type": "string",
+            "description": "The raw opaque state token embedded in the URL."
+          },
+          "url": {
+            "type": "string",
+            "description": "Full GitHub App install URL to open in the browser."
+          }
+        }
+      },
       "InviteMemberRequest": {
         "type": "object",
         "required": [
@@ -994,6 +1191,38 @@
             "items": {
               "$ref": "#/components/schemas/MemberItem"
             }
+          }
+        }
+      },
+      "ListReposResponse": {
+        "type": "object",
+        "required": [
+          "total_count",
+          "page",
+          "per_page",
+          "repositories"
+        ],
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "repositories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RepoItemResponse"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -1094,6 +1323,42 @@
         "properties": {
           "status": {
             "type": "string"
+          }
+        }
+      },
+      "RepoItemResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "full_name",
+          "private",
+          "archived",
+          "default_branch",
+          "html_url"
+        ],
+        "properties": {
+          "archived": {
+            "type": "boolean"
+          },
+          "default_branch": {
+            "type": "string"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "private": {
+            "type": "boolean"
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -378,7 +378,7 @@
               }
             }
           },
-          "401": {
+          "400": {
             "description": "Invalid or expired state token"
           },
           "503": {

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -41,6 +41,8 @@ utoipa-axum.workspace = true
 sqlx.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+rand.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -13,9 +13,9 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
         health::health_check,
         health::ready_check,
         github::health::github_app_health,
-        // github::webhook::github_webhook is intentionally NOT exposed via OpenAPI:
-        // it is consumed only by GitHub's webhook delivery service, authenticated
-        // by HMAC, and has no schema representation for HeaderMap/Bytes extractors.
+        github::install::github_install_url,
+        github::install::github_callback,
+        github::repos::list_available_repos,
         auth::signup,
         auth::login,
         auth_logout::logout,
@@ -38,6 +38,10 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
         schemas(
             health::ProbeResponse,
             github::health::GithubAppHealthResponse,
+            github::install::InstallUrlResponse,
+            github::install::CallbackResponse,
+            github::repos::RepoItemResponse,
+            github::repos::ListReposResponse,
             auth::SignupRequest,
             auth::SignupResponse,
             auth::LoginRequest,

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -103,7 +103,7 @@ pub struct CallbackResponse {
     ),
     responses(
         (status = 200, description = "Installation created or updated", body = CallbackResponse),
-        (status = 401, description = "Invalid or expired state token"),
+        (status = 400, description = "Invalid or expired state token"),
         (status = 503, description = "GitHub App not configured on this instance"),
     ),
     tag = "github"

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -1,0 +1,221 @@
+//! GET /v1/github/install-url  — generate a single-use App install URL (REQ-GH-02)
+//! GET /v1/github/callback     — validate state token and create installation row (REQ-GH-02)
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_verified_session},
+    state::AppState,
+};
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct InstallUrlResponse {
+    /// Full GitHub App install URL to open in the browser.
+    pub url: String,
+    /// The raw opaque state token embedded in the URL.
+    pub state_token: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/github/install-url",
+    responses(
+        (status = 200, description = "Install URL generated", body = InstallUrlResponse),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified"),
+        (status = 503, description = "GitHub App not configured on this instance"),
+    ),
+    tag = "github"
+)]
+pub async fn github_install_url(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+    let gh = state.gh.as_ref().ok_or(AppError::GithubAppNotConfigured)?;
+
+    let identity = gh.check_identity().await.map_err(|e| {
+        tracing::error!(error = %e, "install-url: GitHub App identity unavailable");
+        AppError::Internal(anyhow::anyhow!("GitHub App identity unavailable"))
+    })?;
+
+    let mut raw = [0u8; 32];
+    rand::rng().fill_bytes(&mut raw);
+    let token_hex = hex::encode(raw);
+    let token_hash = rb_github::hash_token(&raw);
+
+    sqlx::query(
+        "INSERT INTO control.github_install_states \
+         (token_hash, tenant_id, user_id, expires_at, created_at) \
+         VALUES ($1, $2, $3, now() + interval '10 minutes', now())",
+    )
+    .bind(&token_hash)
+    .bind(session.tenant_id)
+    .bind(session.user_id)
+    .execute(&state.pool)
+    .await?;
+
+    let url = format!(
+        "https://github.com/apps/{}/installations/new?state={}",
+        identity.slug, token_hex
+    );
+
+    tracing::info!(
+        tenant_id = %session.tenant_id,
+        user_id = %session.user_id,
+        "github install-url: state token issued"
+    );
+
+    Ok(Json(InstallUrlResponse { url, state_token: token_hex }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackParams {
+    pub installation_id: i64,
+    pub state: String,
+    #[serde(default)]
+    pub setup_action: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CallbackResponse {
+    pub installation_id: i64,
+    pub account_login: String,
+    pub account_type: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/github/callback",
+    params(
+        ("installation_id" = i64, Query, description = "GitHub numeric installation ID"),
+        ("state" = String, Query, description = "Opaque state token from install-url"),
+        ("setup_action" = Option<String>, Query, description = "install or update"),
+    ),
+    responses(
+        (status = 200, description = "Installation created or updated", body = CallbackResponse),
+        (status = 401, description = "Invalid or expired state token"),
+        (status = 503, description = "GitHub App not configured on this instance"),
+    ),
+    tag = "github"
+)]
+pub async fn github_callback(
+    State(state): State<AppState>,
+    Query(params): Query<CallbackParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let gh = state.gh.as_ref().ok_or(AppError::GithubAppNotConfigured)?;
+
+    let raw = hex::decode(&params.state).map_err(|_| AppError::InvalidToken)?;
+    let token_hash = rb_github::hash_token(&raw);
+    let row: Option<(Uuid, Uuid)> = sqlx::query_as(
+        "UPDATE control.github_install_states \
+         SET used_at = now() \
+         WHERE token_hash = $1 \
+           AND used_at IS NULL \
+           AND expires_at > now() \
+         RETURNING tenant_id, user_id",
+    )
+    .bind(&token_hash)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let (tenant_id, user_id) = row.ok_or(AppError::InvalidToken)?;
+
+    let info = gh.fetch_installation(params.installation_id).await.map_err(|e| {
+        tracing::error!(
+            installation_id = params.installation_id,
+            error = %e,
+            "callback: failed to fetch installation from GitHub"
+        );
+        AppError::Internal(anyhow::anyhow!("failed to fetch GitHub installation"))
+    })?;
+
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         ON CONFLICT (github_installation_id) \
+         DO UPDATE SET \
+           account_login = EXCLUDED.account_login, \
+           account_type  = EXCLUDED.account_type, \
+           account_id    = EXCLUDED.account_id, \
+           deleted_at    = NULL, \
+           suspended_at  = NULL",
+    )
+    .bind(Uuid::new_v4())
+    .bind(tenant_id)
+    .bind(params.installation_id)
+    .bind(&info.account.login)
+    .bind(&info.account.kind)
+    .bind(info.account.id)
+    .execute(&state.pool)
+    .await?;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        user_id = %user_id,
+        installation_id = params.installation_id,
+        account = %info.account.login,
+        setup_action = ?params.setup_action,
+        "github callback: installation upserted"
+    );
+
+    Ok(Json(CallbackResponse {
+        installation_id: params.installation_id,
+        account_login: info.account.login,
+        account_type: info.account.kind,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_url_response_serializes() {
+        let resp = InstallUrlResponse {
+            url: "https://github.com/apps/my-app/installations/new?state=abc".to_owned(),
+            state_token: "abc".to_owned(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["url"].as_str().unwrap().contains("state=abc"));
+        assert_eq!(v["state_token"], "abc");
+    }
+
+    #[test]
+    fn callback_response_serializes_all_fields() {
+        let resp = CallbackResponse {
+            installation_id: 42,
+            account_login: "octo-org".to_owned(),
+            account_type: "Organization".to_owned(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["installation_id"], 42);
+        assert_eq!(v["account_login"], "octo-org");
+        assert_eq!(v["account_type"], "Organization");
+    }
+
+    #[test]
+    fn state_token_round_trip() {
+        let raw = [0xdeu8; 32];
+        let token_hex = hex::encode(raw);
+        let hash_at_generation = rb_github::hash_token(&raw);
+        let decoded = hex::decode(&token_hex).unwrap();
+        let hash_at_callback = rb_github::hash_token(&decoded);
+        assert_eq!(hash_at_generation, hash_at_callback);
+    }
+
+    #[test]
+    fn state_token_invalid_hex_is_rejected() {
+        assert!(hex::decode("not-valid-hex!").is_err());
+    }
+}

--- a/services/control-api/src/routes/github/mod.rs
+++ b/services/control-api/src/routes/github/mod.rs
@@ -1,2 +1,4 @@
 pub mod health;
+pub mod install;
+pub mod repos;
 pub mod webhook;

--- a/services/control-api/src/routes/github/repos.rs
+++ b/services/control-api/src/routes/github/repos.rs
@@ -1,0 +1,124 @@
+//! `GET /v1/github/installations/{id}/available-repos` (REQ-GH-03).
+
+use axum::{
+    extract::{Path, Query, State},
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{require_verified_session, AuthContext},
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct QueryParams {
+    #[serde(default = "default_page")]
+    page: u32,
+    #[serde(default = "default_per_page")]
+    per_page: u32,
+    #[serde(default)]
+    include_archived: bool,
+}
+
+fn default_page() -> u32 { 1 }
+fn default_per_page() -> u32 { 30 }
+
+#[derive(Serialize, ToSchema)]
+pub struct RepoItemResponse {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub archived: bool,
+    pub default_branch: String,
+    pub html_url: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct ListReposResponse {
+    pub total_count: u64,
+    pub page: u32,
+    pub per_page: u32,
+    pub repositories: Vec<RepoItemResponse>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/github/installations/{id}/available-repos",
+    params(
+        ("id" = Uuid, Path, description = "Internal installation UUID (from github_installations)"),
+        ("page" = Option<u32>, Query, description = "Page number (default 1)"),
+        ("per_page" = Option<u32>, Query, description = "Results per page 1-100 (default 30)"),
+        ("include_archived" = Option<bool>, Query, description = "Include archived repos (default false)"),
+    ),
+    responses(
+        (status = 200, description = "Paginated list of repositories", body = ListReposResponse),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified"),
+        (status = 404, description = "Installation not found or not owned by this tenant"),
+        (status = 503, description = "GitHub App not configured on this instance"),
+    ),
+    tag = "github"
+)]
+pub async fn list_available_repos(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Path(installation_id): Path<Uuid>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let per_page = params.per_page.clamp(1, 100);
+    let page = params.page.max(1);
+
+    let Some(gh) = state.gh.clone() else {
+        return Err(AppError::GithubAppNotConfigured);
+    };
+
+    let row: Option<(i64,)> = sqlx::query_as(
+        "SELECT github_installation_id \
+         FROM control.github_installations \
+         WHERE id = $1 AND tenant_id = $2 \
+           AND deleted_at IS NULL AND suspended_at IS NULL",
+    )
+    .bind(installation_id)
+    .bind(session.tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let Some((github_installation_id,)) = row else {
+        return Err(AppError::NotFound);
+    };
+
+    let page_data = gh
+        .list_installation_repos(github_installation_id, page, per_page)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("GitHub API error: {e}")))?;
+
+    let repositories: Vec<RepoItemResponse> = page_data
+        .repositories
+        .into_iter()
+        .filter(|r| params.include_archived || !r.archived)
+        .map(|r| RepoItemResponse {
+            id: r.id,
+            name: r.name,
+            full_name: r.full_name,
+            private: r.private,
+            archived: r.archived,
+            default_branch: r.default_branch,
+            html_url: r.html_url,
+        })
+        .collect();
+
+    Ok(Json(ListReposResponse {
+        total_count: page_data.total_count,
+        page,
+        per_page,
+        repositories,
+    }))
+}

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -16,6 +16,8 @@ use crate::routes::{
     auth_logout::logout,
     auth_verify::verify_email,
     github::health::github_app_health,
+    github::install::{github_callback, github_install_url},
+    github::repos::list_available_repos,
     github::webhook::github_webhook,
     health::{health_check, openapi_json, ready_check},
     me::{get_me, switch_tenant},
@@ -24,7 +26,6 @@ use crate::routes::{
 };
 use crate::state::AppState;
 
-/// Assembles the full application router.
 pub fn build(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_check))
@@ -47,6 +48,9 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/tenants/{id}/transfer-ownership", post(transfer_ownership))
         .route("/v1/health/github-app", get(github_app_health))
         .route("/v1/github/webhook", post(github_webhook))
+        .route("/v1/github/install-url", get(github_install_url))
+        .route("/v1/github/callback", get(github_callback))
+        .route("/v1/github/installations/{id}/available-repos", get(list_available_repos))
         .route("/v1/repos", post(connect_repo))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Lands the REQ-GH-02 and REQ-GH-03 endpoints onto `main`. These were implemented in `feature/req-gh-03-list-repos` but missed the squash-merge to `main` when `feature/req-gh-05-installation-token-cache` was merged as `b10f9c4`.

- Adds `GET /v1/github/install-url` — generates a single-use, 10-minute, tenant-bound GitHub App install URL with 256-bit state token stored as SHA-256 in the DB
- Adds `GET /v1/github/callback` — atomically validates and consumes the state token, upserts `github_installations`; idempotent with the `installation.created` webhook
- Adds `GET /v1/github/installations/{id}/available-repos` — paginated listing of accessible repos via the cached installation token; archived repos excluded by default
- Updates `openapi.json` with 3 new paths and 4 new schemas via utoipa annotations
- Regenerates `frontend/src/api/generated/schema.ts` via `npm run gen:api`

Closes #90

## Test plan

- [ ] `cargo check --workspace` → clean
- [ ] `cargo clippy --workspace -- -D warnings` → clean
- [ ] `cargo test --workspace` → all tests pass
- [ ] `openapi.json` includes `/v1/github/install-url`, `/v1/github/callback`, `/v1/github/installations/{id}/available-repos`
- [ ] `npm run gen:api` produces typed client for the 3 new endpoints
- [ ] Verify routes registered in `routes/mod.rs`

Generated with Claude Code
Also delivers REQ-GH-03 (available-repos listing).