### PR TITLE
[REQ-FE-11] fix(frontend): resolve nav link active-state color-contrast violations

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -24,31 +24,19 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
           >
             <Link
               to={routes.repos}
-              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              activeProps={{
-                className:
-                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
-              }}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
             >
               Repos
             </Link>
             <Link
               to={routes.members}
-              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              activeProps={{
-                className:
-                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
-              }}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
             >
               Members
             </Link>
             <Link
               to={routes.apiKeys}
-              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              activeProps={{
-                className:
-                  "rounded-md px-3 py-1.5 text-sm font-medium text-foreground bg-accent",
-              }}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
             >
               API keys
             </Link>

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

- TanStack Router's `activeProps` **merges** rather than replaces `className`, leaving both `text-muted-foreground` and `text-foreground` on the active element simultaneously; stylesheet order causes `text-muted-foreground` to win, producing a contrast ratio of 4.34 (WCAG 2 AA requires 4.5:1)
- Replaced `activeProps` with Tailwind `aria-[current=page]:` variants — TanStack Router already sets `aria-current="page"` on active links, and the resulting attribute-selector has higher CSS specificity than the plain utility, so `text-foreground` and `bg-accent` correctly override the inactive state
- All three nav links (Repos, Members, API Keys) are fixed with the same pattern

## Test plan

- [ ] Run `cd frontend && pnpm run test:e2e -- e2e/axe-dispatch.spec.ts -g 'axe scan: /repos'` — should pass
- [ ] Re-dispatch `frontend-axe-dispatch.yml` against this branch; all 8 routes should pass `axe scan` and `focus-trap probe`
- [ ] Verify active nav link visually shows `text-foreground` on `bg-accent` with no muted color bleed

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)