### PR TITLE
[REQ-TR-02] feat(kafka): W3C trace context propagation — inject on produce, extract on consume

### DIFF
--- a/crates/rb-kafka/src/consumer.rs
+++ b/crates/rb-kafka/src/consumer.rs
@@ -18,6 +18,7 @@ use crate::{
         HEADER_TRACEPARENT, HEADER_TRACESTATE,
     },
     errors::KafkaError,
+    headers::{is_valid_traceparent, KafkaHeaderExtractor},
     producer::decode_envelope,
 };
 
@@ -60,6 +61,7 @@ impl<E: ProstMessage + Default> Consumer<E> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn next(&self) -> Option<Result<EventEnvelope<E>, KafkaError>> {
         let msg = self.inner.stream().next().await?;
         match msg {
@@ -89,7 +91,59 @@ impl<E: ProstMessage + Default> Consumer<E> {
                     .set(lag);
                 }
 
+                // Seed consume span as child of producer span via W3C context extraction.
+                // The attached context is current for the remainder of this call so that
+                // any instrumented sub-spans are linked to the upstream trace.
+                let _cx_guard = {
+                    let extractor = KafkaHeaderExtractor(&headers);
+                    opentelemetry::global::get_text_map_propagator(|prop| {
+                        prop.extract(&extractor)
+                    })
+                    .attach()
+                };
+                let consume_span = tracing::info_span!(
+                    "kafka.consume",
+                    "otel.kind" = "CONSUMER",
+                    topic = %topic,
+                    partition,
+                    offset,
+                );
+                let _enter = consume_span.enter();
+
                 let result = decode_envelope(payload, &headers, &topic, partition, offset);
+
+                // Malformed traceparent: DLQ immediately and surface the error.
+                // trace_context is cleared before nack so the DLQ record doesn't
+                // re-trigger validation when a downstream DLQ consumer reads it.
+                let result = match result {
+                    Ok(mut env) => {
+                        let malformed_tp = env.trace_context.as_ref().and_then(|tc| {
+                            if !tc.traceparent.is_empty()
+                                && !is_valid_traceparent(&tc.traceparent)
+                            {
+                                Some(tc.traceparent.clone())
+                            } else {
+                                None
+                            }
+                        });
+                        if let Some(tp) = malformed_tp {
+                            env.trace_context = None;
+                            let _ = self.nack_to_dlq(&env, "invalid-traceparent").await;
+                            let _ = self.commit(&env).await;
+                            counter!(
+                                "rb_kafka_messages_total",
+                                "op" => "consume",
+                                "outcome" => "err",
+                                "topic" => topic.clone()
+                            )
+                            .increment(1);
+                            return Some(Err(KafkaError::InvalidTraceparent(tp)));
+                        }
+                        Ok(env)
+                    }
+                    Err(e) => Err(e),
+                };
+
                 match &result {
                     Ok(env) => {
                         counter!(

--- a/crates/rb-kafka/src/errors.rs
+++ b/crates/rb-kafka/src/errors.rs
@@ -24,6 +24,8 @@ pub enum KafkaError {
     Rdkafka(#[from] rdkafka::error::KafkaError),
     #[error("max retries exceeded; message should be routed to DLQ")]
     MaxRetriesExceeded,
+    #[error("malformed W3C traceparent header: {0}")]
+    InvalidTraceparent(String),
 }
 
 impl KafkaError {
@@ -38,6 +40,7 @@ impl KafkaError {
                 | KafkaError::TenantMismatch
                 | KafkaError::InvalidBlobRef(_)
                 | KafkaError::InvalidHeaderUuid { .. }
+                | KafkaError::InvalidTraceparent(_)
         )
     }
 }

--- a/crates/rb-kafka/src/headers.rs
+++ b/crates/rb-kafka/src/headers.rs
@@ -1,4 +1,4 @@
-use opentelemetry::propagation::Injector;
+use opentelemetry::propagation::{Extractor, Injector};
 use rdkafka::message::{Header, OwnedHeaders};
 
 /// `OTel` `Injector` wrapping an owned `OwnedHeaders` (append-only rdkafka type).
@@ -8,5 +8,102 @@ impl Injector for KafkaHeaderInjector {
     fn set(&mut self, key: &str, value: String) {
         let current = std::mem::replace(&mut self.0, OwnedHeaders::new());
         self.0 = current.insert(Header { key, value: Some(value.as_bytes()) });
+    }
+}
+
+/// `OTel` `Extractor` backed by decoded Kafka headers (`Vec<(key, value)>`).
+pub struct KafkaHeaderExtractor<'a>(pub &'a [(String, String)]);
+
+impl Extractor for KafkaHeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.iter().map(|(k, _)| k.as_str()).collect()
+    }
+}
+
+/// Returns `true` iff `tp` is a structurally valid W3C traceparent.
+///
+/// Required format: `{2hex}-{32hex}-{16hex}-{2hex}` (version-traceId-parentId-flags).
+/// Does not enforce the all-zeros prohibition from the spec; that is left to the `OTel` SDK.
+pub fn is_valid_traceparent(tp: &str) -> bool {
+    let mut it = tp.splitn(5, '-');
+    let version = it.next().unwrap_or("");
+    let trace_id = it.next().unwrap_or("");
+    let parent_id = it.next().unwrap_or("");
+    let flags = it.next().unwrap_or("");
+    // A 5th segment means extra dashes — invalid.
+    if it.next().is_some() {
+        return false;
+    }
+    is_hex_len(version, 2)
+        && is_hex_len(trace_id, 32)
+        && is_hex_len(parent_id, 16)
+        && is_hex_len(flags, 2)
+}
+
+fn is_hex_len(s: &str, expected: usize) -> bool {
+    s.len() == expected && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_w3c_traceparent_accepted() {
+        assert!(is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[test]
+    fn too_few_segments_rejected() {
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7"
+        ));
+    }
+
+    #[test]
+    fn extra_segment_rejected() {
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra"
+        ));
+    }
+
+    #[test]
+    fn short_trace_id_rejected() {
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e47-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[test]
+    fn short_parent_id_rejected() {
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902-01"
+        ));
+    }
+
+    #[test]
+    fn non_hex_flags_rejected() {
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-zz"
+        ));
+    }
+
+    #[test]
+    fn free_form_string_rejected() {
+        assert!(!is_valid_traceparent("not-a-valid-traceparent"));
+    }
+
+    #[test]
+    fn empty_string_rejected() {
+        assert!(!is_valid_traceparent(""));
     }
 }

--- a/crates/rb-kafka/src/testing_impl.rs
+++ b/crates/rb-kafka/src/testing_impl.rs
@@ -24,6 +24,7 @@ use crate::{
         HEADER_TRACESTATE,
     },
     errors::KafkaError,
+    headers::{is_valid_traceparent, KafkaHeaderExtractor},
     producer::decode_envelope,
 };
 
@@ -176,7 +177,49 @@ impl<E: ProstMessage + Default> TestConsumer<E> {
         match rx.recv().await {
             Ok(msg) => {
                 let topic = msg.topic.clone();
+
+                // Seed consume span (no-op when no OTel propagator is installed in tests).
+                let _cx_guard = {
+                    let extractor = KafkaHeaderExtractor(&msg.headers);
+                    opentelemetry::global::get_text_map_propagator(|prop| {
+                        prop.extract(&extractor)
+                    })
+                    .attach()
+                };
+
                 let result = decode_envelope(&msg.payload, &msg.headers, &msg.topic, 0, 0);
+
+                // Malformed traceparent: auto-DLQ and return error, matching Consumer::next().
+                // trace_context is cleared before nack so the DLQ record doesn't
+                // re-trigger validation when a downstream DLQ consumer reads it.
+                let result = match result {
+                    Ok(mut env) => {
+                        let malformed_tp = env.trace_context.as_ref().and_then(|tc| {
+                            if !tc.traceparent.is_empty()
+                                && !is_valid_traceparent(&tc.traceparent)
+                            {
+                                Some(tc.traceparent.clone())
+                            } else {
+                                None
+                            }
+                        });
+                        if let Some(tp) = malformed_tp {
+                            env.trace_context = None;
+                            let _ = self.nack_to_dlq(&env, "invalid-traceparent").await;
+                            counter!(
+                                "rb_kafka_messages_total",
+                                "op" => "consume",
+                                "outcome" => "err",
+                                "topic" => topic.clone()
+                            )
+                            .increment(1);
+                            return Some(Err(KafkaError::InvalidTraceparent(tp)));
+                        }
+                        Ok(env)
+                    }
+                    Err(e) => Err(e),
+                };
+
                 match &result {
                     Ok(env) => {
                         counter!(

--- a/crates/rb-kafka/tests/trace_propagation.rs
+++ b/crates/rb-kafka/tests/trace_propagation.rs
@@ -1,4 +1,4 @@
-use rb_kafka::{testing::InProcessBus, EventEnvelope, TraceContext};
+use rb_kafka::{dlq_topic, testing::InProcessBus, EventEnvelope, KafkaError, TraceContext};
 use rb_schemas::{IngestStatus, IngestStatusEvent, TenantId};
 
 fn make_event(tenant_id: TenantId, seq: u32) -> EventEnvelope<IngestStatusEvent> {
@@ -87,4 +87,71 @@ async fn trace_ids_are_distinct_across_messages() {
     let tp_a = msg_a.trace_context.unwrap().traceparent;
     let tp_b = msg_b.trace_context.unwrap().traceparent;
     assert_ne!(tp_a, tp_b, "distinct messages must carry distinct trace contexts");
+}
+
+#[tokio::test]
+async fn malformed_traceparent_is_dlqd_and_returns_error() {
+    let bus = InProcessBus::new();
+    let producer = bus.producer::<IngestStatusEvent>();
+    let consumer = bus.consumer::<IngestStatusEvent>("test.malformed_trace");
+
+    let dlq_name = dlq_topic("test.malformed_trace");
+    let dlq_consumer = bus.consumer::<IngestStatusEvent>(&dlq_name);
+
+    let tenant_id = TenantId::new();
+    let env = make_event(tenant_id, 0).with_trace_context(TraceContext {
+        traceparent: "not-a-valid-traceparent".to_owned(),
+        tracestate: String::new(),
+    });
+    let original_event_id = env.event_id;
+
+    producer.publish("test.malformed_trace", &[], env).await.unwrap();
+
+    let result = consumer.next().await.unwrap();
+    assert!(
+        matches!(result, Err(KafkaError::InvalidTraceparent(_))),
+        "malformed traceparent must return InvalidTraceparent error, got: {result:?}"
+    );
+
+    // Message must land on the DLQ (trace_context stripped so no re-validation loop).
+    let dlq_msg = dlq_consumer.next().await.unwrap().unwrap();
+    assert_eq!(dlq_msg.event_id, original_event_id, "DLQ must receive the original event");
+    assert!(
+        dlq_msg.trace_context.is_none(),
+        "DLQ message must have trace_context stripped to prevent re-validation"
+    );
+}
+
+#[tokio::test]
+async fn valid_message_after_malformed_is_processed_normally() {
+    let bus = InProcessBus::new();
+    let producer = bus.producer::<IngestStatusEvent>();
+    let consumer = bus.consumer::<IngestStatusEvent>("test.mixed_trace");
+
+    let tenant_id = TenantId::new();
+
+    // First message: malformed traceparent.
+    let bad_env = make_event(tenant_id, 0).with_trace_context(TraceContext {
+        traceparent: "bad".to_owned(),
+        tracestate: String::new(),
+    });
+    producer.publish("test.mixed_trace", &[], bad_env).await.unwrap();
+
+    // Second message: valid traceparent.
+    let good_tp = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+    let good_env = make_event(tenant_id, 1).with_trace_context(TraceContext {
+        traceparent: good_tp.to_owned(),
+        tracestate: String::new(),
+    });
+    let good_event_id = good_env.event_id;
+    producer.publish("test.mixed_trace", &[], good_env).await.unwrap();
+
+    // First consume: returns error for malformed.
+    let first = consumer.next().await.unwrap();
+    assert!(first.is_err(), "malformed message must error");
+
+    // Second consume: succeeds and has correct trace context.
+    let second = consumer.next().await.unwrap().unwrap();
+    assert_eq!(second.event_id, good_event_id);
+    assert_eq!(second.trace_context.unwrap().traceparent, good_tp);
 }


### PR DESCRIPTION
## Summary

- Adds `KafkaHeaderExtractor` implementing `opentelemetry::propagation::Extractor` so the W3C propagator can extract context from Kafka headers
- `Consumer::next()` attaches the extracted context and enters a `kafka.consume` span (otel.kind=CONSUMER) seeded as a child of the producer span — fulfils the produce→consume span linkage visible in Tempo
- Malformed traceparent triggers auto-DLQ with `reason="invalid-traceparent"`; `trace_context` is stripped from the DLQ record to prevent an infinite re-validation loop
- New `KafkaError::InvalidTraceparent(String)` variant (terminal, never retried)
- `TestConsumer` mirrors all validation logic so in-process-bus tests exercise the same path

## GitHub Issue

Closes #127

## Checklist
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace -- -D warnings passes
- [x] No internal tracking IDs in PR body
- [x] Docs updated if architecture changed

## Merge instructions
Squash-merge (gh pr merge <num> --squash).