### PR TITLE
feat(tombstoner): REQ-IN-12 tombstone consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,8 +189,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -199,7 +199,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1 0.10.6",
+ "sha1",
  "time",
  "tokio",
  "tracing",
@@ -251,7 +251,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -281,9 +281,8 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -292,14 +291,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac 0.13.0",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 0.4.6",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -313,8 +312,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -337,8 +336,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -361,8 +360,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -385,7 +384,7 @@ checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -418,22 +417,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.63.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.62.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "md-5 0.11.0",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
  "pin-project-lite",
- "sha1 0.11.0",
- "sha2 0.11.0",
+ "sha1",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -450,11 +448,32 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -491,13 +510,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
 ]
 
 [[package]]
@@ -535,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1122,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1137,14 +1165,15 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
+ "rand 0.9.4",
+ "regex",
  "rustversion",
- "spin 0.10.0",
 ]
 
 [[package]]
@@ -1518,7 +1547,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -1532,12 +1561,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1778,18 +1801,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2007,7 +2019,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2176,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2293,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2324,7 +2336,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2352,7 +2364,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2468,11 +2480,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2510,16 +2522,6 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
-dependencies = [
- "cfg-if",
- "digest 0.11.2",
 ]
 
 [[package]]
@@ -3408,7 +3410,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3428,7 +3430,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3448,7 +3450,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3759,6 +3761,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -3890,7 +3893,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4001,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4283,17 +4286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,12 +4427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-
-[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,7 +4483,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4575,14 +4561,14 @@ dependencies = [
  "hmac 0.12.1",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -4616,7 +4602,7 @@ dependencies = [
  "home",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
  "once_cell",
  "rand 0.8.6",
@@ -4908,7 +4894,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4934,6 +4920,28 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tombstoner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "metrics",
+ "metrics-util 0.18.0",
+ "rb-kafka",
+ "rb-schemas",
+ "rb-storage-neo4j",
+ "rb-storage-pg",
+ "rb-tenant",
+ "rb-tracing",
+ "reqwest",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5417,9 +5425,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5430,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5440,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5450,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5463,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5506,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5662,6 +5670,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5693,11 +5710,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5713,6 +5747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5723,6 +5763,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5737,10 +5783,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5755,6 +5813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5765,6 +5829,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5779,6 +5849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5789,6 +5865,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/rb-storage-neo4j",
     "services/projector-pg",
     "services/projector-neo4j",
+    "services/tombstoner",
 ]
 
 [workspace.package]

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -110,7 +110,8 @@ services:
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.embed.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.source-files.v1           --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 12 --replication-factor 1 --config retention.ms=2592000000 &&
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.tombstones.v1             --partitions 3  --replication-factor 1 --config retention.ms=604800000
       "
 
   loki:
@@ -279,6 +280,35 @@ services:
         condition: service_healthy
       rb-migrations:
         condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
+  tombstoner:
+    build:
+      context: ..
+      dockerfile: docker/tombstoner/Dockerfile
+    image: ghcr.io/jarnura/rustacean/tombstoner:dev
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: rustbrain123
+      QDRANT_URL: "http://qdrant:6333"
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: tombstoner
+      RUST_LOG: "info,tombstoner=debug"
+    networks:
+      - rb-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
       kafka:
         condition: service_healthy
       otel-collector:

--- a/crates/rb-storage-neo4j/src/graph.rs
+++ b/crates/rb-storage-neo4j/src/graph.rs
@@ -79,6 +79,40 @@ impl TenantGraph {
         Ok(())
     }
 
+    /// Delete all nodes whose `repo_id` property matches `repo_id` for `tenant_id`.
+    ///
+    /// Uses `DETACH DELETE` so all attached relationships are removed too. Idempotent
+    /// (no-op when no matching nodes exist).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CypherError`] on driver or injection failure.
+    pub async fn delete_repo_nodes(
+        &self,
+        tenant_id: &TenantId,
+        repo_id: &str,
+    ) -> Result<(), CypherError> {
+        self.run(
+            tenant_id,
+            "MATCH (n {repo_id: $repo_id}) DETACH DELETE n",
+            &[("repo_id", repo_id)],
+        )
+        .await
+    }
+
+    /// Delete all nodes for `tenant_id`.
+    ///
+    /// The tenant label is injected automatically by [`Self::run`], so this
+    /// removes every node belonging to this tenant and all their relationships.
+    /// Idempotent (no-op when the tenant has no data).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CypherError`] on driver or injection failure.
+    pub async fn delete_all_tenant_nodes(&self, tenant_id: &TenantId) -> Result<(), CypherError> {
+        self.run(tenant_id, "MATCH (n) DETACH DELETE n", &[]).await
+    }
+
     /// Count `TypeInstance` nodes scoped to `tenant_id`.
     ///
     /// Used by projector-neo4j to enforce the `RB_MONOMORPH_NODE_CAP` per ADR-007 §13.7.

--- a/crates/rb-storage-pg/Cargo.toml
+++ b/crates/rb-storage-pg/Cargo.toml
@@ -8,8 +8,9 @@ repository.workspace = true
 
 [dependencies]
 rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
-sqlx.workspace = true
+sqlx.workspace   = true
 thiserror.workspace = true
+uuid.workspace   = true
 
 [dev-dependencies]
 rb-schemas = { path = "../rb-schemas", version = "0.1.0" }

--- a/crates/rb-storage-pg/src/lib.rs
+++ b/crates/rb-storage-pg/src/lib.rs
@@ -76,4 +76,32 @@ impl TenantPool {
         .await?;
         Ok(exists)
     }
+
+    /// Delete all projection rows for `repo_id` from the tenant schema.
+    ///
+    /// Targets `code_files`, `code_symbols`, and `code_relations`. If the
+    /// tenant schema does not exist the call is a no-op (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::Sqlx`] on database failure.
+    pub async fn delete_repo_data(
+        &self,
+        ctx: &TenantCtx,
+        repo_id: uuid::Uuid,
+    ) -> Result<(), StorageError> {
+        if !self.schema_exists(ctx).await? {
+            return Ok(());
+        }
+        let code_files = ctx.qualify("code_files");
+        let code_symbols = ctx.qualify("code_symbols");
+        let code_relations = ctx.qualify("code_relations");
+        for table in [&code_files, &code_symbols, &code_relations] {
+            sqlx::query(&format!("DELETE FROM {table} WHERE repo_id = $1"))
+                .bind(repo_id)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
 }

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -22,6 +22,7 @@ COPY services/audit-worker/Cargo.toml  services/audit-worker/Cargo.toml
 COPY services/ingest-clone/Cargo.toml    services/ingest-clone/Cargo.toml
 COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -13,6 +13,7 @@ COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
 COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml   crates/rb-storage-pg/Cargo.toml
 COPY services/projector-pg/Cargo.toml  services/projector-pg/Cargo.toml
+COPY services/tombstoner/Cargo.toml    services/tombstoner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml        crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml        crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml          crates/rb-kafka/Cargo.toml
+COPY crates/rb-tenant/Cargo.toml         crates/rb-tenant/Cargo.toml
+COPY crates/rb-storage-pg/Cargo.toml     crates/rb-storage-pg/Cargo.toml
+COPY crates/rb-storage-neo4j/Cargo.toml  crates/rb-storage-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/tombstoner/src && \
+    printf 'fn main() {}' > services/tombstoner/src/main.rs && \
+    cargo build --release -p tombstoner 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Copy real source and build.
+COPY crates/                  crates/
+COPY services/tombstoner/     services/tombstoner/
+COPY proto/                   proto/
+
+# Install rdkafka build deps.
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cargo build --release -p tombstoner
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/tombstoner /usr/local/bin/tombstoner
+
+ENTRYPOINT ["/usr/local/bin/tombstoner"]

--- a/services/tombstoner/Cargo.toml
+++ b/services/tombstoner/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "tombstoner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "tombstoner"
+path = "src/main.rs"
+
+[dependencies]
+rb-kafka          = { path = "../../crates/rb-kafka",         version = "0.1.0" }
+rb-schemas        = { path = "../../crates/rb-schemas",       version = "0.1.0" }
+rb-storage-neo4j  = { path = "../../crates/rb-storage-neo4j", version = "0.1.0" }
+rb-storage-pg     = { path = "../../crates/rb-storage-pg",    version = "0.1.0" }
+rb-tenant         = { path = "../../crates/rb-tenant",        version = "0.1.0" }
+rb-tracing        = { path = "../../crates/rb-tracing",       version = "0.1.0" }
+anyhow.workspace     = true
+chrono.workspace     = true
+metrics.workspace    = true
+reqwest.workspace    = true
+serde_json.workspace = true
+sqlx.workspace       = true
+tokio.workspace      = true
+tracing.workspace    = true
+uuid.workspace       = true
+
+[dev-dependencies]
+metrics-util.workspace = true
+
+[lints]
+workspace = true

--- a/services/tombstoner/src/consumer.rs
+++ b/services/tombstoner/src/consumer.rs
@@ -1,0 +1,100 @@
+//! Kafka consumer loop for `rb.tombstones.v1`.
+//!
+//! Consumes [`Tombstone`] protobuf messages and removes all projections for the
+//! indicated (tenant, repo) pair from `PostgreSQL`, `Neo4j`, and `Qdrant`.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use metrics::counter;
+use rb_kafka::{Consumer, ConsumerCfg, EventEnvelope};
+use rb_schemas::Tombstone;
+use rb_storage_neo4j::TenantGraph;
+use rb_storage_pg::TenantPool;
+use tokio::task::JoinHandle;
+
+use crate::delete;
+
+const TOPIC_TOMBSTONES: &str = "rb.tombstones.v1";
+
+/// Spawn the long-running consumer task.
+///
+/// Returns the [`JoinHandle`] so the caller can abort on shutdown.
+#[allow(clippy::missing_errors_doc)]
+pub fn spawn(
+    pool: Arc<TenantPool>,
+    graph: Arc<TenantGraph>,
+    qdrant_url: Option<String>,
+) -> Result<JoinHandle<()>> {
+    let consumer = Consumer::<Tombstone>::new(&ConsumerCfg::new("tombstoner"))?;
+    consumer.subscribe(&[TOPIC_TOMBSTONES])?;
+
+    let handle = tokio::spawn(async move {
+        loop {
+            match consumer.next().await {
+                None => {
+                    tracing::info!("tombstoner: stream ended");
+                    break;
+                }
+                Some(Err(e)) => {
+                    tracing::error!("tombstoner: kafka error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+                Some(Ok(envelope)) => {
+                    handle_envelope(
+                        pool.as_ref(),
+                        graph.as_ref(),
+                        qdrant_url.as_deref(),
+                        &consumer,
+                        envelope,
+                    )
+                    .await;
+                }
+            }
+        }
+    });
+
+    Ok(handle)
+}
+
+async fn handle_envelope(
+    pool: &TenantPool,
+    graph: &TenantGraph,
+    qdrant_url: Option<&str>,
+    consumer: &Consumer<Tombstone>,
+    envelope: EventEnvelope<Tombstone>,
+) {
+    let tenant_id = envelope.tenant_id;
+    let ev = &envelope.payload;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        repo_id   = %ev.repo_id,
+        requested_by = %ev.requested_by,
+        "tombstoner: processing tombstone"
+    );
+
+    match delete::handle_tombstone(pool, graph, qdrant_url, &tenant_id, ev).await {
+        Ok(()) => {
+            counter!("rb_tombstoner_events_total", "outcome" => "ok").increment(1);
+            tracing::info!(
+                tenant_id = %tenant_id,
+                repo_id   = %ev.repo_id,
+                "tombstoner: projections deleted"
+            );
+            if let Err(e) = consumer.commit(&envelope).await {
+                tracing::warn!("tombstoner: commit failed: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                tenant_id = %tenant_id,
+                repo_id   = %ev.repo_id,
+                "tombstoner: deletion failed (transient): {e}"
+            );
+            counter!("rb_tombstoner_events_total", "outcome" => "err").increment(1);
+            // Do not commit — Kafka will redeliver for retry.
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+}

--- a/services/tombstoner/src/delete.rs
+++ b/services/tombstoner/src/delete.rs
@@ -1,0 +1,250 @@
+//! Projection deletion logic for tombstone events.
+//!
+//! Each storage backend is deleted in sequence: `PostgreSQL` → `Neo4j` → `Qdrant`.
+//! The function short-circuits on the first failure and returns the error so
+//! the consumer can retry the whole event atomically (Kafka at-least-once
+//! delivery ensures idempotency).
+
+use anyhow::{Context as _, Result};
+use rb_schemas::{TenantId, Tombstone};
+use rb_storage_neo4j::TenantGraph;
+use rb_storage_pg::TenantPool;
+use rb_tenant::TenantCtx;
+
+/// Delete all projections described by `ev` from every storage backend.
+///
+/// When `ev.repo_id` is empty the deletion is tenant-wide (drops the PG
+/// schema, removes all Neo4j nodes for the tenant, and lists+deletes all
+/// Qdrant collections for the tenant).  When non-empty only data for that
+/// specific repo is removed.
+///
+/// Idempotent: each backend uses IF-NOT-EXISTS / MATCH-with-no-results
+/// semantics so re-delivery of the same tombstone is safe.
+#[allow(clippy::missing_errors_doc)]
+pub async fn handle_tombstone(
+    pool: &TenantPool,
+    graph: &TenantGraph,
+    qdrant_url: Option<&str>,
+    tenant_id: &TenantId,
+    ev: &Tombstone,
+) -> Result<()> {
+    let ctx = TenantCtx::new(*tenant_id);
+    let tenant_wide = ev.repo_id.is_empty();
+
+    // ── PostgreSQL ───────────────────────────────────────────────────────────
+    if tenant_wide {
+        pool.drop_schema(&ctx)
+            .await
+            .context("PG drop_schema failed")?;
+        tracing::debug!(tenant_id = %tenant_id, "tombstoner: PG schema dropped");
+    } else {
+        let repo_uuid = ev
+            .repo_id
+            .parse::<uuid::Uuid>()
+            .with_context(|| format!("invalid repo_id UUID: {}", ev.repo_id))?;
+        pool.delete_repo_data(&ctx, repo_uuid)
+            .await
+            .context("PG delete_repo_data failed")?;
+        tracing::debug!(
+            tenant_id = %tenant_id,
+            repo_id   = %ev.repo_id,
+            "tombstoner: PG repo rows deleted"
+        );
+    }
+
+    // ── Neo4j ────────────────────────────────────────────────────────────────
+    if tenant_wide {
+        graph
+            .delete_all_tenant_nodes(tenant_id)
+            .await
+            .context("Neo4j delete_all_tenant_nodes failed")?;
+        tracing::debug!(tenant_id = %tenant_id, "tombstoner: Neo4j tenant nodes deleted");
+    } else {
+        graph
+            .delete_repo_nodes(tenant_id, &ev.repo_id)
+            .await
+            .context("Neo4j delete_repo_nodes failed")?;
+        tracing::debug!(
+            tenant_id = %tenant_id,
+            repo_id   = %ev.repo_id,
+            "tombstoner: Neo4j repo nodes deleted"
+        );
+    }
+
+    // ── Qdrant (best-effort HTTP) ────────────────────────────────────────────
+    // Qdrant collection naming: `rb_{tenant_id}_{repo_id}` (per-repo) or
+    // `rb_{tenant_id}_*` prefix scan (tenant-wide). Collections are created
+    // by projector-qdrant (REQ-IN-13) when that service is built.
+    match qdrant_url {
+        None => {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                "tombstoner: QDRANT_URL not set — Qdrant deletion skipped"
+            );
+        }
+        Some(url) => {
+            if tenant_wide {
+                delete_qdrant_tenant(url, tenant_id).await?;
+            } else {
+                delete_qdrant_repo(url, tenant_id, &ev.repo_id).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete the Qdrant collection for a single (tenant, repo) pair.
+///
+/// Returns `Ok(())` when the collection does not exist (HTTP 404 = idempotent).
+async fn delete_qdrant_repo(
+    qdrant_url: &str,
+    tenant_id: &TenantId,
+    repo_id: &str,
+) -> Result<()> {
+    let collection = qdrant_collection_name(tenant_id, repo_id);
+    let url = format!("{qdrant_url}/collections/{collection}");
+    let status = reqwest::Client::new()
+        .delete(&url)
+        .send()
+        .await
+        .with_context(|| format!("Qdrant DELETE {url}"))?
+        .status()
+        .as_u16();
+    match status {
+        200 | 204 | 404 => {
+            tracing::debug!(
+                tenant_id  = %tenant_id,
+                repo_id    = %repo_id,
+                collection = %collection,
+                "tombstoner: Qdrant repo collection deleted (or not found)"
+            );
+            Ok(())
+        }
+        code => Err(anyhow::anyhow!(
+            "Qdrant DELETE /collections/{collection} returned unexpected status {code}"
+        )),
+    }
+}
+
+/// Delete all Qdrant collections matching the tenant prefix.
+///
+/// Lists `/collections`, filters by the `rb_{tenant_id}_` prefix, then issues
+/// individual DELETE requests. Idempotent: 404 responses are ignored.
+async fn delete_qdrant_tenant(qdrant_url: &str, tenant_id: &TenantId) -> Result<()> {
+    let client = reqwest::Client::new();
+    let list_url = format!("{qdrant_url}/collections");
+
+    let body: serde_json::Value = client
+        .get(&list_url)
+        .send()
+        .await
+        .context("Qdrant GET /collections failed")?
+        .json()
+        .await
+        .context("Qdrant /collections response was not valid JSON")?;
+
+    let prefix = format!("rb_{tenant_id}_");
+    let names: Vec<String> = body["result"]["collections"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c["name"].as_str())
+                .filter(|name| name.starts_with(&prefix))
+                .map(std::borrow::ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for name in &names {
+        let url = format!("{qdrant_url}/collections/{name}");
+        let status = client
+            .delete(&url)
+            .send()
+            .await
+            .with_context(|| format!("Qdrant DELETE /collections/{name}"))?
+            .status()
+            .as_u16();
+        match status {
+            200 | 204 | 404 => {
+                tracing::debug!(
+                    tenant_id  = %tenant_id,
+                    collection = %name,
+                    "tombstoner: Qdrant tenant collection deleted"
+                );
+            }
+            code => {
+                return Err(anyhow::anyhow!(
+                    "Qdrant DELETE /collections/{name} returned unexpected status {code}"
+                ));
+            }
+        }
+    }
+
+    tracing::debug!(
+        tenant_id = %tenant_id,
+        count     = names.len(),
+        "tombstoner: Qdrant tenant collections deleted"
+    );
+    Ok(())
+}
+
+/// Collection naming convention shared with `projector-qdrant` (REQ-IN-13):
+/// `rb_{tenant_id}_{repo_id}`.
+fn qdrant_collection_name(tenant_id: &TenantId, repo_id: &str) -> String {
+    format!("rb_{tenant_id}_{repo_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_schemas::TenantId;
+
+    #[test]
+    fn qdrant_collection_name_format() {
+        let tid = TenantId::new();
+        let repo = "some-repo-uuid";
+        let name = qdrant_collection_name(&tid, repo);
+        assert!(name.starts_with("rb_"), "must start with rb_");
+        assert!(name.contains(repo), "must contain repo_id");
+        assert!(name.contains(&tid.to_string()), "must contain tenant_id");
+    }
+
+    #[test]
+    fn handle_tombstone_parses_empty_repo_id_as_tenant_wide() {
+        let ev = Tombstone {
+            tenant_id: "t".to_string(),
+            repo_id: String::new(),
+            requested_by: "u".to_string(),
+            emitted_at_ms: 0,
+        };
+        assert!(ev.repo_id.is_empty(), "empty repo_id means tenant-wide");
+    }
+
+    #[test]
+    fn handle_tombstone_detects_repo_specific() {
+        let repo_uuid = uuid::Uuid::new_v4().to_string();
+        let ev = Tombstone {
+            tenant_id: "t".to_string(),
+            repo_id: repo_uuid.clone(),
+            requested_by: "u".to_string(),
+            emitted_at_ms: 0,
+        };
+        assert!(!ev.repo_id.is_empty());
+        assert!(ev.repo_id.parse::<uuid::Uuid>().is_ok(), "repo_id must be a valid UUID");
+    }
+
+    #[test]
+    fn handle_tombstone_rejects_non_uuid_repo_id() {
+        let ev = Tombstone {
+            tenant_id: "t".to_string(),
+            repo_id: "not-a-uuid".to_string(),
+            requested_by: "u".to_string(),
+            emitted_at_ms: 0,
+        };
+        assert!(
+            ev.repo_id.parse::<uuid::Uuid>().is_err(),
+            "non-UUID repo_id must fail parse"
+        );
+    }
+}

--- a/services/tombstoner/src/main.rs
+++ b/services/tombstoner/src/main.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rb_storage_neo4j::TenantGraph;
+use rb_storage_pg::TenantPool;
+
+mod consumer;
+mod delete;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = rb_tracing::init("tombstoner")?;
+
+    let database_url = std::env::var("DATABASE_URL")
+        .context("DATABASE_URL is required")?;
+
+    let pg = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+        .context("failed to connect to PostgreSQL")?;
+    let pool = Arc::new(TenantPool::new(pg));
+
+    let neo4j_uri = std::env::var("NEO4J_URI")
+        .unwrap_or_else(|_| "bolt://neo4j:7687".to_owned());
+    let neo4j_user = std::env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".to_owned());
+    let neo4j_password =
+        std::env::var("NEO4J_PASSWORD").context("NEO4J_PASSWORD is required")?;
+
+    let graph = TenantGraph::connect(&neo4j_uri, &neo4j_user, &neo4j_password)
+        .await
+        .context("failed to connect to Neo4j")?;
+    let graph = Arc::new(graph);
+
+    // Optional Qdrant REST endpoint; tombstoner skips Qdrant deletion when unset.
+    let qdrant_url = std::env::var("QDRANT_URL").ok();
+
+    tracing::info!("tombstoner starting");
+
+    let handle = consumer::spawn(pool, graph, qdrant_url)?;
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received — stopping consumer");
+    handle.abort();
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}

--- a/services/tombstoner/tests/metrics_emitted.rs
+++ b/services/tombstoner/tests/metrics_emitted.rs
@@ -1,0 +1,61 @@
+//! Value-asserting tests for all `rb_tombstoner_*` metrics.
+//!
+//! Uses `metrics_util::debugging::DebuggingRecorder` as the in-process backend.
+
+use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+fn counter_value(
+    entries: &[(
+        metrics_util::CompositeKey,
+        Option<metrics::Unit>,
+        Option<metrics::SharedString>,
+        DebugValue,
+    )],
+    name: &str,
+    labels: &[(&str, &str)],
+) -> u64 {
+    entries
+        .iter()
+        .filter(|(key, _, _, _)| key.key().name() == name)
+        .filter_map(|(key, _, _, value)| {
+            let key_labels: std::collections::HashMap<&str, &str> =
+                key.key().labels().map(|l| (l.key(), l.value())).collect();
+            let matches = labels.iter().all(|(k, v)| key_labels.get(k) == Some(v));
+            if matches {
+                if let DebugValue::Counter(n) = value {
+                    return Some(*n);
+                }
+            }
+            None
+        })
+        .sum()
+}
+
+#[test]
+fn tombstoner_metrics_are_emitted_with_correct_values() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    assert!(
+        recorder.install().is_ok(),
+        "DebuggingRecorder install must succeed"
+    );
+
+    // consumer.rs — successful deletion path
+    metrics::counter!("rb_tombstoner_events_total", "outcome" => "ok").increment(1);
+
+    // consumer.rs — transient failure path
+    metrics::counter!("rb_tombstoner_events_total", "outcome" => "err").increment(1);
+
+    let entries = snapshotter.snapshot().into_vec();
+
+    assert_eq!(
+        counter_value(&entries, "rb_tombstoner_events_total", &[("outcome", "ok")]),
+        1,
+        "events_total outcome=ok must be 1"
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_tombstoner_events_total", &[("outcome", "err")]),
+        1,
+        "events_total outcome=err must be 1"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `services/tombstoner`: a Kafka consumer for `rb.tombstones.v1` that removes all projections for a (tenant, repo) pair across three storage backends
- Extends `rb-storage-pg` with `TenantPool::delete_repo_data()` for repo-specific row deletion
- Extends `rb-storage-neo4j` with `TenantGraph::delete_repo_nodes()` and `delete_all_tenant_nodes()` for Cypher-based cleanup
- Adds `rb.tombstones.v1` topic to compose kafka-init and a `tombstoner` Docker service
- Qdrant deletion implemented via REST HTTP (best-effort, collection name `rb_{tenant_id}_{repo_id}`); skipped when `QDRANT_URL` is unset

**Deletion semantics:**
| Field | Storage | Action |
|-------|---------|--------|
| `repo_id` non-empty | PG | DELETE rows by repo_id from code_files, code_symbols, code_relations |
| `repo_id` non-empty | Neo4j | MATCH (n {repo_id: $repo_id}) DETACH DELETE n |
| `repo_id` non-empty | Qdrant | DELETE /collections/rb_{tenant_id}_{repo_id} |
| `repo_id` empty (tenant-wide) | PG | DROP SCHEMA IF EXISTS … CASCADE |
| `repo_id` empty (tenant-wide) | Neo4j | MATCH (n) DETACH DELETE n |
| `repo_id` empty (tenant-wide) | Qdrant | List + delete all rb_{tenant_id}_* collections |

All paths are idempotent.

## Test plan

- [x] `cargo test -p tombstoner` — 5 tests pass (4 unit + 1 metrics)
- [x] `cargo test -p rb-storage-pg -p rb-storage-neo4j` — all pass
- [x] `cargo clippy` — clean (no warnings)
- [ ] Integration: publish a `Tombstone` to `rb.tombstones.v1` and verify PG schema drop + Neo4j DETACH DELETE executes

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)