### PR TITLE
[RUSAA-68] feat: rb-storage-neo4j — AST-based Cypher tenant label injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,25 @@ jobs:
         # Crate does not exist yet; stub ensures job slot exists in CI matrix
         run: echo "rb-feature-resolver-isolation stub — crate not yet created"
 
+  forbid-direct-neo4j-writes:
+    name: forbid-direct-neo4j-writes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject neo4rs imports outside rb-storage-neo4j
+        run: |
+          matches=$(grep -rn --include="*.rs" "neo4rs" . \
+            | grep -v "^\./crates/rb-storage-neo4j/" \
+            | grep -v "^Binary" || true)
+          if [ -n "$matches" ]; then
+            echo "ERROR: Direct neo4rs usage outside crates/rb-storage-neo4j:"
+            echo "$matches"
+            echo ""
+            echo "All Neo4j access MUST go through rb_storage_neo4j::execute() or ::run()."
+            exit 1
+          fi
+          echo "OK: no direct neo4rs imports outside rb-storage-neo4j"
+
   tenant-isolation:
     name: tenant isolation
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ members = [
     "crates/rb-sse",
     "services/migrate",
     "services/control-api",
-    "services/audit-worker",
-    "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
 ]
 
@@ -90,6 +88,8 @@ hmac = "0.12"
 subtle = "2"
 moka = { version = "0.12", features = ["future"] }
 hex = "0.4"
+# Neo4j driver (rb-storage-neo4j)
+neo4rs = "0.8"
 # Metrics facade (library crates use this; tests use metrics-util for assertions)
 metrics = "0.24"
 metrics-util = { version = "0.18", features = ["debugging"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ members = [
     "crates/rb-sse",
     "services/migrate",
     "services/control-api",
+    "services/audit-worker",
+    "crates/rb-audit-cli",
+    "crates/rb-storage-neo4j",
 ]
 
 [workspace.package]
@@ -51,7 +54,7 @@ rdkafka = { version = "0.37", features = ["cmake-build"] }
 thiserror = "2"
 anyhow = "1"
 # IDs
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 # CLI
 clap = { version = "4", features = ["derive"] }
 # Configuration / YAML

--- a/crates/rb-storage-neo4j/Cargo.toml
+++ b/crates/rb-storage-neo4j/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rb-storage-neo4j"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+neo4rs.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rb-storage-neo4j/src/error.rs
+++ b/crates/rb-storage-neo4j/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CypherError {
+    /// Query contains a bare semicolon outside a string/comment — multi-statement injection attempt.
+    #[error("multi-statement Cypher is not permitted")]
+    MultiStatement,
+
+    /// A `(` in a path-clause context was never closed.
+    #[error("unclosed node pattern: missing ')'")]
+    UnclosedNodePattern,
+
+    /// Neo4j driver error (wraps `neo4rs::Error`).
+    #[error("neo4j error: {0}")]
+    Neo4j(#[from] neo4rs::Error),
+}

--- a/crates/rb-storage-neo4j/src/injector.rs
+++ b/crates/rb-storage-neo4j/src/injector.rs
@@ -1,0 +1,544 @@
+use crate::error::CypherError;
+
+#[derive(PartialEq, Eq)]
+enum ScanState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    Backtick,
+    LineComment,
+    BlockComment,
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Keywords that put us into a path-pattern context (node patterns expected).
+fn is_path_start(upper: &str) -> bool {
+    matches!(upper, "MATCH" | "CREATE" | "MERGE")
+}
+
+/// Keywords that end the current path-pattern context.
+fn is_path_end(upper: &str) -> bool {
+    matches!(
+        upper,
+        "WHERE"
+            | "WITH"
+            | "RETURN"
+            | "SET"
+            | "REMOVE"
+            | "DELETE"
+            | "DETACH"
+            | "ORDER"
+            | "SKIP"
+            | "LIMIT"
+            | "UNION"
+            | "UNWIND"
+            | "CALL"
+            | "YIELD"
+            | "CASE"
+            | "WHEN"
+            | "THEN"
+            | "ELSE"
+            | "END"
+    )
+}
+
+/// Scans from `*i` to the matching `]`, advancing `*i` past the `]`.
+/// Handles strings inside relationship patterns so keywords within them are not misread.
+fn scan_bracket(bytes: &[u8], i: &mut usize) -> Result<String, CypherError> {
+    let mut out = String::new();
+    let mut depth: usize = 1;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while *i < bytes.len() {
+        let b = bytes[*i];
+        if in_single {
+            out.push(b as char);
+            *i += 1;
+            if b == b'\'' {
+                in_single = false;
+            }
+        } else if in_double {
+            out.push(b as char);
+            *i += 1;
+            if b == b'"' {
+                in_double = false;
+            }
+        } else {
+            match b {
+                b'\'' => {
+                    in_single = true;
+                    out.push(b as char);
+                    *i += 1;
+                }
+                b'"' => {
+                    in_double = true;
+                    out.push(b as char);
+                    *i += 1;
+                }
+                b'[' => {
+                    depth += 1;
+                    out.push(b as char);
+                    *i += 1;
+                }
+                b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        *i += 1; // consume ']'
+                        return Ok(out);
+                    }
+                    out.push(b as char);
+                    *i += 1;
+                }
+                _ => {
+                    out.push(b as char);
+                    *i += 1;
+                }
+            }
+        }
+    }
+    Ok(out) // unclosed bracket — let caller decide; not a security concern
+}
+
+/// Collects the content of a node pattern `(...)`, advancing `*i` past the closing `)`.
+///
+/// Handles strings and `{...}` property maps. Does NOT recurse on inner `(...)` because
+/// Cypher node patterns do not nest parentheses in their label/property position.
+fn collect_node_pattern(bytes: &[u8], i: &mut usize) -> Result<String, CypherError> {
+    let mut inner = String::new();
+    let mut brace_depth: usize = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while *i < bytes.len() {
+        let b = bytes[*i];
+
+        if in_single {
+            if b == b'\\' && *i + 1 < bytes.len() {
+                inner.push(b as char);
+                inner.push(bytes[*i + 1] as char);
+                *i += 2;
+            } else {
+                inner.push(b as char);
+                *i += 1;
+                if b == b'\'' {
+                    in_single = false;
+                }
+            }
+            continue;
+        }
+
+        if in_double {
+            if b == b'\\' && *i + 1 < bytes.len() {
+                inner.push(b as char);
+                inner.push(bytes[*i + 1] as char);
+                *i += 2;
+            } else {
+                inner.push(b as char);
+                *i += 1;
+                if b == b'"' {
+                    in_double = false;
+                }
+            }
+            continue;
+        }
+
+        match b {
+            b'\'' => {
+                in_single = true;
+                inner.push(b as char);
+                *i += 1;
+            }
+            b'"' => {
+                in_double = true;
+                inner.push(b as char);
+                *i += 1;
+            }
+            b'{' => {
+                brace_depth += 1;
+                inner.push(b as char);
+                *i += 1;
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                inner.push(b as char);
+                *i += 1;
+            }
+            b')' if brace_depth == 0 => {
+                *i += 1; // consume closing ')'
+                return Ok(inner);
+            }
+            _ => {
+                inner.push(b as char);
+                *i += 1;
+            }
+        }
+    }
+    Err(CypherError::UnclosedNodePattern)
+}
+
+/// Splices `:<label>` into the node-pattern interior immediately after the optional variable.
+///
+/// ```text
+/// ""           → ":Label"
+/// "n"          → "n:Label"
+/// "n:Foo"      → "n:Label:Foo"
+/// ":Foo"       → ":Label:Foo"
+/// "n {p: $v}"  → "n:Label {p: $v}"
+/// ```
+fn splice_label(inner: &str, label: &str) -> String {
+    let trimmed = inner.trim_start();
+    let leading_ws = &inner[..inner.len() - trimmed.len()];
+
+    // Find end of optional variable identifier
+    let var_end = trimmed
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(trimmed.len());
+    let var = &trimmed[..var_end];
+    let rest = &trimmed[var_end..];
+
+    format!("{leading_ws}{var}:{label}{rest}")
+}
+
+/// Rewrites `cypher` so that every node pattern in a MATCH / MERGE / CREATE / OPTIONAL MATCH
+/// clause has `:<label>` injected after the optional variable and before any existing labels.
+///
+/// Also rejects queries that contain a bare semicolon outside a string or comment, as those
+/// indicate multi-statement injection attempts.
+///
+/// # Errors
+///
+/// - [`CypherError::MultiStatement`] — semicolon found outside a string/comment.
+/// - [`CypherError::UnclosedNodePattern`] — `(` in a path clause was never closed.
+pub fn inject_tenant_label(cypher: &str, label: &str) -> Result<String, CypherError> {
+    let bytes = cypher.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    let mut out = String::with_capacity(cypher.len() + label.len() * 4);
+    let mut state = ScanState::Normal;
+
+    // Whether the most recent non-whitespace content was a bare identifier character.
+    // A `(` that follows an identifier is a function call, not a node pattern.
+    let mut last_was_ident = false;
+
+    // Whether the scanner is inside a MATCH/CREATE/MERGE path clause.
+    let mut in_path_clause = false;
+
+    while i < len {
+        let b = bytes[i];
+
+        match state {
+            ScanState::SingleQuote => {
+                if b == b'\\' && i + 1 < len {
+                    out.push(b as char);
+                    out.push(bytes[i + 1] as char);
+                    i += 2;
+                } else {
+                    out.push(b as char);
+                    i += 1;
+                    if b == b'\'' {
+                        state = ScanState::Normal;
+                        last_was_ident = false;
+                    }
+                }
+            }
+
+            ScanState::DoubleQuote => {
+                if b == b'\\' && i + 1 < len {
+                    out.push(b as char);
+                    out.push(bytes[i + 1] as char);
+                    i += 2;
+                } else {
+                    out.push(b as char);
+                    i += 1;
+                    if b == b'"' {
+                        state = ScanState::Normal;
+                        last_was_ident = false;
+                    }
+                }
+            }
+
+            ScanState::Backtick => {
+                out.push(b as char);
+                i += 1;
+                if b == b'`' {
+                    state = ScanState::Normal;
+                    last_was_ident = true; // backtick-quoted identifier
+                }
+            }
+
+            ScanState::LineComment => {
+                out.push(b as char);
+                i += 1;
+                if b == b'\n' {
+                    state = ScanState::Normal;
+                }
+            }
+
+            ScanState::BlockComment => {
+                out.push(b as char);
+                i += 1;
+                if b == b'*' && i < len && bytes[i] == b'/' {
+                    out.push('/');
+                    i += 1;
+                    state = ScanState::Normal;
+                }
+            }
+
+            ScanState::Normal => {
+                // String starters
+                if b == b'\'' {
+                    state = ScanState::SingleQuote;
+                    out.push(b as char);
+                    i += 1;
+                    last_was_ident = false;
+                    continue;
+                }
+                if b == b'"' {
+                    state = ScanState::DoubleQuote;
+                    out.push(b as char);
+                    i += 1;
+                    last_was_ident = false;
+                    continue;
+                }
+                if b == b'`' {
+                    state = ScanState::Backtick;
+                    out.push(b as char);
+                    i += 1;
+                    continue;
+                }
+
+                // Comments
+                if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+                    state = ScanState::LineComment;
+                    out.push('/');
+                    out.push('/');
+                    i += 2;
+                    continue;
+                }
+                if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+                    state = ScanState::BlockComment;
+                    out.push('/');
+                    out.push('*');
+                    i += 2;
+                    continue;
+                }
+
+                // Reject multi-statement injection
+                if b == b';' {
+                    return Err(CypherError::MultiStatement);
+                }
+
+                // Relationship bracket — scan without keyword processing to prevent
+                // relationship type names (e.g. `:WHERE`) from exiting path context.
+                if b == b'[' {
+                    i += 1;
+                    let content = scan_bracket(bytes, &mut i)?;
+                    out.push('[');
+                    out.push_str(&content);
+                    out.push(']');
+                    last_was_ident = false;
+                    continue;
+                }
+
+                // Identifier / keyword
+                if is_ident_char(b) {
+                    let word_start = i;
+                    while i < len && is_ident_char(bytes[i]) {
+                        i += 1;
+                    }
+                    let word = &cypher[word_start..i];
+                    let upper = word.to_ascii_uppercase();
+
+                    if is_path_start(&upper) {
+                        in_path_clause = true;
+                        // Allow `MATCH(n)` (no space) — keyword itself is not an identifier
+                        // for the purpose of distinguishing function calls.
+                        last_was_ident = false;
+                    } else if is_path_end(&upper) {
+                        in_path_clause = false;
+                        last_was_ident = true;
+                    } else {
+                        last_was_ident = true;
+                    }
+                    out.push_str(word);
+                    continue;
+                }
+
+                // Node pattern: `(` in path context NOT preceded by a bare identifier
+                if b == b'(' && in_path_clause && !last_was_ident {
+                    i += 1;
+                    let inner = collect_node_pattern(bytes, &mut i)?;
+                    let patched = splice_label(&inner, label);
+                    out.push('(');
+                    out.push_str(&patched);
+                    out.push(')');
+                    last_was_ident = false;
+                    continue;
+                }
+
+                // Whitespace does not change last_was_ident
+                if !b.is_ascii_whitespace() {
+                    last_was_ident = false;
+                }
+                out.push(b as char);
+                i += 1;
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LBL: &str = "Tenant_aabbcc112233445566778899";
+
+    fn inj(s: &str) -> String {
+        inject_tenant_label(s, LBL).expect("should not fail")
+    }
+
+    #[test]
+    fn rejects_semicolon() {
+        assert!(matches!(
+            inject_tenant_label("MATCH (n) RETURN n; DROP ALL", LBL),
+            Err(CypherError::MultiStatement)
+        ));
+    }
+
+    #[test]
+    fn injects_simple_match() {
+        let out = inj("MATCH (n) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn injects_with_existing_label() {
+        let out = inj("MATCH (n:Person) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL}:Person)")), "got: {out}");
+    }
+
+    #[test]
+    fn injects_anonymous_node() {
+        let out = inj("MATCH ()-[r]->(n:Foo) RETURN n");
+        assert!(out.contains(&format!("(:{LBL})")), "got: {out}");
+        assert!(out.contains(&format!("(n:{LBL}:Foo)")), "got: {out}");
+    }
+
+    #[test]
+    fn injects_create() {
+        let out = inj("CREATE (n:Person {name: $name})");
+        assert!(out.contains(&format!("(n:{LBL}:Person")), "got: {out}");
+    }
+
+    #[test]
+    fn injects_merge() {
+        let out = inj("MERGE (n:Foo {id: $id})");
+        assert!(out.contains(&format!("(n:{LBL}:Foo")), "got: {out}");
+    }
+
+    #[test]
+    fn injects_optional_match() {
+        let out = inj("OPTIONAL MATCH (n:Bar) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL}:Bar)")), "got: {out}");
+    }
+
+    #[test]
+    fn does_not_inject_function_call() {
+        let out = inj("MATCH (n) RETURN count(n)");
+        // count(n) must remain unchanged
+        assert!(out.contains("count(n)"), "got: {out}");
+    }
+
+    #[test]
+    fn does_not_inject_in_where_paren_expr() {
+        // RETURN (expr) — last token before ( is RETURN keyword, which is a path-ender
+        // so in_path_clause is false; no injection
+        let out = inj("MATCH (n) WHERE (n.age > 18) RETURN n");
+        // (n.age > 18) should NOT be injected
+        assert!(!out.contains(&format!("({LBL}")), "got: {out}");
+        // The MATCH node should be injected
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn semicolon_in_string_is_ok() {
+        let out = inj("MATCH (n) WHERE n.name = ';' RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn match_keyword_no_space() {
+        let out = inj("MATCH(n) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn path_with_multiple_nodes() {
+        let out = inj("MATCH (a)-[r]->(b) RETURN a, b");
+        assert!(out.contains(&format!("(a:{LBL})")), "got: {out}");
+        assert!(out.contains(&format!("(b:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn relationship_type_name_where_does_not_break_path_clause() {
+        // `:WHERE` as a relationship type name must not end path clause context
+        let out = inj("MATCH (a)-[r:WHERE]->(b) RETURN a, b");
+        assert!(out.contains(&format!("(a:{LBL})")), "got: {out}");
+        assert!(out.contains(&format!("(b:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn block_comment_does_not_trigger_keyword() {
+        let out = inj("MATCH /* RETURN */ (n) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn line_comment_does_not_trigger_keyword() {
+        let out = inj("MATCH (n) // RETURN\n RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn keyword_in_string_does_not_affect_state() {
+        let out = inj("MATCH (n) WHERE n.name = 'RETURN WHERE' RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn node_with_no_variable() {
+        let out = inj("MATCH (:Person) RETURN 1");
+        assert!(out.contains(&format!("(:{LBL}:Person)")), "got: {out}");
+    }
+
+    #[test]
+    fn empty_node_pattern() {
+        let out = inj("MATCH () RETURN 1");
+        assert!(out.contains(&format!("(:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn preserves_properties() {
+        let out = inj("MATCH (n:Foo {name: $n, age: $a}) RETURN n");
+        assert!(out.contains(&format!("(n:{LBL}:Foo {{name: $n, age: $a}})")), "got: {out}");
+    }
+
+    #[test]
+    fn semicolon_in_block_comment_rejected() {
+        // Semicolon outside string/comment is rejected; inside block comment is allowed...
+        // wait, actually the semicolon is INSIDE the block comment here, so should NOT be rejected.
+        let out = inj("MATCH (n) /* ; */ RETURN n");
+        assert!(out.contains(&format!("(n:{LBL})")), "got: {out}");
+    }
+
+    #[test]
+    fn semicolon_after_comment_rejected() {
+        let r = inject_tenant_label("MATCH (n) /* comment */ ; RETURN n", LBL);
+        assert!(matches!(r, Err(CypherError::MultiStatement)));
+    }
+}

--- a/crates/rb-storage-neo4j/src/label.rs
+++ b/crates/rb-storage-neo4j/src/label.rs
@@ -9,7 +9,8 @@ use rb_schemas::TenantId;
 /// schema-name derivation in `rb-tenant::TenantCtx`.
 #[must_use]
 pub fn tenant_label(tenant_id: &TenantId) -> String {
-    let bytes = tenant_id.as_uuid().as_bytes();
+    let uuid = tenant_id.as_uuid();
+    let bytes = uuid.as_bytes();
     let mut hex = String::with_capacity(24);
     for b in &bytes[4..] {
         use std::fmt::Write as _;

--- a/crates/rb-storage-neo4j/src/label.rs
+++ b/crates/rb-storage-neo4j/src/label.rs
@@ -1,0 +1,57 @@
+use rb_schemas::TenantId;
+
+/// Derives the Neo4j tenant label for `tenant_id`.
+///
+/// Format: `Tenant_<24 lowercase hex chars>` — identical derivation to `rb-tenant`'s schema
+/// name but with a capital-T prefix (Neo4j label convention).
+///
+/// The 24 hex chars come from bytes 4..16 of the UUID (lower 96 bits), matching the
+/// schema-name derivation in `rb-tenant::TenantCtx`.
+#[must_use]
+pub fn tenant_label(tenant_id: &TenantId) -> String {
+    let bytes = tenant_id.as_uuid().as_bytes();
+    let mut hex = String::with_capacity(24);
+    for b in &bytes[4..] {
+        use std::fmt::Write as _;
+        write!(hex, "{b:02x}").expect("infallible write to String");
+    }
+    format!("Tenant_{hex}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_schemas::TenantId;
+
+    #[test]
+    fn label_starts_with_tenant_prefix() {
+        let label = tenant_label(&TenantId::new());
+        assert!(label.starts_with("Tenant_"));
+    }
+
+    #[test]
+    fn label_has_correct_length() {
+        let label = tenant_label(&TenantId::new());
+        // "Tenant_" (7) + 24 hex = 31 chars
+        assert_eq!(label.len(), 31);
+    }
+
+    #[test]
+    fn label_is_valid_neo4j_identifier() {
+        let label = tenant_label(&TenantId::new());
+        assert!(label.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
+    }
+
+    #[test]
+    fn label_is_deterministic() {
+        let id = TenantId::new();
+        assert_eq!(tenant_label(&id), tenant_label(&id));
+    }
+
+    #[test]
+    fn different_tenants_have_different_labels() {
+        let l1 = tenant_label(&TenantId::new());
+        let l2 = tenant_label(&TenantId::new());
+        assert_ne!(l1, l2);
+    }
+}

--- a/crates/rb-storage-neo4j/src/lib.rs
+++ b/crates/rb-storage-neo4j/src/lib.rs
@@ -1,0 +1,74 @@
+//! `rb-storage-neo4j` — the **only** approved Neo4j write path for the platform.
+//!
+//! All callers MUST use [`execute`] or [`run`] instead of `neo4rs::Graph` directly.
+//! The CI job `forbid-direct-neo4j-writes` enforces this at build time.
+
+mod error;
+mod injector;
+mod label;
+
+pub use error::CypherError;
+pub use injector::inject_tenant_label;
+
+use rb_schemas::TenantId;
+use std::collections::HashMap;
+
+/// Neo4j query parameters. Keys are parameter names (without the leading `$`).
+pub type Params = HashMap<String, neo4rs::BoltType>;
+
+/// Result type for this crate.
+pub type Result<T> = std::result::Result<T, CypherError>;
+
+/// Executes `cypher` against `graph` with tenant-label isolation enforced.
+///
+/// Before execution:
+/// 1. Rejects multi-statement Cypher (bare `;`) with [`CypherError::MultiStatement`].
+/// 2. Injects the tenant label onto every node pattern in
+///    `MATCH` / `MERGE` / `CREATE` / `OPTIONAL MATCH` clauses.
+///
+/// # Errors
+///
+/// - [`CypherError::MultiStatement`]
+/// - [`CypherError::UnclosedNodePattern`]
+/// - [`CypherError::Neo4j`]
+pub async fn execute(
+    graph: &neo4rs::Graph,
+    cypher: &str,
+    tenant: &TenantId,
+    params: Params,
+) -> Result<Vec<neo4rs::Row>> {
+    let lbl = label::tenant_label(tenant);
+    let safe_cypher = inject_tenant_label(cypher, &lbl)?;
+    let q = params
+        .into_iter()
+        .fold(neo4rs::query(&safe_cypher), |q, (k, v)| q.param(&k, v));
+    let mut stream = graph.execute(q).await.map_err(CypherError::Neo4j)?;
+    let mut rows = Vec::new();
+    loop {
+        match stream.next().await {
+            Ok(Some(row)) => rows.push(row),
+            Ok(None) => break,
+            Err(e) => return Err(CypherError::Neo4j(e)),
+        }
+    }
+    Ok(rows)
+}
+
+/// Fire-and-forget variant of [`execute`] for writes that return no rows.
+///
+/// # Errors
+///
+/// Same as [`execute`].
+pub async fn run(
+    graph: &neo4rs::Graph,
+    cypher: &str,
+    tenant: &TenantId,
+    params: Params,
+) -> Result<()> {
+    let lbl = label::tenant_label(tenant);
+    let safe_cypher = inject_tenant_label(cypher, &lbl)?;
+    let q = params
+        .into_iter()
+        .fold(neo4rs::query(&safe_cypher), |q, (k, v)| q.param(&k, v));
+    Ok(graph.run(q).await?)
+}

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/001.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/001.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; DROP ALL

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/002.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/002.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n;

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/003.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/003.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Person); MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/004.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/004.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Foo {id: $id}); RETURN 1

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/005.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/005.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n ;

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/006.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/006.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n;;

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/007.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/007.cypher
@@ -1,0 +1,1 @@
+MATCH (n) /* comment */ RETURN n; DROP ALL

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/008.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/008.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/009.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/009.cypher
@@ -1,0 +1,1 @@
+CREATE (a:Foo {name: 'Alice'}); MATCH (b) RETURN b

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/010.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/010.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Person {id: 1}) RETURN n; MATCH (admin:Admin) RETURN admin.password

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/011.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/011.cypher
@@ -1,0 +1,1 @@
+; MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/012.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/012.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.name;

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/013.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/013.cypher
@@ -1,0 +1,1 @@
+OPTIONAL MATCH (n) RETURN n; CALL db.schema.visualization()

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/014.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/014.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Node {id: $id}) ON CREATE SET n.created = timestamp(); RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/015.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/015.cypher
@@ -1,0 +1,1 @@
+MATCH (n) DELETE n; MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/016.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/016.cypher
@@ -1,0 +1,1 @@
+MATCH (n) DETACH DELETE n; CREATE (a:Foo)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/017.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/017.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.password; MATCH (m:Admin) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/018.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/018.cypher
@@ -1,0 +1,1 @@
+CREATE INDEX ON :Person(name); MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/019.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/019.cypher
@@ -1,0 +1,1 @@
+MATCH (n) SET n.leaked = true; RETURN 1

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/020.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/020.cypher
@@ -1,0 +1,1 @@
+MATCH (n:User {id: $id}) RETURN n; CALL apoc.cypher.doIt('MATCH (m) DELETE m')

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/021.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/021.cypher
@@ -1,0 +1,3 @@
+MATCH (n) RETURN n
+;
+MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/022.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/022.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n;/* comment */MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/023.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/023.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Foo) WHERE n.id = $id RETURN n; MATCH (secret:Secret) RETURN secret

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/024.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/024.cypher
@@ -1,0 +1,1 @@
+WITH 1 AS x; MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/025.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/025.cypher
@@ -1,0 +1,1 @@
+UNWIND [1,2,3] AS x; MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/026.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/026.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN count(n); MATCH (m:Privileged) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/027.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/027.cypher
@@ -1,0 +1,1 @@
+MATCH (n)-[r]->(m) RETURN n; MATCH (admin:Admin) RETURN admin

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/028.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/028.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Foo); MERGE (m:Bar)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/029.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/029.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.name; MATCH (n) RETURN n.secret

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/030.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/030.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.x = 1 RETURN n; RETURN 1

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/031.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/031.cypher
@@ -1,0 +1,2 @@
+MATCH (n) RETURN n;
+MATCH (m) RETURN m;

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/032.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/032.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; -- sql style comment attempt

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/033.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/033.cypher
@@ -1,0 +1,1 @@
+CREATE (:Foo);CREATE (:Bar)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/034.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/034.cypher
@@ -1,0 +1,1 @@
+MATCH (n:A), (m:B) RETURN n, m; MATCH (x:C) RETURN x

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/035.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/035.cypher
@@ -1,0 +1,2 @@
+MATCH (n) RETURN n
+;MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/036.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/036.cypher
@@ -1,0 +1,2 @@
+MATCH (n) // inline comment
+RETURN n; MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/037.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/037.cypher
@@ -1,0 +1,1 @@
+CALL db.labels(); MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/038.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/038.cypher
@@ -1,0 +1,1 @@
+CALL db.labels(); RETURN 1

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/039.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/039.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name = $name RETURN n; MATCH (m) WHERE m.name = 'admin' RETURN m.secret

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/040.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/040.cypher
@@ -1,0 +1,2 @@
+MATCH (n) RETURN n.id;
+MATCH (m:System) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/041.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/041.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Node {id: $id}); MATCH (all) RETURN all

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/042.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/042.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.active = true RETURN n; MATCH (n) SET n.active = false

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/043.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/043.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Person) RETURN n.email; MATCH (n:Person) SET n.password = $p

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/044.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/044.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; MATCH (n) REMOVE n.secret

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/045.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/045.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; CALL apoc.export.csv.all('data.csv', {})

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/046.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/046.cypher
@@ -1,0 +1,2 @@
+MATCH (n) RETURN n
+; MATCH (m) DETACH DELETE m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/047.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/047.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n;MATCH (m) RETURN m;MATCH (k) RETURN k

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/048.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/048.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n ;MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/049.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/049.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Foo {x: $x}) ON MATCH SET n.y = $y; RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/050.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/050.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.data; MATCH (n) WHERE id(n) = 0 RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/051.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/051.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Backdoor {admin: true}); MATCH (m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/052.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/reject/052.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n; CALL apoc.schema.assert({},{},true)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/001.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/001.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/002.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/002.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Person) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/003.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/003.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Person {name: $name}) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/004.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/004.cypher
@@ -1,0 +1,1 @@
+OPTIONAL MATCH (n:Foo) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/005.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/005.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Person {name: $name})

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/006.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/006.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Foo {id: $id})

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/007.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/007.cypher
@@ -1,0 +1,1 @@
+MATCH (a)-[r]->(b) RETURN a, r, b

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/008.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/008.cypher
@@ -1,0 +1,1 @@
+MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a, b

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/009.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/009.cypher
@@ -1,0 +1,1 @@
+MATCH (n)-[*1..5]->(m) RETURN n, m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/010.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/010.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name = ';' RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/011.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/011.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name = 'MATCH CREATE MERGE' RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/012.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/012.cypher
@@ -1,0 +1,2 @@
+MATCH (n) // comment
+RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/013.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/013.cypher
@@ -1,0 +1,1 @@
+MATCH /* block comment */ (n) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/014.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/014.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Foo {prop: 'value with ) paren'}) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/015.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/015.cypher
@@ -1,0 +1,1 @@
+MATCH ()-[r]->(n:Target) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/016.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/016.cypher
@@ -1,0 +1,1 @@
+MATCH (:Source)-[r]->(:Target) RETURN r

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/017.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/017.cypher
@@ -1,0 +1,1 @@
+MATCH (n:A), (m:B) RETURN n, m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/018.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/018.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.active = true RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/019.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/019.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Node {id: $id, name: $name, created: $ts})

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/020.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/020.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Entity {id: $id}) ON CREATE SET n.name = $name ON MATCH SET n.updated = $ts

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/021.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/021.cypher
@@ -1,0 +1,1 @@
+MATCH (n:User {id: $id}) SET n.lastSeen = $ts RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/022.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/022.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Secret) RETURN n.password

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/023.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/023.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Admin) RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/024.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/024.cypher
@@ -1,0 +1,1 @@
+MATCH (all) RETURN all

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/025.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/025.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.creditCard

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/026.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/026.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.ssn

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/027.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/027.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.apiKey

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/028.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/028.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN n.password

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/029.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/029.cypher
@@ -1,0 +1,1 @@
+MATCH (n)-[:KNOWS*]->(m) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/030.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/030.cypher
@@ -1,0 +1,1 @@
+MATCH p=(n)-[r*1..3]-(m) RETURN p

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/031.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/031.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Person) WHERE n.age > 18 RETURN n ORDER BY n.name SKIP 0 LIMIT 10

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/032.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/032.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WITH n ORDER BY n.created DESC LIMIT 100 RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/033.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/033.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name =~ '.*admin.*' RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/034.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/034.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.email STARTS WITH 'admin' RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/035.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/035.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Source)-[r:RELATES_TO]->(m:Destination) RETURN n, r, m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/036.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/036.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Foo)-[:EDGE]->(m:Bar)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/037.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/037.cypher
@@ -1,0 +1,1 @@
+MERGE (a:Node {id: $a}) MERGE (b:Node {id: $b}) CREATE (a)-[:LINK]->(b)

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/038.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/038.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Code {sha: $sha}) RETURN n.content

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/039.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/039.cypher
@@ -1,0 +1,1 @@
+MATCH (n:File)-[:DEFINES]->(s:Symbol {name: $name}) RETURN n, s

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/040.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/040.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.token = $token RETURN n.userId

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/041.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/041.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name = "double-quoted; injection attempt" RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/042.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/042.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.data = `backtick-string-attempt` RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/043.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/043.cypher
@@ -1,0 +1,1 @@
+MATCH (n:A {x: 1}), (m:B {y: 2}), (k:C {z: 3}) RETURN n, m, k

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/044.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/044.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.x IN [1, 2, 3] RETURN n

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/045.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/045.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Repo {id: $repo_id})-[:HAS_FILE]->(f:File) RETURN f

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/046.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/046.cypher
@@ -1,0 +1,1 @@
+MATCH (n) RETURN count(n), collect(n.name) AS names

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/047.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/047.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Symbol)-[:CALLS*1..10]->(m:Symbol) WHERE n.id = $id RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/048.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/048.cypher
@@ -1,0 +1,1 @@
+CREATE (n:FileNode {path: $path, content: $content, sha: $sha})

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/049.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/049.cypher
@@ -1,0 +1,1 @@
+MERGE (n:Tenant {id: $id}) ON CREATE SET n.createdAt = $ts

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/050.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/050.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE n.name = $name RETURN n UNION MATCH (m:Alias {name: $name}) RETURN m

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/051.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/051.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Module)-[r:IMPORTS]->(m:Module) RETURN n.name, m.name

--- a/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/052.cypher
+++ b/crates/rb-storage-neo4j/tests/fixtures/cypher_attacks/sanitize/052.cypher
@@ -1,0 +1,1 @@
+MATCH (n) WHERE id(n) = $nid RETURN n

--- a/crates/rb-storage-neo4j/tests/injection_corpus.rs
+++ b/crates/rb-storage-neo4j/tests/injection_corpus.rs
@@ -1,0 +1,64 @@
+/// Runs the 100+ Cypher injection attack corpus.
+///
+/// `reject/` — multi-statement attacks that must return `CypherError::MultiStatement`.
+/// `sanitize/` — cross-tenant access patterns that must be sanitized (tenant label injected).
+use rb_storage_neo4j::{inject_tenant_label, CypherError};
+
+const LABEL: &str = "Tenant_aabbcc112233445566778899";
+const MIN_PER_DIR: usize = 50;
+
+fn run_dir(dir: &str, should_reject: bool) {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let path = format!("{manifest}/tests/fixtures/cypher_attacks/{dir}");
+    let mut count = 0usize;
+
+    let entries = std::fs::read_dir(&path)
+        .unwrap_or_else(|e| panic!("cannot read corpus dir {path}: {e}"));
+
+    for entry in entries {
+        let entry = entry.expect("dir entry");
+        let fpath = entry.path();
+        if fpath.extension().and_then(|e| e.to_str()) != Some("cypher") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&fpath)
+            .unwrap_or_else(|e| panic!("cannot read {fpath:?}: {e}"));
+        let result = inject_tenant_label(&content, LABEL);
+
+        if should_reject {
+            assert!(
+                result.is_err(),
+                "corpus/{dir}/{} — expected CypherError, got Ok:\n{content}",
+                fpath.file_name().unwrap().to_string_lossy(),
+            );
+        } else {
+            let injected = result.unwrap_or_else(|e| {
+                panic!(
+                    "corpus/{dir}/{} — expected Ok, got Err({e}):\n{content}",
+                    fpath.file_name().unwrap().to_string_lossy()
+                )
+            });
+            assert!(
+                injected.contains(LABEL),
+                "corpus/{dir}/{} — tenant label not in output.\nInput:  {content}\nOutput: {injected}",
+                fpath.file_name().unwrap().to_string_lossy(),
+            );
+        }
+        count += 1;
+    }
+
+    assert!(
+        count >= MIN_PER_DIR,
+        "corpus/{dir} has only {count} fixtures — expected ≥{MIN_PER_DIR}"
+    );
+}
+
+#[test]
+fn corpus_reject() {
+    run_dir("reject", true);
+}
+
+#[test]
+fn corpus_sanitize() {
+    run_dir("sanitize", false);
+}


### PR DESCRIPTION
## Summary

- New crate `crates/rb-storage-neo4j`: the only approved Neo4j write path for the platform
- Hand-rolled Cypher scanner that rejects multi-statement queries and injects tenant label on all MATCH/MERGE/CREATE/OPTIONAL MATCH node patterns
- 104-fixture injection attack corpus (52 multi-statement reject + 52 cross-tenant sanitize)
- `forbid-direct-neo4j-writes` CI job enforces that no other crate imports `neo4rs` directly

## Security Impact

**Threat mitigated:** Cross-tenant data access via unfiltered Cypher queries. Without this crate, a `MATCH (n) RETURN n` would return nodes across all tenants. The injector rewrites it to `MATCH (n:Tenant_xxx) RETURN n`.

**Remains open:** Cypher 5 label-union syntax (`n:Foo|Bar`) and existential subqueries (`WHERE EXISTS { MATCH ... }`) are out of scope for v1 — documented as known limitations.

**CI enforcement:** `forbid-direct-neo4j-writes` job fails any PR where `*.rs` outside `crates/rb-storage-neo4j/` imports `neo4rs`.

Closes #160

## Test plan

- [ ] `cargo test -p rb-storage-neo4j` — unit tests in `injector.rs` + corpus tests (104 fixtures)
- [ ] `cargo clippy -p rb-storage-neo4j` — no warnings
- [ ] CI `forbid-direct-neo4j-writes` job passes
- [ ] CI `public-surface` lint passes (private `mod` + explicit `pub use`)