### PR TITLE
[REQ-FE-04] feat(e2e): add baseline Playwright spec set for frontend-e2e CI

### DIFF
--- a/frontend/e2e/axe-dispatch.spec.ts
+++ b/frontend/e2e/axe-dispatch.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 import { mkdirSync, writeFileSync } from "fs";
 import path from "path";
+import {
+  ME_RESPONSE,
+  REPOS_RESPONSE,
+  MEMBERS_RESPONSE,
+  API_KEYS_RESPONSE,
+} from "./fixtures/mock-api";
 
 const ALL_ROUTES = [
   "/login",
@@ -16,6 +22,27 @@ const ALL_ROUTES = [
 
 const scanRouteEnv = (process.env.SCAN_ROUTE ?? "").trim();
 const routes: string[] = scanRouteEnv ? [scanRouteEnv] : [...ALL_ROUTES];
+
+type MockFn = (page: import("@playwright/test").Page) => Promise<void>;
+
+const ROUTE_MOCKS: Partial<Record<string, MockFn>> = {
+  "/repos": async (page) => {
+    await page.route("**/v1/me", (r) => r.fulfill({ json: ME_RESPONSE }));
+    await page.route("**/v1/repos", (r) => r.fulfill({ json: REPOS_RESPONSE }));
+  },
+  "/members": async (page) => {
+    await page.route("**/v1/me", (r) => r.fulfill({ json: ME_RESPONSE }));
+    await page.route("**/v1/tenants/*/members", (r) =>
+      r.fulfill({ json: MEMBERS_RESPONSE }),
+    );
+  },
+  "/api-keys": async (page) => {
+    await page.route("**/v1/me", (r) => r.fulfill({ json: ME_RESPONSE }));
+    await page.route("**/v1/api-keys", (r) =>
+      r.fulfill({ json: API_KEYS_RESPONSE }),
+    );
+  },
+};
 
 const OUT_DIR = path.resolve("axe-results");
 
@@ -63,6 +90,9 @@ test.describe("axe-dispatch", () => {
     const slug = routeToSlug(route);
 
     test(`axe scan: ${route}`, async ({ page }, testInfo) => {
+      const mock = ROUTE_MOCKS[route];
+      if (mock) await mock(page);
+
       await page.goto(route);
 
       const result = await new AxeBuilder({ page })
@@ -97,6 +127,9 @@ test.describe("axe-dispatch", () => {
     });
 
     test(`focus-trap probe: ${route}`, async ({ page }, testInfo) => {
+      const mock = ROUTE_MOCKS[route];
+      if (mock) await mock(page);
+
       await page.goto(route);
 
       const focusOrder: FocusEntry[] = [];

--- a/frontend/e2e/axe-dispatch.spec.ts
+++ b/frontend/e2e/axe-dispatch.spec.ts
@@ -94,6 +94,7 @@ test.describe("axe-dispatch", () => {
       if (mock) await mock(page);
 
       await page.goto(route);
+      await page.waitForLoadState("networkidle");
 
       const result = await new AxeBuilder({ page })
         .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -1,11 +1,11 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 import {
-  ME_RESPONSE,
   REPOS_RESPONSE,
   REPOS_EMPTY_RESPONSE,
   REPO_ITEM,
   MEMBERS_RESPONSE,
+  mockAuthenticatedSession,
 } from "./fixtures/mock-api";
 
 // Runs @axe-core/playwright against the main routes and fails on any
@@ -24,10 +24,35 @@ async function scanPage(
   );
 }
 
+type MockFn = (page: import("@playwright/test").Page) => Promise<void>;
+
+const ROUTE_MOCKS: Partial<Record<string, MockFn>> = {
+  "/repos": async (page) => {
+    await mockAuthenticatedSession(page);
+    await page.route("**/v1/repos", (r) => r.fulfill({ json: REPOS_RESPONSE }));
+  },
+  "/repos-empty": async (page) => {
+    await mockAuthenticatedSession(page);
+    await page.route("**/v1/repos", (r) =>
+      r.fulfill({ json: REPOS_EMPTY_RESPONSE }),
+    );
+  },
+  [`/repos/${REPO_ITEM.repo_id}`]: async (page) => {
+    await mockAuthenticatedSession(page);
+    await page.route("**/v1/repos", (r) => r.fulfill({ json: REPOS_RESPONSE }));
+  },
+  "/members": async (page) => {
+    await mockAuthenticatedSession(page);
+    await page.route("**/v1/tenants/*/members", (r) =>
+      r.fulfill({ json: MEMBERS_RESPONSE }),
+    );
+  },
+};
+
 test.describe("Axe accessibility scan — main routes", () => {
   test("login page has no serious/critical violations", async ({ page }) => {
     await page.goto("/login");
-    await page.waitForLoadState("networkidle");
+    await expect(page.getByRole("heading")).toBeVisible();
 
     const violations = await scanPage(page);
     expect(
@@ -39,15 +64,13 @@ test.describe("Axe accessibility scan — main routes", () => {
   test("repos list page has no serious/critical violations", async ({
     page,
   }) => {
-    await page.route("**/v1/me", (route) =>
-      route.fulfill({ json: ME_RESPONSE }),
-    );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({ json: REPOS_RESPONSE }),
-    );
+    const mock = ROUTE_MOCKS["/repos"];
+    if (mock) await mock(page);
 
     await page.goto("/repos");
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: "Repositories" }),
+    ).toBeVisible();
 
     const violations = await scanPage(page);
     expect(
@@ -59,15 +82,13 @@ test.describe("Axe accessibility scan — main routes", () => {
   test("repos list (empty state) has no serious/critical violations", async ({
     page,
   }) => {
-    await page.route("**/v1/me", (route) =>
-      route.fulfill({ json: ME_RESPONSE }),
-    );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
-    );
+    const mock = ROUTE_MOCKS["/repos-empty"];
+    if (mock) await mock(page);
 
     await page.goto("/repos");
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: "Repositories" }),
+    ).toBeVisible();
 
     const violations = await scanPage(page);
     expect(
@@ -79,15 +100,11 @@ test.describe("Axe accessibility scan — main routes", () => {
   test("repo detail page has no serious/critical violations", async ({
     page,
   }) => {
-    await page.route("**/v1/me", (route) =>
-      route.fulfill({ json: ME_RESPONSE }),
-    );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({ json: REPOS_RESPONSE }),
-    );
+    const mock = ROUTE_MOCKS[`/repos/${REPO_ITEM.repo_id}`];
+    if (mock) await mock(page);
 
     await page.goto(`/repos/${REPO_ITEM.repo_id}`);
-    await page.waitForLoadState("networkidle");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
 
     const violations = await scanPage(page);
     expect(
@@ -99,15 +116,13 @@ test.describe("Axe accessibility scan — main routes", () => {
   test("connect-repo dialog (ingest trigger surface) has no serious/critical violations", async ({
     page,
   }) => {
-    await page.route("**/v1/me", (route) =>
-      route.fulfill({ json: ME_RESPONSE }),
-    );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
-    );
+    const mock = ROUTE_MOCKS["/repos-empty"];
+    if (mock) await mock(page);
 
     await page.goto("/repos");
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: "Repositories" }),
+    ).toBeVisible();
 
     // Open the connect dialog so the modal surface is included in the scan.
     await page.getByRole("button", { name: "Connect a repo" }).click();
@@ -121,15 +136,13 @@ test.describe("Axe accessibility scan — main routes", () => {
   });
 
   test("members page has no serious/critical violations", async ({ page }) => {
-    await page.route("**/v1/me", (route) =>
-      route.fulfill({ json: ME_RESPONSE }),
-    );
-    await page.route("**/v1/tenants/*/members", (route) =>
-      route.fulfill({ json: MEMBERS_RESPONSE }),
-    );
+    const mock = ROUTE_MOCKS["/members"];
+    if (mock) await mock(page);
 
     await page.goto("/members");
-    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: "Members" }),
+    ).toBeVisible();
 
     const violations = await scanPage(page);
     expect(

--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -31,6 +31,8 @@ const ROUTE_MOCKS: Partial<Record<string, MockFn>> = {
     await mockAuthenticatedSession(page);
     await page.route("**/v1/repos", (r) => r.fulfill({ json: REPOS_RESPONSE }));
   },
+  // "/repos-empty" is a conceptual alias: the real route is /repos but mocked
+  // with an empty list to exercise the empty-state UI branch.
   "/repos-empty": async (page) => {
     await mockAuthenticatedSession(page);
     await page.route("**/v1/repos", (r) =>

--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -1,0 +1,140 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_RESPONSE,
+  REPOS_EMPTY_RESPONSE,
+  REPO_ITEM,
+  MEMBERS_RESPONSE,
+} from "./fixtures/mock-api";
+
+// Runs @axe-core/playwright against the main routes and fails on any
+// serious or critical accessibility violations.
+
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function scanPage(
+  page: import("@playwright/test").Page,
+): Promise<import("axe-core").Result[]> {
+  const results = await new AxeBuilder({ page })
+    .withTags(WCAG_TAGS)
+    .analyze();
+  return results.violations.filter(
+    (v) => v.impact === "serious" || v.impact === "critical",
+  );
+}
+
+test.describe("Axe accessibility scan — main routes", () => {
+  test("login page has no serious/critical violations", async ({ page }) => {
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repos list page has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repos list (empty state) has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("repo detail page has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_RESPONSE }),
+    );
+
+    await page.goto(`/repos/${REPO_ITEM.repo_id}`);
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("connect-repo dialog (ingest trigger surface) has no serious/critical violations", async ({
+    page,
+  }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({ json: REPOS_EMPTY_RESPONSE }),
+    );
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    // Open the connect dialog so the modal surface is included in the scan.
+    await page.getByRole("button", { name: "Connect a repo" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+
+  test("members page has no serious/critical violations", async ({ page }) => {
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+    await page.route("**/v1/tenants/*/members", (route) =>
+      route.fulfill({ json: MEMBERS_RESPONSE }),
+    );
+
+    await page.goto("/members");
+    await page.waitForLoadState("networkidle");
+
+    const violations = await scanPage(page);
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/e2e/axe-scan.spec.ts
+++ b/frontend/e2e/axe-scan.spec.ts
@@ -141,7 +141,7 @@ test.describe("Axe accessibility scan — main routes", () => {
 
     await page.goto("/members");
     await expect(
-      page.getByRole("heading", { name: "Members" }),
+      page.getByRole("heading", { name: "Members", exact: true }),
     ).toBeVisible();
 
     const violations = await scanPage(page);

--- a/frontend/e2e/escape-dismissal.spec.ts
+++ b/frontend/e2e/escape-dismissal.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { ReposPage } from "./pages/ReposPage";
+
+test.describe("Escape dismissal (WCAG 2.1.2)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+  });
+
+  test("ConnectRepoDialog closes on Escape key", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await dialog.dismissWithEscape();
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("ConnectRepoDialog closes via ✕ close button", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await dialog.closeButton.click();
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("ConnectRepoDialog closes on backdrop click", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // The backdrop is the dialog overlay element itself (fixed inset-0).
+    // Clicking a corner far outside the inner panel triggers onClose.
+    await dialog.dialog.click({ position: { x: 5, y: 5 } });
+
+    await expect(dialog.dialog).not.toBeVisible();
+  });
+
+  test("dialog can be opened again after Escape dismissal", async ({
+    page,
+  }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+    await dialog.dismissWithEscape();
+    await expect(dialog.dialog).not.toBeVisible();
+
+    // Re-open
+    const dialog2 = await reposPage.openConnectDialog();
+    await expect(dialog2.dialog).toBeVisible();
+  });
+});

--- a/frontend/e2e/field-validation.spec.ts
+++ b/frontend/e2e/field-validation.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   ME_RESPONSE,
-  REPOS_EMPTY_RESPONSE,
+  REPOS_RESPONSE,
 } from "./fixtures/mock-api";
 import { LoginPage } from "./pages/LoginPage";
 
@@ -81,34 +81,59 @@ test.describe("Field-level validation errors", () => {
       await page.route("**/v1/me", (route) =>
         route.fulfill({ json: ME_RESPONSE }),
       );
+      // Use REPOS_RESPONSE so knownInstallationId is set and dialog opens
+      // directly at the pick step (REQ-FE-12 removed the manual install button).
       await page.route("**/v1/repos", (route) => {
         if (route.request().method() === "GET") {
-          return route.fulfill({ json: REPOS_EMPTY_RESPONSE });
+          return route.fulfill({ json: REPOS_RESPONSE });
         }
         return route.continue();
       });
+      // Return one repo so the repo-list section renders (and errors show),
+      // but the test won't click it — leaving github_repo_id unset.
+      await page.route(
+        "**/v1/github/installations/*/available-repos**",
+        (route) =>
+          route.fulfill({
+            json: {
+              total_count: 1,
+              page: 1,
+              per_page: 30,
+              repositories: [
+                {
+                  id: 99999,
+                  name: "api",
+                  full_name: "acme/api",
+                  private: false,
+                  archived: false,
+                  default_branch: "main",
+                  html_url: "https://github.com/acme/api",
+                },
+              ],
+            },
+          }),
+      );
     });
 
-    test("submitting without installation_id shows error alert", async ({
+    test("submitting without github_repo_id shows error alert", async ({
       page,
     }) => {
       await page.goto("/repos");
       await page.waitForLoadState("networkidle");
 
+      // REPOS_RESPONSE has an entry with installation_id so dialog opens at
+      // pick step immediately — no install-step button needed.
       await page.getByRole("button", { name: "Connect a repo" }).click();
-      // Advance past the install step
-      await page
-        .getByRole("button", { name: /I've installed the app/ })
-        .click();
+      await expect(page.getByRole("dialog")).toBeVisible();
 
-      // Submit without filling any fields
+      // Submit without selecting any repo — github_repo_id is never set.
       await page.getByRole("button", { name: "Connect repository" }).click();
 
-      // A role="alert" paragraph renders under the installation_id input.
+      // A role="alert" paragraph renders for the github_repo_id Zod error.
       // Scoped to the dialog to avoid matching unrelated alerts on the page.
       const alert = page.getByRole("dialog").locator('[role="alert"]').first();
       await expect(alert).toBeVisible();
-      await expect(alert).toContainText(/installation id|positive integer/i);
+      await expect(alert).toContainText(/repository id|required/i);
     });
   });
 });

--- a/frontend/e2e/field-validation.spec.ts
+++ b/frontend/e2e/field-validation.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { LoginPage } from "./pages/LoginPage";
+
+test.describe("Field-level validation errors", () => {
+  test.describe("Login form (Field component / aria-invalid)", () => {
+    test("empty submit: errors appear under correct fields with aria-invalid", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      await loginPage.submit();
+
+      // Both inputs get aria-invalid="true"
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+
+      // Error paragraphs appear with role="alert" under the right inputs
+      await expect(loginPage.emailError).toBeVisible();
+      await expect(loginPage.emailError).toContainText(/required|valid/i);
+
+      await expect(loginPage.passwordError).toBeVisible();
+      await expect(loginPage.passwordError).toContainText(/required/i);
+
+      // aria-describedby links each input to its own error id
+      await expect(loginPage.emailInput).toHaveAttribute(
+        "aria-describedby",
+        "email-error",
+      );
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-describedby",
+        "password-error",
+      );
+    });
+
+    test("invalid email format: email-specific error text", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      await loginPage.emailInput.fill("not-an-email");
+      await loginPage.submit();
+
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+      await expect(loginPage.emailError).toContainText(/valid email/i);
+
+      // Password was not touched — its error fires independently
+      await expect(loginPage.passwordInput).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+
+    test("valid email clears aria-invalid after correction", async ({
+      page,
+    }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // Trigger validation
+      await loginPage.submit();
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "true");
+
+      // Fix the email — react-hook-form re-validates on change
+      await loginPage.emailInput.fill("good@example.com");
+      await expect(loginPage.emailInput).toHaveAttribute("aria-invalid", "false");
+      await expect(loginPage.emailError).not.toBeVisible();
+    });
+  });
+
+  test.describe("ConnectRepoDialog pick step (plain input errors)", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route("**/v1/me", (route) =>
+        route.fulfill({ json: ME_RESPONSE }),
+      );
+      await page.route("**/v1/repos", (route) => {
+        if (route.request().method() === "GET") {
+          return route.fulfill({ json: REPOS_EMPTY_RESPONSE });
+        }
+        return route.continue();
+      });
+    });
+
+    test("submitting without installation_id shows error alert", async ({
+      page,
+    }) => {
+      await page.goto("/repos");
+      await page.waitForLoadState("networkidle");
+
+      await page.getByRole("button", { name: "Connect a repo" }).click();
+      // Advance past the install step
+      await page
+        .getByRole("button", { name: /I've installed the app/ })
+        .click();
+
+      // Submit without filling any fields
+      await page.getByRole("button", { name: "Connect repository" }).click();
+
+      // A role="alert" paragraph renders under the installation_id input
+      const alert = page.locator('[role="alert"]').first();
+      await expect(alert).toBeVisible();
+      await expect(alert).toContainText(/installation id|positive integer/i);
+    });
+  });
+});

--- a/frontend/e2e/field-validation.spec.ts
+++ b/frontend/e2e/field-validation.spec.ts
@@ -104,8 +104,9 @@ test.describe("Field-level validation errors", () => {
       // Submit without filling any fields
       await page.getByRole("button", { name: "Connect repository" }).click();
 
-      // A role="alert" paragraph renders under the installation_id input
-      const alert = page.locator('[role="alert"]').first();
+      // A role="alert" paragraph renders under the installation_id input.
+      // Scoped to the dialog to avoid matching unrelated alerts on the page.
+      const alert = page.getByRole("dialog").locator('[role="alert"]').first();
       await expect(alert).toBeVisible();
       await expect(alert).toContainText(/installation id|positive integer/i);
     });

--- a/frontend/e2e/fixtures/mock-api.ts
+++ b/frontend/e2e/fixtures/mock-api.ts
@@ -1,0 +1,93 @@
+import { type Page } from "@playwright/test";
+
+export const ME_RESPONSE = {
+  user: {
+    id: "user-1",
+    email: "test@example.com",
+    email_verified: true,
+    created_at: "2024-01-01T00:00:00Z",
+    status: "active",
+  },
+  current_tenant: {
+    id: "tenant-1",
+    name: "Test Workspace",
+    role: "owner",
+    slug: "test-workspace",
+  },
+  available_tenants: [
+    {
+      id: "tenant-1",
+      name: "Test Workspace",
+      role: "owner",
+      slug: "test-workspace",
+    },
+  ],
+};
+
+export const REPO_ITEM = {
+  repo_id: "repo-1",
+  full_name: "acme/web-app",
+  installation_id: "install-uuid-1",
+  default_branch: "main",
+  status: "connected",
+  connected_at: "2024-01-01T00:00:00Z",
+  connected_by: "user-1",
+};
+
+export const REPOS_RESPONSE = { repos: [REPO_ITEM] };
+export const REPOS_EMPTY_RESPONSE = { repos: [] };
+
+export const INGEST_RESPONSE = { run_id: "run-id-1" };
+
+export const CONNECT_REPO_RESPONSE = {
+  repo_id: "repo-2",
+  full_name: "acme/api",
+  installation_id: "install-uuid-1",
+  default_branch: "main",
+  status: "connected",
+  connected_at: "2024-01-01T00:00:00Z",
+  connected_by: "user-1",
+};
+
+export const MEMBERS_RESPONSE = {
+  members: [
+    {
+      user_id: "user-1",
+      email: "test@example.com",
+      role: "owner",
+      invited_at: "2024-01-01T00:00:00Z",
+    },
+  ],
+};
+
+export const API_KEYS_RESPONSE = { api_keys: [] };
+
+export async function mockAuthenticatedSession(page: Page): Promise<void> {
+  await page.route("**/v1/me", (route) =>
+    route.fulfill({ json: ME_RESPONSE }),
+  );
+}
+
+export async function mockReposList(
+  page: Page,
+  response: { repos: typeof REPO_ITEM[] } = REPOS_RESPONSE,
+): Promise<void> {
+  await page.route("**/v1/repos", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: response });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockIngestTrigger(page: Page): Promise<void> {
+  await page.route("**/v1/repos/*/ingest", (route) =>
+    route.fulfill({ json: INGEST_RESPONSE }),
+  );
+}
+
+export async function mockMembers(page: Page): Promise<void> {
+  await page.route("**/v1/tenants/*/members", (route) =>
+    route.fulfill({ json: MEMBERS_RESPONSE }),
+  );
+}

--- a/frontend/e2e/fixtures/mock-api.ts
+++ b/frontend/e2e/fixtures/mock-api.ts
@@ -60,7 +60,7 @@ export const MEMBERS_RESPONSE = {
   ],
 };
 
-export const API_KEYS_RESPONSE = { api_keys: [] };
+export const API_KEYS_RESPONSE = { keys: [] };
 
 export async function mockAuthenticatedSession(page: Page): Promise<void> {
   await page.route("**/v1/me", (route) =>

--- a/frontend/e2e/focus-trap.spec.ts
+++ b/frontend/e2e/focus-trap.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import { ReposPage } from "./pages/ReposPage";
+
+test.describe("Focus trap in ConnectRepoDialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+  });
+
+  test("Tab key keeps focus inside the open dialog", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // Tab through more steps than there are focusable elements — each press
+    // must stay within the dialog (cycle, not escape).
+    for (let i = 0; i < 9; i++) {
+      await page.keyboard.press("Tab");
+      const inside = await page.evaluate(() => {
+        const d = document.querySelector('[role="dialog"]');
+        return d?.contains(document.activeElement) ?? false;
+      });
+      expect(inside, `Tab press ${String(i + 1)}: focus escaped dialog`).toBe(
+        true,
+      );
+    }
+  });
+
+  test("Shift+Tab wraps focus from first to last element", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // The dialog auto-focuses the first focusable element on mount.
+    // Shift+Tab from first should wrap to the last — still inside the dialog.
+    await page.keyboard.press("Shift+Tab");
+
+    const inside = await page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return d?.contains(document.activeElement) ?? false;
+    });
+    expect(
+      inside,
+      "Shift+Tab from first element should wrap inside dialog",
+    ).toBe(true);
+  });
+
+  test("Tab wraps focus from last to first element", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    // Count focusable elements, then Tab past the last one to trigger wrap.
+    const count = await dialog.getFocusableElements().count();
+    for (let i = 0; i < count; i++) {
+      await page.keyboard.press("Tab");
+    }
+
+    // After count presses focus should have wrapped back inside.
+    const inside = await page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return d?.contains(document.activeElement) ?? false;
+    });
+    expect(inside, "Tab wrap from last element should land inside dialog").toBe(
+      true,
+    );
+  });
+
+  test("focus restores to trigger button after Escape", async ({ page }) => {
+    const reposPage = new ReposPage(page);
+    await reposPage.goto();
+
+    // Click the trigger button — this becomes document.activeElement when the
+    // dialog captures previousFocusRef on mount.
+    const dialog = await reposPage.openConnectDialog();
+    await expect(dialog.dialog).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog.dialog).not.toBeVisible();
+
+    // The dialog cleanup effect restores focus to previousFocusRef.
+    const focusedText = await page.evaluate(
+      () => (document.activeElement as Element | null)?.textContent?.trim() ?? "",
+    );
+    expect(focusedText).toContain("Connect a repo");
+  });
+});

--- a/frontend/e2e/pages/LoginPage.ts
+++ b/frontend/e2e/pages/LoginPage.ts
@@ -1,0 +1,31 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class LoginPage {
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly emailError: Locator;
+  readonly passwordError: Locator;
+
+  constructor(private readonly page: Page) {
+    this.emailInput = page.locator("#email");
+    this.passwordInput = page.locator("#password");
+    this.submitButton = page.getByRole("button", { name: "Sign in" });
+    this.emailError = page.locator("#email-error");
+    this.passwordError = page.locator("#password-error");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/login");
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  async fillAndSubmit(email: string, password: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.submit();
+  }
+}

--- a/frontend/e2e/pages/RepoDetailPage.ts
+++ b/frontend/e2e/pages/RepoDetailPage.ts
@@ -9,7 +9,9 @@ export class RepoDetailPage {
     this.triggerIngestButton = page.getByRole("button", {
       name: "Trigger ingestion",
     });
-    this.ingestQueuedMessage = page.getByText("Ingestion run queued");
+    this.ingestQueuedMessage = page.getByText("Ingestion run queued", {
+      exact: true,
+    });
     this.repoHeading = page.getByRole("heading", { level: 1 });
   }
 

--- a/frontend/e2e/pages/RepoDetailPage.ts
+++ b/frontend/e2e/pages/RepoDetailPage.ts
@@ -1,0 +1,24 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class RepoDetailPage {
+  readonly triggerIngestButton: Locator;
+  readonly ingestQueuedMessage: Locator;
+  readonly repoHeading: Locator;
+
+  constructor(private readonly page: Page) {
+    this.triggerIngestButton = page.getByRole("button", {
+      name: "Trigger ingestion",
+    });
+    this.ingestQueuedMessage = page.getByText("Ingestion run queued");
+    this.repoHeading = page.getByRole("heading", { level: 1 });
+  }
+
+  async goto(repoId: string): Promise<void> {
+    await this.page.goto(`/repos/${repoId}`);
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async triggerIngestion(): Promise<void> {
+    await this.triggerIngestButton.click();
+  }
+}

--- a/frontend/e2e/pages/ReposPage.ts
+++ b/frontend/e2e/pages/ReposPage.ts
@@ -1,0 +1,57 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class ReposPage {
+  readonly connectButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.connectButton = page.getByRole("button", { name: "Connect a repo" });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/repos");
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async openConnectDialog(): Promise<ConnectRepoDialog> {
+    await this.connectButton.click();
+    return new ConnectRepoDialog(this.page);
+  }
+}
+
+export class ConnectRepoDialog {
+  readonly dialog: Locator;
+  readonly closeButton: Locator;
+  readonly installAppButton: Locator;
+  readonly installedButton: Locator;
+  readonly installationIdInput: Locator;
+  readonly connectButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.dialog = page.getByRole("dialog");
+    this.closeButton = page.getByRole("button", { name: "Close" });
+    this.installAppButton = page.getByRole("button", {
+      name: /Install GitHub App/,
+    });
+    this.installedButton = page.getByRole("button", {
+      name: /I've installed the app/,
+    });
+    this.installationIdInput = page.locator("#numeric-install-id");
+    this.connectButton = page.getByRole("button", {
+      name: "Connect repository",
+    });
+  }
+
+  async dismissWithEscape(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+
+  async advanceToPickStep(): Promise<void> {
+    await this.installedButton.click();
+  }
+
+  getFocusableElements(): Locator {
+    return this.dialog.locator(
+      "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+    );
+  }
+}

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -41,14 +41,23 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     const countAfterLoad = reposGetCount;
     expect(countAfterLoad).toBeGreaterThanOrEqual(1);
 
+    // Listen for the invalidation refetch before triggering the mutation.
+    const refetchPromise = page.waitForResponse(
+      (r) => {
+        const url = new URL(r.url());
+        return url.pathname === "/v1/repos" && r.request().method() === "GET";
+      },
+      { timeout: 10_000 },
+    );
+
     // Trigger ingestion — fires POST /v1/repos/{id}/ingest.
     await repoDetailPage.triggerIngestion();
 
-    // The success toast / queued message confirms the mutation resolved.
+    // The success message confirms the mutation resolved.
     await expect(repoDetailPage.ingestQueuedMessage).toBeVisible();
 
     // Wait for TanStack Query to complete the invalidation refetch.
-    await page.waitForLoadState("networkidle");
+    await refetchPromise;
 
     // The query key invalidation must have triggered at least one more GET.
     expect(reposGetCount).toBeGreaterThan(countAfterLoad);
@@ -100,10 +109,20 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     // Fill in a valid numeric installation ID so Zod accepts the form.
     await page.locator("#numeric-install-id").fill("12345678");
 
+    // Listen for the invalidation refetch BEFORE submitting so we don't miss it.
+    const refetchPromise = page.waitForResponse(
+      (r) => {
+        const url = new URL(r.url());
+        return url.pathname === "/v1/repos" && r.request().method() === "GET";
+      },
+      { timeout: 10_000 },
+    );
+
     // Submit — triggers POST /v1/repos which calls onSuccess → invalidateQueries.
     await page.getByRole("button", { name: "Connect repository" }).click();
 
-    await page.waitForLoadState("networkidle");
+    // Wait for TanStack Query to complete the invalidation refetch.
+    await refetchPromise;
 
     // Repos query must have been refetched.
     expect(reposGetCount).toBeGreaterThan(countAfterLoad);

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -4,6 +4,7 @@ import {
   REPOS_RESPONSE,
   REPO_ITEM,
   INGEST_RESPONSE,
+  CONNECT_REPO_RESPONSE,
 } from "./fixtures/mock-api";
 import { RepoDetailPage } from "./pages/RepoDetailPage";
 
@@ -75,24 +76,37 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     await page.route("**/v1/repos", async (route) => {
       if (route.request().method() === "GET") {
         reposGetCount++;
-        await route.fulfill({ json: { repos: [] } });
+        await route.fulfill({ json: REPOS_RESPONSE });
       } else if (route.request().method() === "POST") {
-        // Simulate a successful connect
-        await route.fulfill({
-          json: {
-            repo_id: "repo-2",
-            full_name: "acme/api",
-            installation_id: "install-uuid-1",
-            default_branch: "main",
-            status: "connected",
-            connected_at: "2024-01-01T00:00:00Z",
-            connected_by: "user-1",
-          },
-        });
+        await route.fulfill({ json: CONNECT_REPO_RESPONSE });
       } else {
         await route.continue();
       }
     });
+
+    // Provide an available repo so the picker populates and github_repo_id can be set.
+    await page.route(
+      "**/v1/github/installations/*/available-repos",
+      (route) =>
+        route.fulfill({
+          json: {
+            total_count: 1,
+            page: 1,
+            per_page: 30,
+            repositories: [
+              {
+                id: 99999,
+                name: "api",
+                full_name: "acme/api",
+                private: false,
+                archived: false,
+                default_branch: "main",
+                html_url: "https://github.com/acme/api",
+              },
+            ],
+          },
+        }),
+    );
 
     await page.goto("/repos");
     await page.waitForLoadState("networkidle");
@@ -100,11 +114,13 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     const countAfterLoad = reposGetCount;
     expect(countAfterLoad).toBeGreaterThanOrEqual(1);
 
-    // Open dialog and advance to the pick step.
+    // With REPOS_RESPONSE, knownInstallationId = "install-uuid-1", so the
+    // dialog opens directly at the pick step — no install-step button needed.
     await page.getByRole("button", { name: "Connect a repo" }).click();
-    await page
-      .getByRole("button", { name: /I've installed the app/ })
-      .click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Wait for the available-repo entry and click it to set github_repo_id.
+    await page.getByRole("button", { name: /acme\/api/ }).click();
 
     // Fill in a valid numeric installation ID so Zod accepts the form.
     await page.locator("#numeric-install-id").fill("12345678");

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import {
+  ME_RESPONSE,
+  REPOS_RESPONSE,
+  REPO_ITEM,
+  INGEST_RESPONSE,
+} from "./fixtures/mock-api";
+import { RepoDetailPage } from "./pages/RepoDetailPage";
+
+// Verifies that useTriggerIngest.onSuccess calls qc.invalidateQueries with the
+// repos query key, causing TanStack Query to immediately refetch GET /v1/repos
+// while the component is still mounted (connected-repos / ingest-trigger flow).
+
+test.describe("TanStack Query invalidation on mutation success", () => {
+  test("useTriggerIngest onSuccess refetches the repos query", async ({
+    page,
+  }) => {
+    let reposGetCount = 0;
+
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+
+    await page.route("**/v1/repos", async (route) => {
+      if (route.request().method() === "GET") {
+        reposGetCount++;
+        await route.fulfill({ json: REPOS_RESPONSE });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route("**/v1/repos/*/ingest", (route) =>
+      route.fulfill({ json: INGEST_RESPONSE }),
+    );
+
+    const repoDetailPage = new RepoDetailPage(page);
+    await repoDetailPage.goto(REPO_ITEM.repo_id);
+
+    // At least one GET /v1/repos was made during the initial load.
+    const countAfterLoad = reposGetCount;
+    expect(countAfterLoad).toBeGreaterThanOrEqual(1);
+
+    // Trigger ingestion — fires POST /v1/repos/{id}/ingest.
+    await repoDetailPage.triggerIngestion();
+
+    // The success toast / queued message confirms the mutation resolved.
+    await expect(repoDetailPage.ingestQueuedMessage).toBeVisible();
+
+    // Wait for TanStack Query to complete the invalidation refetch.
+    await page.waitForLoadState("networkidle");
+
+    // The query key invalidation must have triggered at least one more GET.
+    expect(reposGetCount).toBeGreaterThan(countAfterLoad);
+  });
+
+  test("useConnectRepo onSuccess refetches the repos query", async ({
+    page,
+  }) => {
+    let reposGetCount = 0;
+
+    await page.route("**/v1/me", (route) =>
+      route.fulfill({ json: ME_RESPONSE }),
+    );
+
+    await page.route("**/v1/repos", async (route) => {
+      if (route.request().method() === "GET") {
+        reposGetCount++;
+        await route.fulfill({ json: { repos: [] } });
+      } else if (route.request().method() === "POST") {
+        // Simulate a successful connect
+        await route.fulfill({
+          json: {
+            repo_id: "repo-2",
+            full_name: "acme/api",
+            installation_id: "install-uuid-1",
+            default_branch: "main",
+            status: "connected",
+            connected_at: "2024-01-01T00:00:00Z",
+            connected_by: "user-1",
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/repos");
+    await page.waitForLoadState("networkidle");
+
+    const countAfterLoad = reposGetCount;
+    expect(countAfterLoad).toBeGreaterThanOrEqual(1);
+
+    // Open dialog and advance to the pick step.
+    await page.getByRole("button", { name: "Connect a repo" }).click();
+    await page
+      .getByRole("button", { name: /I've installed the app/ })
+      .click();
+
+    // Fill in a valid numeric installation ID so Zod accepts the form.
+    await page.locator("#numeric-install-id").fill("12345678");
+
+    // Submit — triggers POST /v1/repos which calls onSuccess → invalidateQueries.
+    await page.getByRole("button", { name: "Connect repository" }).click();
+
+    await page.waitForLoadState("networkidle");
+
+    // Repos query must have been refetched.
+    expect(reposGetCount).toBeGreaterThan(countAfterLoad);
+  });
+});

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -85,8 +85,10 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     });
 
     // Provide an available repo so the picker populates and github_repo_id can be set.
+    // The trailing ** is required: useAvailableRepos appends ?page=1&per_page=30 which
+    // would break Playwright's glob match if the pattern ends at the literal path segment.
     await page.route(
-      "**/v1/github/installations/*/available-repos",
+      "**/v1/github/installations/*/available-repos**",
       (route) =>
         route.fulfill({
           json: {

--- a/frontend/e2e/query-refetch.spec.ts
+++ b/frontend/e2e/query-refetch.spec.ts
@@ -124,9 +124,6 @@ test.describe("TanStack Query invalidation on mutation success", () => {
     // Wait for the available-repo entry and click it to set github_repo_id.
     await page.getByRole("button", { name: /acme\/api/ }).click();
 
-    // Fill in a valid numeric installation ID so Zod accepts the form.
-    await page.locator("#numeric-install-id").fill("12345678");
-
     // Listen for the invalidation refetch BEFORE submitting so we don't miss it.
     const refetchPromise = page.waitForResponse(
       (r) => {

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -141,7 +141,7 @@ function ApiKeysPageInner({
         <p className="text-sm text-muted-foreground">
           Programmatic access to{" "}
           <span className="font-medium">{tenantName}</span>. Use the{" "}
-          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+          <code className="rounded bg-muted px-1 py-0.5 text-xs text-foreground">
             Authorization: Bearer
           </code>{" "}
           header.


### PR DESCRIPTION
## Summary

- Adds 5 Playwright E2E specs: `escape-dismissal`, `focus-trap`, `field-validation`, `query-refetch`, `axe-scan`
- Adds Page Object Models (`LoginPage`, `ReposPage`, `RepoDetailPage`) and shared `mock-api` fixtures
- Introduces `tsconfig.e2e.json` with DOM lib so e2e files typecheck correctly; removes `e2e/**/*.ts` from `tsconfig.node.json`
- Adds `page.route()` mocks for authenticated routes in `axe-dispatch.spec.ts` so CI scans don't ECONNREFUSED

## Test plan

- [ ] `escape-dismissal.spec.ts` — Escape key closes ConnectRepoDialog (WCAG 2.1.2)
- [ ] `focus-trap.spec.ts` — Tab/Shift+Tab cycles within dialog; focus restores to trigger on close
- [ ] `field-validation.spec.ts` — Zod field errors render under correct inputs; `aria-invalid` set
- [ ] `query-refetch.spec.ts` — `useTriggerIngest`/`useConnectRepo` `onSuccess` invalidates repos query key
- [ ] `axe-scan.spec.ts` — No serious/critical axe violations on main routes
- [ ] `axe-dispatch.spec.ts` — `/repos`, `/members`, `/api-keys` scans pass with mocked API responses
- [ ] `npm run typecheck` passes with zero errors

Closes #102

🤖 Generated with [Claude Code](https://claude.ai/claude-code)