### PR TITLE
[REQ-OP-01] fix(dev-stack): health-port env, SHA persistence, gitignore, JSON hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+/secrets
+compose/.no-auto-rebuild

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -32,7 +32,10 @@ OLLAMA_HOST_PORT=21434
 
 # --- Application ---
 CONTROL_API_HOST_PORT=18080
-RB_BASE_URL=http://100.87.157.74:18080
+# RB_BASE_URL is the user-facing frontend origin used for redirect targets and
+# email links (verification, password reset, GitHub install callback). Must
+# point at the frontend, not the API.
+RB_BASE_URL=http://100.87.157.74:15173
 RB_CORS_ORIGINS=http://100.87.157.74:10080,http://100.87.157.74:15173
 
 # --- Reverse proxy ---

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -69,6 +69,11 @@ RestartSec=30
 Environment="COMPOSE_CMD=docker compose --env-file /opt/rustbrain/compose/tailscale.env -f /opt/rustbrain/compose/dev.yml -f /opt/rustbrain/compose/tailscale.yml"
 Environment="POLL_INTERVAL=60"
 
+# Source the compose env-file into the rebuild script's shell so host-port overrides
+# (e.g. CONTROL_API_HOST_PORT=18080, FRONTEND_HOST_PORT=15173) are visible during
+# health checks. docker compose's --env-file only reaches containers, not this shell.
+Environment="COMPOSE_ENV_FILE=/opt/rustbrain/compose/tailscale.env"
+
 # Optional: post GitHub commit status on rebuild completion
 # Environment="GITHUB_TOKEN=ghp_..."
 # Environment="GITHUB_REPO=jarnura/rustbrain"

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -10,6 +10,10 @@
 # Environment:
 #   COMPOSE_CMD      Full docker compose invocation (default: "docker compose -f <repo>/compose/dev.yml")
 #                    Mars example: "docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+#   COMPOSE_ENV_FILE Path to a docker compose env-file to source into the shell before health checks.
+#                    Required on mars so CONTROL_API_HOST_PORT/FRONTEND_HOST_PORT resolve to the
+#                    remapped ports (e.g. 18080/15173) rather than the dev defaults (8080/15173).
+#                    Example: "/opt/rustbrain/compose/tailscale.env"
 #   RB_REPO_PATH     Repo root path (default: parent of this script)
 #   GITHUB_TOKEN     If set, posts a commit status to GitHub for NEW_SHA
 #   GITHUB_REPO      Required with GITHUB_TOKEN (e.g. "jarnura/rustacean")
@@ -25,6 +29,16 @@ REPO_ROOT="${RB_REPO_PATH:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
 LOG_DIR="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}"
 LOG_FILE="$LOG_DIR/dev-stack-rebuilds.ndjson"
 BYPASS_FILE="$REPO_ROOT/compose/.no-auto-rebuild"
+
+# Source the compose env-file into the shell so host-port overrides
+# (e.g. CONTROL_API_HOST_PORT=18080 on mars) are visible during health checks.
+# docker compose's --env-file flag only passes vars to containers, not to this shell.
+if [[ -n "${COMPOSE_ENV_FILE:-}" && -f "$COMPOSE_ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$COMPOSE_ENV_FILE"
+  set +a
+fi
 
 # -- Helpers -----------------------------------------------------------------
 

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -65,10 +65,15 @@ print(json.dumps({
 post_gh_status() {
   local state="$1" desc="$2"
   [[ -z "${GITHUB_TOKEN:-}" || -z "${GITHUB_REPO:-}" ]] && return 0
+  local body
+  body="$(python3 -c "
+import json, sys
+print(json.dumps({'state': sys.argv[1], 'description': sys.argv[2], 'context': 'dev-stack/auto-rebuild'}))
+" "$state" "$desc")"
   curl -s -o /dev/null \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"state\":\"$state\",\"description\":\"$desc\",\"context\":\"dev-stack/auto-rebuild\"}" \
+    -d "$body" \
     "https://api.github.com/repos/${GITHUB_REPO}/statuses/${NEW_SHA}" || true
 }
 

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -27,18 +27,28 @@ BRANCH="${BRANCH:-main}"
 
 REBUILD_SCRIPT="$SCRIPT_DIR/dev-stack-auto-rebuild.sh"
 
+# Persist LAST_KNOWN_SHA across restarts so commits that land during an outage
+# are not silently dropped when the service comes back up.
+STATE_DIR="${RB_STATE_DIR:-"$HOME/.local/state/rustbrain"}"
+SHA_STATE_FILE="$STATE_DIR/dev-stack-watch-last-sha"
+mkdir -p "$STATE_DIR"
+
 echo "[dev-stack-watch] started — polling $REMOTE/$BRANCH every ${POLL_INTERVAL}s"
 echo "[dev-stack-watch] repo: $REPO_ROOT"
 echo "[dev-stack-watch] rebuild script: $REBUILD_SCRIPT"
 
 cd "$REPO_ROOT"
 
-# Initialise from current remote state (avoids a spurious rebuild on first start)
-if ! git fetch "$REMOTE" "$BRANCH" --quiet 2>/dev/null; then
+# Initialise LAST_KNOWN_SHA: restore from state file to catch commits that arrived
+# during an outage; fall back to current origin/main only on first run.
+git fetch "$REMOTE" "$BRANCH" --quiet 2>/dev/null || \
   echo "[dev-stack-watch] initial fetch failed; will retry on next cycle" >&2
-  LAST_KNOWN_SHA="$(git rev-parse HEAD)"
+if [[ -f "$SHA_STATE_FILE" ]]; then
+  LAST_KNOWN_SHA="$(cat "$SHA_STATE_FILE")"
+  echo "[dev-stack-watch] resuming from persisted SHA $LAST_KNOWN_SHA"
 else
-  LAST_KNOWN_SHA="$(git rev-parse "$REMOTE/$BRANCH")"
+  LAST_KNOWN_SHA="$(git rev-parse "$REMOTE/$BRANCH" 2>/dev/null || git rev-parse HEAD)"
+  echo "$LAST_KNOWN_SHA" > "$SHA_STATE_FILE"
 fi
 
 echo "[dev-stack-watch] tracking from $LAST_KNOWN_SHA"
@@ -67,6 +77,7 @@ while true; do
 
   PREV_SHA="$LAST_KNOWN_SHA"
   LAST_KNOWN_SHA="$NEW_SHA"
+  echo "$LAST_KNOWN_SHA" > "$SHA_STATE_FILE"
 
   echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
   # Never let a rebuild failure crash the watch loop.


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #118, covering all four findings from the PR Reviewer verdict on the original dev-stack auto-rebuild feature.

**H1 — COMPOSE_ENV_FILE sourcing for health checks (HIGH)**

`dev-stack-auto-rebuild.sh` read `${CONTROL_API_HOST_PORT:-8080}` directly from its shell. On mars the port is remapped to 18080 via `compose/tailscale.env`, but `docker compose --env-file` only reaches containers — not the surrounding shell. Every mars rebuild logged `health_failed` even when containers were healthy.

Fix: source `COMPOSE_ENV_FILE` into the shell at startup (`set -a; source …; set +a`). Systemd unit template updated to set `COMPOSE_ENV_FILE=/opt/rustbrain/compose/tailscale.env`.

**M1 — SHA persistence across restarts (MEDIUM)**

On systemd restart `LAST_KNOWN_SHA` was reset to current `origin/main`, silently dropping commits that landed during the outage.

Fix: persist to `$HOME/.local/state/rustbrain/dev-stack-watch-last-sha`; restore on startup, fall back to `origin/main` only on first run.

**L1 — `.gitignore` for bypass sentinel (LOW)**

Docs described `compose/.no-auto-rebuild` as gitignored but no root `.gitignore` existed.

Fix: add root `.gitignore` with `/target`, `/secrets`, and `compose/.no-auto-rebuild`.

**L2 — JSON hygiene in `post_gh_status` (LOW)**

`description` was interpolated directly into the JSON body — safe now but fragile to quotes/backslashes/newlines in future strings.

Fix: build body via `python3 json.dumps(…)`, consistent with `log_record` and other helpers already in the script.

Also included: `compose/tailscale.env` correction of `RB_BASE_URL` to point at the frontend origin (port 15173) rather than the API (port 18080).

## GitHub Issue
Closes #123

## Checklist
- [x] H1: COMPOSE_ENV_FILE sourced in rebuild script; systemd template updated
- [x] M1: dev-stack-watch-last-sha state file written on each new SHA, restored on startup
- [x] L1: root .gitignore with bypass sentinel
- [x] L2: post_gh_status JSON built via python3 json.dumps
- [x] bash -n clean on both scripts
- [x] No internal issue references leak to GitHub