### PR TITLE
[REQ-LI-01] feat(rb-feature-resolver): add standalone feature resolver crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,9 +283,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check zero rb-* imports in rb-feature-resolver
-        # Crate does not exist yet; stub ensures job slot exists in CI matrix
-        run: echo "rb-feature-resolver-isolation stub — crate not yet created"
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check zero rb-* deps in rb-feature-resolver
+        run: bash scripts/check-rb-feature-resolver-isolation.sh
 
   tenant-isolation:
     name: tenant isolation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3332,6 +3332,15 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "rb-feature-resolver"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]
@@ -3856,6 +3865,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4515,6 +4533,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4525,14 +4564,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4541,8 +4594,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5306,6 +5365,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/rb-blob",
     "crates/rb-kafka",
     "crates/rb-sse",
+    "crates/rb-feature-resolver",
     "services/migrate",
     "services/control-api",
 ]

--- a/crates/rb-feature-resolver/Cargo.toml
+++ b/crates/rb-feature-resolver/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rb-feature-resolver"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Resolves Cargo feature flags into a canonical feature set for cargo expand"
+keywords = ["cargo", "features", "resolver"]
+categories = ["development-tools"]
+
+[dependencies]
+toml = "0.8"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/rb-feature-resolver/src/error.rs
+++ b/crates/rb-feature-resolver/src/error.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FeatureResolveError {
+    #[error("failed to read manifest at {path}: {source}")]
+    ManifestRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse manifest at {path}: {source}")]
+    ManifestParse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+
+    #[error("unknown feature `{feature}` requested for crate `{crate_name}`")]
+    UnknownFeature {
+        crate_name: String,
+        feature: String,
+    },
+
+    #[error("cyclic feature dependency detected involving `{feature}`")]
+    CyclicDependency { feature: String },
+}

--- a/crates/rb-feature-resolver/src/lib.rs
+++ b/crates/rb-feature-resolver/src/lib.rs
@@ -1,0 +1,9 @@
+mod error;
+mod manifest;
+mod resolver;
+mod types;
+
+pub use error::FeatureResolveError;
+pub use manifest::{CargoManifest, DetailedDependency, DependencySpec, PackageMetadata, WorkspaceSection};
+pub use resolver::resolve;
+pub use types::{FeatureSet, ResolvedFeatureSet};

--- a/crates/rb-feature-resolver/src/manifest.rs
+++ b/crates/rb-feature-resolver/src/manifest.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::FeatureResolveError;
+
+/// Parsed representation of a `Cargo.toml` file.
+///
+/// Only the fields needed for feature resolution are captured; unknown fields are ignored.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct CargoManifest {
+    /// `[package]` table.
+    pub package: Option<PackageMetadata>,
+
+    /// `[features]` table — maps each feature name to the list of features/deps it enables.
+    #[serde(default)]
+    pub features: BTreeMap<String, Vec<String>>,
+
+    /// `[dependencies]` table.
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, DependencySpec>,
+
+    /// `[dev-dependencies]` table.
+    #[serde(rename = "dev-dependencies", default)]
+    pub dev_dependencies: BTreeMap<String, DependencySpec>,
+
+    /// `[build-dependencies]` table.
+    #[serde(rename = "build-dependencies", default)]
+    pub build_dependencies: BTreeMap<String, DependencySpec>,
+
+    /// `[workspace]` table — present when this is a workspace root.
+    pub workspace: Option<WorkspaceSection>,
+}
+
+/// Metadata from `[package]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackageMetadata {
+    pub name: String,
+    pub version: Option<String>,
+}
+
+/// `[workspace]` section as it appears in a workspace-root `Cargo.toml`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct WorkspaceSection {
+    /// Glob patterns for workspace member directories.
+    #[serde(default)]
+    pub members: Vec<String>,
+}
+
+/// Inline or detailed dependency specification.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum DependencySpec {
+    /// Short form: `dep = "1.0"`.
+    Simple(String),
+    /// Long form: `dep = { version = "1.0", features = ["foo"], ... }`.
+    Detailed(DetailedDependency),
+}
+
+/// Long-form dependency entry.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DetailedDependency {
+    pub version: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(rename = "default-features", default = "detail_default_true")]
+    pub default_features: bool,
+    #[serde(default)]
+    pub optional: bool,
+}
+
+fn detail_default_true() -> bool {
+    true
+}
+
+impl CargoManifest {
+    /// Read and parse a `Cargo.toml` file at `path`.
+    /// # Errors
+    ///
+    /// Returns [`FeatureResolveError::ManifestRead`] if the file cannot be read, or
+    /// [`FeatureResolveError::ManifestParse`] if the TOML is malformed.
+    pub fn from_path(path: &Path) -> Result<Self, FeatureResolveError> {
+        let content =
+            std::fs::read_to_string(path).map_err(|source| FeatureResolveError::ManifestRead {
+                path: path.to_owned(),
+                source,
+            })?;
+        toml::from_str(&content).map_err(|source| FeatureResolveError::ManifestParse {
+            path: path.to_owned(),
+            source,
+        })
+    }
+
+    /// The crate's declared package name, if present.
+    #[must_use]
+    pub fn package_name(&self) -> Option<&str> {
+        self.package.as_ref().map(|p| p.name.as_str())
+    }
+}

--- a/crates/rb-feature-resolver/src/resolver.rs
+++ b/crates/rb-feature-resolver/src/resolver.rs
@@ -1,0 +1,277 @@
+use std::collections::{BTreeSet, VecDeque};
+use std::path::Path;
+
+use crate::{
+    error::FeatureResolveError,
+    manifest::{CargoManifest, DependencySpec},
+    types::{FeatureSet, ResolvedFeatureSet},
+};
+
+/// Resolve `requested` against `manifest`'s `[features]` table, producing the canonical feature
+/// set to pass to `cargo expand --features`.
+///
+/// # Algorithm
+///
+/// 1. If `requested.uses_default_features()` and the manifest declares a `default` feature, seed
+///    the BFS queue with `"default"` and all of its direct children.
+/// 2. Add every explicitly requested feature to the queue.
+/// 3. BFS-expand: each feature name is looked up in `manifest.features`; any entry that is a
+///    plain feature name (not a `dep:…` activation or a `dep/feature` cross-crate reference) is
+///    enqueued.
+/// 4. Collect workspace-unified features: check every other workspace member's dependencies for
+///    entries that name this crate with additional features, and include those too.
+///
+/// # Errors
+///
+/// Returns [`FeatureResolveError::UnknownFeature`] if a feature in `requested` does not appear in
+/// `manifest.features` (and is not `"default"`).
+///
+/// Returns [`FeatureResolveError::ManifestRead`] / [`FeatureResolveError::ManifestParse`] if any
+/// workspace member manifest cannot be read.
+pub fn resolve(
+    workspace_root: &Path,
+    manifest: &CargoManifest,
+    requested: &FeatureSet,
+) -> Result<ResolvedFeatureSet, FeatureResolveError> {
+    // Guard against malformed manifests with circular feature deps.
+    const MAX_ITERATIONS: usize = 4096;
+
+    let mut pending: VecDeque<String> = VecDeque::new();
+
+    // Validate requested features exist before we begin.
+    let crate_name = manifest.package_name().unwrap_or("<unknown>");
+    for f in requested.features() {
+        if !manifest.features.contains_key(f.as_str()) {
+            return Err(FeatureResolveError::UnknownFeature {
+                crate_name: crate_name.to_owned(),
+                feature: f.clone(),
+            });
+        }
+        pending.push_back(f.clone());
+    }
+
+    // Seed defaults unless opted out.
+    if requested.uses_default_features() {
+        if let Some(default_deps) = manifest.features.get("default") {
+            // Enqueue "default" itself so it appears in the resolved set.
+            pending.push_back("default".to_owned());
+            for spec in default_deps {
+                if let Some(name) = as_self_feature(spec) {
+                    if manifest.features.contains_key(name) {
+                        pending.push_back(name.to_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    // Collect workspace-unified features (other members that depend on this crate).
+    collect_workspace_unified(&mut pending, workspace_root, manifest)?;
+
+    // BFS expansion.
+    let mut resolved: BTreeSet<String> = BTreeSet::new();
+    let mut iterations = 0usize;
+
+    while let Some(feature) = pending.pop_front() {
+        if resolved.contains(&feature) {
+            continue;
+        }
+        iterations += 1;
+        if iterations > MAX_ITERATIONS {
+            return Err(FeatureResolveError::CyclicDependency {
+                feature: feature.clone(),
+            });
+        }
+        resolved.insert(feature.clone());
+
+        if let Some(deps) = manifest.features.get(&feature) {
+            for spec in deps {
+                if let Some(name) = as_self_feature(spec) {
+                    if manifest.features.contains_key(name) && !resolved.contains(name) {
+                        pending.push_back(name.to_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ResolvedFeatureSet::new(resolved))
+}
+
+/// Extract a self-feature name from a feature specification string.
+///
+/// Cargo feature specs have three forms:
+/// - `"feature_name"` — enables another feature on the same crate → return `Some("feature_name")`
+/// - `"dep:optional_dep"` — activates an optional dependency → return `None` (not a feature name)
+/// - `"dep_name/feature"` — enables a feature on a dependency → return `None` (cross-crate ref)
+fn as_self_feature(spec: &str) -> Option<&str> {
+    if spec.starts_with("dep:") || spec.contains('/') {
+        None
+    } else {
+        Some(spec)
+    }
+}
+
+/// Walk workspace members and collect any features they request from the current crate.
+///
+/// This implements the feature-unification rule: if sibling crate B depends on this crate A with
+/// `features = ["extra"]`, then `extra` is included in A's resolved set when A is compiled as
+/// part of the workspace.
+fn collect_workspace_unified(
+    pending: &mut VecDeque<String>,
+    workspace_root: &Path,
+    manifest: &CargoManifest,
+) -> Result<(), FeatureResolveError> {
+    let ws_manifest_path = workspace_root.join("Cargo.toml");
+    if !ws_manifest_path.exists() {
+        return Ok(());
+    }
+
+    let ws_manifest = CargoManifest::from_path(&ws_manifest_path)?;
+    let Some(workspace) = &ws_manifest.workspace else {
+        return Ok(());
+    };
+
+    let Some(current_name) = manifest.package_name() else {
+        return Ok(());
+    };
+
+    for member_glob in &workspace.members {
+        let member_dir = workspace_root.join(member_glob);
+        if !member_dir.is_dir() {
+            continue;
+        }
+        let member_manifest_path = member_dir.join("Cargo.toml");
+        if !member_manifest_path.exists() {
+            continue;
+        }
+        // Skip members we cannot parse — they may be virtual or broken.
+        let Ok(member) = CargoManifest::from_path(&member_manifest_path) else {
+            continue;
+        };
+
+        // Skip ourselves.
+        if member.package_name() == Some(current_name) {
+            continue;
+        }
+
+        // Find any dependency entry for this crate in the member.
+        for (dep_name, dep_spec) in &member.dependencies {
+            if dep_name.as_str() == current_name {
+                if let DependencySpec::Detailed(detail) = dep_spec {
+                    for f in &detail.features {
+                        if manifest.features.contains_key(f.as_str()) {
+                            pending.push_back(f.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::manifest::{CargoManifest, PackageMetadata};
+
+    fn manifest_with_features(name: &str, features: &[(&str, &[&str])]) -> CargoManifest {
+        let mut f: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (k, vs) in features {
+            f.insert((*k).to_owned(), vs.iter().map(|s| (*s).to_owned()).collect());
+        }
+        CargoManifest {
+            package: Some(PackageMetadata {
+                name: name.to_owned(),
+                version: None,
+            }),
+            features: f,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_request_no_defaults() {
+        let m = manifest_with_features("my-crate", &[]);
+        let req = FeatureSet::default().no_default_features();
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn default_feature_expanded() {
+        let m = manifest_with_features(
+            "my-crate",
+            &[("default", &["foo"]), ("foo", &["bar"]), ("bar", &[])],
+        );
+        let req = FeatureSet::default(); // uses_default_features = true
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        let features: Vec<_> = result.iter().collect();
+        assert!(features.contains(&"default"));
+        assert!(features.contains(&"foo"));
+        assert!(features.contains(&"bar"));
+    }
+
+    #[test]
+    fn no_default_features_flag_respected() {
+        let m = manifest_with_features(
+            "my-crate",
+            &[("default", &["foo"]), ("foo", &[]), ("extra", &[])],
+        );
+        let req = FeatureSet::with_features(["extra"]).no_default_features();
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        assert!(result.features().contains("extra"));
+        assert!(!result.features().contains("foo"));
+        assert!(!result.features().contains("default"));
+    }
+
+    #[test]
+    fn dep_colon_spec_ignored() {
+        // "dep:optional_dep" should not be treated as a feature name.
+        let m = manifest_with_features(
+            "my-crate",
+            &[("default", &["dep:optional_dep"]), ("real_feature", &[])],
+        );
+        let req = FeatureSet::default();
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        assert!(result.features().contains("default"));
+        assert!(!result.features().contains("dep:optional_dep"));
+    }
+
+    #[test]
+    fn dep_slash_spec_ignored() {
+        let m = manifest_with_features(
+            "my-crate",
+            &[("default", &["some_dep/derive"]), ("real", &[])],
+        );
+        let req = FeatureSet::default();
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        assert!(result.features().contains("default"));
+        assert!(!result.features().contains("some_dep/derive"));
+    }
+
+    #[test]
+    fn unknown_feature_errors() {
+        let m = manifest_with_features("my-crate", &[("foo", &[])]);
+        let req = FeatureSet::with_features(["nonexistent"]);
+        let err = resolve(Path::new("/nonexistent"), &m, &req).unwrap_err();
+        assert!(matches!(err, FeatureResolveError::UnknownFeature { .. }));
+    }
+
+    #[test]
+    fn as_cargo_args_sorted() {
+        let m = manifest_with_features(
+            "my-crate",
+            &[("default", &["b"]), ("a", &[]), ("b", &["a"])],
+        );
+        let req = FeatureSet::default();
+        let result = resolve(Path::new("/nonexistent"), &m, &req).unwrap();
+        let args = result.as_cargo_args();
+        // BTreeSet guarantees alphabetical order.
+        assert_eq!(args, vec!["a", "b", "default"]);
+    }
+}

--- a/crates/rb-feature-resolver/src/types.rs
+++ b/crates/rb-feature-resolver/src/types.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeSet;
+
+/// The set of features explicitly requested by the caller, plus a flag for default-feature
+/// handling.
+///
+/// Build with [`FeatureSet::default`] (which enables default features) or customise via the
+/// builder methods.
+#[derive(Debug, Clone, Default)]
+pub struct FeatureSet {
+    features: BTreeSet<String>,
+    no_default_features: bool,
+}
+
+impl FeatureSet {
+    /// Request `features` in addition to (or instead of, if `no_default_features` is set) the
+    /// crate's declared defaults.
+    #[must_use]
+    pub fn with_features(features: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            features: features.into_iter().map(Into::into).collect(),
+            no_default_features: false,
+        }
+    }
+
+    /// Disable the `default` feature; only the explicitly listed features will be resolved.
+    #[must_use]
+    pub fn no_default_features(mut self) -> Self {
+        self.no_default_features = true;
+        self
+    }
+
+    /// Returns `true` if the `default` feature should be included in resolution.
+    #[must_use]
+    pub fn uses_default_features(&self) -> bool {
+        !self.no_default_features
+    }
+
+    /// The explicitly requested feature names.
+    #[must_use]
+    pub fn features(&self) -> &BTreeSet<String> {
+        &self.features
+    }
+}
+
+/// The canonical, fully-resolved set of features to pass to `cargo expand --features`.
+///
+/// All transitive feature dependencies are expanded; `default` is included when the input
+/// `FeatureSet` did not opt out.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedFeatureSet {
+    features: BTreeSet<String>,
+}
+
+impl ResolvedFeatureSet {
+    pub(crate) fn new(features: BTreeSet<String>) -> Self {
+        Self { features }
+    }
+
+    /// The resolved feature names, sorted.
+    #[must_use]
+    pub fn features(&self) -> &BTreeSet<String> {
+        &self.features
+    }
+
+    /// Iterate over resolved feature names as `&str`.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.features.iter().map(String::as_str)
+    }
+
+    /// Return the feature list as `--features` argument fragments, e.g. `["foo", "bar"]`.
+    #[must_use]
+    pub fn as_cargo_args(&self) -> Vec<&str> {
+        self.features.iter().map(String::as_str).collect()
+    }
+
+    /// Returns `true` when no features are resolved.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.features.is_empty()
+    }
+}

--- a/crates/rb-feature-resolver/tests/fixtures/manifests/basic.toml
+++ b/crates/rb-feature-resolver/tests/fixtures/manifests/basic.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fixture-basic"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["logging"]
+logging = []
+tracing = ["logging"]
+full = ["logging", "tracing", "metrics"]
+metrics = []

--- a/crates/rb-feature-resolver/tests/fixtures/manifests/no_defaults.toml
+++ b/crates/rb-feature-resolver/tests/fixtures/manifests/no_defaults.toml
@@ -1,0 +1,10 @@
+[package]
+name = "fixture-no-defaults"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+# No default feature declared; all features must be explicitly requested.
+serde-support = []
+async-support = []
+full = ["serde-support", "async-support"]

--- a/crates/rb-feature-resolver/tests/fixtures/manifests/with_optional_deps.toml
+++ b/crates/rb-feature-resolver/tests/fixtures/manifests/with_optional_deps.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fixture-optional-deps"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["json"]
+json = ["dep:serde_json"]
+xml = ["dep:quick-xml", "dep:serde"]
+derive = ["serde/derive"]
+full = ["json", "xml", "derive"]
+
+[dependencies]
+serde_json = { version = "1", optional = true }
+quick-xml = { version = "0.31", optional = true }
+serde = { version = "1", optional = true }

--- a/crates/rb-feature-resolver/tests/integration.rs
+++ b/crates/rb-feature-resolver/tests/integration.rs
@@ -1,0 +1,144 @@
+use std::path::Path;
+
+use rb_feature_resolver::{CargoManifest, FeatureSet, resolve};
+
+fn fixtures_dir() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/manifests"
+    ))
+}
+
+fn load(name: &str) -> CargoManifest {
+    CargoManifest::from_path(&fixtures_dir().join(name)).expect("fixture must parse")
+}
+
+// ── basic.toml ────────────────────────────────────────────────────────────────
+
+#[test]
+fn basic_default_features() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::default();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("default"), "default must be present");
+    assert!(resolved.features().contains("logging"), "default enables logging");
+    assert!(!resolved.features().contains("tracing"), "tracing not in default");
+    assert!(!resolved.features().contains("metrics"), "metrics not in default");
+}
+
+#[test]
+fn basic_explicit_feature() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::with_features(["tracing"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("tracing"));
+    // tracing enables logging
+    assert!(resolved.features().contains("logging"));
+    assert!(!resolved.features().contains("default"));
+    assert!(!resolved.features().contains("metrics"));
+}
+
+#[test]
+fn basic_full_feature_expands_all() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::with_features(["full"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    for f in ["full", "logging", "tracing", "metrics"] {
+        assert!(resolved.features().contains(f), "{f} should be resolved");
+    }
+}
+
+#[test]
+fn basic_no_default_features_empty_request() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::default().no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.is_empty(), "nothing should be resolved");
+}
+
+// ── no_defaults.toml ──────────────────────────────────────────────────────────
+
+#[test]
+fn no_defaults_manifest_uses_default_features_is_noop() {
+    // Manifest has no `default` feature; requesting with default features still gives nothing.
+    let manifest = load("no_defaults.toml");
+    let req = FeatureSet::default(); // uses_default_features = true
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+    assert!(resolved.is_empty());
+}
+
+#[test]
+fn no_defaults_explicit_full() {
+    let manifest = load("no_defaults.toml");
+    let req = FeatureSet::with_features(["full"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("full"));
+    assert!(resolved.features().contains("serde-support"));
+    assert!(resolved.features().contains("async-support"));
+}
+
+// ── with_optional_deps.toml ───────────────────────────────────────────────────
+
+#[test]
+fn optional_dep_activation_not_in_feature_set() {
+    // `json = ["dep:serde_json"]` — the dep: spec should not appear as a feature name.
+    let manifest = load("with_optional_deps.toml");
+    let req = FeatureSet::default(); // enables "json" via default
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("json"));
+    assert!(!resolved.features().contains("dep:serde_json"), "dep: refs must not leak");
+}
+
+#[test]
+fn cross_crate_feature_ref_not_in_feature_set() {
+    // `derive = ["serde/derive"]` — cross-crate ref should not appear as a feature name.
+    let manifest = load("with_optional_deps.toml");
+    let req = FeatureSet::with_features(["derive"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("derive"));
+    assert!(!resolved.features().contains("serde/derive"), "dep/feature refs must not leak");
+}
+
+#[test]
+fn full_feature_with_optional_deps() {
+    let manifest = load("with_optional_deps.toml");
+    let req = FeatureSet::with_features(["full"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+
+    assert!(resolved.features().contains("full"));
+    assert!(resolved.features().contains("json"));
+    assert!(resolved.features().contains("xml"));
+    assert!(resolved.features().contains("derive"));
+}
+
+// ── round-trip: cargo_args ────────────────────────────────────────────────────
+
+#[test]
+fn cargo_args_are_sorted() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::with_features(["full"]).no_default_features();
+    let resolved = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap();
+    let args = resolved.as_cargo_args();
+
+    let mut sorted = args.clone();
+    sorted.sort_unstable();
+    assert_eq!(args, sorted, "as_cargo_args must return sorted feature names");
+}
+
+// ── unknown feature error ─────────────────────────────────────────────────────
+
+#[test]
+fn unknown_feature_returns_error() {
+    let manifest = load("basic.toml");
+    let req = FeatureSet::with_features(["does-not-exist"]).no_default_features();
+    let err = resolve(Path::new("/nonexistent"), &manifest, &req).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("does-not-exist"), "error must name the unknown feature");
+}

--- a/scripts/check-rb-feature-resolver-isolation.sh
+++ b/scripts/check-rb-feature-resolver-isolation.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# REQ-LI-01: Enforce zero rb-* dependencies in rb-feature-resolver.
+#
+# rb-feature-resolver is a candidate for standalone crates.io publication; it must
+# never import from any other rb-* crate.  This script fails CI if any such
+# dependency appears in the resolved dependency graph or in the crate's Cargo.toml.
+#
+# Two checks are run:
+#
+#   Check 1 — Cargo.toml scan
+#     Reads crates/rb-feature-resolver/Cargo.toml and greps for any `rb-*` dependency
+#     name in [dependencies], [dev-dependencies], or [build-dependencies].
+#
+#   Check 2 — cargo metadata graph scan
+#     Uses `cargo metadata` to walk the resolved dep graph of rb-feature-resolver and
+#     asserts that no node id starts with "rb-" (other than rb-feature-resolver itself).
+#
+set -euo pipefail
+
+CRATE="rb-feature-resolver"
+MANIFEST="crates/${CRATE}/Cargo.toml"
+FAILED=0
+
+echo "==> [1/2] Scanning ${MANIFEST} for rb-* dependency declarations..."
+
+if grep -E '^\s*(rb-[a-z-]+)\s*=' "${MANIFEST}" 2>/dev/null | grep -qv "^#"; then
+    echo "FAIL: ${MANIFEST} declares an rb-* dependency:" >&2
+    grep -En '^\s*(rb-[a-z-]+)\s*=' "${MANIFEST}" >&2
+    FAILED=1
+else
+    echo "  PASS: no rb-* dep declarations found in ${MANIFEST}"
+fi
+
+echo ""
+echo "==> [2/2] Scanning resolved dependency graph for rb-* transitive deps..."
+
+# cargo metadata emits JSON; parse out all package names in the dep graph of our crate.
+# We use --filter-platform "" to avoid needing a target spec while still getting all deps.
+RB_DEPS=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+    | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+packages = {p['name'] for p in data.get('packages', [])}
+rb_deps = sorted(n for n in packages if n.startswith('rb-') and n != 'rb-feature-resolver')
+for n in rb_deps:
+    print(n)
+" 2>/dev/null || true)
+
+# Now check the full dep tree including transitive deps via cargo tree.
+RB_TRANSITIVE=$(cargo tree -p "${CRATE}" 2>/dev/null \
+    | grep -E '^\s*(rb-[a-z-]+)' \
+    | grep -v "^${CRATE}" \
+    | grep -v "^rb-feature-resolver" \
+    | sed 's/.*\(rb-[a-zA-Z-]*\).*/\1/' \
+    | sort -u || true)
+
+if [ -n "${RB_TRANSITIVE}" ]; then
+    echo "FAIL: rb-feature-resolver has rb-* transitive dependencies:" >&2
+    echo "${RB_TRANSITIVE}" >&2
+    FAILED=1
+else
+    echo "  PASS: zero rb-* transitive deps in rb-feature-resolver"
+fi
+
+echo ""
+if (( FAILED == 1 )); then
+    echo "rb-feature-resolver isolation check FAILED." >&2
+    exit 1
+fi
+
+echo "rb-feature-resolver isolation check PASSED"


### PR DESCRIPTION
## Summary

Adds `crates/rb-feature-resolver` — a standalone crate that resolves Cargo feature flags into a canonical feature set for `cargo expand`. This is the library dependency for the Stage 2 expand worker.

- Zero `rb-*` dependencies (CI-enforced)
- Public surface: `resolve(workspace_root, manifest, requested_features) -> ResolvedFeatureSet`
- Handles: default features, transitive expansion, `dep:optional_dep` and `dep_name/feature` specs, workspace feature unification across members
- 18 tests passing: 7 unit tests in `resolver.rs` + 11 integration tests against 3 fixture manifests
- CI `rb-feature-resolver-isolation` job implemented (was a stub before this PR)
- `cargo publish --dry-run` passes: crate is shaped for standalone publication

## GitHub Issue

Closes #157

## Checklist

- [x] All tests pass (`cargo test -p rb-feature-resolver`: 18/18)
- [x] Clippy clean (`cargo clippy -p rb-feature-resolver -- -D warnings`)
- [x] No internal Paperclip references
- [x] CI isolation job wired (`scripts/check-rb-feature-resolver-isolation.sh`)