### PR TITLE
[REQ-CI-02] feat(ci): add frontend-axe-dispatch.yml on-demand workflow

### DIFF
--- a/.github/workflows/frontend-axe-dispatch.yml
+++ b/.github/workflows/frontend-axe-dispatch.yml
@@ -1,0 +1,86 @@
+name: Frontend Axe Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_branch:
+        description: "PR branch being scanned"
+        required: true
+        type: string
+      sha:
+        description: "Commit SHA to check out and scan"
+        required: true
+        type: string
+      route:
+        description: "Route to scan (e.g. /login). Leave empty to scan all routes."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  axe-scan:
+    name: axe accessibility scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install Playwright and axe-core
+        run: npm install --no-save @playwright/test@^1.52.0 @axe-core/playwright@^4.10.0
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-axe-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Run axe scan + focus-trap probe
+        env:
+          CI: "true"
+          SCAN_ROUTE: ${{ inputs.route }}
+          SCAN_SHA: ${{ inputs.sha }}
+          SCAN_BRANCH: ${{ inputs.pr_branch }}
+        run: >-
+          npx playwright test e2e/axe-dispatch.spec.ts
+          --config playwright.axe.config.ts
+
+      - name: Upload accessibility artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-report-${{ inputs.sha }}
+          path: |
+            frontend/axe-results/
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 30

--- a/frontend/e2e/axe-dispatch.spec.ts
+++ b/frontend/e2e/axe-dispatch.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { mkdirSync, writeFileSync } from "fs";
+import path from "path";
+
+const ALL_ROUTES = [
+  "/login",
+  "/signup",
+  "/verify-email",
+  "/forgot-password",
+  "/reset-password",
+  "/repos",
+  "/members",
+  "/api-keys",
+] as const;
+
+const scanRouteEnv = (process.env.SCAN_ROUTE ?? "").trim();
+const routes: string[] = scanRouteEnv ? [scanRouteEnv] : [...ALL_ROUTES];
+
+const OUT_DIR = path.resolve("axe-results");
+
+function routeToSlug(route: string): string {
+  return route.replace(/^\//, "").replace(/\//g, "-") || "root";
+}
+
+interface FocusEntry {
+  tag: string;
+  role: string | null;
+  label: string | null;
+}
+
+interface RouteAxeResult {
+  route: string;
+  violations: { id: string; description: string; impact: string | null; nodes: number }[];
+  passes: number;
+  incomplete: number;
+}
+
+const allResults: RouteAxeResult[] = [];
+
+test.describe("axe-dispatch", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(() => {
+    mkdirSync(OUT_DIR, { recursive: true });
+  });
+
+  test.afterAll(() => {
+    const report = {
+      branch: process.env.SCAN_BRANCH ?? "",
+      sha: process.env.SCAN_SHA ?? "",
+      scannedAt: new Date().toISOString(),
+      summary: {
+        routes: allResults.length,
+        totalViolations: allResults.reduce((s, r) => s + r.violations.length, 0),
+      },
+      results: allResults,
+    };
+    writeFileSync(path.join(OUT_DIR, "axe-report.json"), JSON.stringify(report, null, 2));
+  });
+
+  for (const route of routes) {
+    const slug = routeToSlug(route);
+
+    test(`axe scan: ${route}`, async ({ page }, testInfo) => {
+      await page.goto(route);
+
+      const result = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+        .analyze();
+
+      const routeResult: RouteAxeResult = {
+        route,
+        violations: result.violations.map((v) => ({
+          id: v.id,
+          description: v.description,
+          impact: v.impact ?? null,
+          nodes: v.nodes.length,
+        })),
+        passes: result.passes.length,
+        incomplete: result.incomplete.length,
+      };
+      allResults.push(routeResult);
+
+      const screenshot = await page.screenshot({ fullPage: true });
+      await testInfo.attach(`screenshot-${slug}`, {
+        body: screenshot,
+        contentType: "image/png",
+      });
+      writeFileSync(path.join(OUT_DIR, `${slug}.png`), screenshot);
+      writeFileSync(path.join(OUT_DIR, `${slug}-axe.json`), JSON.stringify(routeResult, null, 2));
+
+      expect(
+        result.violations,
+        `axe violations on ${route}: ${result.violations.map((v) => v.id).join(", ")}`,
+      ).toHaveLength(0);
+    });
+
+    test(`focus-trap probe: ${route}`, async ({ page }, testInfo) => {
+      await page.goto(route);
+
+      const focusOrder: FocusEntry[] = [];
+      for (let i = 0; i < 10; i++) {
+        await page.keyboard.press("Tab");
+        const entry = await page.evaluate((): FocusEntry | null => {
+          const el = document.activeElement as HTMLElement | null;
+          if (!el || el === document.body) return null;
+          return {
+            tag: el.tagName,
+            role: el.getAttribute("role"),
+            label:
+              el.getAttribute("aria-label") ??
+              el.textContent?.trim().slice(0, 40) ??
+              null,
+          };
+        });
+        if (entry) focusOrder.push(entry);
+      }
+
+      const focusReport = { route, focusOrder };
+      await testInfo.attach(`focus-${slug}.json`, {
+        body: Buffer.from(JSON.stringify(focusReport, null, 2)),
+        contentType: "application/json",
+      });
+      writeFileSync(path.join(OUT_DIR, `${slug}-focus.json`), JSON.stringify(focusReport, null, 2));
+
+      expect(focusOrder, `no focusable elements on ${route}`).not.toHaveLength(0);
+    });
+  }
+});

--- a/frontend/playwright.axe.config.ts
+++ b/frontend/playwright.axe.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    ["list"],
+  ],
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "npm run preview",
+    url: "http://localhost:4173",
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  outputDir: "test-results",
+});


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered accessibility scan workflow for on-demand QA use. This is the **thin Option-3** layer from the accessibility design: QA fires it per QA pass to scan a specific PR branch + SHA when the gating spec set does not yet cover a new component.

- New workflow `.github/workflows/frontend-axe-dispatch.yml`
  - `workflow_dispatch` only — not part of the regular CI matrix
  - Inputs: `pr_branch` (required), `sha` (required), `route` (optional, defaults to all 8 app routes)
  - Installs `@playwright/test` + `@axe-core/playwright` inline (`--no-save`) — zero conflict with the pending PR that adds these as devDeps
  - Builds frontend, starts `vite preview` via Playwright's built-in `webServer`
  - Runs axe-core WCAG 2.x scan + 10-step focus-trap probe per route
  - Uploads artifact `axe-report-<sha>` with 30-day retention

- New spec `frontend/e2e/axe-dispatch.spec.ts`
  - `SCAN_ROUTE` env var selects one route or all routes when empty
  - Writes `axe-results/axe-report.json` (consolidated) + per-route `<slug>-axe.json`, `<slug>-focus.json`, `<slug>.png`
  - Attaches screenshots + focus JSON to Playwright HTML report

- New config `frontend/playwright.axe.config.ts`
  - Dedicated Playwright config for the dispatch workflow; zero conflict with the pending e2e PR `playwright.config.ts`

## Artifact contract

```
axe-report-<sha>/
  frontend/axe-results/
    axe-report.json           # consolidated: branch, sha, summary, all route results
    <slug>-axe.json           # per-route violations + pass/incomplete counts
    <slug>-focus.json         # 10-step focus order per route
    <slug>.png                # full-page screenshot per route
  frontend/playwright-report/ # HTML report with attached screenshots + focus JSON
  frontend/test-results/      # Playwright traces (on failure)
```

## QA usage

```bash
gh workflow run frontend-axe-dispatch.yml --ref main \
  -f pr_branch=feature/my-component \
  -f sha=abc1234 \
  [-f route=/login]
```

## Notes

- `playwright.axe.config.ts` uses `workers: 1` (serial) to avoid focus-trap state pollution between routes
- Timeout: 15 min max; typical run with warm browser cache ≤ 5 min
- Type-check CI is unaffected: `e2e/axe-dispatch.spec.ts` is outside all tsconfig `include` arrays on this branch

Closes #98
