### PR TITLE
[REQ-IN-09] feat: PG projection consumer (projector-pg)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "projector-pg"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "metrics",
+ "metrics-util 0.18.0",
+ "rb-kafka",
+ "rb-schemas",
+ "rb-storage-pg",
+ "rb-tenant",
+ "rb-tracing",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "services/audit-worker",
     "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
+    "services/projector-pg",
 ]
 
 [workspace.package]

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -108,6 +108,7 @@ services:
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.typecheck.commands --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.graph.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.embed.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.source-files.v1           --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 12 --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000
       "
@@ -259,6 +260,29 @@ services:
         condition: service_started
     healthcheck:
       disable: true
+
+  projector-pg:
+    build:
+      context: ..
+      dockerfile: docker/projector-pg/Dockerfile
+    image: ghcr.io/jarnura/rustacean/projector-pg:dev
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: projector-pg
+      RUST_LOG: "info,projector_pg=debug"
+    networks:
+      - rb-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
 
   caddy:
     image: caddy:2-alpine

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -9,6 +9,7 @@ pub use ingest::{
     AuditEvent, EmbeddingPendingEvent, ExpandedFileEvent, GraphRelationEvent, IngestRequest,
     IngestStage, IngestStatus, IngestStatusEvent, ItemKind, ParsedItemEvent, RelationKind,
     SourceFileEvent, Tombstone, TypecheckedItemEvent,
+    parsed_item_event, source_file_event,
 };
 
 /// Newtype over [`Uuid`] representing a tenant identifier.

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -13,11 +13,13 @@ COPY crates/rb-secrets/Cargo.toml      crates/rb-secrets/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml         crates/rb-blob/Cargo.toml
 COPY crates/rb-storage-neo4j/Cargo.toml crates/rb-storage-neo4j/Cargo.toml
+COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml  crates/rb-storage-pg/Cargo.toml
 COPY crates/rb-audit-cli/Cargo.toml   crates/rb-audit-cli/Cargo.toml
 COPY services/migrate/Cargo.toml       services/migrate/Cargo.toml
 COPY services/control-api/Cargo.toml   services/control-api/Cargo.toml
 COPY services/audit-worker/Cargo.toml  services/audit-worker/Cargo.toml
+COPY services/projector-pg/Cargo.toml  services/projector-pg/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml      crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
+COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
+COPY crates/rb-storage-pg/Cargo.toml   crates/rb-storage-pg/Cargo.toml
+COPY services/projector-pg/Cargo.toml  services/projector-pg/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/projector-pg/src && \
+    printf 'fn main() {}' > services/projector-pg/src/main.rs && \
+    cargo build --release -p projector-pg 2>/dev/null || true && \
+    # Remove stub artifacts so real source replaces them.
+    rm -rf crates/*/src services/*/src
+
+# Copy real source and build.
+COPY crates/                 crates/
+COPY services/projector-pg/  services/projector-pg/
+COPY proto/                  proto/
+
+# Install rdkafka build deps.
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cargo build --release -p projector-pg
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/projector-pg /usr/local/bin/projector-pg
+
+ENTRYPOINT ["/usr/local/bin/projector-pg"]

--- a/migrations/tenant/002_code_tables.sql
+++ b/migrations/tenant/002_code_tables.sql
@@ -1,6 +1,9 @@
 -- Wave 5 (ADR-007 §11.9): per-tenant code projection tables.
 -- Written by projector-pg; read by control-api search endpoints.
 
+-- pgvector is required for the code_embeddings table (vector column type).
+CREATE EXTENSION IF NOT EXISTS vector;
+
 -- Source files discovered during clone stage.
 -- Idempotency: (repo_id, relative_path) is UNIQUE.
 CREATE TABLE code_files (

--- a/migrations/tenant/002_code_tables.sql
+++ b/migrations/tenant/002_code_tables.sql
@@ -1,0 +1,71 @@
+-- Wave 5 (ADR-007 §11.9): per-tenant code projection tables.
+-- Written by projector-pg; read by control-api search endpoints.
+
+-- Source files discovered during clone stage.
+-- Idempotency: (repo_id, relative_path) is UNIQUE.
+CREATE TABLE code_files (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo_id         UUID        NOT NULL,
+    relative_path   TEXT        NOT NULL,
+    sha256          TEXT        NOT NULL,  -- hex digest, 64 chars
+    size_bytes      BIGINT      NOT NULL,
+    blob_ref        TEXT,               -- rb-blob:// pointer if large
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, relative_path)
+);
+
+CREATE INDEX idx_code_files_repo ON code_files (repo_id);
+CREATE INDEX idx_code_files_sha256 ON code_files (sha256);
+
+-- Code symbols (functions, structs, enums, traits, etc.) extracted by parser.
+-- Idempotency: (repo_id, fqn) is UNIQUE per ADR-007 §11.9.
+CREATE TABLE code_symbols (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo_id         UUID        NOT NULL,
+    fqn             TEXT        NOT NULL,  -- fully-qualified name
+    kind            TEXT        NOT NULL,  -- ItemKind variant
+    source_path     TEXT,               -- relative path in repo
+    line_start      INTEGER,
+    line_end        INTEGER,
+    blob_ref        TEXT,               -- rb-blob:// pointer for AST JSON
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, fqn)
+);
+
+CREATE INDEX idx_code_symbols_repo ON code_symbols (repo_id);
+CREATE INDEX idx_code_symbols_kind ON code_symbols (kind);
+
+-- Relations between symbols (calls, implements, uses, etc.).
+-- Idempotency: (repo_id, from_fqn, to_fqn, kind) is UNIQUE.
+CREATE TABLE code_relations (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo_id         UUID        NOT NULL,
+    from_fqn        TEXT        NOT NULL,
+    to_fqn          TEXT        NOT NULL,
+    kind            TEXT        NOT NULL,  -- RelationKind variant
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, from_fqn, to_fqn, kind)
+);
+
+CREATE INDEX idx_code_relations_repo ON code_relations (repo_id);
+CREATE INDEX idx_code_relations_from ON code_relations (from_fqn);
+CREATE INDEX idx_code_relations_to ON code_relations (to_fqn);
+
+-- Vector embeddings for semantic search.
+-- One row per (symbol_fqn, model) pair.
+CREATE TABLE code_embeddings (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo_id         UUID        NOT NULL,
+    symbol_fqn      TEXT        NOT NULL,
+    embedding_model TEXT        NOT NULL,  -- e.g. "openai/text-embedding-3-small"
+    dimensions      INTEGER     NOT NULL,
+    vector          vector,              -- pgvector extension
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, symbol_fqn, embedding_model)
+);
+
+CREATE INDEX idx_code_embeddings_repo ON code_embeddings (repo_id);
+CREATE INDEX idx_code_embeddings_vector ON code_embeddings USING ivfflat (vector vector_cosine_ops);

--- a/services/projector-pg/Cargo.toml
+++ b/services/projector-pg/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "projector-pg"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "projector-pg"
+path = "src/main.rs"
+
+[dependencies]
+rb-kafka          = { path = "../../crates/rb-kafka",         version = "0.1.0" }
+rb-schemas        = { path = "../../crates/rb-schemas",       version = "0.1.0" }
+rb-storage-pg     = { path = "../../crates/rb-storage-pg",    version = "0.1.0" }
+rb-tenant         = { path = "../../crates/rb-tenant",        version = "0.1.0" }
+rb-tracing        = { path = "../../crates/rb-tracing",       version = "0.1.0" }
+anyhow.workspace  = true
+chrono.workspace  = true
+metrics.workspace = true
+serde_json.workspace = true
+sqlx.workspace    = true
+thiserror.workspace = true
+tokio.workspace   = true
+tracing.workspace = true
+uuid.workspace    = true
+
+[dev-dependencies]
+metrics-util.workspace = true
+
+[lints]
+workspace = true

--- a/services/projector-pg/src/consumer.rs
+++ b/services/projector-pg/src/consumer.rs
@@ -1,0 +1,255 @@
+//! Kafka consumer loop for `projector-pg`.
+//!
+//! Consumes typed payload events and writes to per-tenant `PostgreSQL` tables
+//! via `TenantPool`. Emits `IngestStatusEvent` per stage completion.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use metrics::counter;
+use rb_kafka::{Consumer, ConsumerCfg, EventEnvelope, Producer, ProducerCfg};
+use rb_schemas::{SourceFileEvent, ParsedItemEvent, GraphRelationEvent, IngestStage, IngestStatus, IngestStatusEvent};
+use rb_storage_pg::TenantPool;
+use rb_tenant::TenantCtx;
+use tokio::task::JoinHandle;
+
+use crate::projection;
+
+const TOPIC_SOURCE_FILE: &str = "rb.source-files.v1";
+const TOPIC_PARSED_ITEMS: &str = "rb.ingest.parse.commands";
+const TOPIC_GRAPH_RELATIONS: &str = "rb.ingest.graph.commands";
+const TOPIC_PROJECTOR_EVENTS: &str = "rb.projector.events";
+
+/// Spawn the long-running consumer task.
+///
+/// Returns the [`JoinHandle`] so the caller can abort on shutdown.
+#[allow(clippy::missing_errors_doc)]
+pub fn spawn(pool: Arc<TenantPool>) -> Result<JoinHandle<()>> {
+    // Source file consumer (from clone stage)
+    let source_consumer = Consumer::<SourceFileEvent>::new(
+        &ConsumerCfg::new("projector-pg-source")
+    )?;
+    source_consumer.subscribe(&[TOPIC_SOURCE_FILE])?;
+
+    // Parsed item consumer (from parse stage)
+    let item_consumer = Consumer::<ParsedItemEvent>::new(
+        &ConsumerCfg::new("projector-pg-items")
+    )?;
+    item_consumer.subscribe(&[TOPIC_PARSED_ITEMS])?;
+
+    // Relation consumer (from graph stage)
+    let relation_consumer = Consumer::<GraphRelationEvent>::new(
+        &ConsumerCfg::new("projector-pg-relations")
+    )?;
+    relation_consumer.subscribe(&[TOPIC_GRAPH_RELATIONS])?;
+
+    let producer = Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
+
+    let handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = source_consumer.next() => {
+                    match result {
+                        None => {
+                            tracing::info!("projector_pg: source consumer stream ended");
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("projector_pg: source kafka error: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                        Some(Ok(envelope)) => {
+                            handle_source_file(&pool, &source_consumer, producer.as_ref(), envelope).await;
+                        }
+                    }
+                }
+                result = item_consumer.next() => {
+                    match result {
+                        None => {
+                            tracing::info!("projector_pg: item consumer stream ended");
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("projector_pg: item kafka error: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                        Some(Ok(envelope)) => {
+                            handle_parsed_item(&pool, &item_consumer, producer.as_ref(), envelope).await;
+                        }
+                    }
+                }
+                result = relation_consumer.next() => {
+                    match result {
+                        None => {
+                            tracing::info!("projector_pg: relation consumer stream ended");
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("projector_pg: relation kafka error: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                        Some(Ok(envelope)) => {
+                            handle_relation(&pool, &relation_consumer, producer.as_ref(), envelope).await;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(handle)
+}
+
+async fn handle_source_file(
+    pool: &TenantPool,
+    consumer: &Consumer<SourceFileEvent>,
+    producer: &Producer<IngestStatusEvent>,
+    envelope: EventEnvelope<SourceFileEvent>,
+) {
+    let ev = &envelope.payload;
+    let tenant_id = envelope.tenant_id;
+    let tenant_ctx = TenantCtx::new(tenant_id);
+    let ingest_run_id = ev.ingest_run_id.clone();
+
+    match projection::write_source_file(pool, &tenant_ctx, &envelope.tenant_id, ev).await {
+        Ok(()) => {
+            counter!("rb_projector_pg_events_total", "event_type" => "source_file", "outcome" => "ok")
+                .increment(1);
+            if let Err(e) = consumer.commit(&envelope).await {
+                tracing::warn!("projector_pg: source commit failed: {e}");
+            }
+            emit_ok_status(producer, &tenant_id, &ingest_run_id, IngestStage::ProjectPg).await;
+        }
+        Err(e) => {
+            tracing::error!(
+                tenant_id = %tenant_id,
+                path = %ev.relative_path,
+                "projector_pg: source write failed: {e}"
+            );
+            counter!("rb_projector_pg_events_total", "event_type" => "source_file", "outcome" => "err")
+                .increment(1);
+            emit_failed_status(producer, &tenant_id, &ingest_run_id, &format!("source_write_failed: {e}"))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+}
+
+async fn handle_parsed_item(
+    pool: &TenantPool,
+    consumer: &Consumer<ParsedItemEvent>,
+    producer: &Producer<IngestStatusEvent>,
+    envelope: EventEnvelope<ParsedItemEvent>,
+) {
+    let ev = &envelope.payload;
+    let tenant_id = envelope.tenant_id;
+    let tenant_ctx = TenantCtx::new(tenant_id);
+    let ingest_run_id = ev.ingest_run_id.clone();
+
+    match projection::write_parsed_item(pool, &tenant_ctx, &envelope.tenant_id, ev).await {
+        Ok(()) => {
+            counter!("rb_projector_pg_events_total", "event_type" => "parsed_item", "outcome" => "ok")
+                .increment(1);
+            if let Err(e) = consumer.commit(&envelope).await {
+                tracing::warn!("projector_pg: item commit failed: {e}");
+            }
+            emit_ok_status(producer, &tenant_id, &ingest_run_id, IngestStage::ProjectPg).await;
+        }
+        Err(e) => {
+            tracing::error!(
+                tenant_id = %tenant_id,
+                fqn = %ev.fqn,
+                "projector_pg: item write failed: {e}"
+            );
+            counter!("rb_projector_pg_events_total", "event_type" => "parsed_item", "outcome" => "err")
+                .increment(1);
+            emit_failed_status(producer, &tenant_id, &ingest_run_id, &format!("item_write_failed: {e}"))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+}
+
+async fn handle_relation(
+    pool: &TenantPool,
+    consumer: &Consumer<GraphRelationEvent>,
+    producer: &Producer<IngestStatusEvent>,
+    envelope: EventEnvelope<GraphRelationEvent>,
+) {
+    let ev = &envelope.payload;
+    let tenant_id = envelope.tenant_id;
+    let tenant_ctx = TenantCtx::new(tenant_id);
+    let ingest_run_id = ev.ingest_run_id.clone();
+
+    match projection::write_relation(pool, &tenant_ctx, &envelope.tenant_id, ev).await {
+        Ok(()) => {
+            counter!("rb_projector_pg_events_total", "event_type" => "relation", "outcome" => "ok")
+                .increment(1);
+            if let Err(e) = consumer.commit(&envelope).await {
+                tracing::warn!("projector_pg: relation commit failed: {e}");
+            }
+            emit_ok_status(producer, &tenant_id, &ingest_run_id, IngestStage::ProjectPg).await;
+        }
+        Err(e) => {
+            tracing::error!(
+                tenant_id = %tenant_id,
+                from_fqn = %ev.from_fqn,
+                to_fqn = %ev.to_fqn,
+                "projector_pg: relation write failed: {e}"
+            );
+            counter!("rb_projector_pg_events_total", "event_type" => "relation", "outcome" => "err")
+                .increment(1);
+            emit_failed_status(producer, &tenant_id, &ingest_run_id, &format!("relation_write_failed: {e}"))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+}
+
+async fn emit_ok_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: &rb_schemas::TenantId,
+    ingest_run_id: &str,
+    stage: IngestStage,
+) {
+    let status_ev = IngestStatusEvent {
+        ingest_request_id: String::new(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Done as i32,
+        error_message: String::new(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: stage as i32,
+        stage_seq: 0,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 1,
+    };
+    let env = EventEnvelope::new(*tenant_id, status_ev);
+    let key = tenant_id.to_string();
+    if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), env).await {
+        tracing::error!("projector_pg: failed to publish ok status event: {e}");
+    }
+}
+
+async fn emit_failed_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: &rb_schemas::TenantId,
+    ingest_run_id: &str,
+    error_message: &str,
+) {
+    let status_ev = IngestStatusEvent {
+        ingest_request_id: String::new(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Failed as i32,
+        error_message: error_message.to_owned(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::ProjectPg as i32,
+        stage_seq: 0,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 1,
+    };
+    let env = EventEnvelope::new(*tenant_id, status_ev);
+    let key = tenant_id.to_string();
+    if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), env).await {
+        tracing::error!("projector_pg: failed to publish status event: {e}");
+    }
+}

--- a/services/projector-pg/src/consumer.rs
+++ b/services/projector-pg/src/consumer.rs
@@ -206,13 +206,12 @@ async fn handle_relation(
     }
 }
 
-async fn emit_ok_status(
-    producer: &Producer<IngestStatusEvent>,
+fn build_ok_status_event(
     tenant_id: &rb_schemas::TenantId,
     ingest_run_id: &str,
     stage: IngestStage,
-) {
-    let status_ev = IngestStatusEvent {
+) -> IngestStatusEvent {
+    IngestStatusEvent {
         ingest_request_id: String::new(),
         tenant_id: tenant_id.to_string(),
         status: IngestStatus::Done as i32,
@@ -221,8 +220,35 @@ async fn emit_ok_status(
         stage: stage as i32,
         stage_seq: 0,
         ingest_run_id: ingest_run_id.to_owned(),
-        attempt: 1,
-    };
+        attempt: 0,
+    }
+}
+
+fn build_failed_status_event(
+    tenant_id: &rb_schemas::TenantId,
+    ingest_run_id: &str,
+    error_message: &str,
+) -> IngestStatusEvent {
+    IngestStatusEvent {
+        ingest_request_id: String::new(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Failed as i32,
+        error_message: error_message.to_owned(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::ProjectPg as i32,
+        stage_seq: 0,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 0,
+    }
+}
+
+async fn emit_ok_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: &rb_schemas::TenantId,
+    ingest_run_id: &str,
+    stage: IngestStage,
+) {
+    let status_ev = build_ok_status_event(tenant_id, ingest_run_id, stage);
     let env = EventEnvelope::new(*tenant_id, status_ev);
     let key = tenant_id.to_string();
     if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), env).await {
@@ -236,20 +262,56 @@ async fn emit_failed_status(
     ingest_run_id: &str,
     error_message: &str,
 ) {
-    let status_ev = IngestStatusEvent {
-        ingest_request_id: String::new(),
-        tenant_id: tenant_id.to_string(),
-        status: IngestStatus::Failed as i32,
-        error_message: error_message.to_owned(),
-        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
-        stage: IngestStage::ProjectPg as i32,
-        stage_seq: 0,
-        ingest_run_id: ingest_run_id.to_owned(),
-        attempt: 1,
-    };
+    let status_ev = build_failed_status_event(tenant_id, ingest_run_id, error_message);
     let env = EventEnvelope::new(*tenant_id, status_ev);
     let key = tenant_id.to_string();
     if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), env).await {
         tracing::error!("projector_pg: failed to publish status event: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_schemas::TenantId as SchemasTenantId;
+
+    #[test]
+    fn build_ok_status_event_sets_done_status() {
+        let tid = SchemasTenantId::new();
+        let run_id = "run-abc";
+        let ev = build_ok_status_event(&tid, run_id, IngestStage::ProjectPg);
+        assert_eq!(ev.status, IngestStatus::Done as i32);
+        assert_eq!(ev.stage, IngestStage::ProjectPg as i32);
+        assert_eq!(ev.ingest_run_id, run_id);
+        assert_eq!(ev.tenant_id, tid.to_string());
+        assert!(ev.error_message.is_empty());
+        assert_eq!(ev.attempt, 0, "first attempt must be 0 per proto convention");
+    }
+
+    #[test]
+    fn build_ok_status_event_uses_provided_stage() {
+        let tid = SchemasTenantId::new();
+        let ev = build_ok_status_event(&tid, "run-1", IngestStage::Clone);
+        assert_eq!(ev.stage, IngestStage::Clone as i32);
+    }
+
+    #[test]
+    fn build_failed_status_event_sets_failed_status() {
+        let tid = SchemasTenantId::new();
+        let run_id = "run-def";
+        let err = "something went wrong";
+        let ev = build_failed_status_event(&tid, run_id, err);
+        assert_eq!(ev.status, IngestStatus::Failed as i32);
+        assert_eq!(ev.stage, IngestStage::ProjectPg as i32);
+        assert_eq!(ev.ingest_run_id, run_id);
+        assert_eq!(ev.error_message, err);
+        assert_eq!(ev.attempt, 0, "first attempt must be 0 per proto convention");
+    }
+
+    #[test]
+    fn build_failed_status_event_always_uses_project_pg_stage() {
+        let tid = SchemasTenantId::new();
+        let ev = build_failed_status_event(&tid, "run-1", "err");
+        assert_eq!(ev.stage, IngestStage::ProjectPg as i32);
     }
 }

--- a/services/projector-pg/src/lib.rs
+++ b/services/projector-pg/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod consumer;
+pub mod projection;

--- a/services/projector-pg/src/lib.rs
+++ b/services/projector-pg/src/lib.rs
@@ -1,2 +1,5 @@
-pub mod consumer;
-pub mod projection;
+mod consumer;
+mod projection;
+
+pub use consumer::spawn;
+pub use projection::{ProjectionError, write_source_file, write_parsed_item, write_relation};

--- a/services/projector-pg/src/main.rs
+++ b/services/projector-pg/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use rb_storage_pg::TenantPool;
 
-use projector_pg::consumer;
+use projector_pg::spawn;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     tracing::info!("projector-pg starting");
 
-    let handle = consumer::spawn(Arc::clone(&pool))?;
+    let handle = spawn(pool)?;
 
     shutdown_signal().await;
     tracing::info!("shutdown signal received — stopping consumer");

--- a/services/projector-pg/src/main.rs
+++ b/services/projector-pg/src/main.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rb_storage_pg::TenantPool;
+
+use projector_pg::consumer;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = rb_tracing::init("projector-pg")?;
+
+    let database_url = std::env::var("DATABASE_URL")
+        .context("DATABASE_URL is required")?;
+
+    let pg = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&database_url)
+        .await
+        .context("failed to connect to PostgreSQL")?;
+    let pool = TenantPool::new(pg);
+    let pool = Arc::new(pool);
+
+    tracing::info!("projector-pg starting");
+
+    let handle = consumer::spawn(Arc::clone(&pool))?;
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received — stopping consumer");
+    handle.abort();
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}

--- a/services/projector-pg/src/projection.rs
+++ b/services/projector-pg/src/projection.rs
@@ -1,0 +1,276 @@
+//! `PostgreSQL` projection logic for item and relation events.
+//!
+//! All writes go through `TenantPool` with fully-qualified table names
+//! (ADR-007 §11.9 / REQ-IN-09).
+
+use anyhow::{Context as _, Result};
+use rb_schemas::{ParsedItemEvent, SourceFileEvent, GraphRelationEvent, ItemKind, RelationKind, TenantId};
+use rb_schemas::{source_file_event, parsed_item_event};
+use rb_storage_pg::{StorageError, TenantPool};
+use rb_tenant::TenantCtx;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError {
+    #[error("tenant mismatch: envelope={envelope}, event={event}")]
+    TenantMismatch { envelope: String, event: String },
+}
+
+fn verify_tenant(envelope_tenant: &TenantId, event_tenant: &str) -> Result<(), ProjectionError> {
+    if envelope_tenant.to_string() != event_tenant {
+        return Err(ProjectionError::TenantMismatch {
+            envelope: envelope_tenant.to_string(),
+            event: event_tenant.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Write a `SourceFileEvent` to the tenant's `code_files` table.
+///
+/// Idempotent: uses `ON CONFLICT (repo_id, relative_path) DO UPDATE`.
+#[allow(clippy::missing_errors_doc)]
+pub async fn write_source_file(
+    pool: &TenantPool,
+    tenant_ctx: &TenantCtx,
+    envelope_tenant: &TenantId,
+    ev: &SourceFileEvent,
+) -> Result<()> {
+    verify_tenant(envelope_tenant, &ev.tenant_id)?;
+    let table = tenant_ctx.qualify("code_files");
+    let blob_ref = match &ev.body {
+        Some(source_file_event::Body::BlobRef(s)) => Some(s.as_str()),
+        _ => None,
+    };
+
+    let repo_id = parse_uuid(&ev.repo_id)
+        .context("invalid repo_id in SourceFileEvent")?;
+
+    sqlx::query(&format!(
+        r"INSERT INTO {table} (repo_id, relative_path, sha256, size_bytes, blob_ref)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (repo_id, relative_path) DO UPDATE SET
+               sha256 = EXCLUDED.sha256,
+               size_bytes = EXCLUDED.size_bytes,
+               blob_ref = EXCLUDED.blob_ref,
+               updated_at = now()"
+    ))
+    .bind(repo_id)
+    .bind(&ev.relative_path)
+    .bind(&ev.sha256)
+    .bind(ev.size_bytes)
+    .bind(blob_ref)
+    .execute(pool.control())
+    .await
+    .map_err(StorageError::Sqlx)
+    .context("failed to upsert source file")?;
+
+    Ok(())
+}
+
+/// Write a `ParsedItemEvent` to the tenant's `code_symbols` table.
+///
+/// Idempotent: uses `ON CONFLICT (repo_id, fqn) DO UPDATE`.
+#[allow(clippy::missing_errors_doc)]
+pub async fn write_parsed_item(
+    pool: &TenantPool,
+    tenant_ctx: &TenantCtx,
+    envelope_tenant: &TenantId,
+    ev: &ParsedItemEvent,
+) -> Result<()> {
+    verify_tenant(envelope_tenant, &ev.tenant_id)?;
+    let table = tenant_ctx.qualify("code_symbols");
+    let kind = item_kind_str(ItemKind::try_from(ev.kind).unwrap_or(ItemKind::Unspecified));
+    let blob_ref = match &ev.body {
+        Some(parsed_item_event::Body::BlobRef(s)) => Some(s.as_str()),
+        _ => None,
+    };
+
+    let repo_id = parse_uuid(&ev.repo_id)
+        .context("invalid repo_id in ParsedItemEvent")?;
+
+    sqlx::query(&format!(
+        r"INSERT INTO {table} (repo_id, fqn, kind, source_path, line_start, line_end, blob_ref)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           ON CONFLICT (repo_id, fqn) DO UPDATE SET
+               kind = EXCLUDED.kind,
+               source_path = EXCLUDED.source_path,
+               line_start = EXCLUDED.line_start,
+               line_end = EXCLUDED.line_end,
+               blob_ref = EXCLUDED.blob_ref,
+               updated_at = now()"
+    ))
+    .bind(repo_id)
+    .bind(&ev.fqn)
+    .bind(kind)
+    .bind(&ev.source_path)
+    .bind(ev.line_start)
+    .bind(ev.line_end)
+    .bind(blob_ref)
+    .execute(pool.control())
+    .await
+    .map_err(StorageError::Sqlx)
+    .context("failed to upsert parsed item")?;
+
+    Ok(())
+}
+
+/// Write a `GraphRelationEvent` to the tenant's `code_relations` table.
+///
+/// Idempotent: uses `ON CONFLICT (repo_id, from_fqn, to_fqn, kind) DO NOTHING`.
+#[allow(clippy::missing_errors_doc)]
+pub async fn write_relation(
+    pool: &TenantPool,
+    tenant_ctx: &TenantCtx,
+    envelope_tenant: &TenantId,
+    ev: &GraphRelationEvent,
+) -> Result<()> {
+    verify_tenant(envelope_tenant, &ev.tenant_id)?;
+    let table = tenant_ctx.qualify("code_relations");
+    let kind = relation_kind_str(
+        RelationKind::try_from(ev.kind).unwrap_or(RelationKind::Unspecified)
+    );
+
+    let repo_id = parse_uuid(&ev.repo_id)
+        .context("invalid repo_id in GraphRelationEvent")?;
+
+    sqlx::query(&format!(
+        r"INSERT INTO {table} (repo_id, from_fqn, to_fqn, kind)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (repo_id, from_fqn, to_fqn, kind) DO NOTHING"
+    ))
+    .bind(repo_id)
+    .bind(&ev.from_fqn)
+    .bind(&ev.to_fqn)
+    .bind(kind)
+    .execute(pool.control())
+    .await
+    .map_err(StorageError::Sqlx)
+    .context("failed to upsert relation")?;
+
+    Ok(())
+}
+
+/// Parse a UUID string, returning a sqlx-friendly type.
+fn parse_uuid(s: &str) -> Result<uuid::Uuid> {
+    s.parse::<uuid::Uuid>().context("invalid UUID format")
+}
+
+/// Map `ItemKind` to the database string representation.
+fn item_kind_str(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Fn => "FN",
+        ItemKind::Struct => "STRUCT",
+        ItemKind::Enum => "ENUM",
+        ItemKind::Trait => "TRAIT",
+        ItemKind::Impl => "IMPL",
+        ItemKind::Mod => "MOD",
+        ItemKind::Const => "CONST",
+        ItemKind::TraitMethod => "TRAIT_METHOD",
+        ItemKind::ImplBlock => "IMPL_BLOCK",
+        ItemKind::AssocType => "ASSOC_TYPE",
+        ItemKind::AssocConst => "ASSOC_CONST",
+        ItemKind::TypeParam => "TYPE_PARAM",
+        ItemKind::LifetimeParam => "LIFETIME_PARAM",
+        ItemKind::ConstParam => "CONST_PARAM",
+        ItemKind::WherePredicate => "WHERE_PREDICATE",
+        ItemKind::DynTraitUsage => "DYN_TRAIT_USAGE",
+        ItemKind::TypeInstance => "TYPE_INSTANCE",
+        ItemKind::MacroDef => "MACRO_DEF",
+        ItemKind::Unspecified => "UNSPECIFIED",
+    }
+}
+
+/// Map `RelationKind` to the database string representation.
+fn relation_kind_str(kind: RelationKind) -> &'static str {
+    match kind {
+        RelationKind::Calls => "CALLS",
+        RelationKind::Impls => "IMPLS",
+        RelationKind::UsesType => "USES_TYPE",
+        RelationKind::Imports => "IMPORTS",
+        RelationKind::Derives => "DERIVES",
+        RelationKind::BoundedBy => "BOUNDED_BY",
+        RelationKind::WhereClausePredicate => "WHERE_CLAUSE_PREDICATE",
+        RelationKind::ExtendsTrait => "EXTENDS_TRAIT",
+        RelationKind::BlanketImplFor => "BLANKET_IMPL_FOR",
+        RelationKind::AssocTypeBinding => "ASSOC_TYPE_BINDING",
+        RelationKind::HasTypeParam => "HAS_TYPE_PARAM",
+        RelationKind::HasLifetimeParam => "HAS_LIFETIME_PARAM",
+        RelationKind::HasConstParam => "HAS_CONST_PARAM",
+        RelationKind::MonomorphizedFrom => "MONOMORPHIZED_FROM",
+        RelationKind::TypeArgBinds => "TYPE_ARG_BINDS",
+        RelationKind::CallInstantiates => "CALL_INSTANTIATES",
+        RelationKind::MacroGeneratedBy => "MACRO_GENERATED_BY",
+        RelationKind::DynDispatchCandidate => "DYN_DISPATCH_CANDIDATE",
+        RelationKind::ErasedInto => "ERASED_INTO",
+        RelationKind::Unspecified => "UNSPECIFIED",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_schemas::TenantId as SchemasTenantId;
+
+    #[test]
+    fn item_kind_str_covers_all_stable_kinds() {
+        for kind in [
+            ItemKind::Fn,
+            ItemKind::Struct,
+            ItemKind::Enum,
+            ItemKind::Trait,
+            ItemKind::Impl,
+            ItemKind::Mod,
+            ItemKind::Const,
+        ] {
+            let s = item_kind_str(kind);
+            assert!(!s.is_empty());
+            assert!(s.chars().all(|c| c.is_ascii_uppercase() || c == '_'));
+        }
+    }
+
+    #[test]
+    fn relation_kind_str_covers_all_stable_kinds() {
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Impls,
+            RelationKind::UsesType,
+            RelationKind::Imports,
+            RelationKind::Derives,
+        ] {
+            let s = relation_kind_str(kind);
+            assert!(!s.is_empty());
+            assert!(s.chars().all(|c| c.is_ascii_uppercase() || c == '_'));
+        }
+    }
+
+    #[test]
+    fn verify_tenant_rejects_mismatch() {
+        let envelope_tid = SchemasTenantId::new();
+        let event_tid = SchemasTenantId::new();
+        let result = verify_tenant(&envelope_tid, &event_tid.to_string());
+        assert!(result.is_err(), "mismatched tenants must be rejected");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("tenant mismatch"), "expected tenant mismatch, got: {err_msg}");
+    }
+
+    #[test]
+    fn verify_tenant_accepts_matching() {
+        let tid = SchemasTenantId::new();
+        let result = verify_tenant(&tid, &tid.to_string());
+        assert!(result.is_ok(), "matching tenants must be accepted");
+    }
+
+    #[test]
+    fn parse_uuid_rejects_invalid() {
+        let result = parse_uuid("not-a-uuid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_uuid_accepts_valid() {
+        let uid = uuid::Uuid::new_v4();
+        let result = parse_uuid(&uid.to_string());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), uid);
+    }
+}

--- a/services/projector-pg/tests/integration.rs
+++ b/services/projector-pg/tests/integration.rs
@@ -1,0 +1,571 @@
+//! Integration tests for `projector-pg` projection logic.
+//!
+//! Requires a running Postgres instance. Set `TEST_DATABASE_URL` to run:
+//!   docker compose -f compose/test.yml up -d postgres
+//!   `TEST_DATABASE_URL=postgres://rustbrain:rustbrain@localhost:5433/rustbrain` \
+//!     cargo test -p projector-pg
+
+use rb_schemas::{
+    GraphRelationEvent, ItemKind, ParsedItemEvent, RelationKind,
+    SourceFileEvent, TenantId, source_file_event, parsed_item_event,
+};
+use rb_storage_pg::TenantPool;
+use rb_tenant::TenantCtx;
+use sqlx::postgres::PgPoolOptions;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn test_url() -> Option<String> {
+    std::env::var("TEST_DATABASE_URL").ok()
+}
+
+async fn make_pool(url: &str) -> TenantPool {
+    let pg = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(url)
+        .await
+        .expect("connect to test DB");
+    TenantPool::new(pg)
+}
+
+fn new_ctx() -> TenantCtx {
+    TenantCtx::new(TenantId::new())
+}
+
+macro_rules! skip_no_db {
+    ($url:ident) => {
+        let Some($url) = test_url() else {
+            eprintln!("SKIP: TEST_DATABASE_URL not set");
+            return;
+        };
+    };
+}
+
+/// Set up a tenant schema with the `code_tables` migration applied.
+async fn setup_tenant(pool: &TenantPool, ctx: &TenantCtx) {
+    pool.create_schema(ctx).await.expect("create schema");
+    let schema = ctx.schema_name();
+
+    // code_files
+    sqlx::query(&format!(
+        r"CREATE TABLE IF NOT EXISTS {schema}.code_files (
+            id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+            repo_id         UUID        NOT NULL,
+            relative_path   TEXT        NOT NULL,
+            sha256          TEXT        NOT NULL,
+            size_bytes      BIGINT      NOT NULL,
+            blob_ref        TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (repo_id, relative_path)
+        )"
+    ))
+    .execute(pool.control())
+    .await
+    .expect("create code_files");
+
+    // code_symbols
+    sqlx::query(&format!(
+        r"CREATE TABLE IF NOT EXISTS {schema}.code_symbols (
+            id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+            repo_id         UUID        NOT NULL,
+            fqn             TEXT        NOT NULL,
+            kind            TEXT        NOT NULL,
+            source_path     TEXT,
+            line_start      INTEGER,
+            line_end        INTEGER,
+            blob_ref        TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (repo_id, fqn)
+        )"
+    ))
+    .execute(pool.control())
+    .await
+    .expect("create code_symbols");
+
+    // code_relations
+    sqlx::query(&format!(
+        r"CREATE TABLE IF NOT EXISTS {schema}.code_relations (
+            id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+            repo_id         UUID        NOT NULL,
+            from_fqn        TEXT        NOT NULL,
+            to_fqn          TEXT        NOT NULL,
+            kind            TEXT        NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (repo_id, from_fqn, to_fqn, kind)
+        )"
+    ))
+    .execute(pool.control())
+    .await
+    .expect("create code_relations");
+}
+
+async fn teardown_tenant(pool: &TenantPool, ctx: &TenantCtx) {
+    let _ = pool.drop_schema(ctx).await;
+}
+
+// ── source file projection ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn write_source_file_inserts_row() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = SourceFileEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/main.rs".to_string(),
+        sha256: "abc123".to_string(),
+        size_bytes: 1024,
+        emitted_at_ms: 0,
+        body: None,
+    };
+
+    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("write_source_file");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_files",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "one row must be inserted");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_source_file_upsert_is_idempotent() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = SourceFileEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/main.rs".to_string(),
+        sha256: "v1".to_string(),
+        size_bytes: 100,
+        emitted_at_ms: 0,
+        body: None,
+    };
+
+    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("first write");
+
+    let ev_v2 = SourceFileEvent {
+        sha256: "v2".to_string(),
+        size_bytes: 200,
+        ..ev.clone()
+    };
+    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev_v2)
+        .await
+        .expect("second write (upsert)");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_files",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "upsert must not duplicate rows");
+
+    let sha: String = sqlx::query_scalar(&format!(
+        "SELECT sha256 FROM {}.code_files WHERE repo_id = $1 AND relative_path = $2",
+        ctx.schema_name()
+    ))
+    .bind(repo_id)
+    .bind("src/main.rs")
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(sha, "v2", "sha256 must be updated on upsert");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_source_file_rejects_tenant_mismatch() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let envelope_tid = TenantId::new();
+    let different_tid = TenantId::new();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = SourceFileEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: different_tid.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/main.rs".to_string(),
+        sha256: "abc".to_string(),
+        size_bytes: 100,
+        emitted_at_ms: 0,
+        body: None,
+    };
+
+    let result = projector_pg::projection::write_source_file(&pool, &ctx, &envelope_tid, &ev).await;
+    assert!(result.is_err(), "tenant mismatch must be rejected");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_source_file_with_blob_ref() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = SourceFileEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/large_file.rs".to_string(),
+        sha256: "def456".to_string(),
+        size_bytes: 1_000_000,
+        emitted_at_ms: 0,
+        body: Some(source_file_event::Body::BlobRef("rb-blob://test".to_string())),
+    };
+
+    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("write with blob_ref");
+
+    let blob: Option<String> = sqlx::query_scalar(&format!(
+        "SELECT blob_ref FROM {}.code_files WHERE repo_id = $1 AND relative_path = $2",
+        ctx.schema_name()
+    ))
+    .bind(repo_id)
+    .bind("src/large_file.rs")
+    .fetch_optional(pool.control())
+    .await
+    .unwrap()
+    .flatten();
+    assert_eq!(blob.as_deref(), Some("rb-blob://test"), "blob_ref must be stored");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+// ── parsed item projection ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn write_parsed_item_inserts_row() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = ParsedItemEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        fqn: "crate::module::my_function".to_string(),
+        kind: ItemKind::Fn as i32,
+        source_path: "src/module.rs".to_string(),
+        line_start: 42,
+        line_end: 55,
+        emitted_at_ms: 0,
+        body: None,
+    };
+
+    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("write_parsed_item");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_symbols",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "one symbol must be inserted");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_parsed_item_upsert_is_idempotent() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = ParsedItemEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        fqn: "crate::module::Foo".to_string(),
+        kind: ItemKind::Struct as i32,
+        source_path: "src/module.rs".to_string(),
+        line_start: 10,
+        line_end: 20,
+        emitted_at_ms: 0,
+        body: None,
+    };
+
+    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("first write");
+
+    let ev_v2 = ParsedItemEvent {
+        line_start: 11,
+        line_end: 21,
+        ..ev.clone()
+    };
+    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev_v2)
+        .await
+        .expect("upsert");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_symbols",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "upsert must not duplicate symbols");
+
+    let (ls, le): (Option<i32>, Option<i32>) = sqlx::query_as(&format!(
+        "SELECT line_start, line_end FROM {}.code_symbols WHERE repo_id = $1 AND fqn = $2",
+        ctx.schema_name()
+    ))
+    .bind(repo_id)
+    .bind("crate::module::Foo")
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(ls, Some(11), "line_start must be updated");
+    assert_eq!(le, Some(21), "line_end must be updated");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_parsed_item_with_blob_ref() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = ParsedItemEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        fqn: "crate::module::large_fn".to_string(),
+        kind: ItemKind::Fn as i32,
+        source_path: "src/module.rs".to_string(),
+        line_start: 1,
+        line_end: 500,
+        emitted_at_ms: 0,
+        body: Some(parsed_item_event::Body::BlobRef("rb-blob://ast-json".to_string())),
+    };
+
+    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("write with blob_ref");
+
+    let blob: Option<String> = sqlx::query_scalar(&format!(
+        "SELECT blob_ref FROM {}.code_symbols WHERE repo_id = $1 AND fqn = $2",
+        ctx.schema_name()
+    ))
+    .bind(repo_id)
+    .bind("crate::module::large_fn")
+    .fetch_optional(pool.control())
+    .await
+    .unwrap()
+    .flatten();
+    assert_eq!(blob.as_deref(), Some("rb-blob://ast-json"));
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+// ── relation projection ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn write_relation_inserts_row() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = GraphRelationEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        from_fqn: "crate::module::foo".to_string(),
+        to_fqn: "crate::module::bar".to_string(),
+        kind: RelationKind::Calls as i32,
+        emitted_at_ms: 0,
+    };
+
+    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("write_relation");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_relations",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "one relation must be inserted");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_relation_dedup_is_idempotent() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let tid = *ctx.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = GraphRelationEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid.to_string(),
+        repo_id: repo_id.to_string(),
+        from_fqn: "crate::module::A".to_string(),
+        to_fqn: "crate::module::B".to_string(),
+        kind: RelationKind::Impls as i32,
+        emitted_at_ms: 0,
+    };
+
+    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("first write");
+    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+        .await
+        .expect("second write (DO NOTHING)");
+
+    let count: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_relations",
+        ctx.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "DO NOTHING must not duplicate relations");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+#[tokio::test]
+async fn write_relation_rejects_tenant_mismatch() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx = new_ctx();
+    setup_tenant(&pool, &ctx).await;
+
+    let envelope_tid = TenantId::new();
+    let different_tid = TenantId::new();
+    let repo_id = uuid::Uuid::new_v4();
+    let ev = GraphRelationEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: different_tid.to_string(),
+        repo_id: repo_id.to_string(),
+        from_fqn: "crate::A".to_string(),
+        to_fqn: "crate::B".to_string(),
+        kind: RelationKind::Calls as i32,
+        emitted_at_ms: 0,
+    };
+
+    let result = projector_pg::projection::write_relation(&pool, &ctx, &envelope_tid, &ev).await;
+    assert!(result.is_err(), "tenant mismatch must be rejected");
+
+    teardown_tenant(&pool, &ctx).await;
+}
+
+// ── cross-tenant isolation ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn projection_is_tenant_isolated() {
+    skip_no_db!(url);
+    let pool = make_pool(&url).await;
+    let ctx_a = new_ctx();
+    let ctx_b = new_ctx();
+    setup_tenant(&pool, &ctx_a).await;
+    setup_tenant(&pool, &ctx_b).await;
+
+    let tid_a = *ctx_a.tenant_id();
+    let tid_b = *ctx_b.tenant_id();
+    let repo_id = uuid::Uuid::new_v4();
+
+    let ev_a = SourceFileEvent {
+        ingest_run_id: "run-1".to_string(),
+        tenant_id: tid_a.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/a.rs".to_string(),
+        sha256: "aaa".to_string(),
+        size_bytes: 100,
+        emitted_at_ms: 0,
+        body: None,
+    };
+    projector_pg::projection::write_source_file(&pool, &ctx_a, &tid_a, &ev_a)
+        .await
+        .expect("write to A");
+
+    let ev_b = SourceFileEvent {
+        ingest_run_id: "run-2".to_string(),
+        tenant_id: tid_b.to_string(),
+        repo_id: repo_id.to_string(),
+        relative_path: "src/b.rs".to_string(),
+        sha256: "bbb".to_string(),
+        size_bytes: 200,
+        emitted_at_ms: 0,
+        body: None,
+    };
+    projector_pg::projection::write_source_file(&pool, &ctx_b, &tid_b, &ev_b)
+        .await
+        .expect("write to B");
+
+    let count_a: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_files",
+        ctx_a.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    let count_b: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {}.code_files",
+        ctx_b.schema_name()
+    ))
+    .fetch_one(pool.control())
+    .await
+    .unwrap();
+    assert_eq!(count_a, 1, "tenant A must have exactly 1 row");
+    assert_eq!(count_b, 1, "tenant B must have exactly 1 row");
+
+    teardown_tenant(&pool, &ctx_a).await;
+    teardown_tenant(&pool, &ctx_b).await;
+}

--- a/services/projector-pg/tests/integration.rs
+++ b/services/projector-pg/tests/integration.rs
@@ -127,7 +127,7 @@ async fn write_source_file_inserts_row() {
         body: None,
     };
 
-    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+    projector_pg::write_source_file(&pool, &ctx, &tid, &ev)
         .await
         .expect("write_source_file");
 
@@ -163,7 +163,7 @@ async fn write_source_file_upsert_is_idempotent() {
         body: None,
     };
 
-    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+    projector_pg::write_source_file(&pool, &ctx, &tid, &ev)
         .await
         .expect("first write");
 
@@ -172,7 +172,7 @@ async fn write_source_file_upsert_is_idempotent() {
         size_bytes: 200,
         ..ev.clone()
     };
-    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev_v2)
+    projector_pg::write_source_file(&pool, &ctx, &tid, &ev_v2)
         .await
         .expect("second write (upsert)");
 
@@ -220,7 +220,7 @@ async fn write_source_file_rejects_tenant_mismatch() {
         body: None,
     };
 
-    let result = projector_pg::projection::write_source_file(&pool, &ctx, &envelope_tid, &ev).await;
+    let result = projector_pg::write_source_file(&pool, &ctx, &envelope_tid, &ev).await;
     assert!(result.is_err(), "tenant mismatch must be rejected");
 
     teardown_tenant(&pool, &ctx).await;
@@ -246,7 +246,7 @@ async fn write_source_file_with_blob_ref() {
         body: Some(source_file_event::Body::BlobRef("rb-blob://test".to_string())),
     };
 
-    projector_pg::projection::write_source_file(&pool, &ctx, &tid, &ev)
+    projector_pg::write_source_file(&pool, &ctx, &tid, &ev)
         .await
         .expect("write with blob_ref");
 
@@ -289,7 +289,7 @@ async fn write_parsed_item_inserts_row() {
         body: None,
     };
 
-    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+    projector_pg::write_parsed_item(&pool, &ctx, &tid, &ev)
         .await
         .expect("write_parsed_item");
 
@@ -327,7 +327,7 @@ async fn write_parsed_item_upsert_is_idempotent() {
         body: None,
     };
 
-    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+    projector_pg::write_parsed_item(&pool, &ctx, &tid, &ev)
         .await
         .expect("first write");
 
@@ -336,7 +336,7 @@ async fn write_parsed_item_upsert_is_idempotent() {
         line_end: 21,
         ..ev.clone()
     };
-    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev_v2)
+    projector_pg::write_parsed_item(&pool, &ctx, &tid, &ev_v2)
         .await
         .expect("upsert");
 
@@ -386,7 +386,7 @@ async fn write_parsed_item_with_blob_ref() {
         body: Some(parsed_item_event::Body::BlobRef("rb-blob://ast-json".to_string())),
     };
 
-    projector_pg::projection::write_parsed_item(&pool, &ctx, &tid, &ev)
+    projector_pg::write_parsed_item(&pool, &ctx, &tid, &ev)
         .await
         .expect("write with blob_ref");
 
@@ -426,7 +426,7 @@ async fn write_relation_inserts_row() {
         emitted_at_ms: 0,
     };
 
-    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+    projector_pg::write_relation(&pool, &ctx, &tid, &ev)
         .await
         .expect("write_relation");
 
@@ -461,10 +461,10 @@ async fn write_relation_dedup_is_idempotent() {
         emitted_at_ms: 0,
     };
 
-    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+    projector_pg::write_relation(&pool, &ctx, &tid, &ev)
         .await
         .expect("first write");
-    projector_pg::projection::write_relation(&pool, &ctx, &tid, &ev)
+    projector_pg::write_relation(&pool, &ctx, &tid, &ev)
         .await
         .expect("second write (DO NOTHING)");
 
@@ -500,7 +500,7 @@ async fn write_relation_rejects_tenant_mismatch() {
         emitted_at_ms: 0,
     };
 
-    let result = projector_pg::projection::write_relation(&pool, &ctx, &envelope_tid, &ev).await;
+    let result = projector_pg::write_relation(&pool, &ctx, &envelope_tid, &ev).await;
     assert!(result.is_err(), "tenant mismatch must be rejected");
 
     teardown_tenant(&pool, &ctx).await;
@@ -531,7 +531,7 @@ async fn projection_is_tenant_isolated() {
         emitted_at_ms: 0,
         body: None,
     };
-    projector_pg::projection::write_source_file(&pool, &ctx_a, &tid_a, &ev_a)
+    projector_pg::write_source_file(&pool, &ctx_a, &tid_a, &ev_a)
         .await
         .expect("write to A");
 
@@ -545,7 +545,7 @@ async fn projection_is_tenant_isolated() {
         emitted_at_ms: 0,
         body: None,
     };
-    projector_pg::projection::write_source_file(&pool, &ctx_b, &tid_b, &ev_b)
+    projector_pg::write_source_file(&pool, &ctx_b, &tid_b, &ev_b)
         .await
         .expect("write to B");
 

--- a/services/projector-pg/tests/metrics_emitted.rs
+++ b/services/projector-pg/tests/metrics_emitted.rs
@@ -1,0 +1,67 @@
+use metrics_util::debugging::{DebuggingRecorder, DebugValue};
+
+fn counter_value(
+    entries: &[(metrics_util::CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue)],
+    name: &str,
+    labels: &[(&str, &str)],
+) -> u64 {
+    entries
+        .iter()
+        .filter(|(key, _, _, _)| key.key().name() == name)
+        .filter_map(|(key, _, _, value)| {
+            let key_labels: std::collections::HashMap<&str, &str> = key
+                .key()
+                .labels()
+                .map(|l| (l.key(), l.value()))
+                .collect();
+            let matches = labels.iter().all(|(k, v)| key_labels.get(k) == Some(v));
+            if matches {
+                if let DebugValue::Counter(n) = value {
+                    return Some(*n);
+                }
+            }
+            None
+        })
+        .sum()
+}
+
+#[test]
+fn rb_projector_pg_events_total_metric_is_emitted() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    assert!(recorder.install().is_ok(), "DebuggingRecorder install must succeed");
+
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "source_file", "outcome" => "ok").increment(1);
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "parsed_item", "outcome" => "ok").increment(1);
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "relation", "outcome" => "ok").increment(1);
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "source_file", "outcome" => "err").increment(1);
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "parsed_item", "outcome" => "err").increment(1);
+    metrics::counter!("rb_projector_pg_events_total", "event_type" => "relation", "outcome" => "err").increment(1);
+
+    let entries = snapshotter.snapshot().into_vec();
+
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "source_file"), ("outcome", "ok")]),
+        1,
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "parsed_item"), ("outcome", "ok")]),
+        1,
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "relation"), ("outcome", "ok")]),
+        1,
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "source_file"), ("outcome", "err")]),
+        1,
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "parsed_item"), ("outcome", "err")]),
+        1,
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_projector_pg_events_total", &[("event_type", "relation"), ("outcome", "err")]),
+        1,
+    );
+}


### PR DESCRIPTION
## Summary

Implement the `projector-pg` service (REQ-IN-09) that consumes all item/relation events from Kafka and writes to per-tenant PostgreSQL schema tables via `TenantPool`.

## GitHub Issue

Closes #169

## Checklist
- [x] Tests pass (10 unit tests + 11 integration tests)
- [x] No new dependencies (uses existing workspace crates)
- [x] No destructive schema changes (additive migration only)
- [x] Clippy clean with -D warnings

## Key Changes

- `services/projector-pg/` — consumer loop, projection logic, status emission
- `crates/rb-schemas/src/lib.rs` — re-export `source_file_event` and `parsed_item_event` submodules
- `migrations/tenant/002_code_tables.sql` — per-tenant projection tables
- `docker/projector-pg/Dockerfile` — multi-stage build

## Merge instructions

Squash-merge (`gh pr merge 170 --squash`).