### PR TITLE
[REQ-FE-03] feat(frontend): repo management UI

### DIFF
--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -21,3 +21,14 @@ export {
   useTransferOwnership,
 } from "./useTenantMembers";
 export { useHealth, healthQueryKey } from "./useHealth";
+export {
+  useRepos,
+  reposQueryKey,
+  useConnectRepo,
+  useTriggerIngest,
+  useAvailableRepos,
+  type RepoItem,
+  type AvailableRepo,
+  type AvailableReposResponse,
+} from "./useRepos";
+export { useGithubInstallUrl } from "./useGithubInstall";

--- a/frontend/src/api/hooks/useGithubInstall.ts
+++ b/frontend/src/api/hooks/useGithubInstall.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type InstallUrlResponse = components["schemas"]["InstallUrlResponse"];
+
+export function useGithubInstallUrl() {
+  return useMutation<InstallUrlResponse, ApiError, void>({
+    mutationFn: async () => {
+      const { data, error, response } = await apiClient.GET("/v1/github/install-url");
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -8,7 +8,7 @@ import { apiClient, toApiError, type ApiError } from "../client";
 import type { components } from "../generated/schema";
 
 type RepoItem = components["schemas"]["RepoItem"];
-type ListReposResponse = components["schemas"]["ListReposResponse"];
+type ConnectedReposResponse = components["schemas"]["ConnectedReposResponse"];
 type ConnectRepoRequest = components["schemas"]["ConnectRepoRequest"];
 type ConnectRepoResponse = components["schemas"]["ConnectRepoResponse"];
 type TriggerIngestResponse = components["schemas"]["TriggerIngestResponse"];
@@ -41,9 +41,9 @@ export const availableReposQueryKey = (installationId: string, page: number) =>
 
 export function useRepos(
   tenantId: string,
-  options?: Omit<UseQueryOptions<ListReposResponse, ApiError>, "queryKey" | "queryFn">,
+  options?: Omit<UseQueryOptions<ConnectedReposResponse, ApiError>, "queryKey" | "queryFn">,
 ) {
-  return useQuery<ListReposResponse, ApiError>({
+  return useQuery<ConnectedReposResponse, ApiError>({
     queryKey: reposQueryKey(tenantId),
     queryFn: async () => {
       const { data, error, response } = await apiClient.GET("/v1/repos");

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -1,0 +1,116 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type RepoItem = components["schemas"]["RepoItem"];
+type ListReposResponse = components["schemas"]["ListReposResponse"];
+type ConnectRepoRequest = components["schemas"]["ConnectRepoRequest"];
+type ConnectRepoResponse = components["schemas"]["ConnectRepoResponse"];
+type TriggerIngestResponse = components["schemas"]["TriggerIngestResponse"];
+
+// AvailableRepo is the runtime shape returned by GET /v1/github/installations/{id}/available-repos.
+// The generated schema incorrectly maps it to ListReposResponse (a naming collision in the backend).
+export interface AvailableRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  archived: boolean;
+  default_branch: string;
+  html_url: string;
+}
+export interface AvailableReposResponse {
+  total_count: number;
+  page: number;
+  per_page: number;
+  repositories: AvailableRepo[];
+}
+
+export type { RepoItem };
+
+export const reposQueryKey = (tenantId: string) =>
+  ["tenants", tenantId, "repos"] as const;
+
+export const availableReposQueryKey = (installationId: string, page: number) =>
+  ["github", "installations", installationId, "available-repos", page] as const;
+
+export function useRepos(
+  tenantId: string,
+  options?: Omit<UseQueryOptions<ListReposResponse, ApiError>, "queryKey" | "queryFn">,
+) {
+  return useQuery<ListReposResponse, ApiError>({
+    queryKey: reposQueryKey(tenantId),
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET("/v1/repos");
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0,
+    ...options,
+  });
+}
+
+export function useConnectRepo(tenantId: string) {
+  const qc = useQueryClient();
+  return useMutation<ConnectRepoResponse, ApiError, ConnectRepoRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await apiClient.POST("/v1/repos", { body });
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: reposQueryKey(tenantId) });
+    },
+  });
+}
+
+export function useTriggerIngest() {
+  return useMutation<TriggerIngestResponse, ApiError, string>({
+    mutationFn: async (repoId) => {
+      const { data, error, response } = await apiClient.POST(
+        "/v1/repos/{id}/ingest",
+        { params: { path: { id: repoId } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+  });
+}
+
+export function useAvailableRepos(
+  installationId: string,
+  page = 1,
+  options?: Omit<
+    UseQueryOptions<AvailableReposResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<AvailableReposResponse, ApiError>({
+    queryKey: availableReposQueryKey(installationId, page),
+    queryFn: async () => {
+      // Cast needed: generated schema incorrectly maps this response to ListReposResponse
+      // (name collision with repos::ListReposResponse). The actual runtime shape is AvailableReposResponse.
+      const { data, error, response } = await apiClient.GET(
+        "/v1/github/installations/{id}/available-repos",
+        { params: { path: { id: installationId }, query: { page, per_page: 30 } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data as unknown as AvailableReposResponse;
+    },
+    enabled: installationId.length > 0,
+    ...options,
+  });
+}

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -73,7 +73,8 @@ export function useConnectRepo(tenantId: string) {
   });
 }
 
-export function useTriggerIngest() {
+export function useTriggerIngest(tenantId: string) {
+  const qc = useQueryClient();
   return useMutation<TriggerIngestResponse, ApiError, string>({
     mutationFn: async (repoId) => {
       const { data, error, response } = await apiClient.POST(
@@ -84,6 +85,9 @@ export function useTriggerIngest() {
         throw toApiError(response.status, error);
       }
       return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: reposQueryKey(tenantId) });
     },
   });
 }

--- a/frontend/src/components/repos/PageContainer.tsx
+++ b/frontend/src/components/repos/PageContainer.tsx
@@ -1,0 +1,7 @@
+export function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/components/repos/StatusBadge.tsx
+++ b/frontend/src/components/repos/StatusBadge.tsx
@@ -1,0 +1,19 @@
+interface StatusBadgeProps {
+  readonly status: string;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -6,6 +6,7 @@ export const routes = {
   forgotPassword: "/forgot-password",
   resetPassword: "/reset-password",
   repos: "/repos",
+  repoDetail: "/repos/$repoId",
   members: "/members",
   apiKeys: "/api-keys",
 } as const;

--- a/frontend/src/lib/validation/repos.ts
+++ b/frontend/src/lib/validation/repos.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const connectRepoFormSchema = z.object({
+  installation_id: z
+    .number({ message: "Installation ID is required" })
+    .int()
+    .positive("Installation ID must be a positive integer"),
+  github_repo_id: z
+    .number({ message: "Repository ID is required" })
+    .int()
+    .positive("Repository ID must be a positive integer"),
+  default_branch: z.string().optional(),
+});
+
+export type ConnectRepoFormValues = z.infer<typeof connectRepoFormSchema>;

--- a/frontend/src/pages/RepoDetailPage.tsx
+++ b/frontend/src/pages/RepoDetailPage.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner";
 import { useMe, useRepos, useTriggerIngest } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { routes } from "@/lib/routes";
+import { StatusBadge } from "@/components/repos/StatusBadge";
+import { PageContainer } from "@/components/repos/PageContainer";
 
 export function RepoDetailPage(): JSX.Element {
   const { repoId } = useParams({ from: "/repos/$repoId" });
@@ -48,7 +50,7 @@ function RepoDetailInner({
   tenantId,
 }: RepoDetailInnerProps): JSX.Element {
   const repos = useRepos(tenantId);
-  const triggerIngest = useTriggerIngest();
+  const triggerIngest = useTriggerIngest(tenantId);
   const [ingestRunId, setIngestRunId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -170,28 +172,4 @@ function RepoDetailInner({
       )}
     </PageContainer>
   );
-}
-
-function StatusBadge({ status }: { readonly status: string }): JSX.Element {
-  const colors =
-    status === "connected"
-      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
-      : status === "ingesting"
-        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-        : "border-border bg-muted text-muted-foreground";
-  return (
-    <span
-      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function PageContainer({
-  children,
-}: {
-  readonly children: React.ReactNode;
-}): JSX.Element {
-  return <div className="container max-w-3xl py-8">{children}</div>;
 }

--- a/frontend/src/pages/RepoDetailPage.tsx
+++ b/frontend/src/pages/RepoDetailPage.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { Link, useParams } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { useMe, useRepos, useTriggerIngest } from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+
+export function RepoDetailPage(): JSX.Element {
+  const { repoId } = useParams({ from: "/repos/$repoId" });
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">
+          You need to be signed in.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-2 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <RepoDetailInner repoId={repoId} tenantId={me.data.current_tenant.id} />
+  );
+}
+
+interface RepoDetailInnerProps {
+  readonly repoId: string;
+  readonly tenantId: string;
+}
+
+function RepoDetailInner({
+  repoId,
+  tenantId,
+}: RepoDetailInnerProps): JSX.Element {
+  const repos = useRepos(tenantId);
+  const triggerIngest = useTriggerIngest();
+  const [ingestRunId, setIngestRunId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const repo = repos.data?.repos.find((r) => r.repo_id === repoId) ?? null;
+
+  const handleIngest = async () => {
+    if (!repo) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await triggerIngest.mutateAsync(repo.repo_id);
+      setIngestRunId(result.run_id);
+      toast.success("Ingestion run queued.");
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not trigger ingestion."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <PageContainer>
+      <nav className="mb-4">
+        <Link
+          to={routes.repos}
+          className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+        >
+          ← Repositories
+        </Link>
+      </nav>
+
+      {repos.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading repository…</p>
+      ) : repos.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(repos.error, "Could not load repository.")}
+        </p>
+      ) : !repo ? (
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Repository not found
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This repository could not be found in your workspace.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <header className="flex flex-col gap-1">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {repo.full_name}
+            </h1>
+            <StatusBadge status={repo.status} />
+          </header>
+
+          <section
+            aria-labelledby="repo-details-heading"
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <h2
+              id="repo-details-heading"
+              className="mb-3 text-sm font-medium"
+            >
+              Details
+            </h2>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+              <dt className="text-muted-foreground">Default branch</dt>
+              <dd className="font-mono">{repo.default_branch}</dd>
+
+              <dt className="text-muted-foreground">Repository ID</dt>
+              <dd className="truncate font-mono text-xs">{repo.repo_id}</dd>
+
+              <dt className="text-muted-foreground">Connected</dt>
+              <dd>
+                {new Date(repo.connected_at).toLocaleString()}
+              </dd>
+            </dl>
+          </section>
+
+          <section
+            aria-labelledby="ingest-heading"
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <h2 id="ingest-heading" className="mb-1 text-sm font-medium">
+              Ingestion
+            </h2>
+            <p className="mb-4 text-xs text-muted-foreground">
+              Trigger a full ingestion run to index the latest state of this
+              repository.
+            </p>
+
+            {ingestRunId ? (
+              <div className="rounded-md bg-muted px-3 py-2 text-sm">
+                <p className="font-medium text-foreground">
+                  Ingestion run queued
+                </p>
+                <p className="mt-0.5 font-mono text-xs text-muted-foreground">
+                  Run ID: {ingestRunId}
+                </p>
+              </div>
+            ) : (
+              <button
+                type="button"
+                disabled={busy || repo.status !== "connected"}
+                onClick={handleIngest}
+                title={
+                  repo.status !== "connected"
+                    ? "Repository must be in connected status to trigger ingestion"
+                    : undefined
+                }
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {busy ? "Queuing run…" : "Trigger ingestion"}
+              </button>
+            )}
+          </section>
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: string }): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import {
   useMe,
   useRepos,
@@ -12,6 +14,12 @@ import {
 } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { routes } from "@/lib/routes";
+import {
+  connectRepoFormSchema,
+  type ConnectRepoFormValues,
+} from "@/lib/validation/repos";
+import { StatusBadge } from "@/components/repos/StatusBadge";
+import { PageContainer } from "@/components/repos/PageContainer";
 
 // ---------------------------------------------------------------------------
 // ReposPage — entry point
@@ -152,20 +160,6 @@ function RepoRow({ repo }: { readonly repo: RepoItem }): JSX.Element {
   );
 }
 
-function StatusBadge({ status }: { readonly status: string }): JSX.Element {
-  const colors =
-    status === "connected"
-      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
-      : status === "ingesting"
-        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-        : "border-border bg-muted text-muted-foreground";
-  return (
-    <span className={`rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}>
-      {status}
-    </span>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Empty state
 // ---------------------------------------------------------------------------
@@ -189,8 +183,16 @@ function EmptyState({ onConnect }: { readonly onConnect: () => void }): JSX.Elem
 }
 
 // ---------------------------------------------------------------------------
-// Connect repo dialog
+// Connect repo dialog — focus trap + Escape
 // ---------------------------------------------------------------------------
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
 
 type ConnectStep = "install" | "pick";
 
@@ -213,13 +215,53 @@ function ConnectRepoDialog({
   const [resolvedInstallId, setResolvedInstallId] = useState<string>(
     installationId ?? "",
   );
-  // Numeric installation_id (GitHub's i64) required by POST /v1/repos.
-  // Not available from connected-repos list (which only stores internal UUID).
-  // User must supply it; they can find it in the GitHub App callback response.
-  const [numericInstallId, setNumericInstallId] = useState("");
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Save trigger element; focus first focusable on mount; restore on unmount
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const focusables = getFocusableElements(dialogRef.current);
+    focusables[0]?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  // Escape key closes dialog; Tab/Shift+Tab cycles within dialog
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusables = getFocusableElements(dialogRef.current);
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!first || !last) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="connect-repo-title"
@@ -259,8 +301,6 @@ function ConnectRepoDialog({
           <PickRepoStep
             tenantId={tenantId}
             installationUuid={resolvedInstallId}
-            numericInstallId={numericInstallId}
-            onNumericInstallIdChange={setNumericInstallId}
             onSuccess={onSuccess}
           />
         )}
@@ -319,45 +359,50 @@ function InstallStep({
 }
 
 // ---------------------------------------------------------------------------
-// Step 2 — Pick repo from available list
+// Step 2 — Pick repo from available list (with field-level validation)
 // ---------------------------------------------------------------------------
 
 interface PickRepoStepProps {
   readonly tenantId: string;
   readonly installationUuid: string;
-  readonly numericInstallId: string;
-  readonly onNumericInstallIdChange: (v: string) => void;
   readonly onSuccess: () => void;
 }
 
 function PickRepoStep({
   tenantId,
   installationUuid,
-  numericInstallId,
-  onNumericInstallIdChange,
   onSuccess,
 }: PickRepoStepProps): JSX.Element {
   const available = useAvailableRepos(installationUuid, 1, {
     enabled: installationUuid.length > 0,
   });
   const connect = useConnectRepo(tenantId);
-  const [selected, setSelected] = useState<AvailableRepo | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const numericId = Number(numericInstallId);
-  const canConnect =
-    selected !== null && Number.isFinite(numericId) && numericId > 0;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<ConnectRepoFormValues>({
+    resolver: zodResolver(connectRepoFormSchema),
+  });
 
-  const handleConnect = async () => {
-    if (!selected || !canConnect) {
-      return;
-    }
+  const selectedRepoId = watch("github_repo_id");
+
+  const handleSelectRepo = (repo: AvailableRepo) => {
+    setValue("github_repo_id", repo.id, { shouldValidate: true });
+    setValue("default_branch", repo.default_branch || undefined);
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
     setBusy(true);
     try {
       const result = await connect.mutateAsync({
-        installation_id: numericId,
-        github_repo_id: selected.id,
-        default_branch: selected.default_branch || null,
+        installation_id: values.installation_id,
+        github_repo_id: values.github_repo_id,
+        default_branch: values.default_branch ?? null,
       });
       toast.success(`Connected ${result.full_name}.`);
       onSuccess();
@@ -366,10 +411,10 @@ function PickRepoStep({
     } finally {
       setBusy(false);
     }
-  };
+  });
 
   return (
-    <div className="flex flex-col gap-4">
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
       {/* Numeric installation ID input */}
       <div className="flex flex-col gap-1">
         <label
@@ -383,15 +428,20 @@ function PickRepoStep({
           type="number"
           min={1}
           placeholder="e.g. 12345678"
-          value={numericInstallId}
-          onChange={(e) => onNumericInstallIdChange(e.target.value)}
+          {...register("installation_id", { valueAsNumber: true })}
           className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
-        <p className="text-xs text-muted-foreground">
-          Find this in the GitHub App callback response (
-          <code className="rounded bg-muted px-1 text-xs">installation_id</code> field)
-          or your GitHub App settings.
-        </p>
+        {errors.installation_id ? (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.installation_id.message}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Find this in the GitHub App callback response (
+            <code className="rounded bg-muted px-1 text-xs">installation_id</code>{" "}
+            field) or your GitHub App settings.
+          </p>
+        )}
       </div>
 
       {/* Available repos list */}
@@ -412,14 +462,19 @@ function PickRepoStep({
           <p className="text-xs font-medium text-foreground">
             Select a repository
           </p>
+          {errors.github_repo_id ? (
+            <p className="text-xs text-destructive" role="alert">
+              {errors.github_repo_id.message}
+            </p>
+          ) : null}
           <ul className="max-h-48 divide-y divide-border overflow-y-auto rounded-md border border-border bg-card">
             {available.data.repositories.map((repo) => (
               <li key={repo.id}>
                 <button
                   type="button"
-                  onClick={() => setSelected(repo)}
+                  onClick={() => handleSelectRepo(repo)}
                   className={`w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground ${
-                    selected?.id === repo.id
+                    selectedRepoId === repo.id
                       ? "bg-primary/10 font-medium"
                       : ""
                   }`}
@@ -439,25 +494,12 @@ function PickRepoStep({
       )}
 
       <button
-        type="button"
-        disabled={!canConnect || busy}
-        onClick={handleConnect}
+        type="submit"
+        disabled={busy}
         className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy ? "Connecting…" : "Connect repository"}
       </button>
-    </div>
+    </form>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Layout helper
-// ---------------------------------------------------------------------------
-
-function PageContainer({
-  children,
-}: {
-  readonly children: React.ReactNode;
-}): JSX.Element {
-  return <div className="container max-w-3xl py-8">{children}</div>;
 }

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,0 +1,463 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  useMe,
+  useRepos,
+  useConnectRepo,
+  useAvailableRepos,
+  useGithubInstallUrl,
+  type RepoItem,
+  type AvailableRepo,
+} from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+
+// ---------------------------------------------------------------------------
+// ReposPage — entry point
+// ---------------------------------------------------------------------------
+
+export function ReposPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need to be signed in to manage repositories.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return <ReposPageInner tenantId={me.data.current_tenant.id} />;
+}
+
+// ---------------------------------------------------------------------------
+// Inner page (tenant resolved)
+// ---------------------------------------------------------------------------
+
+interface ReposPageInnerProps {
+  readonly tenantId: string;
+}
+
+function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
+  const repos = useRepos(tenantId);
+  const [showConnect, setShowConnect] = useState(false);
+
+  const connectedList: readonly RepoItem[] = repos.data?.repos ?? [];
+
+  // Derive the installation UUID from the first connected repo (if any).
+  // This lets us populate the available-repos picker for subsequent connects.
+  const knownInstallationId = connectedList[0]?.installation_id ?? null;
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Connected GitHub repositories for this workspace.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowConnect(true)}
+          className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Connect a repo
+        </button>
+      </header>
+
+      {repos.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading repositories…</p>
+      ) : repos.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(repos.error, "Could not load repositories.")}
+        </p>
+      ) : connectedList.length === 0 ? (
+        <EmptyState onConnect={() => setShowConnect(true)} />
+      ) : (
+        <RepoList repos={connectedList} />
+      )}
+
+      {showConnect ? (
+        <ConnectRepoDialog
+          tenantId={tenantId}
+          installationId={knownInstallationId}
+          onClose={() => setShowConnect(false)}
+          onSuccess={() => setShowConnect(false)}
+        />
+      ) : null}
+    </PageContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Repo list
+// ---------------------------------------------------------------------------
+
+function RepoList({ repos }: { readonly repos: readonly RepoItem[] }): JSX.Element {
+  return (
+    <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+      {repos.map((repo) => (
+        <RepoRow key={repo.repo_id} repo={repo} />
+      ))}
+    </ul>
+  );
+}
+
+function RepoRow({ repo }: { readonly repo: RepoItem }): JSX.Element {
+  const connectedAt = new Date(repo.connected_at);
+  const relativeDate = Number.isNaN(connectedAt.getTime())
+    ? "—"
+    : connectedAt.toLocaleDateString();
+
+  return (
+    <li className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{repo.full_name}</span>
+        <span className="text-xs text-muted-foreground">
+          Branch: <span className="font-mono">{repo.default_branch}</span>
+          {" · "}
+          Connected {relativeDate}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusBadge status={repo.status} />
+        <Link
+          to="/repos/$repoId"
+          params={{ repoId: repo.repo_id }}
+          className="rounded-md border border-border px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          View
+        </Link>
+      </div>
+    </li>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: string }): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span className={`rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}>
+      {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState({ onConnect }: { readonly onConnect: () => void }): JSX.Element {
+  return (
+    <div className="flex flex-col items-center rounded-lg border border-dashed border-border py-12 text-center">
+      <p className="text-sm font-medium text-foreground">No repositories connected</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Connect a GitHub repository to start indexing your codebase.
+      </p>
+      <button
+        type="button"
+        onClick={onConnect}
+        className="mt-4 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Connect your first repo
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connect repo dialog
+// ---------------------------------------------------------------------------
+
+type ConnectStep = "install" | "pick";
+
+interface ConnectRepoDialogProps {
+  readonly tenantId: string;
+  readonly installationId: string | null;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+function ConnectRepoDialog({
+  tenantId,
+  installationId,
+  onClose,
+  onSuccess,
+}: ConnectRepoDialogProps): JSX.Element {
+  const [step, setStep] = useState<ConnectStep>(
+    installationId ? "pick" : "install",
+  );
+  const [resolvedInstallId, setResolvedInstallId] = useState<string>(
+    installationId ?? "",
+  );
+  // Numeric installation_id (GitHub's i64) required by POST /v1/repos.
+  // Not available from connected-repos list (which only stores internal UUID).
+  // User must supply it; they can find it in the GitHub App callback response.
+  const [numericInstallId, setNumericInstallId] = useState("");
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="connect-repo-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="flex w-full max-w-lg flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-xl">
+        <div className="flex items-start justify-between">
+          <h2
+            id="connect-repo-title"
+            className="text-lg font-semibold tracking-tight"
+          >
+            Connect a repository
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        {step === "install" ? (
+          <InstallStep
+            onInstalled={(installUuid) => {
+              setResolvedInstallId(installUuid);
+              setStep("pick");
+            }}
+          />
+        ) : (
+          <PickRepoStep
+            tenantId={tenantId}
+            installationUuid={resolvedInstallId}
+            numericInstallId={numericInstallId}
+            onNumericInstallIdChange={setNumericInstallId}
+            onSuccess={onSuccess}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Install GitHub App
+// ---------------------------------------------------------------------------
+
+function InstallStep({
+  onInstalled,
+}: {
+  readonly onInstalled: (installUuid: string) => void;
+}): JSX.Element {
+  const installUrl = useGithubInstallUrl();
+
+  const handleInstall = async () => {
+    try {
+      const result = await installUrl.mutateAsync();
+      window.open(result.url, "_blank", "noopener");
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not generate install link."));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        First, install the GitHub App on the organization or account that owns
+        the repositories you want to connect.
+      </p>
+      <button
+        type="button"
+        disabled={installUrl.isPending}
+        onClick={handleInstall}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {installUrl.isPending ? "Generating link…" : "Install GitHub App →"}
+      </button>
+      <p className="text-xs text-muted-foreground">
+        After installing, return here and click{" "}
+        <strong>I&apos;ve installed the app</strong>.
+      </p>
+      <button
+        type="button"
+        onClick={() => onInstalled("")}
+        className="self-start text-sm font-medium text-primary hover:underline"
+      >
+        I&apos;ve installed the app →
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Pick repo from available list
+// ---------------------------------------------------------------------------
+
+interface PickRepoStepProps {
+  readonly tenantId: string;
+  readonly installationUuid: string;
+  readonly numericInstallId: string;
+  readonly onNumericInstallIdChange: (v: string) => void;
+  readonly onSuccess: () => void;
+}
+
+function PickRepoStep({
+  tenantId,
+  installationUuid,
+  numericInstallId,
+  onNumericInstallIdChange,
+  onSuccess,
+}: PickRepoStepProps): JSX.Element {
+  const available = useAvailableRepos(installationUuid, 1, {
+    enabled: installationUuid.length > 0,
+  });
+  const connect = useConnectRepo(tenantId);
+  const [selected, setSelected] = useState<AvailableRepo | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const numericId = Number(numericInstallId);
+  const canConnect =
+    selected !== null && Number.isFinite(numericId) && numericId > 0;
+
+  const handleConnect = async () => {
+    if (!selected || !canConnect) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await connect.mutateAsync({
+        installation_id: numericId,
+        github_repo_id: selected.id,
+        default_branch: selected.default_branch || null,
+      });
+      toast.success(`Connected ${result.full_name}.`);
+      onSuccess();
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not connect repository."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Numeric installation ID input */}
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="numeric-install-id"
+          className="text-xs font-medium text-foreground"
+        >
+          GitHub installation ID (numeric)
+        </label>
+        <input
+          id="numeric-install-id"
+          type="number"
+          min={1}
+          placeholder="e.g. 12345678"
+          value={numericInstallId}
+          onChange={(e) => onNumericInstallIdChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <p className="text-xs text-muted-foreground">
+          Find this in the GitHub App callback response (
+          <code className="rounded bg-muted px-1 text-xs">installation_id</code> field)
+          or your GitHub App settings.
+        </p>
+      </div>
+
+      {/* Available repos list */}
+      {installationUuid.length === 0 ? (
+        <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          Return here after installing the GitHub App to see available repositories.
+        </p>
+      ) : available.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading available repos…</p>
+      ) : available.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(available.error, "Could not load repositories.")}
+        </p>
+      ) : !available.data || available.data.repositories.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No repositories accessible.</p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-medium text-foreground">
+            Select a repository
+          </p>
+          <ul className="max-h-48 divide-y divide-border overflow-y-auto rounded-md border border-border bg-card">
+            {available.data.repositories.map((repo) => (
+              <li key={repo.id}>
+                <button
+                  type="button"
+                  onClick={() => setSelected(repo)}
+                  className={`w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground ${
+                    selected?.id === repo.id
+                      ? "bg-primary/10 font-medium"
+                      : ""
+                  }`}
+                >
+                  <span className="block font-medium">{repo.full_name}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {repo.private ? "Private" : "Public"}
+                    {" · "}
+                    {repo.default_branch}
+                    {repo.archived ? " · archived" : ""}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <button
+        type="button"
+        disabled={!canConnect || busy}
+        onClick={handleConnect}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {busy ? "Connecting…" : "Connect repository"}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layout helper
+// ---------------------------------------------------------------------------
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,7 +12,8 @@ import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
 import { LoginPage } from "@/pages/LoginPage";
 import { MembersPage } from "@/pages/MembersPage";
-import { ReposPlaceholderPage } from "@/pages/ReposPlaceholderPage";
+import { ReposPage } from "@/pages/ReposPage";
+import { RepoDetailPage } from "@/pages/RepoDetailPage";
 import { ResetPasswordPage } from "@/pages/ResetPasswordPage";
 import { SignupPage } from "@/pages/SignupPage";
 import { VerifyEmailPage } from "@/pages/VerifyEmailPage";
@@ -80,7 +81,13 @@ const resetPasswordRoute = createRoute({
 const reposRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: routes.repos,
-  component: ReposPlaceholderPage,
+  component: ReposPage,
+});
+
+const repoDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.repoDetail,
+  component: RepoDetailPage,
 });
 
 const membersRoute = createRoute({
@@ -112,6 +119,7 @@ const routeTree = rootRoute.addChildren([
   forgotPasswordRoute,
   resetPasswordRoute,
   reposRoute,
+  repoDetailRoute,
   membersRoute,
   apiKeysRoute,
   catchAllRoute,


### PR DESCRIPTION
## Summary

- `ReposPage` (`/repos`): list connected repos with status badges, empty state, "Connect a repo" two-step dialog (install GitHub App → pick repo from available list)
- `RepoDetailPage` (`/repos/$repoId`): details card (default branch, ID, connected date) + ingestion section with trigger button
- Hooks: `useRepos`, `useConnectRepo`, `useTriggerIngest`, `useAvailableRepos`, `useGithubInstallUrl`
- Zod schema `connectRepoFormSchema` for connect-repo form validation
- Route `/repos/$repoId` added to TanStack Router

## Technical notes

- Custom `AvailableRepo` / `AvailableReposResponse` interfaces work around utoipa schema-name collision (both `github::repos` and `repos` register a `ListReposResponse` schema; utoipa deduplicates to the connected-repos version, making the generated type unusable for the available-repos endpoint)
- Connect flow requires manual numeric `installation_id` input because `GET /v1/repos` returns only internal UUID; follow-up: create child issue for `GET /v1/github/installations`
- Trigger ingestion button is disabled when `repo.status !== "connected"` to prevent invalid API calls

## Test plan

- [ ] `/repos` shows spinner while loading, error message on failure, empty state when no repos connected
- [ ] "Connect a repo" opens dialog at install step when no installation UUID is known
- [ ] Install GitHub App link opens in new tab
- [ ] "I've installed the app" advances to pick step
- [ ] Available repos list populates from `GET /v1/github/installations/{id}/available-repos`
- [ ] Selecting a repo + entering numeric install ID enables the Connect button
- [ ] Successful connect shows toast and closes dialog, list refreshes
- [ ] `/repos/$repoId` shows repo details for a known repo
- [ ] Trigger ingestion button disabled for non-`connected` status repos
- [ ] Trigger ingestion queues run and shows run_id

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)