### PR TITLE
[REQ-GH-07] feat: GET /v1/repos — list connected repos for tenant

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -343,7 +343,13 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        readonly get?: never;
+        /**
+         * List all connected repositories for the current session's tenant.
+         * @description Soft-deleted repos (`archived_at IS NOT NULL`) are excluded.
+         *     Results are ordered by `connected_at DESC` (most recently connected first).
+         *     Requires a verified session.
+         */
+        readonly get: operations["list_repos"];
         readonly put?: never;
         /**
          * Connect a GitHub repository to the calling user's active tenant.
@@ -514,6 +520,9 @@ export interface components {
             /** Format: uuid */
             readonly repo_id: string;
         };
+        readonly ConnectedReposResponse: {
+            readonly repos: readonly components["schemas"]["RepoItem"][];
+        };
         readonly CreateApiKeyRequest: {
             /** @description Human-readable label for the key. */
             readonly name: string;
@@ -615,6 +624,19 @@ export interface components {
             readonly user_id: string;
         };
         readonly ProbeResponse: {
+            readonly status: string;
+        };
+        readonly RepoItem: {
+            /** Format: date-time */
+            readonly connected_at: string;
+            /** Format: uuid */
+            readonly connected_by: string;
+            readonly default_branch: string;
+            readonly full_name: string;
+            /** Format: uuid */
+            readonly installation_id: string;
+            /** Format: uuid */
+            readonly repo_id: string;
             readonly status: string;
         };
         readonly RepoItemResponse: {
@@ -1290,6 +1312,40 @@ export interface operations {
             };
             /** @description Target tenant not found or inactive */
             readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly list_repos: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description List of connected repos */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ConnectedReposResponse"];
+                };
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified */
+            readonly 403: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -585,6 +585,32 @@
       }
     },
     "/v1/repos": {
+      "get": {
+        "tags": [
+          "repos"
+        ],
+        "summary": "List all connected repositories for the current session's tenant.",
+        "description": "Soft-deleted repos (`archived_at IS NOT NULL`) are excluded.\nResults are ordered by `connected_at DESC` (most recently connected first).\nRequires a verified session.",
+        "operationId": "list_repos",
+        "responses": {
+          "200": {
+            "description": "List of connected repos",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectedReposResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified"
+          }
+        }
+      },
       "post": {
         "tags": [
           "repos"
@@ -1046,6 +1072,20 @@
           }
         }
       },
+      "ConnectedReposResponse": {
+        "type": "object",
+        "required": [
+          "repos"
+        ],
+        "properties": {
+          "repos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RepoItem"
+            }
+          }
+        }
+      },
       "CreateApiKeyRequest": {
         "type": "object",
         "required": [
@@ -1372,6 +1412,45 @@
           }
         }
       },
+      "RepoItem": {
+        "type": "object",
+        "required": [
+          "repo_id",
+          "full_name",
+          "default_branch",
+          "status",
+          "connected_by",
+          "connected_at",
+          "installation_id"
+        ],
+        "properties": {
+          "connected_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "connected_by": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "default_branch": {
+            "type": "string"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "installation_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "repo_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
       "RepoItemResponse": {
         "type": "object",
         "required": [
@@ -1655,7 +1734,7 @@
     },
     {
       "name": "repos",
-      "description": "Repository management"
+      "description": "Connected repository management"
     }
   ]
 }

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -33,6 +33,7 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
         tenants::remove_member,
         tenants::transfer_ownership,
         repos::connect_repo,
+        repos::list_repos,
         repos::trigger_ingest,
     ),
     components(
@@ -69,6 +70,8 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
             tenants::TransferOwnershipRequest,
             repos::ConnectRepoRequest,
             repos::ConnectRepoResponse,
+            repos::RepoItem,
+            repos::ConnectedReposResponse,
             repos::TriggerIngestResponse,
         )
     ),
@@ -88,7 +91,7 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
         (name = "tenants", description = "Tenant membership and role management"),
         (name = "api_keys", description = "API key management"),
         (name = "github", description = "GitHub App integration"),
-        (name = "repos", description = "Repository management"),
+        (name = "repos", description = "Connected repository management"),
     ),
 )]
 pub struct ApiDoc;

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -21,7 +21,7 @@ use crate::routes::{
     github::webhook::github_webhook,
     health::{health_check, openapi_json, ready_check},
     me::{get_me, switch_tenant},
-    repos::{connect_repo, trigger_ingest},
+    repos::{connect_repo, list_repos, trigger_ingest},
     tenants::{invite_member, list_members, remove_member, transfer_ownership, update_member_role},
 };
 use crate::state::AppState;
@@ -51,7 +51,7 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/github/install-url", get(github_install_url))
         .route("/v1/github/callback", get(github_callback))
         .route("/v1/github/installations/{id}/available-repos", get(list_available_repos))
-        .route("/v1/repos", post(connect_repo))
+        .route("/v1/repos", post(connect_repo).get(list_repos))
         .route("/v1/repos/{id}/ingest", post(trigger_ingest))
         .with_state(state)
 }

--- a/services/control-api/src/routes/repos.rs
+++ b/services/control-api/src/routes/repos.rs
@@ -1,5 +1,6 @@
 //! Repo management endpoints.
-//! - `POST /v1/repos` — Connect a GitHub repo to the tenant (REQ-GH-04).
+//! - `POST /v1/repos`          — Connect a GitHub repo to the tenant (REQ-GH-04).
+//! - `GET  /v1/repos`          — List connected repos for the tenant (REQ-GH-07).
 //! - `POST /v1/repos/{id}/ingest` — Trigger an ingestion run (REQ-GH-08).
 
 use axum::{
@@ -8,6 +9,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use chrono::{DateTime, Utc};
 use rb_github::GhError;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -19,9 +21,8 @@ use crate::{
     state::AppState,
 };
 
-
 // ---------------------------------------------------------------------------
-// POST /v1/repos
+// POST /v1/repos — request / response types
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -40,6 +41,43 @@ pub struct ConnectRepoResponse {
     pub full_name: String,
     pub default_branch: String,
 }
+
+// ---------------------------------------------------------------------------
+// GET /v1/repos — response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RepoItem {
+    pub repo_id: Uuid,
+    pub full_name: String,
+    pub default_branch: String,
+    pub status: String,
+    pub connected_by: Uuid,
+    pub connected_at: DateTime<Utc>,
+    pub installation_id: Uuid,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConnectedReposResponse {
+    pub repos: Vec<RepoItem>,
+}
+
+type RepoRow = (Uuid, String, String, String, Uuid, DateTime<Utc>, Uuid);
+
+// ---------------------------------------------------------------------------
+// POST /v1/repos/{id}/ingest — response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TriggerIngestResponse {
+    pub run_id: Uuid,
+    pub repo_id: Uuid,
+    pub status: String,
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/repos
+// ---------------------------------------------------------------------------
 
 /// Connect a GitHub repository to the calling user's active tenant.
 ///
@@ -138,17 +176,56 @@ pub async fn connect_repo(
     ))
 }
 
+// ---------------------------------------------------------------------------
+// GET /v1/repos
+// ---------------------------------------------------------------------------
+
+/// List all connected repositories for the current session's tenant.
+///
+/// Soft-deleted repos (`archived_at IS NOT NULL`) are excluded.
+/// Results are ordered by `connected_at DESC` (most recently connected first).
+/// Requires a verified session.
+#[utoipa::path(
+    get,
+    path = "/v1/repos",
+    responses(
+        (status = 200, description = "List of connected repos", body = ConnectedReposResponse),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified"),
+    ),
+    tag = "repos"
+)]
+pub async fn list_repos(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let rows: Vec<RepoRow> = sqlx::query_as(
+        "SELECT id, full_name, default_branch, status, connected_by, connected_at, installation_id \
+         FROM control.repos \
+         WHERE tenant_id = $1 AND archived_at IS NULL \
+         ORDER BY connected_at DESC",
+    )
+    .bind(session.tenant_id)
+    .fetch_all(&state.pool)
+    .await?;
+
+    let repos = rows
+        .into_iter()
+        .map(
+            |(repo_id, full_name, default_branch, status, connected_by, connected_at, installation_id)| {
+                RepoItem { repo_id, full_name, default_branch, status, connected_by, connected_at, installation_id }
+            },
+        )
+        .collect();
+
+    Ok(Json(ConnectedReposResponse { repos }))
+}
 
 // ---------------------------------------------------------------------------
 // POST /v1/repos/{id}/ingest — REQ-GH-08
 // ---------------------------------------------------------------------------
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct TriggerIngestResponse {
-    pub run_id: Uuid,
-    pub repo_id: Uuid,
-    pub status: String,
-}
 
 /// Trigger an asynchronous ingestion run for a connected repository.
 ///
@@ -229,6 +306,9 @@ pub async fn trigger_ingest(
     ))
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -243,6 +323,8 @@ mod tests {
             email_verified: true,
         }
     }
+
+    // ----- connect_repo auth tests (REQ-GH-04) -----
 
     #[test]
     fn anonymous_auth_rejected() {
@@ -346,6 +428,8 @@ mod tests {
         assert_eq!(result, "main");
     }
 
+    // ----- trigger_ingest response types (REQ-GH-08) -----
+
     #[test]
     fn trigger_ingest_response_serializes_correctly() {
         let run_id = Uuid::new_v4();
@@ -394,5 +478,42 @@ mod tests {
             AppError::IngestRunAlreadyInFlight.to_string(),
             "an ingestion run is already in progress for this repository"
         );
+    }
+
+    // ----- list_repos response types (REQ-GH-07) -----
+
+    #[test]
+    fn repo_item_serializes_all_fields() {
+        let item = RepoItem {
+            repo_id: Uuid::new_v4(),
+            full_name: "acme/backend".to_owned(),
+            default_branch: "main".to_owned(),
+            status: "connected".to_owned(),
+            connected_by: Uuid::new_v4(),
+            connected_at: Utc::now(),
+            installation_id: Uuid::new_v4(),
+        };
+        let val = serde_json::to_value(&item).unwrap();
+        assert!(val.get("repo_id").is_some());
+        assert_eq!(val["full_name"], "acme/backend");
+        assert_eq!(val["default_branch"], "main");
+        assert_eq!(val["status"], "connected");
+        assert!(val.get("connected_by").is_some());
+        assert!(val.get("connected_at").is_some());
+        assert!(val.get("installation_id").is_some());
+    }
+
+    #[test]
+    fn list_response_wraps_repos_array() {
+        let resp = ConnectedReposResponse { repos: vec![] };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["repos"].is_array());
+    }
+
+    #[test]
+    fn list_response_empty_is_valid() {
+        let resp = ConnectedReposResponse { repos: vec![] };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"repos\":[]"));
     }
 }


### PR DESCRIPTION
## Summary

Implements `GET /v1/repos` (REQ-GH-07) — lists all connected GitHub repositories for the calling session's active tenant.

- Returns `[{ repo_id, full_name, default_branch, status, connected_by, connected_at, installation_id }]`
- Scoped to `session.tenant_id`; soft-deleted rows (`archived_at IS NOT NULL`) excluded
- Results ordered by `connected_at DESC`
- Auth: verified session only (`require_verified_session`)
- `repos.rs` merged with `connect_repo` (REQ-GH-04) — both handlers co-located
- Routes combined: `.route("/v1/repos", post(connect_repo).get(list_repos))`
- OpenAPI spec updated; `openapi.json` and `frontend/src/api/generated/schema.ts` regenerated

Closes #92

## Test plan

- [ ] `cargo test -p control-api` passes (97 unit tests)
- [ ] `GET /v1/repos` returns 200 with repos array for verified session
- [ ] `GET /v1/repos` returns 401 for anonymous / expired session
- [ ] `GET /v1/repos` returns 403 for unverified email
- [ ] Tenant isolation: repos from other tenants not returned
- [ ] Soft-deleted repos excluded from response
- [ ] `POST /v1/repos` (connect) still works after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)