### PR TITLE
[REQ-OP-01] feat(compose): dev-stack auto-rebuild + restart on main merge

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -79,6 +79,23 @@ docker compose -f compose/dev.yml exec postgres \
 
 See `docs/PORT_MAP.md` for the full port table, including Tailscale remapping for mars.
 
+## Auto-rebuild on main merge (mars)
+
+The dev-stack on mars is kept current automatically. When a commit lands on `main` that touches a built service, `scripts/dev-stack-watch.sh` detects the new SHA and calls `scripts/dev-stack-auto-rebuild.sh`, which rebuilds only the affected images and restarts the containers.
+
+**To skip one rebuild cycle** (e.g. during a planned manual intervention):
+```bash
+touch compose/.no-auto-rebuild   # on mars, before the merge
+```
+The file is consumed and deleted on the next polling cycle.
+
+**To query recent rebuild results:**
+```bash
+scripts/dev-stack-auto-rebuild.sh --logs 10
+```
+
+Full documentation: [docs/dev-stack-auto-rebuild.md](../docs/dev-stack-auto-rebuild.md)
+
 ## Tear down
 
 ```bash

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -1,0 +1,182 @@
+# Dev-stack Auto-rebuild
+
+When a commit lands on `main` that touches a built service (control-api, frontend), the dev-stack on mars automatically rebuilds the affected images and restarts the containers. UAT always runs against `main` HEAD.
+
+## How it works
+
+Two scripts live in `scripts/`:
+
+| Script | Purpose |
+|--------|---------|
+| `dev-stack-watch.sh` | Polls `origin/main` every 60 s. When a new SHA appears, calls `dev-stack-auto-rebuild.sh`. |
+| `dev-stack-auto-rebuild.sh` | Diffs changed paths, builds only affected images, restarts containers, health-checks, and logs the result. |
+
+### Selective rebuild rules
+
+The rebuild script maps changed file paths to services:
+
+| Changed path | Service rebuilt |
+|---|---|
+| `services/control-api/**`, `crates/**`, `Cargo.toml`, `Cargo.lock`, `docker/control-api/**`, `migrations/**`, `proto/**` | `control-api` (+ re-runs `rb-migrations`) |
+| `frontend/**`, `docker/frontend/**` | `frontend` |
+| `compose/dev.yml`, `compose/full.yml`, `compose/tailscale.yml`, `compose/tailscale.env`, `compose/scripts/**` | both services |
+| Anything else (docs, `.github/`, governance, …) | **no rebuild** |
+
+Rebuilds are idempotent — re-running is safe. Migrations are always re-run before control-api restarts; they skip already-applied versions.
+
+### Health checks
+
+After restart the script waits 15 s then probes:
+
+- **control-api** — `GET http://localhost:${CONTROL_API_HOST_PORT:-8080}/health` → expects HTTP 200
+- **frontend** — `GET http://localhost:${FRONTEND_HOST_PORT:-15173}/` → expects HTTP 200
+
+Results are written to the rebuild log and optionally posted as a GitHub commit status.
+
+## Setup on mars
+
+### 1. Clone or pull the repo
+
+```bash
+cd /opt/rustbrain   # or wherever the repo lives on mars
+git pull
+```
+
+### 2. Make scripts executable
+
+```bash
+chmod +x scripts/dev-stack-watch.sh scripts/dev-stack-auto-rebuild.sh
+```
+
+### 3. Create the systemd service
+
+```bash
+sudo tee /etc/systemd/system/rustbrain-dev-watch.service <<'EOF'
+[Unit]
+Description=Rustbrain dev-stack auto-rebuild watcher
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/opt/rustbrain
+ExecStart=/opt/rustbrain/scripts/dev-stack-watch.sh /opt/rustbrain
+Restart=on-failure
+RestartSec=30
+
+# Compose command for mars (Tailscale overlay)
+Environment="COMPOSE_CMD=docker compose --env-file /opt/rustbrain/compose/tailscale.env -f /opt/rustbrain/compose/dev.yml -f /opt/rustbrain/compose/tailscale.yml"
+Environment="POLL_INTERVAL=60"
+
+# Optional: post GitHub commit status on rebuild completion
+# Environment="GITHUB_TOKEN=ghp_..."
+# Environment="GITHUB_REPO=jarnura/rustbrain"
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+Adjust `User=` and `WorkingDirectory=` / `ExecStart=` paths to match your actual mars layout.
+
+### 4. Enable and start
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now rustbrain-dev-watch
+sudo systemctl status rustbrain-dev-watch
+```
+
+### 5. Verify
+
+Tail the service log:
+```bash
+journalctl -fu rustbrain-dev-watch
+```
+
+On the next merge to `main` that touches a service, you should see:
+```
+[dev-stack-watch] new commit: <prev> → <new>
+[dev-stack-auto-rebuild] building control-api...
+[dev-stack-auto-rebuild] all healthy: control-api=ok
+```
+
+## Querying rebuild logs
+
+Each rebuild appends one NDJSON line to `~/.local/state/rustbrain/dev-stack-rebuilds.ndjson`.
+
+```bash
+# Show last 10 rebuilds
+scripts/dev-stack-auto-rebuild.sh --logs
+
+# Show last 20 rebuilds
+scripts/dev-stack-auto-rebuild.sh --logs 20
+
+# Full JSON for detailed inspection
+tail -20 ~/.local/state/rustbrain/dev-stack-rebuilds.ndjson | python3 -m json.tool --no-ensure-ascii
+```
+
+Each log record:
+
+```json
+{
+  "timestamp":  "2026-04-30T10:00:00Z",
+  "prev_sha":   "abc12345...",
+  "new_sha":    "def67890...",
+  "rebuilt":    ["control-api"],
+  "result":     "ok",
+  "health":     "control-api=ok",
+  "elapsed_s":  87,
+  "reason":     ""
+}
+```
+
+`result` values: `ok`, `skipped`, `build_failed`, `restart_failed`, `health_failed`.
+
+## Bypassing the auto-rebuild for one merge
+
+If you need to merge to `main` without triggering an auto-rebuild (e.g. during a planned outage or while debugging the stack manually):
+
+```bash
+# On mars, before the merge lands:
+touch /opt/rustbrain/compose/.no-auto-rebuild
+```
+
+The watch script will detect this file on the next polling cycle, skip the rebuild, and **delete the file**. One file = one skip. A second merge after that will rebuild normally.
+
+The file is in `.gitignore` territory — do not commit it.
+
+To disable the watcher entirely for a longer window:
+
+```bash
+sudo systemctl stop rustbrain-dev-watch
+# ... do your manual work ...
+sudo systemctl start rustbrain-dev-watch
+```
+
+## Manual rebuild
+
+To trigger a rebuild outside the watch loop (e.g. after a manual `git pull` or to re-apply a failed rebuild):
+
+```bash
+export COMPOSE_CMD="docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+scripts/dev-stack-auto-rebuild.sh          # diffs HEAD vs HEAD^1
+scripts/dev-stack-auto-rebuild.sh <prev_sha> <new_sha>   # explicit range
+```
+
+## Troubleshooting
+
+**Rebuild never triggers**
+- Check `journalctl -fu rustbrain-dev-watch` — the watch loop should log every new SHA it sees.
+- Confirm the repo on mars has the remote `origin` pointing at GitHub: `git remote -v`.
+- Confirm network access: `git fetch origin main` from the repo directory.
+
+**Health check fails after rebuild**
+- Check container logs: `docker compose -f compose/dev.yml logs --tail=50 control-api`
+- Look at the rebuild log: `scripts/dev-stack-auto-rebuild.sh --logs 5`
+- Manually run: `curl http://localhost:8080/health`
+
+**Build fails**
+- Docker build errors are printed inline and recorded in the NDJSON log.
+- Run `docker compose -f compose/dev.yml build control-api` manually to see the full output.

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Rebuilds and restarts dev-stack services whose source paths changed between two git SHAs.
+#
+# Usage:
+#   scripts/dev-stack-auto-rebuild.sh [PREV_SHA [NEW_SHA]]
+#   scripts/dev-stack-auto-rebuild.sh --logs [N]    # show last N rebuild records (default: 10)
+#
+# If SHAs are omitted, detects PREV_SHA=HEAD^1 and NEW_SHA=HEAD from the repo.
+#
+# Environment:
+#   COMPOSE_CMD      Full docker compose invocation (default: "docker compose -f <repo>/compose/dev.yml")
+#                    Mars example: "docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+#   RB_REPO_PATH     Repo root path (default: parent of this script)
+#   GITHUB_TOKEN     If set, posts a commit status to GitHub for NEW_SHA
+#   GITHUB_REPO      Required with GITHUB_TOKEN (e.g. "jarnura/rustacean")
+#   RB_LOG_DIR       Log directory (default: $HOME/.local/state/rustbrain)
+#
+# Bypass: touch compose/.no-auto-rebuild in the repo root to skip the next rebuild cycle.
+# The file is removed after being honoured. See docs/dev-stack-auto-rebuild.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${RB_REPO_PATH:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
+LOG_DIR="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}"
+LOG_FILE="$LOG_DIR/dev-stack-rebuilds.ndjson"
+BYPASS_FILE="$REPO_ROOT/compose/.no-auto-rebuild"
+
+# -- Helpers -----------------------------------------------------------------
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+log_record() {
+  local result="$1" health="$2" rebuilt_json="$3" reason="$4"
+  local elapsed=$(( $(date +%s) - ELAPSED_START ))
+  python3 -c "
+import json, sys
+print(json.dumps({
+  'timestamp':  sys.argv[1],
+  'prev_sha':   sys.argv[2],
+  'new_sha':    sys.argv[3],
+  'result':     sys.argv[4],
+  'health':     sys.argv[5],
+  'rebuilt':    json.loads(sys.argv[6]),
+  'reason':     sys.argv[7],
+  'elapsed_s':  int(sys.argv[8]),
+}))
+" "$START_TS" "$PREV_SHA" "$NEW_SHA" "$result" "$health" "$rebuilt_json" "$reason" "$elapsed" >> "$LOG_FILE"
+}
+
+post_gh_status() {
+  local state="$1" desc="$2"
+  [[ -z "${GITHUB_TOKEN:-}" || -z "${GITHUB_REPO:-}" ]] && return 0
+  curl -s -o /dev/null \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"state\":\"$state\",\"description\":\"$desc\",\"context\":\"dev-stack/auto-rebuild\"}" \
+    "https://api.github.com/repos/${GITHUB_REPO}/statuses/${NEW_SHA}" || true
+}
+
+# -- Logs mode ---------------------------------------------------------------
+
+if [[ "${1:-}" == "--logs" ]]; then
+  N="${2:-10}"
+  if [[ ! -f "$LOG_FILE" ]]; then
+    echo "No rebuild log at $LOG_FILE"
+    exit 0
+  fi
+  tail -n "$N" "$LOG_FILE" | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        r = json.loads(line)
+        sha = r.get('new_sha', '?')[:8]
+        svc = ','.join(r.get('rebuilt', [])) or '-'
+        print(f\"{r.get('timestamp','')}  sha={sha}  services={svc}  result={r.get('result','?')}  health={r.get('health','?')}  elapsed={r.get('elapsed_s','?')}s\")
+    except Exception:
+        print(line)
+"
+  exit 0
+fi
+
+# -- Main --------------------------------------------------------------------
+
+PREV_SHA="${1:-}"
+NEW_SHA="${2:-}"
+
+cd "$REPO_ROOT"
+
+if [[ -z "$PREV_SHA" || -z "$NEW_SHA" ]]; then
+  NEW_SHA="$(git rev-parse HEAD)"
+  PREV_SHA="$(git rev-parse HEAD^1 2>/dev/null || git rev-parse "$(git rev-list --max-parents=0 HEAD)")"
+fi
+
+START_TS="$(ts)"
+ELAPSED_START="$(date +%s)"
+mkdir -p "$LOG_DIR"
+
+echo "[dev-stack-auto-rebuild] $START_TS  $PREV_SHA → $NEW_SHA"
+
+# -- Bypass check ------------------------------------------------------------
+
+if [[ -f "$BYPASS_FILE" ]]; then
+  echo "[dev-stack-auto-rebuild] bypass file found — skipping this cycle"
+  rm -f "$BYPASS_FILE"
+  log_record "skipped" "" "[]" "bypass file"
+  exit 0
+fi
+
+# -- Detect changed paths ----------------------------------------------------
+
+CHANGED_FILES="$(git diff --name-only "$PREV_SHA" "$NEW_SHA" 2>/dev/null || true)"
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "[dev-stack-auto-rebuild] no changed files — nothing to do"
+  log_record "skipped" "" "[]" "no changed files"
+  exit 0
+fi
+
+REBUILD_CONTROL_API=false
+REBUILD_FRONTEND=false
+
+while IFS= read -r f; do
+  case "$f" in
+    # control-api source: Rust crates, Dockerfiles, migrations, proto
+    services/control-api/*|crates/*|Cargo.toml|Cargo.lock|docker/control-api/*|migrations/*|proto/*)
+      REBUILD_CONTROL_API=true ;;
+    # frontend source
+    frontend/*|docker/frontend/*)
+      REBUILD_FRONTEND=true ;;
+    # compose config changes affect all built services
+    compose/dev.yml|compose/full.yml|compose/tailscale.yml|compose/tailscale.env|compose/scripts/*)
+      REBUILD_CONTROL_API=true
+      REBUILD_FRONTEND=true ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+if [[ "$REBUILD_CONTROL_API" == "false" && "$REBUILD_FRONTEND" == "false" ]]; then
+  echo "[dev-stack-auto-rebuild] no service paths changed — skipping"
+  log_record "skipped" "" "[]" "no service paths changed"
+  exit 0
+fi
+
+# -- Build -------------------------------------------------------------------
+
+SERVICES_REBUILT=()
+
+COMPOSE_CMD="${COMPOSE_CMD:-docker compose -f $REPO_ROOT/compose/dev.yml}"
+
+post_gh_status "pending" "Dev-stack rebuild in progress"
+
+if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] building control-api..."
+  if ! $COMPOSE_CMD build control-api 2>&1; then
+    echo "[dev-stack-auto-rebuild] control-api build FAILED"
+    log_record "build_failed" "" '["control-api"]' "control-api build error"
+    post_gh_status "failure" "control-api build failed"
+    exit 1
+  fi
+  SERVICES_REBUILT+=(control-api)
+fi
+
+if [[ "$REBUILD_FRONTEND" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] building frontend..."
+  if ! $COMPOSE_CMD build frontend 2>&1; then
+    echo "[dev-stack-auto-rebuild] frontend build FAILED"
+    log_record "build_failed" "" '["frontend"]' "frontend build error"
+    post_gh_status "failure" "frontend build failed"
+    exit 1
+  fi
+  SERVICES_REBUILT+=(frontend)
+fi
+
+# -- Restart -----------------------------------------------------------------
+
+if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] re-running migrations..."
+  # Blocks until rb-migrations exits (restart: "no"). Idempotent — skips applied versions.
+  if ! $COMPOSE_CMD up --force-recreate rb-migrations 2>&1; then
+    echo "[dev-stack-auto-rebuild] rb-migrations FAILED"
+    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "migrations failed"
+    post_gh_status "failure" "rb-migrations failed"
+    exit 1
+  fi
+
+  echo "[dev-stack-auto-rebuild] restarting control-api..."
+  if ! $COMPOSE_CMD up -d --no-deps --force-recreate control-api 2>&1; then
+    echo "[dev-stack-auto-rebuild] control-api restart FAILED"
+    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "control-api compose up error"
+    post_gh_status "failure" "control-api restart failed"
+    exit 1
+  fi
+fi
+
+if [[ "$REBUILD_FRONTEND" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] restarting frontend..."
+  if ! $COMPOSE_CMD up -d --no-deps --force-recreate frontend 2>&1; then
+    echo "[dev-stack-auto-rebuild] frontend restart FAILED"
+    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "frontend compose up error"
+    post_gh_status "failure" "frontend restart failed"
+    exit 1
+  fi
+fi
+
+# -- Health check ------------------------------------------------------------
+
+echo "[dev-stack-auto-rebuild] waiting 15s for services to stabilise..."
+sleep 15
+
+HEALTH_OK=true
+HEALTH_DETAIL=""
+
+if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+  PORT="${CONTROL_API_HOST_PORT:-8080}"
+  HTTP_CODE="$(curl -s -o /tmp/rb-health-check.json -w "%{http_code}" \
+    --max-time 10 "http://localhost:${PORT}/health" 2>/dev/null || echo "000")"
+  if [[ "$HTTP_CODE" == "200" ]]; then
+    HEALTH_DETAIL="${HEALTH_DETAIL}control-api=ok "
+  else
+    HEALTH_OK=false
+    HEALTH_DETAIL="${HEALTH_DETAIL}control-api=FAIL(${HTTP_CODE}) "
+    echo "[dev-stack-auto-rebuild] control-api health check failed: HTTP $HTTP_CODE"
+  fi
+fi
+
+if [[ "$REBUILD_FRONTEND" == "true" ]]; then
+  PORT="${FRONTEND_HOST_PORT:-15173}"
+  HTTP_CODE="$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 10 "http://localhost:${PORT}/" 2>/dev/null || echo "000")"
+  if [[ "$HTTP_CODE" == "200" ]]; then
+    HEALTH_DETAIL="${HEALTH_DETAIL}frontend=ok "
+  else
+    HEALTH_OK=false
+    HEALTH_DETAIL="${HEALTH_DETAIL}frontend=FAIL(${HTTP_CODE}) "
+    echo "[dev-stack-auto-rebuild] frontend health check failed: HTTP $HTTP_CODE"
+  fi
+fi
+
+REBUILT_JSON="$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")"
+HEALTH_DETAIL="${HEALTH_DETAIL% }"  # trim trailing space
+
+if [[ "$HEALTH_OK" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] all healthy: $HEALTH_DETAIL"
+  log_record "ok" "$HEALTH_DETAIL" "$REBUILT_JSON" ""
+  post_gh_status "success" "Dev-stack healthy after rebuild: $HEALTH_DETAIL"
+else
+  echo "[dev-stack-auto-rebuild] UNHEALTHY after rebuild: $HEALTH_DETAIL"
+  log_record "health_failed" "$HEALTH_DETAIL" "$REBUILT_JSON" "health check failed"
+  post_gh_status "failure" "Dev-stack unhealthy after rebuild: $HEALTH_DETAIL"
+  exit 1
+fi

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Polls origin/main for new commits and triggers dev-stack-auto-rebuild.sh on changes.
+# Designed to run as a persistent systemd service on mars.
+#
+# Usage:
+#   scripts/dev-stack-watch.sh [REPO_PATH]
+#
+# Environment:
+#   POLL_INTERVAL   Seconds between git fetch polls (default: 60)
+#   REMOTE          Remote name to poll (default: origin)
+#   BRANCH          Branch to track (default: main)
+#   COMPOSE_CMD     Passed through to dev-stack-auto-rebuild.sh
+#
+# Logs: journald captures stdout/stderr when run as a systemd service.
+# Rebuild records are written by dev-stack-auto-rebuild.sh to
+#   $HOME/.local/state/rustbrain/dev-stack-rebuilds.ndjson
+#
+# See docs/dev-stack-auto-rebuild.md for setup instructions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${1:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+
+REBUILD_SCRIPT="$SCRIPT_DIR/dev-stack-auto-rebuild.sh"
+
+echo "[dev-stack-watch] started — polling $REMOTE/$BRANCH every ${POLL_INTERVAL}s"
+echo "[dev-stack-watch] repo: $REPO_ROOT"
+echo "[dev-stack-watch] rebuild script: $REBUILD_SCRIPT"
+
+cd "$REPO_ROOT"
+
+# Initialise from current remote state (avoids a spurious rebuild on first start)
+if ! git fetch "$REMOTE" "$BRANCH" --quiet 2>/dev/null; then
+  echo "[dev-stack-watch] initial fetch failed; will retry on next cycle" >&2
+  LAST_KNOWN_SHA="$(git rev-parse HEAD)"
+else
+  LAST_KNOWN_SHA="$(git rev-parse "$REMOTE/$BRANCH")"
+fi
+
+echo "[dev-stack-watch] tracking from $LAST_KNOWN_SHA"
+
+while true; do
+  sleep "$POLL_INTERVAL"
+
+  if ! git fetch "$REMOTE" "$BRANCH" --quiet 2>/dev/null; then
+    echo "[dev-stack-watch] fetch failed — will retry" >&2
+    continue
+  fi
+
+  NEW_SHA="$(git rev-parse "$REMOTE/$BRANCH")"
+
+  if [[ "$NEW_SHA" == "$LAST_KNOWN_SHA" ]]; then
+    continue
+  fi
+
+  echo "[dev-stack-watch] new commit: $LAST_KNOWN_SHA → $NEW_SHA"
+
+  # Fast-forward the local branch if it is currently checked out on main.
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ "$CURRENT_BRANCH" == "$BRANCH" ]]; then
+    git merge --ff-only "$REMOTE/$BRANCH" --quiet 2>/dev/null || true
+  fi
+
+  PREV_SHA="$LAST_KNOWN_SHA"
+  LAST_KNOWN_SHA="$NEW_SHA"
+
+  echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
+  # Never let a rebuild failure crash the watch loop.
+  "$REBUILD_SCRIPT" "$PREV_SHA" "$NEW_SHA" || \
+    echo "[dev-stack-watch] rebuild exited non-zero — see logs for details" >&2
+done


### PR DESCRIPTION
## Summary

Implements the durable fix for UAT-on-stale-images: when any commit lands on `main` that touches a built service (control-api, frontend), the dev-stack on mars automatically rebuilds the affected images, re-runs migrations if needed, restarts containers, and health-checks.

- **Selective rebuild** — only rebuilds services whose source paths changed. Docs-only or governance-only merges are skipped automatically.
- **Bypass** — `touch compose/.no-auto-rebuild` on mars skips exactly one cycle, then self-deletes.
- **Log querying** — `scripts/dev-stack-auto-rebuild.sh --logs [N]` shows the last N rebuild records from NDJSON log.
- **GitHub commit status** — optional; set `GITHUB_TOKEN` + `GITHUB_REPO` in the systemd unit env.
- **≤10 min target** — 60 s poll + build + 15 s settle = well under 10 min for incremental builds.

## GitHub Issue

Closes #117

## Files changed

| File | What |
|------|------|
| `scripts/dev-stack-auto-rebuild.sh` | Selective rebuild + health check + NDJSON log |
| `scripts/dev-stack-watch.sh` | 60 s git-poll loop; designed as a systemd service |
| `docs/dev-stack-auto-rebuild.md` | Setup guide, bypass procedure, log querying, troubleshooting |
| `compose/README.md` | Auto-rebuild quick-reference section |

## Checklist
- [x] `bash -n` syntax check passes on both scripts
- [x] `--logs` mode verified with empty and populated log file
- [x] Skips correctly when SHAs are identical (no changed files)
- [x] File sizes within 600-line cap
- [x] No internal board references in any added file