### PR TITLE
[REQ-IN-13] fix(kafka): Gate-2 follow-up — DlqRouter, consume_lag_seconds, e2e_latency_seconds (#124)

### DIFF
--- a/crates/rb-kafka/src/consumer.rs
+++ b/crates/rb-kafka/src/consumer.rs
@@ -13,9 +13,9 @@ use crate::{
     config::ConsumerCfg,
     dlq::dlq_topic,
     envelope::{
-        EventEnvelope, HEADER_ATTEMPT, HEADER_BLOB_REF, HEADER_DLQ_AT, HEADER_DLQ_REASON,
-        HEADER_EVENT_ID, HEADER_SCHEMA_VERSION, HEADER_TENANT_ID, HEADER_TRACEPARENT,
-        HEADER_TRACESTATE,
+        EventEnvelope, HEADER_ATTEMPT, HEADER_BLOB_REF, HEADER_CREATED_AT_MS, HEADER_DLQ_AT,
+        HEADER_DLQ_REASON, HEADER_EVENT_ID, HEADER_SCHEMA_VERSION, HEADER_TENANT_ID,
+        HEADER_TRACEPARENT, HEADER_TRACESTATE,
     },
     errors::KafkaError,
     producer::decode_envelope,
@@ -40,6 +40,9 @@ impl<E: ProstMessage + Default> Consumer<E> {
             .set("session.timeout.ms", cfg.session_timeout.as_millis().to_string())
             .create()?;
 
+        // DLQ delivery is best-effort: acks=1 avoids blocking the consume loop on
+        // broker unavailability. Losing a DLQ record is preferable to stalling the
+        // pipeline; ops alerts on rb_kafka_dlq_total drops catch silent failures.
         let dlq_producer = ClientConfig::new()
             .set("bootstrap.servers", &cfg.bootstrap_servers)
             .set("acks", "1")
@@ -149,12 +152,17 @@ impl<E: ProstMessage + Default> Consumer<E> {
         let event_id_str = env.event_id.to_string();
         let attempt_str = env._meta.attempt.to_string();
         let schema_str = env.schema_version.as_str();
+        let created_at_ms_str = env.created_at.timestamp_millis().to_string();
 
         let mut headers = rdkafka::message::OwnedHeaders::new()
             .insert(Header { key: HEADER_TENANT_ID, value: Some(tenant_str.as_bytes()) })
             .insert(Header { key: HEADER_EVENT_ID, value: Some(event_id_str.as_bytes()) })
             .insert(Header { key: HEADER_SCHEMA_VERSION, value: Some(schema_str.as_bytes()) })
-            .insert(Header { key: HEADER_ATTEMPT, value: Some(attempt_str.as_bytes()) });
+            .insert(Header { key: HEADER_ATTEMPT, value: Some(attempt_str.as_bytes()) })
+            .insert(Header {
+                key: HEADER_CREATED_AT_MS,
+                value: Some(created_at_ms_str.as_bytes()),
+            });
 
         if let Some(ref blob_ref) = env.blob_ref {
             headers = headers

--- a/crates/rb-kafka/src/dlq.rs
+++ b/crates/rb-kafka/src/dlq.rs
@@ -10,6 +10,40 @@ pub fn retry_topic(original: &str) -> String {
     format!("{original}.retry")
 }
 
+/// Routes a source topic to its DLQ and retry siblings (ADR-006 §3.1).
+///
+/// Wave-5 stage workers use `DlqRouter::new(topic)` to obtain the correct
+/// sink topic without hard-coding the `.dlq` / `.retry` suffix convention.
+#[derive(Debug, Clone)]
+pub struct DlqRouter {
+    source: String,
+}
+
+impl DlqRouter {
+    #[must_use]
+    pub fn new(source_topic: impl Into<String>) -> Self {
+        Self { source: source_topic.into() }
+    }
+
+    /// Returns the DLQ topic name for this source topic.
+    #[must_use]
+    pub fn dlq_topic(&self) -> String {
+        dlq_topic(&self.source)
+    }
+
+    /// Returns the retry topic name for this source topic.
+    #[must_use]
+    pub fn retry_topic(&self) -> String {
+        retry_topic(&self.source)
+    }
+
+    /// Returns the original source topic name.
+    #[must_use]
+    pub fn source_topic(&self) -> &str {
+        &self.source
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -22,5 +56,13 @@ mod tests {
     #[test]
     fn retry_topic_appends_suffix() {
         assert_eq!(retry_topic("rb.ingest.parse.commands"), "rb.ingest.parse.commands.retry");
+    }
+
+    #[test]
+    fn dlq_router_delegates_to_helpers() {
+        let router = DlqRouter::new("rb.ingest.clone.commands");
+        assert_eq!(router.source_topic(), "rb.ingest.clone.commands");
+        assert_eq!(router.dlq_topic(), "rb.ingest.clone.commands.dlq");
+        assert_eq!(router.retry_topic(), "rb.ingest.clone.commands.retry");
     }
 }

--- a/crates/rb-kafka/src/envelope.rs
+++ b/crates/rb-kafka/src/envelope.rs
@@ -11,6 +11,7 @@ pub const HEADER_ATTEMPT: &str = "x-rb-attempt";
 pub const HEADER_TRACEPARENT: &str = "traceparent";
 pub const HEADER_TRACESTATE: &str = "tracestate";
 pub const HEADER_PROCESS_AFTER_MS: &str = "x-rb-process-after-ms";
+pub const HEADER_CREATED_AT_MS: &str = "x-rb-created-at-ms";
 pub const HEADER_DLQ_REASON: &str = "x-rb-dlq-reason";
 pub const HEADER_DLQ_AT: &str = "x-rb-dlq-at";
 

--- a/crates/rb-kafka/src/lib.rs
+++ b/crates/rb-kafka/src/lib.rs
@@ -15,7 +15,7 @@ pub mod testing {
 
 pub use config::{ConsumerCfg, ProducerCfg};
 pub use consumer::Consumer;
-pub use dlq::{dlq_topic, retry_topic};
+pub use dlq::{dlq_topic, retry_topic, DlqRouter};
 pub use envelope::{DeliveryReport, EnvelopeMeta, EventEnvelope, SchemaVersion, TraceContext};
 pub use errors::KafkaError;
 pub use producer::Producer;

--- a/crates/rb-kafka/src/producer.rs
+++ b/crates/rb-kafka/src/producer.rs
@@ -13,8 +13,8 @@ use crate::{
     config::ProducerCfg,
     envelope::{
         DeliveryReport, EnvelopeMeta, EventEnvelope, SchemaVersion, TraceContext, HEADER_ATTEMPT,
-        HEADER_BLOB_REF, HEADER_EVENT_ID, HEADER_PROCESS_AFTER_MS, HEADER_SCHEMA_VERSION,
-        HEADER_TENANT_ID, HEADER_TRACEPARENT, HEADER_TRACESTATE,
+        HEADER_BLOB_REF, HEADER_CREATED_AT_MS, HEADER_EVENT_ID, HEADER_PROCESS_AFTER_MS,
+        HEADER_SCHEMA_VERSION, HEADER_TENANT_ID, HEADER_TRACEPARENT, HEADER_TRACESTATE,
     },
     errors::KafkaError,
     headers::KafkaHeaderInjector,
@@ -49,6 +49,7 @@ impl<E: ProstMessage> Producer<E> {
         key: &[u8],
         envelope: EventEnvelope<E>,
     ) -> Result<DeliveryReport, KafkaError> {
+        let created_at = envelope.created_at;
         let headers = build_headers(&envelope);
         let payload = envelope.payload.encode_to_vec();
 
@@ -66,6 +67,11 @@ impl<E: ProstMessage> Producer<E> {
                     "topic" => topic.to_owned()
                 )
                 .increment(1);
+                #[allow(clippy::cast_precision_loss)]
+                let e2e_secs =
+                    (chrono::Utc::now() - created_at).num_milliseconds().max(0) as f64 / 1_000.0;
+                histogram!("rb_kafka_e2e_latency_seconds", "topic" => topic.to_owned())
+                    .record(e2e_secs);
                 Ok(DeliveryReport { topic: topic.to_owned(), partition, offset })
             }
             Err((e, _)) => {
@@ -94,6 +100,7 @@ impl<E: ProstMessage> Producer<E> {
         mut envelope: EventEnvelope<E>,
         policy: &RetryPolicy,
     ) -> Result<DeliveryReport, KafkaError> {
+        let created_at = envelope.created_at;
         let next_attempt = envelope._meta.attempt + 1;
         envelope._meta.attempt = next_attempt;
 
@@ -122,11 +129,10 @@ impl<E: ProstMessage> Producer<E> {
             "attempt" => next_attempt.to_string()
         )
         .increment(1);
-        histogram!(
-            "rb_kafka_e2e_latency_seconds",
-            "topic" => topic.to_owned()
-        )
-        .record(0.0);
+        #[allow(clippy::cast_precision_loss)]
+        let e2e_secs =
+            (chrono::Utc::now() - created_at).num_milliseconds().max(0) as f64 / 1_000.0;
+        histogram!("rb_kafka_e2e_latency_seconds", "topic" => topic.to_owned()).record(e2e_secs);
 
         Ok(DeliveryReport { topic: retry_topic.to_owned(), partition, offset })
     }
@@ -153,6 +159,7 @@ fn build_headers<E: ProstMessage>(envelope: &EventEnvelope<E>) -> OwnedHeaders {
     let tenant_str = envelope.tenant_id.to_string();
     let event_id_str = envelope.event_id.to_string();
     let attempt_str = envelope._meta.attempt.to_string();
+    let created_at_ms_str = envelope.created_at.timestamp_millis().to_string();
 
     let mut h = OwnedHeaders::new();
     h = h.insert(Header { key: HEADER_TENANT_ID, value: Some(tenant_str.as_bytes()) });
@@ -162,6 +169,10 @@ fn build_headers<E: ProstMessage>(envelope: &EventEnvelope<E>) -> OwnedHeaders {
         value: Some(envelope.schema_version.as_str().as_bytes()),
     });
     h = h.insert(Header { key: HEADER_ATTEMPT, value: Some(attempt_str.as_bytes()) });
+    h = h.insert(Header {
+        key: HEADER_CREATED_AT_MS,
+        value: Some(created_at_ms_str.as_bytes()),
+    });
 
     if let Some(ref blob_ref) = envelope.blob_ref {
         h = h.insert(Header { key: HEADER_BLOB_REF, value: Some(blob_ref.as_bytes()) });
@@ -253,13 +264,18 @@ pub fn decode_envelope<E: ProstMessage + Default>(
     let payload_msg =
         E::decode(payload).map_err(|e| KafkaError::Deserialization(e.to_string()))?;
 
+    let created_at = get(HEADER_CREATED_AT_MS)
+        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(chrono::DateTime::from_timestamp_millis)
+        .unwrap_or_else(chrono::Utc::now);
+
     Ok(EventEnvelope {
         tenant_id,
         event_id,
         schema_version,
         trace_context,
         blob_ref,
-        created_at: chrono::Utc::now(),
+        created_at,
         payload: payload_msg,
         _meta: EnvelopeMeta { topic: topic.to_owned(), partition, offset, attempt },
     })

--- a/crates/rb-kafka/src/testing_impl.rs
+++ b/crates/rb-kafka/src/testing_impl.rs
@@ -19,8 +19,9 @@ use uuid::Uuid;
 use crate::{
     dlq::dlq_topic,
     envelope::{
-        DeliveryReport, EventEnvelope, HEADER_ATTEMPT, HEADER_BLOB_REF, HEADER_EVENT_ID,
-        HEADER_SCHEMA_VERSION, HEADER_TENANT_ID, HEADER_TRACEPARENT, HEADER_TRACESTATE,
+        DeliveryReport, EventEnvelope, HEADER_ATTEMPT, HEADER_BLOB_REF, HEADER_CREATED_AT_MS,
+        HEADER_EVENT_ID, HEADER_SCHEMA_VERSION, HEADER_TENANT_ID, HEADER_TRACEPARENT,
+        HEADER_TRACESTATE,
     },
     errors::KafkaError,
     producer::decode_envelope,
@@ -131,6 +132,7 @@ impl<E: ProstMessage> TestProducer<E> {
             }
         }
 
+        let created_at = envelope.created_at;
         let headers = envelope_to_headers(&envelope);
         let payload = envelope.payload.encode_to_vec();
 
@@ -148,6 +150,10 @@ impl<E: ProstMessage> TestProducer<E> {
             "topic" => topic.to_owned()
         )
         .increment(1);
+        #[allow(clippy::cast_precision_loss)]
+        let e2e_secs =
+            (chrono::Utc::now() - created_at).num_milliseconds().max(0) as f64 / 1_000.0;
+        histogram!("rb_kafka_e2e_latency_seconds", "topic" => topic.to_owned()).record(e2e_secs);
 
         Ok(DeliveryReport { topic: topic.to_owned(), partition: 0, offset: 0 })
     }
@@ -259,6 +265,7 @@ fn envelope_to_headers<E: ProstMessage>(env: &EventEnvelope<E>) -> Vec<(String, 
         (HEADER_EVENT_ID.to_owned(), env.event_id.to_string()),
         (HEADER_SCHEMA_VERSION.to_owned(), env.schema_version.as_str().to_owned()),
         (HEADER_ATTEMPT.to_owned(), env._meta.attempt.to_string()),
+        (HEADER_CREATED_AT_MS.to_owned(), env.created_at.timestamp_millis().to_string()),
     ];
     if let Some(ref blob) = env.blob_ref {
         h.push((HEADER_BLOB_REF.to_owned(), blob.clone()));

--- a/crates/rb-kafka/tests/metrics_emitted.rs
+++ b/crates/rb-kafka/tests/metrics_emitted.rs
@@ -63,11 +63,12 @@ async fn all_required_metric_names_are_emitted() {
         .map(|(composite_key, _, _, _)| composite_key.key().name().to_owned())
         .collect();
 
-    // All 6 required names must appear at least once.
+    // All required metric names must appear at least once.
     let required = [
         "rb_kafka_messages_total",
         "rb_kafka_consume_lag_seconds",
         "rb_kafka_dlq_total",
+        "rb_kafka_e2e_latency_seconds",
     ];
 
     for name in &required {

--- a/infra/kafka/topics.yaml
+++ b/infra/kafka/topics.yaml
@@ -1,4 +1,8 @@
 topics:
+  # replication_factor: 1 throughout — correct for single-broker local/CI
+  # environments. Raise to 3 (min.insync.replicas=2) before promoting to
+  # a multi-broker production cluster.
+
   # ── Base command topics (8) ───────────────────────────────────────────────
   - name: rb.ingest.clone.commands
     partitions: 6


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #120 (squash-merged as `fc4a149`). Three HIGH + one MED + one LOW finding from the Gate 2 PR Reviewer verdict (issue #124 lists the original findings) were left unresolved when the board merged. This PR closes all five.

Closes #124

## Changes

### HIGH-1 — `DlqRouter` missing from public surface (ADR-006 §3.1)
- `crates/rb-kafka/src/dlq.rs`: add `DlqRouter { source }` with `new / dlq_topic / retry_topic / source_topic`
- `crates/rb-kafka/src/lib.rs`: `pub use dlq::DlqRouter`
- Test: `dlq_router_delegates_to_helpers` (lib unit)

### HIGH-2 — `rb_kafka_consume_lag_seconds` always ~0
- `crates/rb-kafka/src/envelope.rs`: add `HEADER_CREATED_AT_MS = "x-rb-created-at-ms"`
- `producer.rs / build_headers()`: write epoch-ms header on every outbound message
- `producer.rs / decode_envelope()`: parse header → `created_at` instead of `Utc::now()`
- `consumer.rs / nack_to_dlq()`: preserve `created_at_ms` through DLQ routing
- `testing_impl.rs / envelope_to_headers()`: mirror header in in-process bus

### HIGH-3 — `rb_kafka_e2e_latency_seconds` not emitted by `publish()`
- `producer.rs / publish()`: record `(Utc::now() - created_at)` histogram on success
- `producer.rs / publish_retry()`: replace hardcoded `record(0.0)` with actual elapsed
- `testing_impl.rs / TestProducer::publish()`: mirror emission
- `tests/metrics_emitted.rs`: add `rb_kafka_e2e_latency_seconds` to required names

### MED-1 — DLQ producer `acks=1` rationale undocumented
- `consumer.rs / Consumer::new()`: add comment explaining best-effort intentionality

### LOW-1 — `replication_factor: 1` silently wrong for prod clusters
- `infra/kafka/topics.yaml`: add header comment noting rf=1 is local/CI only

## Test plan

- [ ] `cargo test -p rb-kafka` — 21 tests pass (6 lib + 15 integration)
- [ ] `cargo check -p rb-kafka` — 0 warnings
- [ ] CI 16/16 checks green at HEAD

