### PR TITLE
[REQ-FE-04] feat(frontend): ingestion theatre — SSE-driven live pipeline view

### DIFF
--- a/frontend/e2e/ingestion-theatre.spec.ts
+++ b/frontend/e2e/ingestion-theatre.spec.ts
@@ -1,0 +1,155 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { mockAuthenticatedSession } from "./fixtures/mock-api";
+
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function mockSseStream(
+  page: import("@playwright/test").Page,
+  events: string[] = [],
+): Promise<void> {
+  await page.route("**/v1/ingest/events", async (route) => {
+    const body = events.join("") || "";
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+      body,
+    });
+  });
+}
+
+async function setupPage(page: import("@playwright/test").Page): Promise<void> {
+  await mockAuthenticatedSession(page);
+  await mockSseStream(page);
+}
+
+test.describe("Ingestion Theatre — empty state", () => {
+  test("renders empty state when no events on the bus", async ({ page }) => {
+    await setupPage(page);
+    await page.goto("/ingestion");
+
+    await expect(
+      page.getByRole("heading", { name: "Ingestion Theatre" }),
+    ).toBeVisible();
+
+    const emptyState = page.getByTestId("ingestion-empty-state");
+    await expect(emptyState).toBeVisible();
+    await expect(
+      emptyState.getByText("No ingestion in progress"),
+    ).toBeVisible();
+  });
+
+  test("empty state shows all 6 pipeline stages as pending", async ({
+    page,
+  }) => {
+    await setupPage(page);
+    await page.goto("/ingestion");
+
+    const stages = ["clone", "expand", "parse", "typecheck", "graph", "embed"];
+    for (const stage of stages) {
+      await expect(
+        page.getByRole("listitem").filter({ hasText: stage }),
+      ).toBeVisible();
+    }
+  });
+
+  test("empty state a11y: no serious/critical axe violations", async ({
+    page,
+  }) => {
+    await setupPage(page);
+    await page.goto("/ingestion");
+    await expect(
+      page.getByRole("heading", { name: "Ingestion Theatre" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .analyze();
+    const violations = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+});
+
+test.describe("Ingestion Theatre — live events", () => {
+  test("processing event flips clone stage to running", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockSseStream(page, [
+      "id: evt-1\n",
+      "event: ingest.status\n",
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","error_message":"","occurred_at_ms":1700000001000}\n',
+      "\n",
+    ]);
+
+    await page.goto("/ingestion");
+    await expect(page.getByTestId("ingestion-active-state")).toBeVisible();
+
+    const cloneItem = page.getByRole("listitem").filter({ hasText: "clone" });
+    await expect(cloneItem).toBeVisible();
+    await expect(cloneItem.getByText("Running")).toBeVisible();
+  });
+
+  test("done event flips all stages to done", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockSseStream(page, [
+      "id: evt-2\n",
+      "event: ingest.status\n",
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"done","error_message":"","occurred_at_ms":1700000002000}\n',
+      "\n",
+    ]);
+
+    await page.goto("/ingestion");
+    await expect(page.getByTestId("ingestion-active-state")).toBeVisible();
+
+    const stages = ["clone", "expand", "parse", "typecheck", "graph", "embed"];
+    for (const stage of stages) {
+      const item = page.getByRole("listitem").filter({ hasText: stage });
+      await expect(item.getByText("Done")).toBeVisible();
+    }
+  });
+
+  test("populated state a11y: no serious/critical axe violations", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockSseStream(page, [
+      "id: evt-3\n",
+      "event: ingest.status\n",
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","error_message":"","occurred_at_ms":1700000003000}\n',
+      "\n",
+    ]);
+
+    await page.goto("/ingestion");
+    await expect(page.getByTestId("ingestion-active-state")).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .analyze();
+    const violations = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+});
+
+test.describe("Ingestion Theatre — auth gate", () => {
+  test("redirects to login when not authenticated", async ({ page }) => {
+    await page.route("**/v1/me", (route) => route.fulfill({ status: 401 }));
+    await mockSseStream(page);
+
+    await page.goto("/ingestion");
+    await expect(page.locator("text=Sign in to view ingestion progress")).toBeVisible();
+  });
+});
+

--- a/frontend/e2e/ingestion-theatre.spec.ts
+++ b/frontend/e2e/ingestion-theatre.spec.ts
@@ -94,7 +94,9 @@ test.describe("Ingestion Theatre — live events", () => {
 
     const cloneItem = page.getByRole("listitem").filter({ hasText: "clone" });
     await expect(cloneItem).toBeVisible();
-    await expect(cloneItem.getByText("Running")).toBeVisible();
+    await expect(
+      cloneItem.getByRole("img", { name: "clone stage: Running" }),
+    ).toBeVisible();
   });
 
   test("done event flips all stages to done", async ({ page }) => {
@@ -112,7 +114,9 @@ test.describe("Ingestion Theatre — live events", () => {
     const stages = ["clone", "expand", "parse", "typecheck", "graph", "embed"];
     for (const stage of stages) {
       const item = page.getByRole("listitem").filter({ hasText: stage });
-      await expect(item.getByText("Done")).toBeVisible();
+      await expect(
+        item.getByRole("img", { name: `${stage} stage: Done` }),
+      ).toBeVisible();
     }
   });
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -40,6 +40,12 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
             >
               API keys
             </Link>
+            <Link
+              to={routes.ingestion}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
+            >
+              Ingestion
+            </Link>
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />

--- a/frontend/src/hooks/useEventStream.ts
+++ b/frontend/src/hooks/useEventStream.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from "react";
+
+export type EventStreamReadyState = "connecting" | "open" | "closed";
+
+export interface StreamedEvent {
+  readonly id: string | null;
+  readonly type: string;
+  readonly data: string;
+}
+
+export interface UseEventStreamResult {
+  readonly events: ReadonlyArray<StreamedEvent>;
+  readonly lastEventId: string | null;
+  readonly readyState: EventStreamReadyState;
+}
+
+const RECONNECT_DELAY_MS = 5_000;
+
+export function useEventStream(url: string): UseEventStreamResult {
+  const [events, setEvents] = useState<StreamedEvent[]>([]);
+  const [lastEventId, setLastEventId] = useState<string | null>(null);
+  const [readyState, setReadyState] = useState<EventStreamReadyState>("connecting");
+
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    let es: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const connect = () => {
+      if (cancelledRef.current) return;
+
+      es = new EventSource(url, { withCredentials: true });
+      setReadyState("connecting");
+
+      es.onopen = () => {
+        if (!cancelledRef.current) setReadyState("open");
+      };
+
+      const handleEvent = (event: MessageEvent) => {
+        if (cancelledRef.current) return;
+        const streamed: StreamedEvent = {
+          id: event.lastEventId || null,
+          type: event.type,
+          data: event.data,
+        };
+        if (event.lastEventId) {
+          setLastEventId(event.lastEventId);
+        }
+        setEvents((prev) => [...prev, streamed]);
+      };
+
+      es.addEventListener("ingest.status", handleEvent);
+
+      es.addEventListener("stream-reset", () => {
+        if (!cancelledRef.current) setEvents([]);
+      });
+
+      es.onerror = () => {
+        if (cancelledRef.current) return;
+        setReadyState("closed");
+        es?.close();
+        reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelledRef.current = true;
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      es?.close();
+      setReadyState("closed");
+    };
+  }, [url]);
+
+  return { events, lastEventId, readyState };
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -9,6 +9,7 @@ export const routes = {
   repoDetail: "/repos/$repoId",
   members: "/members",
   apiKeys: "/api-keys",
+  ingestion: "/ingestion",
 } as const;
 
 export type RoutePath = (typeof routes)[keyof typeof routes];

--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -1,0 +1,252 @@
+import { useMe } from "@/api";
+import { PageContainer } from "@/components/repos/PageContainer";
+import { useEventStream } from "@/hooks/useEventStream";
+
+const PIPELINE_STAGES = [
+  "clone",
+  "expand",
+  "parse",
+  "typecheck",
+  "graph",
+  "embed",
+] as const;
+
+type PipelineStage = (typeof PIPELINE_STAGES)[number];
+type StageStatus = "pending" | "running" | "done" | "error";
+type IngestStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "failed"
+  | "unspecified"
+  | "unknown";
+
+interface IngestStatusEvent {
+  ingest_request_id: string;
+  tenant_id: string;
+  status: IngestStatus;
+  error_message: string;
+  occurred_at_ms: number;
+}
+
+interface StageState {
+  readonly stage: PipelineStage;
+  readonly status: StageStatus;
+}
+
+function parseIngestEvent(raw: string): IngestStatusEvent | null {
+  try {
+    return JSON.parse(raw) as IngestStatusEvent;
+  } catch {
+    return null;
+  }
+}
+
+function deriveStageStates(
+  events: ReadonlyArray<{ data: string }>,
+): StageState[] {
+  const initial: StageState[] = PIPELINE_STAGES.map((stage) => ({
+    stage,
+    status: "pending",
+  }));
+
+  if (events.length === 0) return initial;
+
+  const parsed = events
+    .map((e) => parseIngestEvent(e.data))
+    .filter((e): e is IngestStatusEvent => e !== null);
+
+  if (parsed.length === 0) return initial;
+
+  const latest = parsed[parsed.length - 1];
+  if (!latest) return initial;
+
+  switch (latest.status) {
+    case "processing":
+      return PIPELINE_STAGES.map((stage, i) => ({
+        stage,
+        status: i === 0 ? "running" : "pending",
+      }));
+    case "done":
+      return PIPELINE_STAGES.map((stage) => ({ stage, status: "done" }));
+    case "failed":
+      return PIPELINE_STAGES.map((stage, i) => ({
+        stage,
+        status: i === 0 ? "error" : "pending",
+      }));
+    default:
+      return initial;
+  }
+}
+
+const STATUS_LABEL: Record<StageStatus, string> = {
+  pending: "Pending",
+  running: "Running",
+  done: "Done",
+  error: "Error",
+};
+
+const STATUS_COLOR: Record<StageStatus, string> = {
+  pending: "text-muted-foreground",
+  running: "text-blue-600 dark:text-blue-400",
+  done: "text-green-600 dark:text-green-400",
+  error: "text-destructive",
+};
+
+const STATUS_INDICATOR: Record<StageStatus, string> = {
+  pending:
+    "h-3 w-3 rounded-full border-2 border-muted-foreground/50 bg-transparent",
+  running: "h-3 w-3 rounded-full bg-blue-500 animate-pulse",
+  done: "h-3 w-3 rounded-full bg-green-500",
+  error: "h-3 w-3 rounded-full bg-destructive",
+};
+
+interface StageRowProps {
+  readonly state: StageState;
+  readonly index: number;
+  readonly isLast: boolean;
+}
+
+function StageRow({ state, index, isLast }: StageRowProps): JSX.Element {
+  return (
+    <li className="flex items-start gap-4">
+      <div className="flex flex-col items-center">
+        <div
+          role="img"
+          aria-label={`${state.stage} stage: ${STATUS_LABEL[state.status]}`}
+          className={STATUS_INDICATOR[state.status]}
+        />
+        {!isLast && (
+          <div
+            aria-hidden="true"
+            className="mt-1 h-8 w-0.5 bg-border"
+          />
+        )}
+      </div>
+      <div className="pb-8 last:pb-0">
+        <p className="text-sm font-medium capitalize">{state.stage}</p>
+        <p className={`text-xs ${STATUS_COLOR[state.status]}`}>
+          {STATUS_LABEL[state.status]}
+        </p>
+      </div>
+      <span className="sr-only">
+        Step {index + 1} of {PIPELINE_STAGES.length}: {state.stage},{" "}
+        {STATUS_LABEL[state.status]}
+      </span>
+    </li>
+  );
+}
+
+function IngestionTheatreInner(): JSX.Element {
+  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+  const { events, readyState } = useEventStream(
+    `${apiBase}/v1/ingest/events`,
+  );
+
+  const ingestEvents = events.filter((e) => e.type === "ingest.status");
+  const stageStates = deriveStageStates(ingestEvents);
+  const hasEvents = ingestEvents.length > 0;
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Ingestion Theatre
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Live pipeline progress for this workspace
+        </p>
+      </header>
+
+      <div className="flex items-center gap-2 mb-6">
+        <span
+          aria-hidden="true"
+          className={`h-2 w-2 rounded-full ${
+            readyState === "open"
+              ? "bg-green-500"
+              : readyState === "connecting"
+                ? "bg-yellow-500 animate-pulse"
+                : "bg-muted-foreground"
+          }`}
+        />
+        <span className="text-xs text-muted-foreground capitalize">
+          {readyState === "open"
+            ? "Connected — live"
+            : readyState === "connecting"
+              ? "Connecting…"
+              : "Disconnected"}
+        </span>
+      </div>
+
+      {!hasEvents ? (
+        <section
+          aria-label="No ingestion in progress"
+          data-testid="ingestion-empty-state"
+          className="rounded-lg border border-border bg-card p-6"
+        >
+          <h2 className="mb-2 text-sm font-medium">No ingestion in progress</h2>
+          <p className="text-sm text-muted-foreground">
+            Start an ingestion run from a repository to see live pipeline
+            progress here.
+          </p>
+
+          <div aria-label="Pipeline stages — all pending" className="mt-6">
+            <ol aria-label="Pipeline stages">
+              {stageStates.map((state, i) => (
+                <StageRow
+                  key={state.stage}
+                  state={state}
+                  index={i}
+                  isLast={i === PIPELINE_STAGES.length - 1}
+                />
+              ))}
+            </ol>
+          </div>
+        </section>
+      ) : (
+        <section
+          aria-label="Ingestion pipeline"
+          data-testid="ingestion-active-state"
+          className="rounded-lg border border-border bg-card p-6"
+        >
+          <h2 className="mb-4 text-sm font-medium">Pipeline progress</h2>
+
+          <ol aria-label="Pipeline stages">
+            {stageStates.map((state, i) => (
+              <StageRow
+                key={state.stage}
+                state={state}
+                index={i}
+                isLast={i === PIPELINE_STAGES.length - 1}
+              />
+            ))}
+          </ol>
+        </section>
+      )}
+    </PageContainer>
+  );
+}
+
+export function IngestionTheatre(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">
+          Sign in to view ingestion progress.
+        </p>
+      </PageContainer>
+    );
+  }
+
+  return <IngestionTheatreInner />;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
+import { IngestionTheatre } from "@/pages/IngestionTheatre";
 import { LoginPage } from "@/pages/LoginPage";
 import { MembersPage } from "@/pages/MembersPage";
 import { ReposPage } from "@/pages/ReposPage";
@@ -109,6 +110,12 @@ const apiKeysRoute = createRoute({
   component: ApiKeysPage,
 });
 
+const ingestionRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.ingestion,
+  component: IngestionTheatre,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -129,6 +136,7 @@ const routeTree = rootRoute.addChildren([
   repoDetailRoute,
   membersRoute,
   apiKeysRoute,
+  ingestionRoute,
   catchAllRoute,
 ]);
 


### PR DESCRIPTION
## Summary

- Add `useEventStream(url)` hook wrapping native `EventSource` with reconnect and `Last-Event-Id` support
- Add `/ingestion` route: auth-gated, tenant-scoped, subscribes to `GET /v1/ingest/events`
- Stage-by-stage timeline (clone→expand→parse→typecheck→graph→embed) with pending/running/done/error indicators
- Empty state renders before any events arrive; axe-core a11y clean on both states
- Fix: Playwright locators scoped to `aria-label` on stage indicator (avoids sr-only strict-mode collision)

## GitHub Issue

Closes #144

## Checklist

- [x] TypeScript: `tsc -p tsconfig.app.json --noEmit` and `tsc -p tsconfig.e2e.json --noEmit` — 0 errors
- [x] ESLint: 0 errors on all new/modified files
- [x] Playwright spec: empty state, live events, auth gate, axe-core a11y
- [x] Rebased onto `fe84184` (current main)
- [x] No internal identifiers in PR body
- [x] Docs not changed (frontend-only, no architecture change)

## Merge instructions

Squash-merge (gh pr merge <num> --squash).