### PR TITLE
[REQ-CI-01] feat(ci): codegen-drift gate — detect stale openapi.json and schema.ts on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,40 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
       - run: bash scripts/check-openapi-sync.sh
 
+  codegen-drift:
+    name: codegen drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install rdkafka build dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build control-api binary
+        run: cargo build -p control-api --quiet
+      - name: Regenerate openapi.json in place
+        run: ./target/debug/control-api print-openapi > openapi.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Regenerate frontend schema in place
+        working-directory: frontend
+        run: npm run gen:api
+      - name: Detect drift via git diff
+        run: |
+          if ! git diff --exit-code openapi.json frontend/src/api/generated/schema.ts; then
+            echo ""
+            echo "::error::Generated artefacts are stale. Run the following commands and commit the result:"
+            echo "::error::  cargo run -p control-api -- print-openapi > openapi.json"
+            echo "::error::  cd frontend && npm run gen:api"
+            exit 1
+          fi
+
   frontend-typecheck:
     name: frontend typecheck
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,24 @@
 
 Run `make review-ready` from the repo root before opening a PR. It runs `cargo fmt --check`, `cargo clippy`, the full workspace test suite, `cargo deny check`, and an OpenAPI freshness check — and also runs `pnpm lint`, `pnpm typecheck`, and `pnpm test` automatically if your branch touches `frontend/`. All steps execute even if earlier ones fail so you see the complete picture in one pass. Fix everything flagged before pushing; PRs that fail these checks are returned without review.
 
+## Regenerating generated artefacts
+
+The repository tracks two generated files. Regenerate them whenever you change the API surface:
+
+### OpenAPI spec (`openapi.json`)
+
+```bash
+cargo run -p control-api -- print-openapi > openapi.json
+```
+
+### Frontend TypeScript schema (`frontend/src/api/generated/schema.ts`)
+
+```bash
+cd frontend && npm run gen:api
+```
+
+Both commands must be re-run (in that order) whenever control-api handler signatures change. The CI `codegen-drift` job enforces this by running `git diff --exit-code` over both files on every PR.
+
 ## Branch naming
 
 Branch names must match `^(feature|fix|chore|test|docs)/[a-z0-9][a-z0-9-]*$`. `make review-ready` enforces this and prints a rename hint on failure.


### PR DESCRIPTION
## Summary

Adds a dedicated `codegen-drift` CI job that catches stale generated artefacts before merge.

**Root cause:** REQ-GH-04, REQ-GH-08, REQ-GH-02, REQ-FE-12 each shipped with at least one follow-up commit to regenerate types or the OpenAPI spec because the contract changed without refreshing the artefacts in the same PR.

**How it works:**
1. Builds the `control-api` binary (Swatinem/rust-cache keeps this fast on warm runs)
2. Regenerates `openapi.json` in-place via `./target/debug/control-api print-openapi`
3. Installs frontend deps and regenerates `frontend/src/api/generated/schema.ts` via `npm run gen:api`
4. Runs `git diff --exit-code` over both artefacts — fails with an actionable error if anything changed

**Error message shown on failure:**
```
Generated artefacts are stale. Run the following commands and commit the result:
  cargo run -p control-api -- print-openapi > openapi.json
  cd frontend && npm run gen:api
```

Also adds `CONTRIBUTING.md` documenting the regeneration workflow for contributors.

## GitHub Issue

Closes #135

## Checklist

- [x] `codegen-drift` job runs on every PR
- [x] Fails with actionable message if either artefact is stale
- [x] Rust and Node toolchains cached (sub-2-min target on warm runs)
- [x] `CONTRIBUTING.md` updated with regeneration commands
- [ ] Wired as required check (branch protection — escalate to board if needed)