### PR TITLE
fix(docker): pin control-api builder to rust:1-bookworm, switch runtime to bookworm-slim

### DIFF
--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:latest AS builder
+FROM rust:1-bookworm AS builder
 
 WORKDIR /app
 
@@ -37,7 +37,18 @@ RUN apt-get update -qq && \
 RUN cargo build --release -p control-api
 
 # ── Stage 2: minimal runtime image ────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+# debian:bookworm-slim matches the builder's glibc 2.36 and supplies libz + sasl2
+# required by rdkafka at runtime (distroless/cc-debian12 lacks libz.so.1).
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
 
 COPY --from=builder /app/target/release/control-api /usr/local/bin/control-api
 


### PR DESCRIPTION
## Summary

- **Bug**: `rust:latest` builder (now Debian Trixie, glibc 2.41) produces a binary incompatible with `distroless/cc-debian12:nonroot` runtime (glibc 2.36). Additionally `distroless/cc` does not ship `libz.so.1`, required by rdkafka.
- **Fix**: Pin builder to `rust:1-bookworm` (glibc 2.36) and switch runtime to `debian:bookworm-slim` with `ca-certificates libssl3 libsasl2-2 zlib1g libcurl4` installed. Nonroot UID/GID 65532 recreated explicitly.
- **Evidence**: `docker run --rm rust:latest sh -c "ldd --version | head -1"` → `GLIBC 2.41`; `debian:bookworm` → `GLIBC 2.36`. Mismatch confirmed against live images.

## Verification

Glibc version evidence (live image check, no full build needed):
- `rust:latest` → **glibc 2.41** (Debian Trixie — worsened from 2.38 originally noted)
- `debian:bookworm` → **glibc 2.36**
- Main Dockerfile still has `FROM rust:latest` + `distroless/cc-debian12` — B2/B3 are reproducible

## Checklist

- [x] Single-file change, minimal diff
- [x] Builder and runtime now both on Bookworm (glibc 2.36 — matched)
- [x] All rdkafka runtime deps supplied: libssl3, libsasl2-2, zlib1g, libcurl4
- [x] Nonroot security posture preserved (UID/GID 65532)
- [x] No internal tracker references in PR title