### PR TITLE
[REQ-FE-12] feat(repos): redirect-driven GitHub App install flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
+ "urlencoding",
  "utoipa",
  "utoipa-axum",
  "uuid",
@@ -3542,6 +3543,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/docs/qa/frontend-runtime-scenarios.md
+++ b/docs/qa/frontend-runtime-scenarios.md
@@ -1,0 +1,43 @@
+# Frontend Runtime Scenarios
+
+Canonical list of FE runtime scenarios that must be covered by the gating Playwright spec set.
+Engineers add rows when new scenarios are introduced. QA flags `GAP` rows as soft caveats in QA reports.
+
+**Last reviewed:** 2026-04-28  
+**Owner:** QA Engineer (RUSAA-234)  
+**Related:** RUSAA-229 (design), RUSAA-230 (CI job + AGENTS.md reference), RUSAA-231 (CI job), RUSAA-232 (baseline specs)
+
+---
+
+## Scenarios
+
+| ID | Behaviour | WCAG ref | Status | Spec file | Owner |
+|----|-----------|----------|--------|-----------|-------|
+| FE-S-001 | Unauthenticated `GET /` redirects to `/login` and `#root` is visible | — | READY | `frontend/e2e/smoke.spec.ts` | QA |
+| FE-S-002 | `/login` passes axe WCAG 2.1 AA scan (0 violations) | WCAG 2.1 AA | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-003 | `/signup` passes axe WCAG 2.1 AA scan (0 violations) | WCAG 2.1 AA | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-004 | `/forgot-password` passes axe WCAG 2.1 AA scan (0 violations) | WCAG 2.1 AA | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-005 | `/repos` passes axe WCAG 2.1 AA scan (0 violations) | WCAG 2.1 AA | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-006 | All gated routes have ≥ 1 focusable element reachable via Tab | WCAG 2.1 SC 2.1.1 | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-007 | Nav link active-state meets WCAG 2.1 AA colour-contrast ratio (≥ 4.5 : 1) | WCAG 2.1 SC 1.4.3 | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+| FE-S-008 | GitHub App install callback (`GET /repos?install=success`) shows success state without error banner | — | GAP | — | FE engineer |
+| FE-S-009 | Authenticated user navigating to `/repos` sees populated repo list (or empty-state CTA) | — | GAP | — | FE engineer |
+| FE-S-010 | `/reset-password` passes axe WCAG 2.1 AA scan (0 violations) | WCAG 2.1 AA | READY | `frontend/e2e/axe-dispatch.spec.ts` | QA |
+
+---
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| `READY` | Scenario is covered by a spec that runs in the gating CI job |
+| `GAP` | Scenario is known but has no covering spec yet; QA flags this as a soft caveat in QA reports |
+| `WONT_COVER` | Deliberately excluded (note reason in the row) |
+
+---
+
+## Gap tracking
+
+Gaps FE-S-008 and FE-S-009 require authenticated-user test fixtures that are not yet wired into the E2E harness. Both should be addressed after the session/cookie injection helper lands.
+
+QA will update this file when new specs are merged and will flag any new `GAP` rows in QA report comments.

--- a/frontend/e2e/repos-connect.spec.ts
+++ b/frontend/e2e/repos-connect.spec.ts
@@ -1,164 +1,158 @@
 import { test, expect } from "@playwright/test";
 
-const TEST_UUID = "11111111-2222-3333-4444-555555555555";
+// Must be a valid RFC 4122 UUID (Zod v4 z.uuid() enforces version+variant bits)
+const TEST_UUID = "12345678-1234-4321-89ab-1234567890ab";
+
+// Shared mock response shapes matching the generated API schema
+const ME_RESPONSE = {
+  user: {
+    id: "user-uuid-1",
+    email: "user@example.com",
+    email_verified: true,
+    status: "active",
+    created_at: "2024-01-01T00:00:00Z",
+  },
+  current_tenant: { id: "tenant-uuid-1", name: "Acme", role: "owner", slug: "acme" },
+  available_tenants: [
+    { id: "tenant-uuid-1", name: "Acme", role: "owner", slug: "acme" },
+  ],
+};
+
+async function mockBase(page: import("@playwright/test").Page) {
+  await page.route("**/v1/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ME_RESPONSE),
+    }),
+  );
+  await page.route("**/v1/repos", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ repos: [] }),
+      });
+    }
+    return route.continue();
+  });
+}
 
 test.describe("GitHub App install redirect flow", () => {
   test("install button triggers same-tab navigation to install URL", async ({
     page,
   }) => {
+    // The install-url mock returns a same-origin sentinel so we can assert
+    // window.location.assign fired (not window.open) via page.waitForURL.
+    const sentinelUrl = "http://localhost:4173/__install_sentinel__";
+    await mockBase(page);
     await page.route("**/v1/github/install-url", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ url: "https://github.com/apps/test-app/installations/new" }),
+        body: JSON.stringify({ url: sentinelUrl, state_token: "test-tok" }),
       }),
     );
-    await page.route("**/v1/auth/me", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          id: "user-1",
-          email: "user@example.com",
-          email_verified: true,
-          current_tenant: { id: "tenant-1", name: "Acme" },
-        }),
-      }),
+    // Absorb the sentinel so it doesn't 404-crash
+    await page.route("**/__install_sentinel__**", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: "<html/>" }),
     );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ repos: [] }),
-      }),
-    );
-
-    let assignedUrl = "";
-    await page.addInitScript(() => {
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...window.location,
-          assign: (url: string) => {
-            (window as unknown as Record<string, unknown>).__assignedUrl__ = url;
-          },
-        },
-      });
-    });
 
     await page.goto("/repos");
     await page.getByRole("button", { name: "Connect a repo" }).click();
     await page.getByRole("button", { name: /Install GitHub App/ }).click();
-    await page.waitForTimeout(200);
 
-    assignedUrl = await page.evaluate(
-      () => (window as unknown as Record<string, unknown>).__assignedUrl__ as string,
-    );
-    expect(assignedUrl).toContain("github.com/apps");
+    // window.location.assign navigates in the same tab — page URL changes.
+    // window.open would NOT change the page URL.
+    await page.waitForURL("**/__install_sentinel__**");
+    expect(page.url()).toContain("__install_sentinel__");
   });
 
   test("redirect params auto-open dialog at pick step, show toast, clear URL", async ({
     page,
   }) => {
-    await page.route("**/v1/auth/me", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          id: "user-1",
-          email: "user@example.com",
-          email_verified: true,
-          current_tenant: { id: "tenant-1", name: "Acme" },
+    await mockBase(page);
+    await page.route(
+      `**/v1/github/installations/${TEST_UUID}/available-repos**`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            total_count: 0,
+            page: 1,
+            per_page: 30,
+            repositories: [],
+          }),
         }),
-      }),
-    );
-    await page.route("**/v1/repos", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ repos: [] }),
-      }),
-    );
-    await page.route(`**/v1/github/installations/${TEST_UUID}/available-repos**`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ total_count: 0, page: 1, per_page: 30, repositories: [] }),
-      }),
     );
 
     await page.goto(
       `/repos?install=success&installation_uuid=${TEST_UUID}&account_login=acme-org`,
     );
 
-    // Dialog should open directly at pick step (no install button visible)
+    // Dialog auto-opens at pick step — role="dialog" is set explicitly on the overlay div
     await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.locator("#numeric-install-id")).not.toBeVisible();
 
-    // Toast fires
+    // No numeric installation ID input present
+    await expect(page.locator("#numeric-install-id")).not.toBeAttached();
+
+    // Toast fires with account name
     await expect(page.getByText(/Installed on acme-org/)).toBeVisible();
 
-    // URL params cleaned up
+    // URL cleaned up — no install params remain
     await expect(page).toHaveURL(/\/repos$/);
   });
 
   test("pick step submits without numeric input, using UUID from closure", async ({
     page,
   }) => {
-    await page.route("**/v1/auth/me", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          id: "user-1",
-          email: "user@example.com",
-          email_verified: true,
-          current_tenant: { id: "tenant-1", name: "Acme" },
-        }),
-      }),
-    );
+    let connectBody: Record<string, unknown> = {};
+
+    await mockBase(page);
     await page.route("**/v1/repos", async (route) => {
-      if (route.request().method() === "GET") {
+      if (route.request().method() === "POST") {
+        connectBody = route.request().postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            repo_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            full_name: "acme-org/myrepo",
+            default_branch: "main",
+          }),
+        });
+      } else {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
           body: JSON.stringify({ repos: [] }),
         });
-      } else {
-        const body = route.request().postDataJSON() as Record<string, unknown>;
-        expect(body.installation_id).toBe(TEST_UUID);
-        await route.fulfill({
-          status: 201,
-          contentType: "application/json",
-          body: JSON.stringify({
-            repo_id: "repo-uuid-1",
-            full_name: "acme-org/myrepo",
-            default_branch: "main",
-          }),
-        });
       }
     });
-    await page.route(`**/v1/github/installations/${TEST_UUID}/available-repos**`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          total_count: 1,
-          page: 1,
-          per_page: 30,
-          repositories: [
-            {
-              id: 42,
-              name: "myrepo",
-              full_name: "acme-org/myrepo",
-              private: false,
-              archived: false,
-              default_branch: "main",
-              html_url: "https://github.com/acme-org/myrepo",
-            },
-          ],
+    await page.route(
+      `**/v1/github/installations/${TEST_UUID}/available-repos**`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            total_count: 1,
+            page: 1,
+            per_page: 30,
+            repositories: [
+              {
+                id: 42,
+                name: "myrepo",
+                full_name: "acme-org/myrepo",
+                private: false,
+                archived: false,
+                default_branch: "main",
+                html_url: "https://github.com/acme-org/myrepo",
+              },
+            ],
+          }),
         }),
-      }),
     );
 
     await page.goto(
@@ -166,9 +160,14 @@ test.describe("GitHub App install redirect flow", () => {
     );
 
     await expect(page.getByRole("dialog")).toBeVisible();
-    await page.getByRole("button", { name: "acme-org/myrepo" }).click();
+    // Select the repo from the list
+    await page.getByRole("button", { name: /acme-org\/myrepo/ }).click();
     await page.getByRole("button", { name: /Connect repository/ }).click();
 
     await expect(page.getByText(/Connected acme-org\/myrepo/)).toBeVisible();
+
+    // Verify the POST body used the UUID from the URL (not a numeric field)
+    expect(connectBody.installation_id).toBe(TEST_UUID);
+    expect(typeof connectBody.installation_id).toBe("string");
   });
 });

--- a/frontend/e2e/repos-connect.spec.ts
+++ b/frontend/e2e/repos-connect.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "@playwright/test";
+
+const TEST_UUID = "11111111-2222-3333-4444-555555555555";
+
+test.describe("GitHub App install redirect flow", () => {
+  test("install button triggers same-tab navigation to install URL", async ({
+    page,
+  }) => {
+    await page.route("**/v1/github/install-url", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ url: "https://github.com/apps/test-app/installations/new" }),
+      }),
+    );
+    await page.route("**/v1/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "user-1",
+          email: "user@example.com",
+          email_verified: true,
+          current_tenant: { id: "tenant-1", name: "Acme" },
+        }),
+      }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ repos: [] }),
+      }),
+    );
+
+    let assignedUrl = "";
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...window.location,
+          assign: (url: string) => {
+            (window as unknown as Record<string, unknown>).__assignedUrl__ = url;
+          },
+        },
+      });
+    });
+
+    await page.goto("/repos");
+    await page.getByRole("button", { name: "Connect a repo" }).click();
+    await page.getByRole("button", { name: /Install GitHub App/ }).click();
+    await page.waitForTimeout(200);
+
+    assignedUrl = await page.evaluate(
+      () => (window as unknown as Record<string, unknown>).__assignedUrl__ as string,
+    );
+    expect(assignedUrl).toContain("github.com/apps");
+  });
+
+  test("redirect params auto-open dialog at pick step, show toast, clear URL", async ({
+    page,
+  }) => {
+    await page.route("**/v1/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "user-1",
+          email: "user@example.com",
+          email_verified: true,
+          current_tenant: { id: "tenant-1", name: "Acme" },
+        }),
+      }),
+    );
+    await page.route("**/v1/repos", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ repos: [] }),
+      }),
+    );
+    await page.route(`**/v1/github/installations/${TEST_UUID}/available-repos**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_count: 0, page: 1, per_page: 30, repositories: [] }),
+      }),
+    );
+
+    await page.goto(
+      `/repos?install=success&installation_uuid=${TEST_UUID}&account_login=acme-org`,
+    );
+
+    // Dialog should open directly at pick step (no install button visible)
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.locator("#numeric-install-id")).not.toBeVisible();
+
+    // Toast fires
+    await expect(page.getByText(/Installed on acme-org/)).toBeVisible();
+
+    // URL params cleaned up
+    await expect(page).toHaveURL(/\/repos$/);
+  });
+
+  test("pick step submits without numeric input, using UUID from closure", async ({
+    page,
+  }) => {
+    await page.route("**/v1/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "user-1",
+          email: "user@example.com",
+          email_verified: true,
+          current_tenant: { id: "tenant-1", name: "Acme" },
+        }),
+      }),
+    );
+    await page.route("**/v1/repos", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ repos: [] }),
+        });
+      } else {
+        const body = route.request().postDataJSON() as Record<string, unknown>;
+        expect(body.installation_id).toBe(TEST_UUID);
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            repo_id: "repo-uuid-1",
+            full_name: "acme-org/myrepo",
+            default_branch: "main",
+          }),
+        });
+      }
+    });
+    await page.route(`**/v1/github/installations/${TEST_UUID}/available-repos**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total_count: 1,
+          page: 1,
+          per_page: 30,
+          repositories: [
+            {
+              id: 42,
+              name: "myrepo",
+              full_name: "acme-org/myrepo",
+              private: false,
+              archived: false,
+              default_branch: "main",
+              html_url: "https://github.com/acme-org/myrepo",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto(
+      `/repos?install=success&installation_uuid=${TEST_UUID}&account_login=acme-org`,
+    );
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: "acme-org/myrepo" }).click();
+    await page.getByRole("button", { name: /Connect repository/ }).click();
+
+    await expect(page.getByText(/Connected acme-org\/myrepo/)).toBeVisible();
+  });
+});

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -509,10 +509,10 @@ export interface components {
              */
             readonly github_repo_id: number;
             /**
-             * Format: int64
-             * @description GitHub numeric installation ID (from the App install callback).
+             * Format: uuid
+             * @description Internal installation UUID (from the GitHub App install redirect).
              */
-            readonly installation_id: number;
+            readonly installation_id: string;
         };
         readonly ConnectRepoResponse: {
             readonly default_branch: string;

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -494,12 +494,6 @@ export interface components {
             readonly name: string;
             readonly scopes: readonly components["schemas"]["Scope"][];
         };
-        readonly CallbackResponse: {
-            readonly account_login: string;
-            readonly account_type: string;
-            /** Format: int64 */
-            readonly installation_id: number;
-        };
         readonly ConnectRepoRequest: {
             /** @description Default branch override. If omitted, the value is fetched from GitHub. */
             readonly default_branch?: string | null;
@@ -1089,14 +1083,12 @@ export interface operations {
         };
         readonly requestBody?: never;
         readonly responses: {
-            /** @description Installation created or updated */
-            readonly 200: {
+            /** @description Redirect to frontend repos page */
+            readonly 302: {
                 headers: {
                     readonly [name: string]: unknown;
                 };
-                content: {
-                    readonly "application/json": components["schemas"]["CallbackResponse"];
-                };
+                content?: never;
             };
             /** @description Invalid or expired state token */
             readonly 400: {

--- a/frontend/src/lib/validation/repos.ts
+++ b/frontend/src/lib/validation/repos.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 
 export const connectRepoFormSchema = z.object({
-  installation_id: z
-    .number({ message: "Installation ID is required" })
-    .int()
-    .positive("Installation ID must be a positive integer"),
   github_repo_id: z
     .number({ message: "Repository ID is required" })
     .int()

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -69,13 +69,17 @@ function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
   const [showConnect, setShowConnect] = useState(false);
   const [dialogInstallId, setDialogInstallId] = useState<string | null>(null);
   const search = useSearch({ from: routes.repos });
-  const navigate = useNavigate();
 
   const connectedList: readonly RepoItem[] = repos.data?.repos ?? [];
+  const installHandledRef = useRef(false);
 
   // Auto-open connect dialog when redirected back from GitHub App install.
+  // We use window.history.replaceState instead of navigate() to clean the URL
+  // without going through TanStack Router, which would remount this component
+  // and reset the ref — causing a duplicate toast.
   useEffect(() => {
-    if (search.install === "success" && search.installation_uuid) {
+    if (!installHandledRef.current && search.install === "success" && search.installation_uuid) {
+      installHandledRef.current = true;
       setDialogInstallId(search.installation_uuid);
       setShowConnect(true);
       toast.success(
@@ -83,7 +87,7 @@ function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
           ? `Installed on ${search.account_login}. Pick a repo to connect.`
           : "App installed. Pick a repo to connect.",
       );
-      void navigate({ to: routes.repos, search: {} });
+      window.history.replaceState(null, "", routes.repos);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -67,12 +67,31 @@ interface ReposPageInnerProps {
 function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
   const repos = useRepos(tenantId);
   const [showConnect, setShowConnect] = useState(false);
+  const [dialogInstallId, setDialogInstallId] = useState<string | null>(null);
+  const search = useSearch({ from: routes.repos });
+  const navigate = useNavigate();
 
   const connectedList: readonly RepoItem[] = repos.data?.repos ?? [];
 
-  // Derive the installation UUID from the first connected repo (if any).
-  // This lets us populate the available-repos picker for subsequent connects.
-  const knownInstallationId = connectedList[0]?.installation_id ?? null;
+  // Auto-open connect dialog when redirected back from GitHub App install.
+  useEffect(() => {
+    if (search.install === "success" && search.installation_uuid) {
+      setDialogInstallId(search.installation_uuid);
+      setShowConnect(true);
+      toast.success(
+        search.account_login
+          ? `Installed on ${search.account_login}. Pick a repo to connect.`
+          : "App installed. Pick a repo to connect.",
+      );
+      void navigate({ to: routes.repos, search: {} });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Derive the installation UUID from the first connected repo (if any) as
+  // fallback for returning users who already have a connection.
+  const knownInstallationId =
+    dialogInstallId ?? connectedList[0]?.installation_id ?? null;
 
   return (
     <PageContainer>
@@ -209,12 +228,8 @@ function ConnectRepoDialog({
   onClose,
   onSuccess,
 }: ConnectRepoDialogProps): JSX.Element {
-  const [step, setStep] = useState<ConnectStep>(
-    installationId ? "pick" : "install",
-  );
-  const [resolvedInstallId, setResolvedInstallId] = useState<string>(
-    installationId ?? "",
-  );
+  const step: ConnectStep = installationId ? "pick" : "install";
+  const resolvedInstallId = installationId ?? "";
 
   const dialogRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
@@ -291,12 +306,7 @@ function ConnectRepoDialog({
         </div>
 
         {step === "install" ? (
-          <InstallStep
-            onInstalled={(installUuid) => {
-              setResolvedInstallId(installUuid);
-              setStep("pick");
-            }}
-          />
+          <InstallStep />
         ) : (
           <PickRepoStep
             tenantId={tenantId}
@@ -313,17 +323,13 @@ function ConnectRepoDialog({
 // Step 1 — Install GitHub App
 // ---------------------------------------------------------------------------
 
-function InstallStep({
-  onInstalled,
-}: {
-  readonly onInstalled: (installUuid: string) => void;
-}): JSX.Element {
+function InstallStep(): JSX.Element {
   const installUrl = useGithubInstallUrl();
 
   const handleInstall = async () => {
     try {
       const result = await installUrl.mutateAsync();
-      window.open(result.url, "_blank", "noopener");
+      window.location.assign(result.url);
     } catch (err) {
       toast.error(formatApiError(err, "Could not generate install link."));
     }
@@ -333,7 +339,8 @@ function InstallStep({
     <div className="flex flex-col gap-4">
       <p className="text-sm text-muted-foreground">
         First, install the GitHub App on the organization or account that owns
-        the repositories you want to connect.
+        the repositories you want to connect. You&apos;ll be redirected back
+        here automatically after installing.
       </p>
       <button
         type="button"
@@ -342,17 +349,6 @@ function InstallStep({
         className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {installUrl.isPending ? "Generating link…" : "Install GitHub App →"}
-      </button>
-      <p className="text-xs text-muted-foreground">
-        After installing, return here and click{" "}
-        <strong>I&apos;ve installed the app</strong>.
-      </p>
-      <button
-        type="button"
-        onClick={() => onInstalled("")}
-        className="self-start text-sm font-medium text-primary hover:underline"
-      >
-        I&apos;ve installed the app →
       </button>
     </div>
   );
@@ -380,7 +376,6 @@ function PickRepoStep({
   const [busy, setBusy] = useState(false);
 
   const {
-    register,
     handleSubmit,
     setValue,
     watch,
@@ -400,7 +395,7 @@ function PickRepoStep({
     setBusy(true);
     try {
       const result = await connect.mutateAsync({
-        installation_id: values.installation_id,
+        installation_id: installationUuid,
         github_repo_id: values.github_repo_id,
         default_branch: values.default_branch ?? null,
       });
@@ -415,35 +410,6 @@ function PickRepoStep({
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      {/* Numeric installation ID input */}
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor="numeric-install-id"
-          className="text-xs font-medium text-foreground"
-        >
-          GitHub installation ID (numeric)
-        </label>
-        <input
-          id="numeric-install-id"
-          type="number"
-          min={1}
-          placeholder="e.g. 12345678"
-          {...register("installation_id", { valueAsNumber: true })}
-          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        />
-        {errors.installation_id ? (
-          <p className="text-xs text-destructive" role="alert">
-            {errors.installation_id.message}
-          </p>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            Find this in the GitHub App callback response (
-            <code className="rounded bg-muted px-1 text-xs">installation_id</code>{" "}
-            field) or your GitHub App settings.
-          </p>
-        )}
-      </div>
-
       {/* Available repos list */}
       {installationUuid.length === 0 ? (
         <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -78,9 +78,16 @@ const resetPasswordRoute = createRoute({
   component: ResetPasswordPage,
 });
 
+const reposSearchSchema = z.object({
+  install: z.enum(["success"]).optional(),
+  installation_uuid: z.uuid().optional(),
+  account_login: z.string().optional(),
+});
+
 const reposRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: routes.repos,
+  validateSearch: reposSearchSchema,
   component: ReposPage,
 });
 

--- a/openapi.json
+++ b/openapi.json
@@ -1046,9 +1046,9 @@
             "description": "GitHub numeric repository ID (from the list-repos response)."
           },
           "installation_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "GitHub numeric installation ID (from the App install callback)."
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal installation UUID (from the GitHub App install redirect)."
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -368,15 +368,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Installation created or updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CallbackResponse"
-                }
-              }
-            }
+          "302": {
+            "description": "Redirect to frontend repos page"
           },
           "400": {
             "description": "Invalid or expired state token"
@@ -1003,26 +996,6 @@
             "items": {
               "$ref": "#/components/schemas/Scope"
             }
-          }
-        }
-      },
-      "CallbackResponse": {
-        "type": "object",
-        "required": [
-          "installation_id",
-          "account_login",
-          "account_type"
-        ],
-        "properties": {
-          "account_login": {
-            "type": "string"
-          },
-          "account_type": {
-            "type": "string"
-          },
-          "installation_id": {
-            "type": "integer",
-            "format": "int64"
           }
         }
       },

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -43,6 +43,7 @@ uuid.workspace = true
 chrono.workspace = true
 rand.workspace = true
 hex.workspace = true
+urlencoding = "2"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -41,7 +41,6 @@ use crate::routes::{api_keys, auth, auth_logout, auth_verify, github, health, me
             health::ProbeResponse,
             github::health::GithubAppHealthResponse,
             github::install::InstallUrlResponse,
-            github::install::CallbackResponse,
             github::repos::RepoItemResponse,
             github::repos::ListReposResponse,
             auth::SignupRequest,

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -4,11 +4,12 @@
 use axum::{
     Json,
     extract::{Query, State},
-    response::IntoResponse,
+    response::{IntoResponse, Redirect},
 };
 use rand::RngCore as _;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use urlencoding::encode as urlencode;
 use uuid::Uuid;
 
 use crate::{
@@ -86,13 +87,6 @@ pub struct CallbackParams {
     pub setup_action: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
-pub struct CallbackResponse {
-    pub installation_id: i64,
-    pub account_login: String,
-    pub account_type: String,
-}
-
 #[utoipa::path(
     get,
     path = "/v1/github/callback",
@@ -102,7 +96,7 @@ pub struct CallbackResponse {
         ("setup_action" = Option<String>, Query, description = "install or update"),
     ),
     responses(
-        (status = 200, description = "Installation created or updated", body = CallbackResponse),
+        (status = 302, description = "Redirect to frontend repos page"),
         (status = 400, description = "Invalid or expired state token"),
         (status = 503, description = "GitHub App not configured on this instance"),
     ),
@@ -139,7 +133,7 @@ pub async fn github_callback(
         AppError::Internal(anyhow::anyhow!("failed to fetch GitHub installation"))
     })?;
 
-    sqlx::query(
+    let (installation_uuid,): (Uuid,) = sqlx::query_as(
         "INSERT INTO control.github_installations \
          (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
          VALUES ($1, $2, $3, $4, $5, $6) \
@@ -149,7 +143,8 @@ pub async fn github_callback(
            account_type  = EXCLUDED.account_type, \
            account_id    = EXCLUDED.account_id, \
            deleted_at    = NULL, \
-           suspended_at  = NULL",
+           suspended_at  = NULL \
+         RETURNING id",
     )
     .bind(Uuid::new_v4())
     .bind(tenant_id)
@@ -157,23 +152,25 @@ pub async fn github_callback(
     .bind(&info.account.login)
     .bind(&info.account.kind)
     .bind(info.account.id)
-    .execute(&state.pool)
+    .fetch_one(&state.pool)
     .await?;
 
     tracing::info!(
         tenant_id = %tenant_id,
         user_id = %user_id,
         installation_id = params.installation_id,
+        installation_uuid = %installation_uuid,
         account = %info.account.login,
         setup_action = ?params.setup_action,
         "github callback: installation upserted"
     );
 
-    Ok(Json(CallbackResponse {
-        installation_id: params.installation_id,
-        account_login: info.account.login,
-        account_type: info.account.kind,
-    }))
+    Ok(Redirect::to(&format!(
+        "{}/repos?install=success&installation_uuid={}&account_login={}",
+        state.config.base_url,
+        installation_uuid,
+        urlencode(&info.account.login),
+    )))
 }
 
 #[cfg(test)]
@@ -189,19 +186,6 @@ mod tests {
         let v = serde_json::to_value(&resp).unwrap();
         assert!(v["url"].as_str().unwrap().contains("state=abc"));
         assert_eq!(v["state_token"], "abc");
-    }
-
-    #[test]
-    fn callback_response_serializes_all_fields() {
-        let resp = CallbackResponse {
-            installation_id: 42,
-            account_login: "octo-org".to_owned(),
-            account_type: "Organization".to_owned(),
-        };
-        let v = serde_json::to_value(&resp).unwrap();
-        assert_eq!(v["installation_id"], 42);
-        assert_eq!(v["account_login"], "octo-org");
-        assert_eq!(v["account_type"], "Organization");
     }
 
     #[test]

--- a/services/control-api/src/routes/repos.rs
+++ b/services/control-api/src/routes/repos.rs
@@ -27,8 +27,8 @@ use crate::{
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ConnectRepoRequest {
-    /// GitHub numeric installation ID (from the App install callback).
-    pub installation_id: i64,
+    /// Internal installation UUID (from the GitHub App install redirect).
+    pub installation_id: Uuid,
     /// GitHub numeric repository ID (from the list-repos response).
     pub github_repo_id: i64,
     /// Default branch override. If omitted, the value is fetched from GitHub.
@@ -108,9 +108,9 @@ pub async fn connect_repo(
 
     let gh = state.gh.as_ref().ok_or(AppError::GithubAppNotConfigured)?;
 
-    let row: Option<(Uuid,)> = sqlx::query_as(
-        "SELECT id FROM control.github_installations \
-         WHERE github_installation_id = $1 \
+    let row: Option<(i64,)> = sqlx::query_as(
+        "SELECT github_installation_id FROM control.github_installations \
+         WHERE id = $1 \
            AND tenant_id = $2 \
            AND deleted_at IS NULL \
            AND suspended_at IS NULL",
@@ -120,10 +120,10 @@ pub async fn connect_repo(
     .fetch_optional(&state.pool)
     .await?;
 
-    let (installation_uuid,) = row.ok_or(AppError::NotFound)?;
+    let (numeric_installation_id,) = row.ok_or(AppError::NotFound)?;
 
     let repo_info = gh
-        .fetch_repo(body.installation_id, body.github_repo_id)
+        .fetch_repo(numeric_installation_id, body.github_repo_id)
         .await
         .map_err(|e| match e {
             GhError::ApiError { status: 404, .. } | GhError::ApiError { status: 403, .. } => {
@@ -142,7 +142,7 @@ pub async fn connect_repo(
     )
     .bind(repo_id)
     .bind(session.tenant_id)
-    .bind(installation_uuid)
+    .bind(body.installation_id)
     .bind(body.github_repo_id)
     .bind(&repo_info.full_name)
     .bind(&default_branch)

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -343,6 +343,32 @@ async fn webhook_returns_202_for_unmodelled_installation_action() {
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
 }
 
+// ─── GitHub callback tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn callback_returns_503_when_app_not_configured() {
+    let app = build(state_without_gh());
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/github/callback?installation_id=1&state=aabbcc")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn callback_returns_400_for_invalid_hex_state() {
+    let app = build(state_with_gh(b"shh"));
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/github/callback?installation_id=1&state=not-valid-hex!")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 /// `installation_repositories` with action other than added/removed (e.g.
 /// future GitHub additions) returns 202.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- **Backend (f0a46c0)**: GitHub App callback now issues a 302 redirect to `/repos?install=success&installation_uuid=<uuid>&account_login=<login>` instead of returning JSON; installation UUID returned via `RETURNING id` from the upsert.
- **Backend (22d47ca)**: `POST /v1/repos` now accepts the internal installation UUID instead of the numeric GitHub installation ID; handler looks up `github_installation_id` internally for the GitHub API call.
- **Frontend**: Same-tab redirect flow — `InstallStep` calls `window.location.assign` instead of `window.open`; no manual "I've installed the app" button.
- **Frontend**: `ReposPageInner` reads `install` / `installation_uuid` / `account_login` search params on mount, auto-opens the connect dialog at the pick step, shows a toast, and clears the URL params.
- **Frontend**: `PickRepoStep` drops the numeric installation ID form field entirely; submits using the `installationUuid` closure value.
- **Schema**: `openapi.json` and generated `schema.ts` updated — `ConnectRepoRequest.installation_id` is now `string` (uuid format).
- **E2E**: `e2e/repos-connect.spec.ts` with three Playwright specs covering the redirect, dialog auto-open, and submit flow.

## Test plan

- [ ] `npm run typecheck` passes (clean `src/` — pre-existing e2e `@playwright/test` module errors are unrelated)
- [ ] `npm run lint` passes with 0 warnings
- [ ] Install GitHub App → browser navigates same-tab to GitHub install page (no popup)
- [ ] After GitHub install, redirect lands on `/repos?install=success&...` → dialog auto-opens at repo-pick step, toast fires, URL cleaned up
- [ ] Pick a repo and submit → `POST /v1/repos` called with UUID `installation_id`, no numeric field visible
- [ ] Returning users (repos already connected) still skip step 1 as before
- [ ] E2E specs in `e2e/repos-connect.spec.ts` pass

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)