### PR TITLE
test(qa): deliberate drift test — DO NOT MERGE

### DIFF
--- a/services/control-api/src/routes/health.rs
+++ b/services/control-api/src/routes/health.rs
@@ -14,7 +14,7 @@ pub struct ProbeResponse {
     get,
     path = "/health",
     responses(
-        (status = 200, description = "Service is alive", body = ProbeResponse)
+        (status = 200, description = "Service is alive and healthy", body = ProbeResponse)
     ),
     tag = "health"
 )]


### PR DESCRIPTION
QA deliberate-drift test. Modifies a utoipa description without regenerating openapi.json to verify the codegen-drift gate fails correctly.