### PR TITLE
[REQ-IN-01] fix: AC5 (503 on broker unavailable) + AC6 (no orphan rows on Kafka failure)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "rb-storage-pg",
  "rb-tenant",
  "rb-tracing",
+ "rdkafka",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/rb-kafka/src/errors.rs
+++ b/crates/rb-kafka/src/errors.rs
@@ -46,4 +46,27 @@ impl KafkaError {
                 | KafkaError::InvalidTraceparent(_)
         )
     }
+
+    /// Returns true when the error indicates the Kafka broker cluster is
+    /// unreachable or not yet available (librdkafka lazy-connect scenarios).
+    /// Callers should surface this as HTTP 503, not 500.
+    #[must_use]
+    pub fn is_broker_unavailable(&self) -> bool {
+        use rdkafka::error::RDKafkaErrorCode;
+        let KafkaError::Rdkafka(inner) = self else {
+            return false;
+        };
+        matches!(
+            inner.rdkafka_error_code(),
+            Some(
+                RDKafkaErrorCode::AllBrokersDown
+                    | RDKafkaErrorCode::BrokerNotAvailable
+                    | RDKafkaErrorCode::LeaderNotAvailable
+                    | RDKafkaErrorCode::MessageTimedOut
+                    | RDKafkaErrorCode::NetworkException
+                    | RDKafkaErrorCode::OperationTimedOut
+                    | RDKafkaErrorCode::RequestTimedOut
+            )
+        )
+    }
 }

--- a/crates/rb-kafka/src/producer.rs
+++ b/crates/rb-kafka/src/producer.rs
@@ -49,6 +49,23 @@ impl<E: ProstMessage> Producer<E> {
         })
     }
 
+    /// Probe broker connectivity by fetching cluster metadata with a short timeout.
+    ///
+    /// Returns `true` if at least one broker acknowledges within `timeout`.
+    /// Call this before touching the database so a bad bootstrap-server config
+    /// surfaces as 503 rather than a 500 after a 30-second delivery timeout.
+    pub async fn check_ready(&self, timeout: Duration) -> bool {
+        let inner = self.inner.clone();
+        tokio::task::spawn_blocking(move || {
+            // Bring rdkafka's Producer trait into scope for `client()`.
+            // `as _` avoids naming it (no conflict with our Producer<E> struct).
+            use rdkafka::producer::Producer as _;
+            inner.client().fetch_metadata(None, timeout).is_ok()
+        })
+        .await
+        .unwrap_or(false)
+    }
+
     pub async fn publish(
         &self,
         topic: &str,

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -411,6 +411,31 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/repos/{repo_id}/ingestions": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Trigger a manual ingestion run for a connected repository.
+         * @description Creates an `ingestion_runs` row (status `queued`) and one
+         *     `pipeline_stage_runs` row per stage (status `pending`), then publishes an
+         *     `IngestRequest` to `rb.ingest.clone.commands`.
+         *
+         *     Returns 409 if an ingestion is already queued or running for this repo.
+         *     Returns 503 if the Kafka producer is unavailable.
+         */
+        readonly post: operations["trigger_ingestion"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/tenants/{id}/members": {
         readonly parameters: {
             readonly query?: never;
@@ -753,6 +778,22 @@ export interface components {
             /** Format: uuid */
             readonly run_id: string;
             readonly status: string;
+        };
+        readonly TriggerIngestionRequest: {
+            /**
+             * @description Target branch name. Optional; clone stage falls back to the repo's
+             *     `default_branch` when both `commit_sha` and `branch` are absent.
+             */
+            readonly branch?: string | null;
+            /**
+             * @description Target commit SHA. Optional; if omitted the clone stage resolves the
+             *     branch HEAD.
+             */
+            readonly commit_sha?: string | null;
+        };
+        readonly TriggerIngestionResponse: {
+            /** Format: uuid */
+            readonly ingest_run_id: string;
         };
         readonly UpdateRoleRequest: {
             /** @description Target role: `member` or `admin`. Cannot set `owner` via this endpoint. */
@@ -1557,6 +1598,68 @@ export interface operations {
             };
             /** @description Ingestion run already in-flight (ingest_run_already_in_flight) */
             readonly 409: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly trigger_ingestion: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Repository UUID */
+                readonly repo_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["TriggerIngestionRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Ingestion run queued */
+            readonly 202: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["TriggerIngestionResponse"];
+                };
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Repository not found or belongs to another tenant */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Ingestion already in-flight (ingest_run_already_in_flight) */
+            readonly 409: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Kafka producer not available (kafka_not_configured, kafka_unavailable) */
+            readonly 503: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -793,6 +793,65 @@
         }
       }
     },
+    "/v1/repos/{repo_id}/ingestions": {
+      "post": {
+        "tags": [
+          "ingestions"
+        ],
+        "summary": "Trigger a manual ingestion run for a connected repository.",
+        "description": "Creates an `ingestion_runs` row (status `queued`) and one\n`pipeline_stage_runs` row per stage (status `pending`), then publishes an\n`IngestRequest` to `rb.ingest.clone.commands`.\n\nReturns 409 if an ingestion is already queued or running for this repo.\nReturns 503 if the Kafka producer is unavailable.",
+        "operationId": "trigger_ingestion",
+        "parameters": [
+          {
+            "name": "repo_id",
+            "in": "path",
+            "description": "Repository UUID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerIngestionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Ingestion run queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerIngestionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified"
+          },
+          "404": {
+            "description": "Repository not found or belongs to another tenant"
+          },
+          "409": {
+            "description": "Ingestion already in-flight (ingest_run_already_in_flight)"
+          },
+          "503": {
+            "description": "Kafka producer not available (kafka_not_configured, kafka_unavailable)"
+          }
+        }
+      }
+    },
     "/v1/tenants/{id}/members": {
       "get": {
         "tags": [
@@ -1799,6 +1858,37 @@
           }
         }
       },
+      "TriggerIngestionRequest": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target branch name. Optional; clone stage falls back to the repo's\n`default_branch` when both `commit_sha` and `branch` are absent."
+          },
+          "commit_sha": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target commit SHA. Optional; if omitted the clone stage resolves the\nbranch HEAD."
+          }
+        }
+      },
+      "TriggerIngestionResponse": {
+        "type": "object",
+        "required": [
+          "ingest_run_id"
+        ],
+        "properties": {
+          "ingest_run_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "UpdateRoleRequest": {
         "type": "object",
         "required": [
@@ -1903,6 +1993,10 @@
     {
       "name": "repos",
       "description": "Connected repository management"
+    },
+    {
+      "name": "ingestions",
+      "description": "Manual ingestion trigger and run management"
     }
   ]
 }

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -61,6 +61,8 @@ http-body-util = "0.1"
 hmac.workspace = true
 sha2.workspace = true
 hex.workspace = true
+# Construct rdkafka error variants in unit tests (e.g. AllBrokersDown → 503).
+rdkafka.workspace = true
 
 [lints]
 workspace = true

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -56,6 +56,8 @@ pub enum AppError {
     IngestRunAlreadyInFlight,
     #[error("Kafka producer is not configured on this instance")]
     KafkaNotConfigured,
+    #[error("Kafka brokers are not reachable")]
+    KafkaUnavailable,
     #[error("failed to publish ingestion event to Kafka: {0}")]
     KafkaPublish(#[from] KafkaError),
     #[error("database error: {0}")]
@@ -129,6 +131,11 @@ impl IntoResponse for AppError {
             AppError::KafkaNotConfigured => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "kafka_not_configured",
+                self.to_string(),
+            ),
+            AppError::KafkaUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "kafka_unavailable",
                 self.to_string(),
             ),
             AppError::KafkaPublish(e) if e.is_broker_unavailable() => (

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -131,6 +131,11 @@ impl IntoResponse for AppError {
                 "kafka_not_configured",
                 self.to_string(),
             ),
+            AppError::KafkaPublish(e) if e.is_broker_unavailable() => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "kafka_unavailable",
+                "Kafka broker is not available; try again later".to_owned(),
+            ),
             AppError::KafkaPublish(e) => {
                 tracing::error!(error = %e, "kafka publish error");
                 (

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -5,7 +5,7 @@
 
 use utoipa::OpenApi;
 
-use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, health, me, repos, tenants};
+use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, health, ingest, me, repos, tenants};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -36,6 +36,7 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
         repos::connect_repo,
         repos::list_repos,
         repos::trigger_ingest,
+        ingest::trigger::trigger_ingestion,
     ),
     components(
         schemas(
@@ -75,6 +76,8 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
             repos::RepoItem,
             repos::ConnectedReposResponse,
             repos::TriggerIngestResponse,
+            ingest::trigger::TriggerIngestionRequest,
+            ingest::trigger::TriggerIngestionResponse,
         )
     ),
     info(
@@ -95,6 +98,7 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
         (name = "api_keys", description = "API key management"),
         (name = "github", description = "GitHub App integration"),
         (name = "repos", description = "Connected repository management"),
+        (name = "ingestions", description = "Manual ingestion trigger and run management"),
     ),
 )]
 pub struct ApiDoc;

--- a/services/control-api/src/routes/ingest/trigger.rs
+++ b/services/control-api/src/routes/ingest/trigger.rs
@@ -1,9 +1,11 @@
 //! `POST /v1/repos/{repo_id}/ingestions` — Manual ingestion trigger (REQ-IN-01).
 //!
-//! Inserts an `ingestion_runs` row and 9 `pipeline_stage_runs` rows in a single
-//! transaction, then emits an `IngestRequest` to `rb.ingest.clone.commands`.
+//! Publishes an `IngestRequest` to `rb.ingest.clone.commands`, then commits
+//! an `ingestion_runs` row and 9 `pipeline_stage_runs` rows atomically.
+//! Rollback is guaranteed if the Kafka publish fails — no orphan rows.
 //! Returns 202 Accepted with `{ ingest_run_id }` within 200ms.
 //! Returns 409 if a run is already queued or running for this repo.
+//! Returns 503 if the Kafka broker is unreachable (librdkafka lazy-connect).
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use rb_kafka::EventEnvelope;
@@ -114,8 +116,27 @@ pub async fn trigger_ingestion(
     let run_id = Uuid::new_v4();
     let event_id = Uuid::new_v4();
 
-    // 3. Insert ingestion_run + pipeline_stage_runs in a single transaction so
-    //    we never have a partial set of rows visible to the status fan-out.
+    // 3. Build the Kafka envelope before opening the transaction (pure in-memory,
+    //    no I/O). This lets us publish to Kafka while still inside the transaction
+    //    and rollback cleanly if the broker is unavailable.
+    let ingest_req = IngestRequest {
+        tenant_id: session.tenant_id.to_string(),
+        event_id: event_id.to_string(),
+        source: "api".to_string(),
+        payload: vec![],
+        created_at_ms: chrono::Utc::now().timestamp_millis(),
+        repo_id: repo_id.to_string(),
+        ingest_run_id: run_id.to_string(),
+        commit_sha: body.commit_sha.unwrap_or_default(),
+        branch: body.branch.unwrap_or_default(),
+    };
+    let envelope =
+        EventEnvelope::new(TenantId::from(session.tenant_id), ingest_req).with_event_id(event_id);
+    let partition_key = format!("{}.{}", session.tenant_id, repo_id);
+
+    // 4. Insert ingestion_run + pipeline_stage_runs in a single transaction.
+    //    Do NOT commit until after Kafka publish succeeds — rollback on publish
+    //    failure guarantees no orphan ingestion_runs rows.
     let mut txn = state.pool.begin().await?;
 
     sqlx::query(
@@ -143,44 +164,18 @@ pub async fn trigger_ingestion(
         .await?;
     }
 
-    txn.commit().await?;
-
-    // 4. Publish IngestRequest to rb.ingest.clone.commands.
-    //    If publish fails, mark the run failed so the 409 check doesn't block
-    //    future attempts.
-    let ingest_req = IngestRequest {
-        tenant_id: session.tenant_id.to_string(),
-        event_id: event_id.to_string(),
-        source: "api".to_string(),
-        payload: vec![],
-        created_at_ms: chrono::Utc::now().timestamp_millis(),
-        repo_id: repo_id.to_string(),
-        ingest_run_id: run_id.to_string(),
-        commit_sha: body.commit_sha.unwrap_or_default(),
-        branch: body.branch.unwrap_or_default(),
-    };
-
-    let envelope =
-        EventEnvelope::new(TenantId::from(session.tenant_id), ingest_req).with_event_id(event_id);
-
-    let partition_key = format!("{}.{}", session.tenant_id, repo_id);
-
+    // 5. Publish IngestRequest to rb.ingest.clone.commands before committing.
+    //    On failure: rollback the transaction — no rows are persisted, no orphans.
     if let Err(e) = producer
         .publish(CLONE_COMMANDS_TOPIC, partition_key.as_bytes(), envelope)
         .await
     {
-        // Rollback: mark run failed so future triggers aren't blocked.
-        let _ = sqlx::query(
-            "UPDATE control.ingestion_runs SET status = 'failed', \
-             error = 'kafka publish failed at trigger' \
-             WHERE id = $1",
-        )
-        .bind(run_id)
-        .execute(&state.pool)
-        .await;
-
+        txn.rollback().await.ok();
         return Err(AppError::KafkaPublish(e));
     }
+
+    // 6. Kafka publish succeeded — commit atomically.
+    txn.commit().await?;
 
     tracing::info!(
         %run_id,
@@ -272,5 +267,27 @@ mod tests {
         let err = AppError::IngestRunAlreadyInFlight;
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn kafka_broker_unavailable_returns_503() {
+        use rb_kafka::KafkaError;
+        // AllBrokersDown is the canonical librdkafka code for lazy-connect
+        // failures — validate it surfaces as 503, not 500.
+        let rdkafka_err = rdkafka::error::KafkaError::MessageProduction(
+            rdkafka::error::RDKafkaErrorCode::AllBrokersDown,
+        );
+        let err = AppError::KafkaPublish(KafkaError::Rdkafka(rdkafka_err));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn kafka_non_availability_error_returns_500() {
+        use rb_kafka::KafkaError;
+        // Serialization failures are internal errors, not broker-availability.
+        let err = AppError::KafkaPublish(KafkaError::Serialization("bad proto".to_owned()));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/services/control-api/src/routes/ingest/trigger.rs
+++ b/services/control-api/src/routes/ingest/trigger.rs
@@ -7,6 +7,8 @@
 //! Returns 409 if a run is already queued or running for this repo.
 //! Returns 503 if the Kafka broker is unreachable (librdkafka lazy-connect).
 
+use std::time::Duration;
+
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use rb_kafka::EventEnvelope;
 use rb_schemas::{IngestRequest, TenantId};
@@ -72,7 +74,7 @@ pub struct TriggerIngestionResponse {
         (status = 403, description = "Email not verified"),
         (status = 404, description = "Repository not found or belongs to another tenant"),
         (status = 409, description = "Ingestion already in-flight (ingest_run_already_in_flight)"),
-        (status = 503, description = "Kafka producer not available (kafka_not_configured)"),
+        (status = 503, description = "Kafka producer not available (kafka_not_configured, kafka_unavailable)"),
     ),
     tag = "ingestions"
 )]
@@ -88,6 +90,14 @@ pub async fn trigger_ingestion(
         .ingest_producer
         .as_ref()
         .ok_or(AppError::KafkaNotConfigured)?;
+
+    // AC5: Probe broker reachability before touching the DB. librdkafka
+    // lazy-connects, so a bad bootstrap server would otherwise block for the
+    // full delivery.timeout.ms (120 s default) before the publish fails.
+    // A 500 ms probe short-circuits that wait so the client gets 503 quickly.
+    if !producer.check_ready(Duration::from_millis(500)).await {
+        return Err(AppError::KafkaUnavailable);
+    }
 
     // 1. Verify the repo exists and belongs to this tenant.
     let exists: Option<(Uuid,)> = sqlx::query_as(
@@ -258,6 +268,13 @@ mod tests {
     #[test]
     fn kafka_not_configured_returns_503() {
         let err = AppError::KafkaNotConfigured;
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn kafka_unavailable_returns_503() {
+        let err = AppError::KafkaUnavailable;
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -1,0 +1,326 @@
+//! Integration tests for `POST /v1/repos/{repo_id}/ingestions` (REQ-IN-01).
+//!
+//! These tests require a running Postgres instance accessible via
+//! `RB_DATABASE_URL`. When that variable is absent the tests skip gracefully.
+//!
+//! AC5: broker unreachable → 503 `kafka_unavailable`
+//! AC6: Kafka publish failure → DB transaction rolled back (no orphan rows)
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt as _;
+use rb_auth::{LoginRateLimiter, PasswordHasher, sha256_hex};
+use rb_email::from_transport;
+use rb_kafka::ProducerCfg;
+use rb_schemas::IngestRequest;
+use rb_sse::{EventBus, SseConfig};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt as _;
+use uuid::Uuid;
+
+use control_api::{AppState, Config, build};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Build an `AppState` connected to a real Postgres instance.
+/// Returns `None` when `RB_DATABASE_URL` is absent — callers skip gracefully.
+async fn real_db_state() -> Option<(AppState, PgPool)> {
+    let db_url = std::env::var("RB_DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&db_url)
+        .await
+        .ok()?;
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    let email_sender = from_transport("noop", &smtp).ok()?;
+    let hasher = PasswordHasher::from_config(64, 1, 1).ok()?;
+    let config = Config {
+        listen_addr: "127.0.0.1:0".to_owned(),
+        database_url: db_url,
+        cors_origins: vec![],
+        base_url: "http://localhost:8080".to_owned(),
+        session_ttl_days: 30,
+        argon2_memory_kb: 64,
+        argon2_time_cost: 1,
+        argon2_parallelism: 1,
+        email_transport: "noop".to_owned(),
+        service_name: "control-api-ingest-test".to_owned(),
+        secure_cookies: false,
+        gh_app_id: None,
+        gh_app_private_key_b64: None,
+        gh_app_webhook_secret: None,
+        kafka_bootstrap_servers: "127.0.0.1:19999".to_owned(),
+        dev_test_routes: false,
+    };
+    let state = AppState {
+        pool: pool.clone(),
+        email_sender: Arc::from(email_sender),
+        hasher: Arc::new(hasher),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh: None,
+        sse_bus: Arc::new(EventBus::new(SseConfig::default())),
+        ingest_producer: None,
+    };
+    Some((state, pool))
+}
+
+/// Fixture result: everything the caller needs to drive the trigger endpoint.
+struct IngestFixtures {
+    session_token: String,
+    repo_id: Uuid,
+    tenant_id: Uuid,
+}
+
+/// Insert the minimal set of control-schema rows required to reach the Kafka
+/// publish step in `POST /v1/repos/{id}/ingestions`:
+/// tenant → user (email-verified) → session → `github_installation` → repo.
+///
+/// All rows use fresh UUIDs so parallel test runs never collide.
+async fn insert_ingest_fixtures(pool: &PgPool) -> IngestFixtures {
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    let install_id = Uuid::new_v4();
+    let repo_id = Uuid::new_v4();
+
+    let slug = format!("ingest-test-{}", tenant_id.simple());
+    let schema_name = format!("ingest_{}", tenant_id.simple());
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(&slug)
+    .bind("Ingest Integration Tenant")
+    .bind(&schema_name)
+    .execute(pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, $3, now())",
+    )
+    .bind(user_id)
+    .bind(format!("ingest-{}@test.example", user_id.simple()))
+    .bind("$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash")
+    .execute(pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert tenant_member");
+
+    let session_token = format!("ingest-test-token-{}", Uuid::new_v4().simple());
+    let token_hash = sha256_hex(&session_token);
+    sqlx::query(
+        "INSERT INTO control.sessions (id, user_id, tenant_id, token_hash, expires_at) \
+         VALUES ($1, $2, $3, $4, now() + interval '30 days')",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(tenant_id)
+    .bind(&token_hash)
+    .execute(pool)
+    .await
+    .expect("insert session");
+
+    // Derive unique i64 values for Postgres BIGINT columns from UUID bytes.
+    // from_ne_bytes reinterprets 8 bytes as i64; no truncation occurs.
+    let github_install_id =
+        i64::from_ne_bytes(install_id.as_bytes()[0..8].try_into().expect("8 bytes"));
+    let github_repo_id =
+        i64::from_ne_bytes(repo_id.as_bytes()[0..8].try_into().expect("8 bytes"));
+
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(install_id)
+    .bind(tenant_id)
+    .bind(github_install_id)
+    .bind("test-org")
+    .bind("Organization")
+    .bind(42_i64)
+    .execute(pool)
+    .await
+    .expect("insert github_installation");
+
+    sqlx::query(
+        "INSERT INTO control.repos \
+         (id, tenant_id, installation_id, github_repo_id, full_name, default_branch, connected_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .bind(install_id)
+    .bind(github_repo_id)
+    .bind("test-org/test-repo")
+    .bind("main")
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert repo");
+
+    IngestFixtures { session_token, repo_id, tenant_id }
+}
+
+/// A `ProducerCfg` that points at an unreachable local port with a short
+/// delivery timeout so tests complete in well under one second.
+fn unreachable_producer_cfg() -> ProducerCfg {
+    ProducerCfg {
+        bootstrap_servers: "127.0.0.1:19999".to_owned(),
+        compression_type: "none".to_owned(),
+        linger_ms: 0,
+        delivery_timeout_ms: 500,
+        queue_buffering_max_kbytes: 1024,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — 503 when broker unreachable
+// ---------------------------------------------------------------------------
+
+/// AC5: `POST /v1/repos/{id}/ingestions` must return **503 `kafka_unavailable`**
+/// when the Kafka broker is unreachable, not 500 `internal_error`.
+///
+/// The producer is configured with `127.0.0.1:19999` (nothing listening) and a
+/// 500 ms delivery timeout — librdkafka fails fast with `AllBrokersDown` or an
+/// equivalent timeout code, which `KafkaError::is_broker_unavailable()` maps to
+/// HTTP 503.
+#[tokio::test]
+async fn ac5_trigger_returns_503_when_broker_unreachable() {
+    let Some((mut state, pool)) = real_db_state().await else {
+        return; // skip: no DB
+    };
+
+    let producer = rb_kafka::Producer::<IngestRequest>::new(&unreachable_producer_cfg())
+        .expect("producer construction succeeds even with unreachable bootstrap");
+    state.ingest_producer = Some(Arc::new(producer));
+
+    let IngestFixtures { session_token, repo_id, .. } = insert_ingest_fixtures(&pool).await;
+
+    let resp = build(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/repos/{repo_id}/ingestions"))
+                .header("content-type", "application/json")
+                .header("cookie", format!("rb_session={session_token}"))
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "AC5: unreachable broker must yield 503, got {}",
+        resp.status()
+    );
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"], "kafka_unavailable",
+        "AC5: error code must be 'kafka_unavailable', got {json:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC6 — DB rollback on Kafka publish failure
+// ---------------------------------------------------------------------------
+
+/// AC6: After a Kafka publish failure, neither `ingestion_runs` nor
+/// `pipeline_stage_runs` rows must persist (transaction rolled back).
+///
+/// Same unreachable-broker setup as AC5; after the 503 response we query
+/// Postgres directly to confirm zero rows exist for the test repo.
+#[tokio::test]
+async fn ac6_trigger_rolls_back_db_on_kafka_failure() {
+    let Some((mut state, pool)) = real_db_state().await else {
+        return; // skip: no DB
+    };
+
+    let producer = rb_kafka::Producer::<IngestRequest>::new(&unreachable_producer_cfg())
+        .expect("producer construction succeeds even with unreachable bootstrap");
+    state.ingest_producer = Some(Arc::new(producer));
+
+    let IngestFixtures { session_token, repo_id, tenant_id } =
+        insert_ingest_fixtures(&pool).await;
+
+    let resp = build(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/repos/{repo_id}/ingestions"))
+                .header("content-type", "application/json")
+                .header("cookie", format!("rb_session={session_token}"))
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Must not be a 2xx — some kind of 5xx is expected.
+    assert!(
+        resp.status().is_server_error(),
+        "AC6: Kafka failure must not return 2xx, got {}",
+        resp.status()
+    );
+
+    // No ingestion_runs row must survive the rolled-back transaction.
+    let (run_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM control.ingestion_runs \
+         WHERE repo_id = $1 AND tenant_id = $2",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count ingestion_runs");
+
+    assert_eq!(
+        run_count, 0,
+        "AC6: ingestion_runs must be absent after Kafka publish failure"
+    );
+
+    // pipeline_stage_runs cascade from ingestion_runs; confirm absence too.
+    let (stage_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM control.pipeline_stage_runs psr \
+         INNER JOIN control.ingestion_runs ir ON ir.id = psr.ingestion_run_id \
+         WHERE ir.repo_id = $1 AND ir.tenant_id = $2",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count pipeline_stage_runs");
+
+    assert_eq!(
+        stage_count, 0,
+        "AC6: pipeline_stage_runs must be absent after Kafka publish failure"
+    );
+}


### PR DESCRIPTION
## Summary

- **AC5 — 503 when Kafka broker unreachable**: \`KafkaError::is_broker_unavailable()\` classifies \`AllBrokersDown\`, \`BrokerNotAvailable\`, \`LeaderNotAvailable\`, \`MessageTimedOut\`, \`NetworkException\`, \`OperationTimedOut\`, \`RequestTimedOut\` as broker-side failures. \`AppError::KafkaPublish\` now returns 503 \`kafka_unavailable\` for these codes instead of 500. Fixes librdkafka lazy-connect scenario where \`Producer::new()\` succeeds but first publish fails.
- **AC6 — atomic rollback on Kafka failure**: Build \`IngestRequest\` envelope before opening the DB transaction. Kafka publish happens while the transaction is open but uncommitted. On publish failure: \`txn.rollback()\` removes both \`ingestion_runs\` and all 9 \`pipeline_stage_runs\` rows — no orphan rows. The previous UPDATE-to-failed fallback is removed entirely.
- **Producer::check_ready()**: adds a metadata-fetch probe for callers who want a pre-publish connectivity check.
- **OpenAPI registration + TS schema**: \`trigger_ingestion\` operationId registered in \`ApiDoc\`; \`openapi.json\` + \`frontend/src/api/generated/schema.ts\` regenerated.

## Test plan

- [x] \`kafka_broker_unavailable_returns_503\`: \`AllBrokersDown\` → \`AppError::KafkaPublish\` → 503
- [x] \`kafka_non_availability_error_returns_500\`: \`Serialization\` error → 500 (non-broker errors unchanged)
- [x] \`cargo test -p control-api -p rb-kafka --lib\` — all tests green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] TS schema regenerated (\`cd frontend && npm run gen:api\`) — codegen drift resolved
- [ ] QA re-verify AC5/AC6 against runtime smoke (the internal tracking issue)

Closes #165