### PR TITLE
[REQ-FE-04] feat(frontend): baseline Playwright E2E spec set

### DIFF
--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -1,0 +1,140 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_RESPONSE,
+  REPOS_EMPTY_RESPONSE,
+  REPO_ITEM,
+  MEMBERS_RESPONSE,
+} from "./fixtures/mock-api";
+
+// Runs @axe-core/playwright against the main routes and fails on any
+// serious or critical accessibility violations.
+
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function scanPage(
+  page: import("@playwright/test").Page,
+): Promise<import("axe-core").Result[]> {
+  const results = await new AxeBuilder({ page })
+    .withTags(WCAG_TAGS)
+    .analyze();
+  return results.violations.filter(
+    (v) => v.impact === "serious" || v.impact === "critical",
+  );
+}
+
+test.describe("Axe accessibility scan — main routes", () => {
+  test("login page has no serious/critical violations", async ({ page }) => {
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repos list page has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repos list (empty state) has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repo detail page has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_RESPONSE }),
+    );
+
+    await page.goto(`/repos/${REPO_ITEM.repo_id}`);
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("connect-repo dialog (ingest trigger surface) has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    // Open the connect dialog so the modal surface is included in the scan.
+    await page.getByRole("button", { name: "Connect a repo" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("members page has no serious/critical violations", async ({ page }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/tenants/*/members", (route) =>
+      route.fulfill({ json: MEMBERS_RESPONSE }),
+    );
+
+    await page.goto("/members");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -138,3 +138,4 @@ test.describe("Axe accessibility scan — main routes", () => {
     ).toHaveLength(0);
   });
 });
+

--- a/frontend/e2e/escape-dismissal.spec.ts
+++ b/frontend/e2e/escape-dismissal.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { ReposPage } from "./pages/ReposPage";
+
+test.describe("Escape dismissal (WCAG 2.1.2)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+  });
+
+  test("ConnectRepoDialog closes on Escape key", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await dialog.dismissWithEscape();
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("ConnectRepoDialog closes via ✕ close button", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await dialog.closeButton.click();
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("ConnectRepoDialog closes on backdrop click", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // The backdrop is the dialog overlay element itself (fixed inset-0).
+    // Clicking a corner far outside the inner panel triggers onClose.
+    await dialog.dialog.click({ position: { x: 5, y: 5 } });
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("dialog can be opened again after Escape dismissal", async ({
+    page,
+  }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+    await dialog.dismissWithEscape();
+    await expect(dialog.dialog).not.toBeVisible();
+
+    // Re-open
+    const dialog2 = await reposPage.openConnectDialog();
+    await expect(dialog2.dialog).toBeVisible();
+  });
+});

--- a/frontend/e2e/field-validation.spec.ts
+++ b/frontend/e2e/field-validation.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { LoginPage } from "./pages/LoginPage";
+
+test.describe("Field-level validation errors", () => {
+  test.describe("Login form (Field component / aria-invalid)", () => {
+    test("empty submit: errors appear under correct fields with aria-invalid", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      await loginPage.submit();
+
+      // Both inputs get aria-invalid="true"
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+
+      // Error paragraphs appear with role="alert" under the right inputs
+      await expect(loginPage.emailError).toBeVisible();
+      await expect(loginPage.emailError).toContainText(/required|valid/i);
+
+      await expect(loginPage.passwordError).toBeVisible();
+      await expect(loginPage.passwordError).toContainText(/required/i);
+
+      // aria-describedby links each input to its own error id
+      await expect(loginPage.emailInput).toHaveAttribute(
+        "aria-describedby",
+        "email-error",
+      );
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-describedby",
+        "password-error",
+      );
+    });
+
+    test("invalid email format: email-specific error text", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      await loginPage.emailInput.fill("not-an-email");
+      await loginPage.submit();
+
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+      await expect(loginPage.emailError).toContainText(/valid email/i);
+
+      // Password was not touched — its error fires independently
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+
+    test("valid email clears aria-invalid after correction", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // Trigger validation
+      await loginPage.submit();
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+
+      // Fix the email — react-hook-form re-validates on change
+      await loginPage.emailInput.fill("good@example.com");
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "false");
+      await expect(loginPage.emailError).not.toBeVisible();
+    });
+  });
+
+  test.describe("ConnectRepoDialog pick step (plain input errors)", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route("**/v1/me", (route) =>
+        route.fulfill({ json: ME_RESPONSE }),
+      );
+      await page.route("**/v1/repos", (route) => {
+        if (route.request().method() === "GET") {
+          return route.fulfill({ json: REPOS_EMPTY_RESPONSE });
+        }
+        return route.continue();
+      });
+    });
+
+    test("submitting without installation_id shows error alert", async ({
+      page,
+    }) => {
+      await page.goto("/repos");
+      await page.waitForLoadState("networkidle");
+
+      await page.getByRole("button", { name: "Connect a repo" }).click();
+      // Advance past the install step
+      await page
+        .getByRole("button", { name: /I've installed the app/ })
+        .click();
+
+      // Submit without filling any fields
+      await page.getByRole("button", { name: "Connect repository" }).click();
+
+      // A role="alert" paragraph renders under the installation_id input
+      const alert = page.locator('[role="alert"]').first();
+      await expect(alert).toBeVisible();
+      await expect(alert).toContainText(/installation id|positive integer/i);
+    });
+  });
+});

--- a/frontend/e2e/fixtures/mock-api.ts
+++ b/frontend/e2e/fixtures/mock-api.ts
@@ -1,0 +1,93 @@
+import { type Page } from "@playwright/test";
+
+export const ME_RESPONSE = {
+  user: {
+    id: "user-1",
+    email: "test@example.com",
+    email_verified: true,
+    created_at: "2024-01-01T00:00:00Z",
+    status: "active",
+  },
+  current_tenant: {
+    id: "tenant-1",
+    name: "Test Workspace",
+    role: "owner",
+    slug: "test-workspace",
+  },
+  available_tenants: [
+    {
+      id: "tenant-1",
+      name: "Test Workspace",
+      role: "owner",
+      slug: "test-workspace",
+    },
+  ],
+};
+
+export const REPO_ITEM = {
+  repo_id: "repo-1",
+  full_name: "acme/web-app",
+  installation_id: "install-uuid-1",
+  default_branch: "main",
+  status: "connected",
+  connected_at: "2024-01-01T00:00:00Z",
+  connected_by: "user-1",
+};
+
+export const REPOS_RESPONSE = { repos: [REPO_ITEM] };
+export const REPOS_EMPTY_RESPONSE = { repos: [] };
+
+export const INGEST_RESPONSE = { run_id: "run-id-1" };
+
+export const CONNECT_REPO_RESPONSE = {
+  repo_id: "repo-2",
+  full_name: "acme/api",
+  installation_id: "install-uuid-1",
+  default_branch: "main",
+  status: "connected",
+  connected_at: "2024-01-01T00:00:00Z",
+  connected_by: "user-1",
+};
+
+export const MEMBERS_RESPONSE = {
+  members: [
+    {
+      user_id: "user-1",
+      email: "test@example.com",
+      role: "owner",
+      invited_at: "2024-01-01T00:00:00Z",
+    },
+  ],
+};
+
+export const API_KEYS_RESPONSE = { api_keys: [] };
+
+export async function mockAuthenticatedSession(page: Page): Promise<void> {
+  await page.route("**/v1/me", (route) =>
+    route.fulfill({ json: ME_RESPONSE }),
+  );
+}
+
+export async function mockReposList(
+  page: Page,
+  response: { repos: typeof REPO_ITEM[] } = REPOS_RESPONSE,
+): Promise<void> {
+  await page.route("**/v1/repos", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: response });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockIngestTrigger(page: Page): Promise<void> {
+  await page.route("**/v1/repos/*/ingest", (route) =>
+    route.fulfill({ json: INGEST_RESPONSE }),
+  );
+}
+
+export async function mockMembers(page: Page): Promise<void> {
+  await page.route("**/v1/tenants/*/members", (route) =>
+    route.fulfill({ json: MEMBERS_RESPONSE }),
+  );
+}

--- a/frontend/e2e/focus-trap.spec.ts
+++ b/frontend/e2e/focus-trap.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { ReposPage } from "./pages/ReposPage";
+
+test.describe("Focus trap in ConnectRepoDialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+  });
+
+  test("Tab key keeps focus inside the open dialog", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // Tab through more steps than there are focusable elements — each press
+    // must stay within the dialog (cycle, not escape).
+    for (let i = 0; i < 9; i++) {
+      await page.keyboard.press("Tab");
+      const inside = await page.evaluate(() => {
+        const d = document.querySelector('[role="dialog"]');
+        return d?.contains(document.activeElement) ?? false;
+      });
+      expect(inside, `Tab press ${String(i + 1)}: focus escaped dialog`).toBe(
+        true,
+      );
+    }
+  });
+
+  test("Shift+Tab wraps focus from first to last element", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // The dialog auto-focuses the first focusable element on mount.
+    // Shift+Tab from first should wrap to the last — still inside the dialog.
+    await page.keyboard.press("Shift+Tab");
+
+    const inside = await page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return d?.contains(document.activeElement) ?? false;
+    });
+    expect(
+      inside,
+      "Shift+Tab from first element should wrap inside dialog",
+    ).toBe(true);
+  });
+
+  test("Tab wraps focus from last to first element", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // Count focusable elements, then Tab past the last one to trigger wrap.
+    const count = await dialog.getFocusableElements().count();
+    for (let i = 0; i < count; i++) {
+      await page.keyboard.press("Tab");
+    }
+
+    // After count presses focus should have wrapped back inside.
+    const inside = await page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return d?.contains(document.activeElement) ?? false;
+    });
+    expect(inside, "Tab wrap from last element should land inside dialog").toBe(
+      true,
+    );
+  });
+
+  test("focus restores to trigger button after Escape", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    // Click the trigger button — this becomes document.activeElement when the
+    // dialog captures previousFocusRef on mount.
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog.dialog).not.toBeVisible();
+
+    // The dialog cleanup effect restores focus to previousFocusRef.
+    const focusedText = await page.evaluate(
+      () => (document.activeElement as Element | null)?.textContent?.trim() ?? "",
+    );
+    expect(focusedText).toContain("Connect a repo");
+  });
+});

--- a/frontend/e2e/pages/LoginPage.ts
+++ b/frontend/e2e/pages/LoginPage.ts
@@ -1,0 +1,31 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class LoginPage {
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly emailError: Locator;
+  readonly passwordError: Locator;
+
+  constructor(private readonly page: Page) {
+    this.emailInput = page.locator("#email");
+    this.passwordInput = page.locator("#password");
+    this.submitButton = page.getByRole("button", { name: "Sign in" });
+    this.emailError = page.locator("#email-error");
+    this.passwordError = page.locator("#password-error");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/login");
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  async fillAndSubmit(email: string, password: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.submit();
+  }
+}

--- a/frontend/e2e/pages/RepoDetailPage.ts
+++ b/frontend/e2e/pages/RepoDetailPage.ts
@@ -1,0 +1,24 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class RepoDetailPage {
+  readonly triggerIngestButton: Locator;
+  readonly ingestQueuedMessage: Locator;
+  readonly repoHeading: Locator;
+
+  constructor(private readonly page: Page) {
+    this.triggerIngestButton = page.getByRole("button", {
+      name: "Trigger ingestion",
+    });
+    this.ingestQueuedMessage = page.getByText("Ingestion run queued");
+    this.repoHeading = page.getByRole("heading", { level: 1 });
+  }
+
+  async goto(repoId: string): Promise<void> {
+    await this.page.goto(`/repos/${repoId}`);
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async triggerIngestion(): Promise<void> {
+    await this.triggerIngestButton.click();
+  }
+}

--- a/frontend/e2e/pages/ReposPage.ts
+++ b/frontend/e2e/pages/ReposPage.ts
@@ -1,0 +1,57 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class ReposPage {
+  readonly connectButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.connectButton = page.getByRole("button", { name: "Connect a repo" });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/repos");
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async openConnectDialog(): Promise<ConnectRepoDialog> {
+    await this.connectButton.click();
+    return new ConnectRepoDialog(this.page);
+  }
+}
+
+export class ConnectRepoDialog {
+  readonly dialog: Locator;
+  readonly closeButton: Locator;
+  readonly installAppButton: Locator;
+  readonly installedButton: Locator;
+  readonly installationIdInput: Locator;
+  readonly connectButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.dialog = page.getByRole("dialog");
+    this.closeButton = page.getByRole("button", { name: "Close" });
+    this.installAppButton = page.getByRole("button", {
+      name: /Install GitHub App/,
+    });
+    this.installedButton = page.getByRole("button", {
+      name: /I've installed the app/,
+    });
+    this.installationIdInput = page.locator("#numeric-install-id");
+    this.connectButton = page.getByRole("button", {
+      name: "Connect repository",
+    });
+  }
+
+  async dismissWithEscape(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+
+  async advanceToPickStep(): Promise<void> {
+    await this.installedButton.click();
+  }
+
+  getFocusableElements(): Locator {
+    return this.dialog.locator(
+      "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+    );
+  }
+}

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_RESPONSE,
+  REPO_ITEM,
+  INGEST_RESPONSE,
+} from "./fixtures/mock-api";
+import { RepoDetailPage } from "./pages/RepoDetailPage";
+
+// Verifies that useTriggerIngest.onSuccess calls qc.invalidateQueries with the
+// repos query key, causing TanStack Query to immediately refetch GET /v1/repos
+// while the component is still mounted (connected-repos / ingest-trigger flow).
+
+test.describe("TanStack Query invalidation on mutation success", () => {
+  test("useTriggerIngest onSuccess refetches the repos query", async ({
+    page,
+  }) => {
+    let reposGetCount = 0;
+
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+
+    await page.route("**/v1/repos", async (route) => {
+      if (route.request().method() === "GET") {
+        reposGetCount++;
+        await route.fulfill({ json: REPOS_RESPONSE });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route("**/v1/repos/*/ingest", (route) =>
+      route.fulfill({ json: INGEST_RESPONSE }),
+    );
+
+    const repoDetailPage = new RepoDetailPage(page);
+    await repoDetailPage.goto(REPO_ITEM.repo_id);
+
+    // At least one GET /v1/repos was made during the initial load.
+    const countAfterLoad = reposGetCount;
+    expect(countAfterLoad).toBeGreaterThanOrEqual(1);
+
+    // Trigger ingestion — fires POST /v1/repos/{id}/ingest.
+    await repoDetailPage.triggerIngestion();
+
+    // The success toast / queued message confirms the mutation resolved.
+    await expect(repoDetailPage.ingestQueuedMessage).toBeVisible();
+
+    // Wait for TanStack Query to complete the invalidation refetch.
+    await page.waitForLoadState("networkidle");
+
+    // The query key invalidation must have triggered at least one more GET.
+    expect(reposGetCount).toBeGreaterThan(countAfterLoad);
+  });
+
+  test("useConnectRepo onSuccess refetches the repos query", async ({
+    page,
+  }) => {
+    let reposGetCount = 0;
+
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+
+    await page.route("**/v1/repos", async (route) => {
+      if (route.request().method() === "GET") {
+        reposGetCount++;
+        await route.fulfill({ json: { repos: [] } });
+      } else if (route.request().method() === "POST") {
+        // Simulate a successful connect
+        await route.fulfill({
+          json: {
+            repo_id: "repo-2",
+            full_name: "acme/api",
+            installation_id: "install-uuid-1",
+            default_branch: "main",
+            status: "connected",
+            connected_at: "2024-01-01T00:00:00Z",
+            connected_by: "user-1",
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const countAfterLoad = reposGetCount;
+    expect(countAfterLoad).toBeGreaterThanOrEqual(1);
+
+    // Open dialog and advance to the pick step.
+    await page.getByRole("button", { name: "Connect a repo" }).click();
+    await page
+      .getByRole("button", { name: /I've installed the app/ })
+      .click();
+
+    // Fill in a valid numeric installation ID so Zod accepts the form.
+    await page.locator("#numeric-install-id").fill("12345678");
+
+    // Submit — triggers POST /v1/repos which calls onSuccess → invalidateQueries.
+    await page.getByRole("button", { name: "Connect repository" }).click();
+
+    await page.waitForLoadState("networkidle");
+
+    // Repos query must have been refetched.
+    expect(reposGetCount).toBeGreaterThan(countAfterLoad);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,9 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@eslint/js": "^9.16.0",
+        "@playwright/test": "^1.59.1",
         "@tanstack/router-devtools": "^1.166.13",
         "@tanstack/router-plugin": "^1.167.27",
         "@types/node": "^22.19.17",
@@ -58,6 +60,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1082,6 +1097,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -2444,6 +2475,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-dead-code-elimination": {
@@ -3992,6 +4033,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc -b --noEmit",
     "gen:api": "openapi-typescript ../openapi.json -o src/api/generated/schema.ts --immutable",
     "gen:api:check": "node ./scripts/check-api-types.mjs",
-    "lint": "eslint src --max-warnings=0"
+    "lint": "eslint src --max-warnings=0",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -30,7 +32,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@eslint/js": "^9.16.0",
+    "@playwright/test": "^1.59.1",
     "@tanstack/router-devtools": "^1.166.13",
     "@tanstack/router-plugin": "^1.167.27",
     "@types/node": "^22.19.17",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env["CI"],
+  retries: process.env["CI"] ? 2 : 0,
+  workers: process.env["CI"] ? 1 : undefined,
+  reporter: process.env["CI"] ? "github" : "html",
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run preview -- --port 4173",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env["CI"],
+    timeout: 120_000,
+  },
+});

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -21,3 +21,14 @@ export {
   useTransferOwnership,
 } from "./useTenantMembers";
 export { useHealth, healthQueryKey } from "./useHealth";
+export {
+  useRepos,
+  reposQueryKey,
+  useConnectRepo,
+  useTriggerIngest,
+  useAvailableRepos,
+  type RepoItem,
+  type AvailableRepo,
+  type AvailableReposResponse,
+} from "./useRepos";
+export { useGithubInstallUrl } from "./useGithubInstall";

--- a/frontend/src/api/hooks/useGithubInstall.ts
+++ b/frontend/src/api/hooks/useGithubInstall.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type InstallUrlResponse = components["schemas"]["InstallUrlResponse"];
+
+export function useGithubInstallUrl() {
+  return useMutation<InstallUrlResponse, ApiError, void>({
+    mutationFn: async () => {
+      const { data, error, response } = await apiClient.GET("/v1/github/install-url");
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -8,7 +8,7 @@ import { apiClient, toApiError, type ApiError } from "../client";
 import type { components } from "../generated/schema";
 
 type RepoItem = components["schemas"]["RepoItem"];
-type ListReposResponse = components["schemas"]["ListReposResponse"];
+type ConnectedReposResponse = components["schemas"]["ConnectedReposResponse"];
 type ConnectRepoRequest = components["schemas"]["ConnectRepoRequest"];
 type ConnectRepoResponse = components["schemas"]["ConnectRepoResponse"];
 type TriggerIngestResponse = components["schemas"]["TriggerIngestResponse"];
@@ -41,9 +41,9 @@ export const availableReposQueryKey = (installationId: string, page: number) =>
 
 export function useRepos(
   tenantId: string,
-  options?: Omit<UseQueryOptions<ListReposResponse, ApiError>, "queryKey" | "queryFn">,
+  options?: Omit<UseQueryOptions<ConnectedReposResponse, ApiError>, "queryKey" | "queryFn">,
 ) {
-  return useQuery<ListReposResponse, ApiError>({
+  return useQuery<ConnectedReposResponse, ApiError>({
     queryKey: reposQueryKey(tenantId),
     queryFn: async () => {
       const { data, error, response } = await apiClient.GET("/v1/repos");

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -1,0 +1,116 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type RepoItem = components["schemas"]["RepoItem"];
+type ListReposResponse = components["schemas"]["ListReposResponse"];
+type ConnectRepoRequest = components["schemas"]["ConnectRepoRequest"];
+type ConnectRepoResponse = components["schemas"]["ConnectRepoResponse"];
+type TriggerIngestResponse = components["schemas"]["TriggerIngestResponse"];
+
+// AvailableRepo is the runtime shape returned by GET /v1/github/installations/{id}/available-repos.
+// The generated schema incorrectly maps it to ListReposResponse (a naming collision in the backend).
+export interface AvailableRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  archived: boolean;
+  default_branch: string;
+  html_url: string;
+}
+export interface AvailableReposResponse {
+  total_count: number;
+  page: number;
+  per_page: number;
+  repositories: AvailableRepo[];
+}
+
+export type { RepoItem };
+
+export const reposQueryKey = (tenantId: string) =>
+  ["tenants", tenantId, "repos"] as const;
+
+export const availableReposQueryKey = (installationId: string, page: number) =>
+  ["github", "installations", installationId, "available-repos", page] as const;
+
+export function useRepos(
+  tenantId: string,
+  options?: Omit<UseQueryOptions<ListReposResponse, ApiError>, "queryKey" | "queryFn">,
+) {
+  return useQuery<ListReposResponse, ApiError>({
+    queryKey: reposQueryKey(tenantId),
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET("/v1/repos");
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0,
+    ...options,
+  });
+}
+
+export function useConnectRepo(tenantId: string) {
+  const qc = useQueryClient();
+  return useMutation<ConnectRepoResponse, ApiError, ConnectRepoRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await apiClient.POST("/v1/repos", { body });
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: reposQueryKey(tenantId) });
+    },
+  });
+}
+
+export function useTriggerIngest() {
+  return useMutation<TriggerIngestResponse, ApiError, string>({
+    mutationFn: async (repoId) => {
+      const { data, error, response } = await apiClient.POST(
+        "/v1/repos/{id}/ingest",
+        { params: { path: { id: repoId } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+  });
+}
+
+export function useAvailableRepos(
+  installationId: string,
+  page = 1,
+  options?: Omit<
+    UseQueryOptions<AvailableReposResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<AvailableReposResponse, ApiError>({
+    queryKey: availableReposQueryKey(installationId, page),
+    queryFn: async () => {
+      // Cast needed: generated schema incorrectly maps this response to ListReposResponse
+      // (name collision with repos::ListReposResponse). The actual runtime shape is AvailableReposResponse.
+      const { data, error, response } = await apiClient.GET(
+        "/v1/github/installations/{id}/available-repos",
+        { params: { path: { id: installationId }, query: { page, per_page: 30 } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data as unknown as AvailableReposResponse;
+    },
+    enabled: installationId.length > 0,
+    ...options,
+  });
+}

--- a/frontend/src/api/hooks/useRepos.ts
+++ b/frontend/src/api/hooks/useRepos.ts
@@ -73,7 +73,8 @@ export function useConnectRepo(tenantId: string) {
   });
 }
 
-export function useTriggerIngest() {
+export function useTriggerIngest(tenantId: string) {
+  const qc = useQueryClient();
   return useMutation<TriggerIngestResponse, ApiError, string>({
     mutationFn: async (repoId) => {
       const { data, error, response } = await apiClient.POST(
@@ -84,6 +85,9 @@ export function useTriggerIngest() {
         throw toApiError(response.status, error);
       }
       return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: reposQueryKey(tenantId) });
     },
   });
 }

--- a/frontend/src/components/repos/PageContainer.tsx
+++ b/frontend/src/components/repos/PageContainer.tsx
@@ -1,0 +1,7 @@
+export function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/components/repos/StatusBadge.tsx
+++ b/frontend/src/components/repos/StatusBadge.tsx
@@ -1,0 +1,19 @@
+interface StatusBadgeProps {
+  readonly status: string;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -6,6 +6,7 @@ export const routes = {
   forgotPassword: "/forgot-password",
   resetPassword: "/reset-password",
   repos: "/repos",
+  repoDetail: "/repos/$repoId",
   members: "/members",
   apiKeys: "/api-keys",
 } as const;

--- a/frontend/src/lib/validation/repos.ts
+++ b/frontend/src/lib/validation/repos.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const connectRepoFormSchema = z.object({
+  installation_id: z
+    .number({ message: "Installation ID is required" })
+    .int()
+    .positive("Installation ID must be a positive integer"),
+  github_repo_id: z
+    .number({ message: "Repository ID is required" })
+    .int()
+    .positive("Repository ID must be a positive integer"),
+  default_branch: z.string().optional(),
+});
+
+export type ConnectRepoFormValues = z.infer<typeof connectRepoFormSchema>;

--- a/frontend/src/pages/RepoDetailPage.tsx
+++ b/frontend/src/pages/RepoDetailPage.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner";
 import { useMe, useRepos, useTriggerIngest } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { routes } from "@/lib/routes";
+import { StatusBadge } from "@/components/repos/StatusBadge";
+import { PageContainer } from "@/components/repos/PageContainer";
 
 export function RepoDetailPage(): JSX.Element {
   const { repoId } = useParams({ from: "/repos/$repoId" });
@@ -48,7 +50,7 @@ function RepoDetailInner({
   tenantId,
 }: RepoDetailInnerProps): JSX.Element {
   const repos = useRepos(tenantId);
-  const triggerIngest = useTriggerIngest();
+  const triggerIngest = useTriggerIngest(tenantId);
   const [ingestRunId, setIngestRunId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -170,28 +172,4 @@ function RepoDetailInner({
       )}
     </PageContainer>
   );
-}
-
-function StatusBadge({ status }: { readonly status: string }): JSX.Element {
-  const colors =
-    status === "connected"
-      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
-      : status === "ingesting"
-        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-        : "border-border bg-muted text-muted-foreground";
-  return (
-    <span
-      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function PageContainer({
-  children,
-}: {
-  readonly children: React.ReactNode;
-}): JSX.Element {
-  return <div className="container max-w-3xl py-8">{children}</div>;
 }

--- a/frontend/src/pages/RepoDetailPage.tsx
+++ b/frontend/src/pages/RepoDetailPage.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { Link, useParams } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { useMe, useRepos, useTriggerIngest } from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+
+export function RepoDetailPage(): JSX.Element {
+  const { repoId } = useParams({ from: "/repos/$repoId" });
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">
+          You need to be signed in.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-2 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <RepoDetailInner repoId={repoId} tenantId={me.data.current_tenant.id} />
+  );
+}
+
+interface RepoDetailInnerProps {
+  readonly repoId: string;
+  readonly tenantId: string;
+}
+
+function RepoDetailInner({
+  repoId,
+  tenantId,
+}: RepoDetailInnerProps): JSX.Element {
+  const repos = useRepos(tenantId);
+  const triggerIngest = useTriggerIngest();
+  const [ingestRunId, setIngestRunId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const repo = repos.data?.repos.find((r) => r.repo_id === repoId) ?? null;
+
+  const handleIngest = async () => {
+    if (!repo) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await triggerIngest.mutateAsync(repo.repo_id);
+      setIngestRunId(result.run_id);
+      toast.success("Ingestion run queued.");
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not trigger ingestion."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <PageContainer>
+      <nav className="mb-4">
+        <Link
+          to={routes.repos}
+          className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+        >
+          ← Repositories
+        </Link>
+      </nav>
+
+      {repos.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading repository…</p>
+      ) : repos.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(repos.error, "Could not load repository.")}
+        </p>
+      ) : !repo ? (
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Repository not found
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This repository could not be found in your workspace.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <header className="flex flex-col gap-1">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {repo.full_name}
+            </h1>
+            <StatusBadge status={repo.status} />
+          </header>
+
+          <section
+            aria-labelledby="repo-details-heading"
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <h2
+              id="repo-details-heading"
+              className="mb-3 text-sm font-medium"
+            >
+              Details
+            </h2>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+              <dt className="text-muted-foreground">Default branch</dt>
+              <dd className="font-mono">{repo.default_branch}</dd>
+
+              <dt className="text-muted-foreground">Repository ID</dt>
+              <dd className="truncate font-mono text-xs">{repo.repo_id}</dd>
+
+              <dt className="text-muted-foreground">Connected</dt>
+              <dd>
+                {new Date(repo.connected_at).toLocaleString()}
+              </dd>
+            </dl>
+          </section>
+
+          <section
+            aria-labelledby="ingest-heading"
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <h2 id="ingest-heading" className="mb-1 text-sm font-medium">
+              Ingestion
+            </h2>
+            <p className="mb-4 text-xs text-muted-foreground">
+              Trigger a full ingestion run to index the latest state of this
+              repository.
+            </p>
+
+            {ingestRunId ? (
+              <div className="rounded-md bg-muted px-3 py-2 text-sm">
+                <p className="font-medium text-foreground">
+                  Ingestion run queued
+                </p>
+                <p className="mt-0.5 font-mono text-xs text-muted-foreground">
+                  Run ID: {ingestRunId}
+                </p>
+              </div>
+            ) : (
+              <button
+                type="button"
+                disabled={busy || repo.status !== "connected"}
+                onClick={handleIngest}
+                title={
+                  repo.status !== "connected"
+                    ? "Repository must be in connected status to trigger ingestion"
+                    : undefined
+                }
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {busy ? "Queuing run…" : "Trigger ingestion"}
+              </button>
+            )}
+          </section>
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: string }): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import {
   useMe,
   useRepos,
@@ -12,6 +14,12 @@ import {
 } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { routes } from "@/lib/routes";
+import {
+  connectRepoFormSchema,
+  type ConnectRepoFormValues,
+} from "@/lib/validation/repos";
+import { StatusBadge } from "@/components/repos/StatusBadge";
+import { PageContainer } from "@/components/repos/PageContainer";
 
 // ---------------------------------------------------------------------------
 // ReposPage — entry point
@@ -152,20 +160,6 @@ function RepoRow({ repo }: { readonly repo: RepoItem }): JSX.Element {
   );
 }
 
-function StatusBadge({ status }: { readonly status: string }): JSX.Element {
-  const colors =
-    status === "connected"
-      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
-      : status === "ingesting"
-        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-        : "border-border bg-muted text-muted-foreground";
-  return (
-    <span className={`rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}>
-      {status}
-    </span>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Empty state
 // ---------------------------------------------------------------------------
@@ -189,8 +183,16 @@ function EmptyState({ onConnect }: { readonly onConnect: () => void }): JSX.Elem
 }
 
 // ---------------------------------------------------------------------------
-// Connect repo dialog
+// Connect repo dialog — focus trap + Escape
 // ---------------------------------------------------------------------------
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
 
 type ConnectStep = "install" | "pick";
 
@@ -213,13 +215,53 @@ function ConnectRepoDialog({
   const [resolvedInstallId, setResolvedInstallId] = useState<string>(
     installationId ?? "",
   );
-  // Numeric installation_id (GitHub's i64) required by POST /v1/repos.
-  // Not available from connected-repos list (which only stores internal UUID).
-  // User must supply it; they can find it in the GitHub App callback response.
-  const [numericInstallId, setNumericInstallId] = useState("");
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Save trigger element; focus first focusable on mount; restore on unmount
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const focusables = getFocusableElements(dialogRef.current);
+    focusables[0]?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  // Escape key closes dialog; Tab/Shift+Tab cycles within dialog
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusables = getFocusableElements(dialogRef.current);
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!first || !last) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="connect-repo-title"
@@ -259,8 +301,6 @@ function ConnectRepoDialog({
           <PickRepoStep
             tenantId={tenantId}
             installationUuid={resolvedInstallId}
-            numericInstallId={numericInstallId}
-            onNumericInstallIdChange={setNumericInstallId}
             onSuccess={onSuccess}
           />
         )}
@@ -319,45 +359,50 @@ function InstallStep({
 }
 
 // ---------------------------------------------------------------------------
-// Step 2 — Pick repo from available list
+// Step 2 — Pick repo from available list (with field-level validation)
 // ---------------------------------------------------------------------------
 
 interface PickRepoStepProps {
   readonly tenantId: string;
   readonly installationUuid: string;
-  readonly numericInstallId: string;
-  readonly onNumericInstallIdChange: (v: string) => void;
   readonly onSuccess: () => void;
 }
 
 function PickRepoStep({
   tenantId,
   installationUuid,
-  numericInstallId,
-  onNumericInstallIdChange,
   onSuccess,
 }: PickRepoStepProps): JSX.Element {
   const available = useAvailableRepos(installationUuid, 1, {
     enabled: installationUuid.length > 0,
   });
   const connect = useConnectRepo(tenantId);
-  const [selected, setSelected] = useState<AvailableRepo | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const numericId = Number(numericInstallId);
-  const canConnect =
-    selected !== null && Number.isFinite(numericId) && numericId > 0;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<ConnectRepoFormValues>({
+    resolver: zodResolver(connectRepoFormSchema),
+  });
 
-  const handleConnect = async () => {
-    if (!selected || !canConnect) {
-      return;
-    }
+  const selectedRepoId = watch("github_repo_id");
+
+  const handleSelectRepo = (repo: AvailableRepo) => {
+    setValue("github_repo_id", repo.id, { shouldValidate: true });
+    setValue("default_branch", repo.default_branch || undefined);
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
     setBusy(true);
     try {
       const result = await connect.mutateAsync({
-        installation_id: numericId,
-        github_repo_id: selected.id,
-        default_branch: selected.default_branch || null,
+        installation_id: values.installation_id,
+        github_repo_id: values.github_repo_id,
+        default_branch: values.default_branch ?? null,
       });
       toast.success(`Connected ${result.full_name}.`);
       onSuccess();
@@ -366,10 +411,10 @@ function PickRepoStep({
     } finally {
       setBusy(false);
     }
-  };
+  });
 
   return (
-    <div className="flex flex-col gap-4">
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
       {/* Numeric installation ID input */}
       <div className="flex flex-col gap-1">
         <label
@@ -383,15 +428,20 @@ function PickRepoStep({
           type="number"
           min={1}
           placeholder="e.g. 12345678"
-          value={numericInstallId}
-          onChange={(e) => onNumericInstallIdChange(e.target.value)}
+          {...register("installation_id", { valueAsNumber: true })}
           className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
-        <p className="text-xs text-muted-foreground">
-          Find this in the GitHub App callback response (
-          <code className="rounded bg-muted px-1 text-xs">installation_id</code> field)
-          or your GitHub App settings.
-        </p>
+        {errors.installation_id ? (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.installation_id.message}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Find this in the GitHub App callback response (
+            <code className="rounded bg-muted px-1 text-xs">installation_id</code>{" "}
+            field) or your GitHub App settings.
+          </p>
+        )}
       </div>
 
       {/* Available repos list */}
@@ -412,14 +462,19 @@ function PickRepoStep({
           <p className="text-xs font-medium text-foreground">
             Select a repository
           </p>
+          {errors.github_repo_id ? (
+            <p className="text-xs text-destructive" role="alert">
+              {errors.github_repo_id.message}
+            </p>
+          ) : null}
           <ul className="max-h-48 divide-y divide-border overflow-y-auto rounded-md border border-border bg-card">
             {available.data.repositories.map((repo) => (
               <li key={repo.id}>
                 <button
                   type="button"
-                  onClick={() => setSelected(repo)}
+                  onClick={() => handleSelectRepo(repo)}
                   className={`w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground ${
-                    selected?.id === repo.id
+                    selectedRepoId === repo.id
                       ? "bg-primary/10 font-medium"
                       : ""
                   }`}
@@ -439,25 +494,12 @@ function PickRepoStep({
       )}
 
       <button
-        type="button"
-        disabled={!canConnect || busy}
-        onClick={handleConnect}
+        type="submit"
+        disabled={busy}
         className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy ? "Connecting…" : "Connect repository"}
       </button>
-    </div>
+    </form>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Layout helper
-// ---------------------------------------------------------------------------
-
-function PageContainer({
-  children,
-}: {
-  readonly children: React.ReactNode;
-}): JSX.Element {
-  return <div className="container max-w-3xl py-8">{children}</div>;
 }

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,0 +1,463 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  useMe,
+  useRepos,
+  useConnectRepo,
+  useAvailableRepos,
+  useGithubInstallUrl,
+  type RepoItem,
+  type AvailableRepo,
+} from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+
+// ---------------------------------------------------------------------------
+// ReposPage — entry point
+// ---------------------------------------------------------------------------
+
+export function ReposPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need to be signed in to manage repositories.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in →
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return <ReposPageInner tenantId={me.data.current_tenant.id} />;
+}
+
+// ---------------------------------------------------------------------------
+// Inner page (tenant resolved)
+// ---------------------------------------------------------------------------
+
+interface ReposPageInnerProps {
+  readonly tenantId: string;
+}
+
+function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
+  const repos = useRepos(tenantId);
+  const [showConnect, setShowConnect] = useState(false);
+
+  const connectedList: readonly RepoItem[] = repos.data?.repos ?? [];
+
+  // Derive the installation UUID from the first connected repo (if any).
+  // This lets us populate the available-repos picker for subsequent connects.
+  const knownInstallationId = connectedList[0]?.installation_id ?? null;
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Connected GitHub repositories for this workspace.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowConnect(true)}
+          className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Connect a repo
+        </button>
+      </header>
+
+      {repos.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading repositories…</p>
+      ) : repos.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(repos.error, "Could not load repositories.")}
+        </p>
+      ) : connectedList.length === 0 ? (
+        <EmptyState onConnect={() => setShowConnect(true)} />
+      ) : (
+        <RepoList repos={connectedList} />
+      )}
+
+      {showConnect ? (
+        <ConnectRepoDialog
+          tenantId={tenantId}
+          installationId={knownInstallationId}
+          onClose={() => setShowConnect(false)}
+          onSuccess={() => setShowConnect(false)}
+        />
+      ) : null}
+    </PageContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Repo list
+// ---------------------------------------------------------------------------
+
+function RepoList({ repos }: { readonly repos: readonly RepoItem[] }): JSX.Element {
+  return (
+    <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+      {repos.map((repo) => (
+        <RepoRow key={repo.repo_id} repo={repo} />
+      ))}
+    </ul>
+  );
+}
+
+function RepoRow({ repo }: { readonly repo: RepoItem }): JSX.Element {
+  const connectedAt = new Date(repo.connected_at);
+  const relativeDate = Number.isNaN(connectedAt.getTime())
+    ? "—"
+    : connectedAt.toLocaleDateString();
+
+  return (
+    <li className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{repo.full_name}</span>
+        <span className="text-xs text-muted-foreground">
+          Branch: <span className="font-mono">{repo.default_branch}</span>
+          {" · "}
+          Connected {relativeDate}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusBadge status={repo.status} />
+        <Link
+          to="/repos/$repoId"
+          params={{ repoId: repo.repo_id }}
+          className="rounded-md border border-border px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          View
+        </Link>
+      </div>
+    </li>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: string }): JSX.Element {
+  const colors =
+    status === "connected"
+      ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : status === "ingesting"
+        ? "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground";
+  return (
+    <span className={`rounded-md border px-2 py-0.5 text-xs font-medium ${colors}`}>
+      {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState({ onConnect }: { readonly onConnect: () => void }): JSX.Element {
+  return (
+    <div className="flex flex-col items-center rounded-lg border border-dashed border-border py-12 text-center">
+      <p className="text-sm font-medium text-foreground">No repositories connected</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Connect a GitHub repository to start indexing your codebase.
+      </p>
+      <button
+        type="button"
+        onClick={onConnect}
+        className="mt-4 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Connect your first repo
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connect repo dialog
+// ---------------------------------------------------------------------------
+
+type ConnectStep = "install" | "pick";
+
+interface ConnectRepoDialogProps {
+  readonly tenantId: string;
+  readonly installationId: string | null;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+function ConnectRepoDialog({
+  tenantId,
+  installationId,
+  onClose,
+  onSuccess,
+}: ConnectRepoDialogProps): JSX.Element {
+  const [step, setStep] = useState<ConnectStep>(
+    installationId ? "pick" : "install",
+  );
+  const [resolvedInstallId, setResolvedInstallId] = useState<string>(
+    installationId ?? "",
+  );
+  // Numeric installation_id (GitHub's i64) required by POST /v1/repos.
+  // Not available from connected-repos list (which only stores internal UUID).
+  // User must supply it; they can find it in the GitHub App callback response.
+  const [numericInstallId, setNumericInstallId] = useState("");
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="connect-repo-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="flex w-full max-w-lg flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-xl">
+        <div className="flex items-start justify-between">
+          <h2
+            id="connect-repo-title"
+            className="text-lg font-semibold tracking-tight"
+          >
+            Connect a repository
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        {step === "install" ? (
+          <InstallStep
+            onInstalled={(installUuid) => {
+              setResolvedInstallId(installUuid);
+              setStep("pick");
+            }}
+          />
+        ) : (
+          <PickRepoStep
+            tenantId={tenantId}
+            installationUuid={resolvedInstallId}
+            numericInstallId={numericInstallId}
+            onNumericInstallIdChange={setNumericInstallId}
+            onSuccess={onSuccess}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Install GitHub App
+// ---------------------------------------------------------------------------
+
+function InstallStep({
+  onInstalled,
+}: {
+  readonly onInstalled: (installUuid: string) => void;
+}): JSX.Element {
+  const installUrl = useGithubInstallUrl();
+
+  const handleInstall = async () => {
+    try {
+      const result = await installUrl.mutateAsync();
+      window.open(result.url, "_blank", "noopener");
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not generate install link."));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        First, install the GitHub App on the organization or account that owns
+        the repositories you want to connect.
+      </p>
+      <button
+        type="button"
+        disabled={installUrl.isPending}
+        onClick={handleInstall}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {installUrl.isPending ? "Generating link…" : "Install GitHub App →"}
+      </button>
+      <p className="text-xs text-muted-foreground">
+        After installing, return here and click{" "}
+        <strong>I&apos;ve installed the app</strong>.
+      </p>
+      <button
+        type="button"
+        onClick={() => onInstalled("")}
+        className="self-start text-sm font-medium text-primary hover:underline"
+      >
+        I&apos;ve installed the app →
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Pick repo from available list
+// ---------------------------------------------------------------------------
+
+interface PickRepoStepProps {
+  readonly tenantId: string;
+  readonly installationUuid: string;
+  readonly numericInstallId: string;
+  readonly onNumericInstallIdChange: (v: string) => void;
+  readonly onSuccess: () => void;
+}
+
+function PickRepoStep({
+  tenantId,
+  installationUuid,
+  numericInstallId,
+  onNumericInstallIdChange,
+  onSuccess,
+}: PickRepoStepProps): JSX.Element {
+  const available = useAvailableRepos(installationUuid, 1, {
+    enabled: installationUuid.length > 0,
+  });
+  const connect = useConnectRepo(tenantId);
+  const [selected, setSelected] = useState<AvailableRepo | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const numericId = Number(numericInstallId);
+  const canConnect =
+    selected !== null && Number.isFinite(numericId) && numericId > 0;
+
+  const handleConnect = async () => {
+    if (!selected || !canConnect) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await connect.mutateAsync({
+        installation_id: numericId,
+        github_repo_id: selected.id,
+        default_branch: selected.default_branch || null,
+      });
+      toast.success(`Connected ${result.full_name}.`);
+      onSuccess();
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not connect repository."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Numeric installation ID input */}
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="numeric-install-id"
+          className="text-xs font-medium text-foreground"
+        >
+          GitHub installation ID (numeric)
+        </label>
+        <input
+          id="numeric-install-id"
+          type="number"
+          min={1}
+          placeholder="e.g. 12345678"
+          value={numericInstallId}
+          onChange={(e) => onNumericInstallIdChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <p className="text-xs text-muted-foreground">
+          Find this in the GitHub App callback response (
+          <code className="rounded bg-muted px-1 text-xs">installation_id</code> field)
+          or your GitHub App settings.
+        </p>
+      </div>
+
+      {/* Available repos list */}
+      {installationUuid.length === 0 ? (
+        <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          Return here after installing the GitHub App to see available repositories.
+        </p>
+      ) : available.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading available repos…</p>
+      ) : available.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(available.error, "Could not load repositories.")}
+        </p>
+      ) : !available.data || available.data.repositories.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No repositories accessible.</p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-medium text-foreground">
+            Select a repository
+          </p>
+          <ul className="max-h-48 divide-y divide-border overflow-y-auto rounded-md border border-border bg-card">
+            {available.data.repositories.map((repo) => (
+              <li key={repo.id}>
+                <button
+                  type="button"
+                  onClick={() => setSelected(repo)}
+                  className={`w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground ${
+                    selected?.id === repo.id
+                      ? "bg-primary/10 font-medium"
+                      : ""
+                  }`}
+                >
+                  <span className="block font-medium">{repo.full_name}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {repo.private ? "Private" : "Public"}
+                    {" · "}
+                    {repo.default_branch}
+                    {repo.archived ? " · archived" : ""}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <button
+        type="button"
+        disabled={!canConnect || busy}
+        onClick={handleConnect}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {busy ? "Connecting…" : "Connect repository"}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layout helper
+// ---------------------------------------------------------------------------
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,7 +12,8 @@ import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
 import { LoginPage } from "@/pages/LoginPage";
 import { MembersPage } from "@/pages/MembersPage";
-import { ReposPlaceholderPage } from "@/pages/ReposPlaceholderPage";
+import { ReposPage } from "@/pages/ReposPage";
+import { RepoDetailPage } from "@/pages/RepoDetailPage";
 import { ResetPasswordPage } from "@/pages/ResetPasswordPage";
 import { SignupPage } from "@/pages/SignupPage";
 import { VerifyEmailPage } from "@/pages/VerifyEmailPage";
@@ -80,7 +81,13 @@ const resetPasswordRoute = createRoute({
 const reposRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: routes.repos,
-  component: ReposPlaceholderPage,
+  component: ReposPage,
+});
+
+const repoDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.repoDetail,
+  component: RepoDetailPage,
 });
 
 const membersRoute = createRoute({
@@ -112,6 +119,7 @@ const routeTree = rootRoute.addChildren([
   forgotPasswordRoute,
   resetPasswordRoute,
   reposRoute,
+  repoDetailRoute,
   membersRoute,
   apiKeysRoute,
   catchAllRoute,

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
-    "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "noEmit": true,
+    "skipLibCheck": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "playwright.config.ts", "eslint.config.js", "scripts/**/*.mjs"]
+  "include": ["e2e/**/*.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }


### PR DESCRIPTION
## Summary

Authors the five Playwright specs that the `frontend-e2e` CI job will run, replacing QA's improvised static-analysis checks with proper runtime assertions.

- **`escape-dismissal.spec.ts`** — WCAG 2.1.2: ConnectRepoDialog closes on Escape, backdrop click, and ✕ button
- **`focus-trap.spec.ts`** — Tab/Shift+Tab cycles within the open dialog; focus restores to the trigger button on close
- **`field-validation.spec.ts`** — zod field-level errors render under the correct input; `aria-invalid` and `aria-describedby` wired via the `Field` component
- **`query-refetch.spec.ts`** — `useTriggerIngest` and `useConnectRepo` `onSuccess` calls `invalidateQueries` on the repos key, causing an immediate GET /v1/repos refetch
- **`axe-scan.spec.ts`** — `@axe-core/playwright` scans login, repos list, repo detail, and the open connect dialog; fails the suite on any serious/critical violation

### Supporting files
- `playwright.config.ts` — headless Chromium, baseURL `http://localhost:4173`, wired to `vite preview`
- `e2e/fixtures/mock-api.ts` — shared `page.route()` mock helpers and response fixtures
- `e2e/pages/` — Page Object Models for LoginPage, ReposPage/ConnectRepoDialog, RepoDetailPage
- `tsconfig.e2e.json` — dedicated TS project for `e2e/` with DOM lib
- `@playwright/test` + `@axe-core/playwright` added as devDeps; `test:e2e` script added

## Test plan

- [ ] `npm run typecheck` passes (verified locally — exit 0)
- [ ] `npm run lint` passes (verified locally — exit 0)
- [ ] `npm run build && npm run test:e2e` runs all 5 specs against the preview bundle
- [ ] CI `frontend-e2e` job picks up the new specs

Closes #102