### PR TITLE
feat(ingest-status): full status fan-out with DB persistence

### DIFF
--- a/services/control-api/src/ingest_consumer.rs
+++ b/services/control-api/src/ingest_consumer.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
+use anyhow::{Context as _, Result};
 use rb_kafka::{Consumer, ConsumerCfg, TraceContext};
-use rb_schemas::{IngestStatus, IngestStatusEvent};
+use rb_schemas::{IngestStage, IngestStatus, IngestStatusEvent};
 use rb_sse::EventBus;
 use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const TOTAL_PIPELINE_STAGES: i64 = 9;
 
 /// JSON-serialisable mirror of [`IngestStatusEvent`] for SSE wire format.
 ///
@@ -16,17 +21,24 @@ struct IngestStatusEventJson {
     status: &'static str,
     error_message: String,
     occurred_at_ms: i64,
+    stage: Option<&'static str>,
+    stage_seq: i32,
+    ingest_run_id: String,
 }
 
 impl From<&IngestStatusEvent> for IngestStatusEventJson {
     fn from(ev: &IngestStatusEvent) -> Self {
         let status = IngestStatus::try_from(ev.status).map_or("unknown", status_label);
+        let stage = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
         Self {
             ingest_request_id: ev.ingest_request_id.clone(),
             tenant_id: ev.tenant_id.clone(),
             status,
             error_message: ev.error_message.clone(),
             occurred_at_ms: ev.occurred_at_ms,
+            stage,
+            stage_seq: ev.stage_seq,
+            ingest_run_id: ev.ingest_run_id.clone(),
         }
     }
 }
@@ -41,11 +53,43 @@ fn status_label(s: IngestStatus) -> &'static str {
     }
 }
 
+fn stage_label(s: IngestStage) -> Option<&'static str> {
+    match s {
+        IngestStage::Unspecified => None,
+        IngestStage::Clone => Some("clone"),
+        IngestStage::Expand => Some("expand"),
+        IngestStage::Parse => Some("parse"),
+        IngestStage::Typecheck => Some("typecheck"),
+        IngestStage::Extract => Some("extract"),
+        IngestStage::Embed => Some("embed"),
+        IngestStage::ProjectPg => Some("project_pg"),
+        IngestStage::ProjectNeo4j => Some("project_neo4j"),
+        IngestStage::ProjectQdrant => Some("project_qdrant"),
+    }
+}
+
+/// Returns the `pipeline_stage_runs.status` string and optional error
+/// for a given [`IngestStatus`], or `None` if no DB update is warranted.
+fn stage_db_params(
+    status: IngestStatus,
+    error_message: &str,
+) -> Option<(&'static str, Option<String>)> {
+    match status {
+        IngestStatus::Processing => Some(("running", None)),
+        IngestStatus::Done => Some(("succeeded", None)),
+        IngestStatus::Failed => {
+            let err = if error_message.is_empty() {
+                None
+            } else {
+                Some(error_message.to_owned())
+            };
+            Some(("failed", err))
+        }
+        IngestStatus::Pending | IngestStatus::Unspecified => None,
+    }
+}
+
 /// `OTel` [`Extractor`] over a borrowed `&[(String, String)]` header list.
-/// Scoped to this module — mirrors `KafkaHeaderExtractor` from `rb-kafka` without
-/// requiring it to be re-exported.
-///
-/// [`Extractor`]: opentelemetry::propagation::Extractor
 struct HeaderExtractor<'a>(&'a [(String, String)]);
 
 impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
@@ -61,21 +105,10 @@ impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
     }
 }
 
-/// Build a `sse.publish` span that is a child of the upstream producer's trace.
-///
-/// We re-extract the W3C trace context from the envelope so the span shares the
-/// same trace id as `kafka.produce` and `kafka.consume`.  If no trace context is
-/// present the span is still emitted but without a remote parent.
-///
-/// The guard returned by `attach()` is intentionally scoped to this helper —
-/// it is dropped before any `.await` point in the caller (ADR-006 §9.3).
 fn sse_publish_span(
     tenant_id: &rb_schemas::TenantId,
     tc: Option<&TraceContext>,
 ) -> tracing::Span {
-    // Scope the context guard to span construction only.
-    // The guard is dropped when this block exits; the parent relationship is
-    // already captured inside the Span at creation time.
     let _cx_guard = tc.map(|tc| {
         let headers: Vec<(String, String)> = vec![
             ("traceparent".to_owned(), tc.traceparent.clone()),
@@ -94,15 +127,174 @@ fn sse_publish_span(
         "messaging.destination" = "ingest.events",
         "rb.tenant_id" = %tenant_id,
     )
-    // _cx_guard dropped here — parent relationship already captured
+}
+
+/// Update `pipeline_stage_runs` for the given run + stage transition.
+async fn update_stage_run(
+    pool: &PgPool,
+    ingest_run_id: &str,
+    stage: &str,
+    db_status: &str,
+    error: Option<String>,
+) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    match db_status {
+        "running" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'running', started_at = now() \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to running")?;
+        }
+        "succeeded" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'succeeded', finished_at = now() \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to succeeded")?;
+        }
+        "failed" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'failed', finished_at = now(), error = $3 \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .bind(error.as_deref())
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to failed")?;
+        }
+        other => {
+            tracing::warn!(db_status = other, "unknown stage db_status — skipping");
+        }
+    }
+
+    Ok(())
+}
+
+/// Transition `ingestion_runs` when a stage reports `Processing` (first signal
+/// that work has started: move from `queued` → `running`).
+async fn maybe_start_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'running', started_at = COALESCE(started_at, now()) \
+         WHERE id = $1 AND status = 'queued'",
+    )
+    .bind(run_id)
+    .execute(pool)
+    .await
+    .context("failed to transition ingestion_run to running")?;
+
+    Ok(())
+}
+
+/// If all pipeline stages have succeeded, mark the run `succeeded`.
+async fn maybe_complete_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    let succeeded: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM control.pipeline_stage_runs \
+         WHERE ingestion_run_id = $1 AND status = 'succeeded'",
+    )
+    .bind(run_id)
+    .fetch_one(pool)
+    .await
+    .context("failed to count succeeded stages")?;
+
+    if succeeded >= TOTAL_PIPELINE_STAGES {
+        sqlx::query(
+            "UPDATE control.ingestion_runs \
+             SET status = 'succeeded', finished_at = now() \
+             WHERE id = $1 AND status = 'running'",
+        )
+        .bind(run_id)
+        .execute(pool)
+        .await
+        .context("failed to mark ingestion_run succeeded")?;
+    }
+
+    Ok(())
+}
+
+/// Mark `ingestion_runs` as `failed` on any stage failure.
+async fn fail_run(pool: &PgPool, ingest_run_id: &str, error_message: &str) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    let error = if error_message.is_empty() {
+        None
+    } else {
+        Some(error_message)
+    };
+
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'failed', finished_at = now(), error = $2 \
+         WHERE id = $1 AND status IN ('queued', 'running')",
+    )
+    .bind(run_id)
+    .bind(error)
+    .execute(pool)
+    .await
+    .context("failed to mark ingestion_run failed")?;
+
+    Ok(())
+}
+
+/// Apply all DB updates for one [`IngestStatusEvent`].
+async fn handle_db_updates(pool: &PgPool, ev: &IngestStatusEvent) -> Result<()> {
+    let status = IngestStatus::try_from(ev.status).unwrap_or(IngestStatus::Unspecified);
+    let stage_opt = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
+
+    if let Some(stage_str) = stage_opt {
+        if let Some((db_status, error)) = stage_db_params(status, &ev.error_message) {
+            update_stage_run(pool, &ev.ingest_run_id, stage_str, db_status, error).await?;
+        }
+    }
+
+    match status {
+        IngestStatus::Processing => {
+            maybe_start_run(pool, &ev.ingest_run_id).await?;
+        }
+        IngestStatus::Done => {
+            maybe_complete_run(pool, &ev.ingest_run_id).await?;
+        }
+        IngestStatus::Failed => {
+            fail_run(pool, &ev.ingest_run_id, &ev.error_message).await?;
+        }
+        IngestStatus::Pending | IngestStatus::Unspecified => {}
+    }
+
+    Ok(())
 }
 
 /// Spawn the long-running Kafka consumer task that subscribes to
-/// `rb.projector.events` and fans events out through the SSE bus.
+/// `rb.projector.events`, persists status transitions to Postgres, and fans
+/// events out through the SSE bus.
 ///
 /// Returns the [`tokio::task::JoinHandle`] so the caller can abort on shutdown.
-/// Consumer errors are logged and retried; the task only exits on an
-/// unrecoverable Kafka init failure (returned as `Err`).
 ///
 /// # Errors
 ///
@@ -110,6 +302,7 @@ fn sse_publish_span(
 pub fn spawn(
     cfg: &ConsumerCfg,
     sse_bus: Arc<EventBus>,
+    pool: Arc<PgPool>,
 ) -> anyhow::Result<tokio::task::JoinHandle<()>> {
     let consumer = Consumer::<IngestStatusEvent>::new(cfg)?;
     consumer.subscribe(&["rb.projector.events"])?;
@@ -123,17 +316,26 @@ pub fn spawn(
                 }
                 Some(Err(e)) => {
                     tracing::error!("ingest_consumer: kafka error: {e}");
-                    // Brief back-off before retrying to avoid tight error loops.
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 }
                 Some(Ok(envelope)) => {
+                    let ev = &envelope.payload;
                     let tenant_id = envelope.tenant_id;
-                    let json_ev = IngestStatusEventJson::from(&envelope.payload);
 
+                    // Persist to DB before broadcasting; skip commit on error so
+                    // the message is redelivered on restart.
+                    if let Err(e) = handle_db_updates(&pool, ev).await {
+                        tracing::error!(
+                            ingest_run_id = %ev.ingest_run_id,
+                            "ingest_consumer: DB update failed: {e}"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        continue;
+                    }
+
+                    let json_ev = IngestStatusEventJson::from(ev);
                     match serde_json::to_string(&json_ev) {
                         Ok(data) => {
-                            // Build a sse.publish span in the same OTel trace as the producer.
-                            // in_scope ensures the entry guard never crosses an .await boundary.
                             let span =
                                 sse_publish_span(&tenant_id, envelope.trace_context.as_ref());
                             span.in_scope(|| {
@@ -154,4 +356,292 @@ pub fn spawn(
     });
 
     Ok(handle)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── status_label ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn status_label_unspecified() {
+        assert_eq!(status_label(IngestStatus::Unspecified), "unspecified");
+    }
+
+    #[test]
+    fn status_label_pending() {
+        assert_eq!(status_label(IngestStatus::Pending), "pending");
+    }
+
+    #[test]
+    fn status_label_processing() {
+        assert_eq!(status_label(IngestStatus::Processing), "processing");
+    }
+
+    #[test]
+    fn status_label_done() {
+        assert_eq!(status_label(IngestStatus::Done), "done");
+    }
+
+    #[test]
+    fn status_label_failed() {
+        assert_eq!(status_label(IngestStatus::Failed), "failed");
+    }
+
+    // ── stage_label ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn stage_label_unspecified_is_none() {
+        assert!(stage_label(IngestStage::Unspecified).is_none());
+    }
+
+    #[test]
+    fn stage_label_clone() {
+        assert_eq!(stage_label(IngestStage::Clone), Some("clone"));
+    }
+
+    #[test]
+    fn stage_label_expand() {
+        assert_eq!(stage_label(IngestStage::Expand), Some("expand"));
+    }
+
+    #[test]
+    fn stage_label_parse() {
+        assert_eq!(stage_label(IngestStage::Parse), Some("parse"));
+    }
+
+    #[test]
+    fn stage_label_typecheck() {
+        assert_eq!(stage_label(IngestStage::Typecheck), Some("typecheck"));
+    }
+
+    #[test]
+    fn stage_label_extract() {
+        assert_eq!(stage_label(IngestStage::Extract), Some("extract"));
+    }
+
+    #[test]
+    fn stage_label_embed() {
+        assert_eq!(stage_label(IngestStage::Embed), Some("embed"));
+    }
+
+    #[test]
+    fn stage_label_project_pg() {
+        assert_eq!(stage_label(IngestStage::ProjectPg), Some("project_pg"));
+    }
+
+    #[test]
+    fn stage_label_project_neo4j() {
+        assert_eq!(
+            stage_label(IngestStage::ProjectNeo4j),
+            Some("project_neo4j")
+        );
+    }
+
+    #[test]
+    fn stage_label_project_qdrant() {
+        assert_eq!(
+            stage_label(IngestStage::ProjectQdrant),
+            Some("project_qdrant")
+        );
+    }
+
+    // ── stage_db_params ──────────────────────────────────────────────────────
+
+    #[test]
+    fn stage_db_params_processing() {
+        let (status, err) = stage_db_params(IngestStatus::Processing, "").unwrap();
+        assert_eq!(status, "running");
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn stage_db_params_done() {
+        let (status, err) = stage_db_params(IngestStatus::Done, "").unwrap();
+        assert_eq!(status, "succeeded");
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn stage_db_params_failed_with_message() {
+        let (status, err) = stage_db_params(IngestStatus::Failed, "timeout").unwrap();
+        assert_eq!(status, "failed");
+        assert_eq!(err, Some("timeout".to_owned()));
+    }
+
+    #[test]
+    fn stage_db_params_failed_empty_message() {
+        let (status, err) = stage_db_params(IngestStatus::Failed, "").unwrap();
+        assert_eq!(status, "failed");
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn stage_db_params_pending_is_none() {
+        assert!(stage_db_params(IngestStatus::Pending, "").is_none());
+    }
+
+    #[test]
+    fn stage_db_params_unspecified_is_none() {
+        assert!(stage_db_params(IngestStatus::Unspecified, "").is_none());
+    }
+
+    // ── IngestStatusEventJson::from ───────────────────────────────────────────
+
+    fn make_event(status: i32, stage: i32, error: &str) -> IngestStatusEvent {
+        IngestStatusEvent {
+            ingest_request_id: "req-1".to_owned(),
+            tenant_id: "tenant-1".to_owned(),
+            status,
+            error_message: error.to_owned(),
+            occurred_at_ms: 1_700_000_000_000,
+            stage,
+            stage_seq: 1,
+            ingest_run_id: "run-1".to_owned(),
+            attempt: 1,
+        }
+    }
+
+    #[test]
+    fn json_ev_processing_clone() {
+        let ev = make_event(
+            IngestStatus::Processing as i32,
+            IngestStage::Clone as i32,
+            "",
+        );
+        let j = IngestStatusEventJson::from(&ev);
+        assert_eq!(j.status, "processing");
+        assert_eq!(j.stage, Some("clone"));
+        assert_eq!(j.ingest_run_id, "run-1");
+        assert_eq!(j.stage_seq, 1);
+    }
+
+    #[test]
+    fn json_ev_done_embed() {
+        let ev = make_event(IngestStatus::Done as i32, IngestStage::Embed as i32, "");
+        let j = IngestStatusEventJson::from(&ev);
+        assert_eq!(j.status, "done");
+        assert_eq!(j.stage, Some("embed"));
+    }
+
+    #[test]
+    fn json_ev_failed_has_error() {
+        let ev = make_event(IngestStatus::Failed as i32, IngestStage::Parse as i32, "oom");
+        let j = IngestStatusEventJson::from(&ev);
+        assert_eq!(j.status, "failed");
+        assert_eq!(j.error_message, "oom");
+    }
+
+    #[test]
+    fn json_ev_unknown_status_label() {
+        let ev = make_event(999, IngestStage::Clone as i32, "");
+        let j = IngestStatusEventJson::from(&ev);
+        assert_eq!(j.status, "unknown");
+    }
+
+    #[test]
+    fn json_ev_unspecified_stage_is_none() {
+        let ev = make_event(
+            IngestStatus::Processing as i32,
+            IngestStage::Unspecified as i32,
+            "",
+        );
+        let j = IngestStatusEventJson::from(&ev);
+        assert!(j.stage.is_none());
+    }
+
+    #[test]
+    fn json_ev_serialises_to_valid_json() {
+        let ev = make_event(
+            IngestStatus::Done as i32,
+            IngestStage::ProjectPg as i32,
+            "",
+        );
+        let j = IngestStatusEventJson::from(&ev);
+        let s = serde_json::to_string(&j).expect("should serialise");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("should parse");
+        assert_eq!(v["status"], "done");
+        assert_eq!(v["stage"], "project_pg");
+        assert_eq!(v["ingest_run_id"], "run-1");
+    }
+
+    // ── total stages constant ────────────────────────────────────────────────
+
+    #[test]
+    fn total_pipeline_stages_is_9() {
+        assert_eq!(TOTAL_PIPELINE_STAGES, 9);
+    }
+
+    // ── UUID parsing edge cases ──────────────────────────────────────────────
+
+    #[test]
+    fn valid_uuid_parses_ok() {
+        let id = Uuid::new_v4().to_string();
+        assert!(id.parse::<Uuid>().is_ok());
+    }
+
+    #[test]
+    fn invalid_uuid_errors() {
+        assert!("not-a-uuid".parse::<Uuid>().is_err());
+    }
+
+    // ── stage_db_params: all terminal states produce consistent output ────────
+
+    #[test]
+    fn all_non_terminal_statuses_produce_no_db_params() {
+        for status in [IngestStatus::Pending, IngestStatus::Unspecified] {
+            assert!(
+                stage_db_params(status, "any error").is_none(),
+                "{status:?} should not produce a DB update"
+            );
+        }
+    }
+
+    #[test]
+    fn all_terminal_statuses_produce_db_params() {
+        for status in [
+            IngestStatus::Processing,
+            IngestStatus::Done,
+            IngestStatus::Failed,
+        ] {
+            assert!(
+                stage_db_params(status, "").is_some(),
+                "{status:?} should produce a DB update"
+            );
+        }
+    }
+
+    // ── all 9 stage labels are distinct and non-empty ────────────────────────
+
+    #[test]
+    fn all_named_stages_have_distinct_labels() {
+        let stages = [
+            IngestStage::Clone,
+            IngestStage::Expand,
+            IngestStage::Parse,
+            IngestStage::Typecheck,
+            IngestStage::Extract,
+            IngestStage::Embed,
+            IngestStage::ProjectPg,
+            IngestStage::ProjectNeo4j,
+            IngestStage::ProjectQdrant,
+        ];
+
+        let labels: Vec<&'static str> = stages.iter().filter_map(|s| stage_label(*s)).collect();
+        assert_eq!(labels.len(), 9, "all 9 stages should have labels");
+
+        let mut sorted = labels.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), 9, "stage labels must be unique");
+
+        for label in &labels {
+            assert!(!label.is_empty());
+        }
+    }
 }

--- a/services/control-api/src/ingest_consumer/db.rs
+++ b/services/control-api/src/ingest_consumer/db.rs
@@ -1,0 +1,196 @@
+//! Database update functions for ingest status fan-out.
+
+use anyhow::{Context as _, Result};
+use rb_schemas::{IngestStage, IngestStatus, IngestStatusEvent};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::sse::stage_label;
+
+pub(crate) const TOTAL_PIPELINE_STAGES: i64 = 9;
+
+/// Returns the `pipeline_stage_runs.status` string and optional error
+/// for a given [`IngestStatus`], or `None` if no DB update is warranted.
+pub(crate) fn stage_db_params(
+    status: IngestStatus,
+    error_message: &str,
+) -> Option<(&'static str, Option<String>)> {
+    match status {
+        IngestStatus::Processing => Some(("running", None)),
+        IngestStatus::Done => Some(("succeeded", None)),
+        IngestStatus::Failed => {
+            let err = if error_message.is_empty() {
+                None
+            } else {
+                Some(error_message.to_owned())
+            };
+            Some(("failed", err))
+        }
+        IngestStatus::Pending | IngestStatus::Unspecified => None,
+    }
+}
+
+/// Update `pipeline_stage_runs` for the given run + stage transition.
+pub(crate) async fn update_stage_run(
+    pool: &PgPool,
+    ingest_run_id: &str,
+    stage: &str,
+    db_status: &str,
+    error: Option<String>,
+) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    match db_status {
+        "running" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'running', started_at = now() \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to running")?;
+        }
+        "succeeded" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'succeeded', finished_at = now() \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to succeeded")?;
+        }
+        "failed" => {
+            sqlx::query(
+                "UPDATE control.pipeline_stage_runs \
+                 SET status = 'failed', finished_at = now(), error = $3 \
+                 WHERE ingestion_run_id = $1 AND stage = $2",
+            )
+            .bind(run_id)
+            .bind(stage)
+            .bind(error.as_deref())
+            .execute(pool)
+            .await
+            .context("failed to update pipeline_stage_runs to failed")?;
+        }
+        other => {
+            tracing::warn!(db_status = other, "unknown stage db_status — skipping");
+        }
+    }
+
+    Ok(())
+}
+
+/// Transition `ingestion_runs` when a stage reports `Processing` (first signal
+/// that work has started: move from `queued` → `running`).
+pub(crate) async fn maybe_start_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'running', started_at = COALESCE(started_at, now()) \
+         WHERE id = $1 AND status = 'queued'",
+    )
+    .bind(run_id)
+    .execute(pool)
+    .await
+    .context("failed to transition ingestion_run to running")?;
+
+    Ok(())
+}
+
+/// If all pipeline stages have succeeded, mark the run `succeeded`.
+pub(crate) async fn maybe_complete_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    let succeeded: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM control.pipeline_stage_runs \
+         WHERE ingestion_run_id = $1 AND status = 'succeeded'",
+    )
+    .bind(run_id)
+    .fetch_one(pool)
+    .await
+    .context("failed to count succeeded stages")?;
+
+    if succeeded >= TOTAL_PIPELINE_STAGES {
+        sqlx::query(
+            "UPDATE control.ingestion_runs \
+             SET status = 'succeeded', finished_at = now() \
+             WHERE id = $1 AND status = 'running'",
+        )
+        .bind(run_id)
+        .execute(pool)
+        .await
+        .context("failed to mark ingestion_run succeeded")?;
+    }
+
+    Ok(())
+}
+
+/// Mark `ingestion_runs` as `failed` on any stage failure.
+pub(crate) async fn fail_run(
+    pool: &PgPool,
+    ingest_run_id: &str,
+    error_message: &str,
+) -> Result<()> {
+    let run_id: Uuid = ingest_run_id
+        .parse()
+        .context("invalid ingest_run_id UUID")?;
+
+    let error = if error_message.is_empty() {
+        None
+    } else {
+        Some(error_message)
+    };
+
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'failed', finished_at = now(), error = $2 \
+         WHERE id = $1 AND status IN ('queued', 'running')",
+    )
+    .bind(run_id)
+    .bind(error)
+    .execute(pool)
+    .await
+    .context("failed to mark ingestion_run failed")?;
+
+    Ok(())
+}
+
+/// Apply all DB updates for one [`IngestStatusEvent`].
+pub(crate) async fn handle_db_updates(pool: &PgPool, ev: &IngestStatusEvent) -> Result<()> {
+    let status = IngestStatus::try_from(ev.status).unwrap_or(IngestStatus::Unspecified);
+    let stage_opt = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
+
+    if let Some(stage_str) = stage_opt {
+        if let Some((db_status, error)) = stage_db_params(status, &ev.error_message) {
+            update_stage_run(pool, &ev.ingest_run_id, stage_str, db_status, error).await?;
+        }
+    }
+
+    match status {
+        IngestStatus::Processing => {
+            maybe_start_run(pool, &ev.ingest_run_id).await?;
+        }
+        IngestStatus::Done => {
+            maybe_complete_run(pool, &ev.ingest_run_id).await?;
+        }
+        IngestStatus::Failed => {
+            fail_run(pool, &ev.ingest_run_id, &ev.error_message).await?;
+        }
+        IngestStatus::Pending | IngestStatus::Unspecified => {}
+    }
+
+    Ok(())
+}

--- a/services/control-api/src/ingest_consumer/mod.rs
+++ b/services/control-api/src/ingest_consumer/mod.rs
@@ -1,294 +1,18 @@
+mod db;
+mod sse;
+
+#[cfg(test)]
+use db::{TOTAL_PIPELINE_STAGES, stage_db_params};
+#[cfg(test)]
+use sse::{IngestStatusEventJson, stage_label, status_label};
+
 use std::sync::Arc;
 
-use anyhow::{Context as _, Result};
-use rb_kafka::{Consumer, ConsumerCfg, TraceContext};
-use rb_schemas::{IngestStage, IngestStatus, IngestStatusEvent};
+use anyhow::Result;
+use rb_kafka::{Consumer, ConsumerCfg};
+use rb_schemas::IngestStatusEvent;
 use rb_sse::EventBus;
-use serde::Serialize;
 use sqlx::PgPool;
-use uuid::Uuid;
-
-const TOTAL_PIPELINE_STAGES: i64 = 9;
-
-/// JSON-serialisable mirror of [`IngestStatusEvent`] for SSE wire format.
-///
-/// `IngestStatusEvent` is prost-generated and does not implement [`Serialize`];
-/// this newtype bridges the gap without modifying generated code.
-#[derive(Debug, Serialize)]
-struct IngestStatusEventJson {
-    ingest_request_id: String,
-    tenant_id: String,
-    status: &'static str,
-    error_message: String,
-    occurred_at_ms: i64,
-    stage: Option<&'static str>,
-    stage_seq: i32,
-    ingest_run_id: String,
-}
-
-impl From<&IngestStatusEvent> for IngestStatusEventJson {
-    fn from(ev: &IngestStatusEvent) -> Self {
-        let status = IngestStatus::try_from(ev.status).map_or("unknown", status_label);
-        let stage = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
-        Self {
-            ingest_request_id: ev.ingest_request_id.clone(),
-            tenant_id: ev.tenant_id.clone(),
-            status,
-            error_message: ev.error_message.clone(),
-            occurred_at_ms: ev.occurred_at_ms,
-            stage,
-            stage_seq: ev.stage_seq,
-            ingest_run_id: ev.ingest_run_id.clone(),
-        }
-    }
-}
-
-fn status_label(s: IngestStatus) -> &'static str {
-    match s {
-        IngestStatus::Unspecified => "unspecified",
-        IngestStatus::Pending => "pending",
-        IngestStatus::Processing => "processing",
-        IngestStatus::Done => "done",
-        IngestStatus::Failed => "failed",
-    }
-}
-
-fn stage_label(s: IngestStage) -> Option<&'static str> {
-    match s {
-        IngestStage::Unspecified => None,
-        IngestStage::Clone => Some("clone"),
-        IngestStage::Expand => Some("expand"),
-        IngestStage::Parse => Some("parse"),
-        IngestStage::Typecheck => Some("typecheck"),
-        IngestStage::Extract => Some("extract"),
-        IngestStage::Embed => Some("embed"),
-        IngestStage::ProjectPg => Some("project_pg"),
-        IngestStage::ProjectNeo4j => Some("project_neo4j"),
-        IngestStage::ProjectQdrant => Some("project_qdrant"),
-    }
-}
-
-/// Returns the `pipeline_stage_runs.status` string and optional error
-/// for a given [`IngestStatus`], or `None` if no DB update is warranted.
-fn stage_db_params(
-    status: IngestStatus,
-    error_message: &str,
-) -> Option<(&'static str, Option<String>)> {
-    match status {
-        IngestStatus::Processing => Some(("running", None)),
-        IngestStatus::Done => Some(("succeeded", None)),
-        IngestStatus::Failed => {
-            let err = if error_message.is_empty() {
-                None
-            } else {
-                Some(error_message.to_owned())
-            };
-            Some(("failed", err))
-        }
-        IngestStatus::Pending | IngestStatus::Unspecified => None,
-    }
-}
-
-/// `OTel` [`Extractor`] over a borrowed `&[(String, String)]` header list.
-struct HeaderExtractor<'a>(&'a [(String, String)]);
-
-impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0
-            .iter()
-            .find(|(k, _)| k.eq_ignore_ascii_case(key))
-            .map(|(_, v)| v.as_str())
-    }
-
-    fn keys(&self) -> Vec<&str> {
-        self.0.iter().map(|(k, _)| k.as_str()).collect()
-    }
-}
-
-fn sse_publish_span(
-    tenant_id: &rb_schemas::TenantId,
-    tc: Option<&TraceContext>,
-) -> tracing::Span {
-    let _cx_guard = tc.map(|tc| {
-        let headers: Vec<(String, String)> = vec![
-            ("traceparent".to_owned(), tc.traceparent.clone()),
-            ("tracestate".to_owned(), tc.tracestate.clone()),
-        ];
-        opentelemetry::global::get_text_map_propagator(|prop| {
-            prop.extract(&HeaderExtractor(&headers))
-        })
-        .attach()
-    });
-
-    tracing::info_span!(
-        "sse.publish",
-        "otel.kind" = "PRODUCER",
-        "messaging.system" = "sse",
-        "messaging.destination" = "ingest.events",
-        "rb.tenant_id" = %tenant_id,
-    )
-}
-
-/// Update `pipeline_stage_runs` for the given run + stage transition.
-async fn update_stage_run(
-    pool: &PgPool,
-    ingest_run_id: &str,
-    stage: &str,
-    db_status: &str,
-    error: Option<String>,
-) -> Result<()> {
-    let run_id: Uuid = ingest_run_id
-        .parse()
-        .context("invalid ingest_run_id UUID")?;
-
-    match db_status {
-        "running" => {
-            sqlx::query(
-                "UPDATE control.pipeline_stage_runs \
-                 SET status = 'running', started_at = now() \
-                 WHERE ingestion_run_id = $1 AND stage = $2",
-            )
-            .bind(run_id)
-            .bind(stage)
-            .execute(pool)
-            .await
-            .context("failed to update pipeline_stage_runs to running")?;
-        }
-        "succeeded" => {
-            sqlx::query(
-                "UPDATE control.pipeline_stage_runs \
-                 SET status = 'succeeded', finished_at = now() \
-                 WHERE ingestion_run_id = $1 AND stage = $2",
-            )
-            .bind(run_id)
-            .bind(stage)
-            .execute(pool)
-            .await
-            .context("failed to update pipeline_stage_runs to succeeded")?;
-        }
-        "failed" => {
-            sqlx::query(
-                "UPDATE control.pipeline_stage_runs \
-                 SET status = 'failed', finished_at = now(), error = $3 \
-                 WHERE ingestion_run_id = $1 AND stage = $2",
-            )
-            .bind(run_id)
-            .bind(stage)
-            .bind(error.as_deref())
-            .execute(pool)
-            .await
-            .context("failed to update pipeline_stage_runs to failed")?;
-        }
-        other => {
-            tracing::warn!(db_status = other, "unknown stage db_status — skipping");
-        }
-    }
-
-    Ok(())
-}
-
-/// Transition `ingestion_runs` when a stage reports `Processing` (first signal
-/// that work has started: move from `queued` → `running`).
-async fn maybe_start_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
-    let run_id: Uuid = ingest_run_id
-        .parse()
-        .context("invalid ingest_run_id UUID")?;
-
-    sqlx::query(
-        "UPDATE control.ingestion_runs \
-         SET status = 'running', started_at = COALESCE(started_at, now()) \
-         WHERE id = $1 AND status = 'queued'",
-    )
-    .bind(run_id)
-    .execute(pool)
-    .await
-    .context("failed to transition ingestion_run to running")?;
-
-    Ok(())
-}
-
-/// If all pipeline stages have succeeded, mark the run `succeeded`.
-async fn maybe_complete_run(pool: &PgPool, ingest_run_id: &str) -> Result<()> {
-    let run_id: Uuid = ingest_run_id
-        .parse()
-        .context("invalid ingest_run_id UUID")?;
-
-    let succeeded: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM control.pipeline_stage_runs \
-         WHERE ingestion_run_id = $1 AND status = 'succeeded'",
-    )
-    .bind(run_id)
-    .fetch_one(pool)
-    .await
-    .context("failed to count succeeded stages")?;
-
-    if succeeded >= TOTAL_PIPELINE_STAGES {
-        sqlx::query(
-            "UPDATE control.ingestion_runs \
-             SET status = 'succeeded', finished_at = now() \
-             WHERE id = $1 AND status = 'running'",
-        )
-        .bind(run_id)
-        .execute(pool)
-        .await
-        .context("failed to mark ingestion_run succeeded")?;
-    }
-
-    Ok(())
-}
-
-/// Mark `ingestion_runs` as `failed` on any stage failure.
-async fn fail_run(pool: &PgPool, ingest_run_id: &str, error_message: &str) -> Result<()> {
-    let run_id: Uuid = ingest_run_id
-        .parse()
-        .context("invalid ingest_run_id UUID")?;
-
-    let error = if error_message.is_empty() {
-        None
-    } else {
-        Some(error_message)
-    };
-
-    sqlx::query(
-        "UPDATE control.ingestion_runs \
-         SET status = 'failed', finished_at = now(), error = $2 \
-         WHERE id = $1 AND status IN ('queued', 'running')",
-    )
-    .bind(run_id)
-    .bind(error)
-    .execute(pool)
-    .await
-    .context("failed to mark ingestion_run failed")?;
-
-    Ok(())
-}
-
-/// Apply all DB updates for one [`IngestStatusEvent`].
-async fn handle_db_updates(pool: &PgPool, ev: &IngestStatusEvent) -> Result<()> {
-    let status = IngestStatus::try_from(ev.status).unwrap_or(IngestStatus::Unspecified);
-    let stage_opt = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
-
-    if let Some(stage_str) = stage_opt {
-        if let Some((db_status, error)) = stage_db_params(status, &ev.error_message) {
-            update_stage_run(pool, &ev.ingest_run_id, stage_str, db_status, error).await?;
-        }
-    }
-
-    match status {
-        IngestStatus::Processing => {
-            maybe_start_run(pool, &ev.ingest_run_id).await?;
-        }
-        IngestStatus::Done => {
-            maybe_complete_run(pool, &ev.ingest_run_id).await?;
-        }
-        IngestStatus::Failed => {
-            fail_run(pool, &ev.ingest_run_id, &ev.error_message).await?;
-        }
-        IngestStatus::Pending | IngestStatus::Unspecified => {}
-    }
-
-    Ok(())
-}
 
 /// Spawn the long-running Kafka consumer task that subscribes to
 /// `rb.projector.events`, persists status transitions to Postgres, and fans
@@ -303,7 +27,7 @@ pub fn spawn(
     cfg: &ConsumerCfg,
     sse_bus: Arc<EventBus>,
     pool: Arc<PgPool>,
-) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+) -> Result<tokio::task::JoinHandle<()>> {
     let consumer = Consumer::<IngestStatusEvent>::new(cfg)?;
     consumer.subscribe(&["rb.projector.events"])?;
 
@@ -322,9 +46,7 @@ pub fn spawn(
                     let ev = &envelope.payload;
                     let tenant_id = envelope.tenant_id;
 
-                    // Persist to DB before broadcasting; skip commit on error so
-                    // the message is redelivered on restart.
-                    if let Err(e) = handle_db_updates(&pool, ev).await {
+                    if let Err(e) = db::handle_db_updates(&pool, ev).await {
                         tracing::error!(
                             ingest_run_id = %ev.ingest_run_id,
                             "ingest_consumer: DB update failed: {e}"
@@ -333,11 +55,11 @@ pub fn spawn(
                         continue;
                     }
 
-                    let json_ev = IngestStatusEventJson::from(ev);
+                    let json_ev = sse::IngestStatusEventJson::from(ev);
                     match serde_json::to_string(&json_ev) {
                         Ok(data) => {
                             let span =
-                                sse_publish_span(&tenant_id, envelope.trace_context.as_ref());
+                                sse::sse_publish_span(&tenant_id, envelope.trace_context.as_ref());
                             span.in_scope(|| {
                                 sse_bus.publish_raw(&tenant_id, "ingest.status", data);
                             });
@@ -365,6 +87,8 @@ pub fn spawn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rb_schemas::{IngestStage, IngestStatus};
+    use uuid::Uuid;
 
     // ── status_label ─────────────────────────────────────────────────────────
 
@@ -531,7 +255,11 @@ mod tests {
 
     #[test]
     fn json_ev_failed_has_error() {
-        let ev = make_event(IngestStatus::Failed as i32, IngestStage::Parse as i32, "oom");
+        let ev = make_event(
+            IngestStatus::Failed as i32,
+            IngestStage::Parse as i32,
+            "oom",
+        );
         let j = IngestStatusEventJson::from(&ev);
         assert_eq!(j.status, "failed");
         assert_eq!(j.error_message, "oom");
@@ -557,11 +285,7 @@ mod tests {
 
     #[test]
     fn json_ev_serialises_to_valid_json() {
-        let ev = make_event(
-            IngestStatus::Done as i32,
-            IngestStage::ProjectPg as i32,
-            "",
-        );
+        let ev = make_event(IngestStatus::Done as i32, IngestStage::ProjectPg as i32, "");
         let j = IngestStatusEventJson::from(&ev);
         let s = serde_json::to_string(&j).expect("should serialise");
         let v: serde_json::Value = serde_json::from_str(&s).expect("should parse");

--- a/services/control-api/src/ingest_consumer/sse.rs
+++ b/services/control-api/src/ingest_consumer/sse.rs
@@ -1,0 +1,103 @@
+//! SSE event formatting and OpenTelemetry tracing helpers.
+
+use rb_kafka::TraceContext;
+use rb_schemas::{IngestStage, IngestStatus, IngestStatusEvent};
+use serde::Serialize;
+
+/// JSON-serialisable mirror of [`IngestStatusEvent`] for SSE wire format.
+///
+/// `IngestStatusEvent` is prost-generated and does not implement [`Serialize`];
+/// this newtype bridges the gap without modifying generated code.
+#[derive(Debug, Serialize)]
+pub(crate) struct IngestStatusEventJson {
+    pub(crate) ingest_request_id: String,
+    pub(crate) tenant_id: String,
+    pub(crate) status: &'static str,
+    pub(crate) error_message: String,
+    pub(crate) occurred_at_ms: i64,
+    pub(crate) stage: Option<&'static str>,
+    pub(crate) stage_seq: i32,
+    pub(crate) ingest_run_id: String,
+}
+
+impl From<&IngestStatusEvent> for IngestStatusEventJson {
+    fn from(ev: &IngestStatusEvent) -> Self {
+        let status = IngestStatus::try_from(ev.status).map_or("unknown", status_label);
+        let stage = IngestStage::try_from(ev.stage).ok().and_then(stage_label);
+        Self {
+            ingest_request_id: ev.ingest_request_id.clone(),
+            tenant_id: ev.tenant_id.clone(),
+            status,
+            error_message: ev.error_message.clone(),
+            occurred_at_ms: ev.occurred_at_ms,
+            stage,
+            stage_seq: ev.stage_seq,
+            ingest_run_id: ev.ingest_run_id.clone(),
+        }
+    }
+}
+
+pub(crate) fn status_label(s: IngestStatus) -> &'static str {
+    match s {
+        IngestStatus::Unspecified => "unspecified",
+        IngestStatus::Pending => "pending",
+        IngestStatus::Processing => "processing",
+        IngestStatus::Done => "done",
+        IngestStatus::Failed => "failed",
+    }
+}
+
+pub(crate) fn stage_label(s: IngestStage) -> Option<&'static str> {
+    match s {
+        IngestStage::Unspecified => None,
+        IngestStage::Clone => Some("clone"),
+        IngestStage::Expand => Some("expand"),
+        IngestStage::Parse => Some("parse"),
+        IngestStage::Typecheck => Some("typecheck"),
+        IngestStage::Extract => Some("extract"),
+        IngestStage::Embed => Some("embed"),
+        IngestStage::ProjectPg => Some("project_pg"),
+        IngestStage::ProjectNeo4j => Some("project_neo4j"),
+        IngestStage::ProjectQdrant => Some("project_qdrant"),
+    }
+}
+
+/// `OTel` [`Extractor`] over a borrowed `&[(String, String)]` header list.
+pub(crate) struct HeaderExtractor<'a>(pub(crate) &'a [(String, String)]);
+
+impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.iter().map(|(k, _)| k.as_str()).collect()
+    }
+}
+
+pub(crate) fn sse_publish_span(
+    tenant_id: &rb_schemas::TenantId,
+    tc: Option<&TraceContext>,
+) -> tracing::Span {
+    let _cx_guard = tc.map(|tc| {
+        let headers: Vec<(String, String)> = vec![
+            ("traceparent".to_owned(), tc.traceparent.clone()),
+            ("tracestate".to_owned(), tc.tracestate.clone()),
+        ];
+        opentelemetry::global::get_text_map_propagator(|prop| {
+            prop.extract(&HeaderExtractor(&headers))
+        })
+        .attach()
+    });
+
+    tracing::info_span!(
+        "sse.publish",
+        "otel.kind" = "PRODUCER",
+        "messaging.system" = "sse",
+        "messaging.destination" = "ingest.events",
+        "rb.tenant_id" = %tenant_id,
+    )
+}

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -99,7 +99,7 @@ pub async fn run(config: Config) -> Result<()> {
     // not prevent the HTTP server from starting — the SSE endpoint degrades
     // gracefully when Kafka is unavailable (no events; long-poll returns empty).
     let consumer_cfg = ConsumerCfg::new("control-api-sse");
-    match ingest_consumer::spawn(&consumer_cfg, sse_bus) {
+    match ingest_consumer::spawn(&consumer_cfg, sse_bus, Arc::new(state.pool.clone())) {
         Ok(_handle) => tracing::info!("ingest_consumer started"),
         Err(e) => tracing::warn!("ingest_consumer failed to start (Kafka unavailable?): {e}"),
     }


### PR DESCRIPTION
## Summary

- Extend `ingest_consumer::spawn` to accept `Arc<PgPool>` and persist every `IngestStatusEvent` before SSE broadcast
- Update `pipeline_stage_runs.status` (pending→running→succeeded/failed) with timestamps
- Transition `ingestion_runs.status` on first Processing event and terminal outcomes
- Add `stage`, `stage_seq`, `ingest_run_id` to SSE `IngestStatusEventJson`
- Split `ingest_consumer.rs` into focused sub-modules (`db.rs`, `sse.rs`, `mod.rs`) to stay under 600-line cap
- 33 unit tests: all label helpers, `stage_db_params`, JSON serialisation, UUID edge cases

Closes #166

## Test plan

- [x] `cargo build -p control-api` — clean, zero warnings
- [x] `cargo test -p control-api ingest_consumer` — 33/33 pass
- [ ] Integration: start stack, trigger ingestion, verify `pipeline_stage_runs` and `ingestion_runs` update and SSE events arrive at `GET /v1/ingest/events`

## Depends on

- #159 (rb-kafka): stage consumers must publish to rb.ingest-status.v1
- #160 (rb-sse): SSE consumer already live

🤖 Generated with [Claude Code](https://claude.com/claude-code)