### PR TITLE
[REQ-IN-04] feat(expand-worker): Stage 2 Cargo expand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "expand-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "glob",
+ "hex",
+ "metrics",
+ "rb-blob",
+ "rb-feature-resolver",
+ "rb-kafka",
+ "rb-schemas",
+ "rb-tracing",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "tempfile",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+ "walkdir",
+ "zstd",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "services/control-api",
     "services/audit-worker",
     "services/ingest-clone",
+    "services/expand-worker",
     "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
     "services/projector-pg",

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -12,6 +12,9 @@ pub use ingest::{
     parsed_item_event, source_file_event,
 };
 
+// Re-export prost oneof sub-modules so callers can construct body variants.
+pub use ingest::{expanded_file_event, source_file_event, parsed_item_event};
+
 /// Newtype over [`Uuid`] representing a tenant identifier.
 /// Prost-generated event types are re-exported from this crate (see [`IngestRequest`] etc.).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -9,11 +9,8 @@ pub use ingest::{
     AuditEvent, EmbeddingPendingEvent, ExpandedFileEvent, GraphRelationEvent, IngestRequest,
     IngestStage, IngestStatus, IngestStatusEvent, ItemKind, ParsedItemEvent, RelationKind,
     SourceFileEvent, Tombstone, TypecheckedItemEvent,
-    parsed_item_event, source_file_event,
+    expanded_file_event, parsed_item_event, source_file_event,
 };
-
-// Re-export prost oneof sub-modules so callers can construct body variants.
-pub use ingest::{expanded_file_event, source_file_event, parsed_item_event};
 
 /// Newtype over [`Uuid`] representing a tenant identifier.
 /// Prost-generated event types are re-exported from this crate (see [`IngestRequest`] etc.).

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -23,6 +23,7 @@ COPY services/ingest-clone/Cargo.toml    services/ingest-clone/Cargo.toml
 COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
+COPY services/expand-worker/Cargo.toml   services/expand-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/proto/rust_brain/v1/pipeline.proto
+++ b/proto/rust_brain/v1/pipeline.proto
@@ -41,6 +41,9 @@ message ExpandedFileEvent {
   string source_sha256   = 10;
   // Resolved Cargo feature set used for this expansion.
   repeated string features = 11;
+  // True when cargo expand exited non-zero but produced partial stdout.
+  // Downstream stages treat this as best-effort; macro-generated items may be absent.
+  bool partial = 12;
 }
 
 message ParsedItemEvent {

--- a/services/expand-worker/Cargo.toml
+++ b/services/expand-worker/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "expand-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "expand-worker"
+path = "src/main.rs"
+
+[dependencies]
+rb-blob              = { path = "../../crates/rb-blob",             version = "0.1.0" }
+rb-feature-resolver  = { path = "../../crates/rb-feature-resolver", version = "0.1.0" }
+rb-kafka             = { path = "../../crates/rb-kafka",            version = "0.1.0" }
+rb-schemas           = { path = "../../crates/rb-schemas",          version = "0.1.0" }
+rb-tracing           = { path = "../../crates/rb-tracing",          version = "0.1.0" }
+
+anyhow.workspace   = true
+bytes.workspace    = true
+chrono.workspace   = true
+hex.workspace      = true
+metrics.workspace  = true
+serde.workspace    = true
+serde_json.workspace = true
+sha2.workspace     = true
+tokio.workspace    = true
+tracing.workspace  = true
+uuid.workspace     = true
+
+glob     = "0.3"
+tar      = "0.4"
+tempfile = "3"
+toml     = "0.8"
+walkdir  = "2"
+zstd     = "0.13"
+
+[lints]
+workspace = true

--- a/services/expand-worker/src/archive.rs
+++ b/services/expand-worker/src/archive.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+
+pub fn extract_tar_zst(data: &[u8], dest: &Path) -> Result<()> {
+    let decoded = zstd::decode_all(std::io::Cursor::new(data))
+        .context("failed to decompress zstd archive")?;
+    let mut archive = tar::Archive::new(std::io::Cursor::new(decoded));
+    archive.unpack(dest).context("failed to unpack tar archive")?;
+    Ok(())
+}

--- a/services/expand-worker/src/consumer.rs
+++ b/services/expand-worker/src/consumer.rs
@@ -21,7 +21,7 @@ use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use metrics::counter;
 use rb_blob::{BlobRef, BlobStore};
-use rb_kafka::{Consumer, EventEnvelope, Producer};
+use rb_kafka::{Consumer, EventEnvelope, Producer, RetryPolicy};
 use rb_schemas::{
     ExpandedFileEvent, IngestRequest, IngestStage, IngestStatus, IngestStatusEvent, TenantId,
     expanded_file_event,
@@ -69,6 +69,7 @@ pub async fn run(
             }
             Some(Ok(envelope)) => {
                 let ingest_run_id = envelope.payload.ingest_run_id.clone();
+                let event_id = envelope.payload.event_id.clone();
                 let tenant_id = envelope.tenant_id;
                 match process_expand(&ctx, &envelope).await {
                     Ok(()) => {
@@ -78,7 +79,9 @@ pub async fn run(
                         }
                     }
                     Err(e) => {
+                        let attempt = envelope._meta.attempt + 1;
                         tracing::error!(
+                            attempt,
                             %ingest_run_id,
                             tenant_id = %tenant_id,
                             "expand_worker: processing failed: {e:#}"
@@ -88,10 +91,28 @@ pub async fn run(
                             &ctx.status_producer,
                             tenant_id,
                             &ingest_run_id,
+                            &event_id,
                             &format!("expand_failed: {e:#}"),
                         )
                         .await;
-                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        let policy = RetryPolicy::default();
+                        if policy.is_terminal(attempt) {
+                            tracing::warn!(
+                                attempt,
+                                %ingest_run_id,
+                                "expand_worker: max retries exceeded — routing to DLQ"
+                            );
+                            counter!("rb_expand_worker_dlq_total").increment(1);
+                            if let Err(dlq_err) = consumer.nack_to_dlq(&envelope, &format!("{e:#}")).await {
+                                tracing::error!(%ingest_run_id, "expand_worker: nack_to_dlq failed: {dlq_err}");
+                            }
+                            if let Err(commit_err) = consumer.commit(&envelope).await {
+                                tracing::warn!(%ingest_run_id, "expand_worker: commit after DLQ failed: {commit_err}");
+                            }
+                        } else {
+                            let delay = policy.next_delay(attempt).unwrap_or(Duration::from_secs(1));
+                            tokio::time::sleep(delay).await;
+                        }
                     }
                 }
             }
@@ -237,6 +258,10 @@ async fn expand_crate(
         format!("{relative_path}/src/lib.rs")
     };
 
+    let source_sha256 = std::fs::read(workspace_root.join(&relative_path))
+        .map(|bytes| hex::encode(Sha256::digest(&bytes)))
+        .unwrap_or_default();
+
     let body = if expanded_bytes.len() <= INLINE_MAX_BYTES {
         expanded_file_event::Body::InlinePayload(expanded_bytes.to_vec())
     } else {
@@ -253,7 +278,7 @@ async fn expand_crate(
         body: Some(body),
         size_bytes,
         emitted_at_ms: chrono::Utc::now().timestamp_millis(),
-        source_sha256: String::new(),
+        source_sha256,
         features: feature_list,
         partial,
     };
@@ -345,10 +370,11 @@ async fn emit_failed_status(
     producer: &Producer<IngestStatusEvent>,
     tenant_id: TenantId,
     ingest_run_id: &str,
+    ingest_request_id: &str,
     error_message: &str,
 ) {
     let ev = IngestStatusEvent {
-        ingest_request_id: String::new(),
+        ingest_request_id: ingest_request_id.to_owned(),
         tenant_id: tenant_id.to_string(),
         status: IngestStatus::Failed as i32,
         error_message: error_message.to_owned(),
@@ -546,6 +572,50 @@ mod tests {
     fn stage_seq_is_2_for_expand() {
         // Expand is the second pipeline stage (Clone=1, Expand=2).
         assert_eq!(IngestStage::Expand as i32, 2);
+    }
+
+    #[test]
+    fn retry_policy_terminal_at_max_attempts() {
+        let policy = RetryPolicy::default();
+        assert!(!policy.is_terminal(0));
+        assert!(!policy.is_terminal(1));
+        assert!(!policy.is_terminal(2));
+        assert!(policy.is_terminal(3), "attempt 3 must be terminal (DLQ path)");
+    }
+
+    #[test]
+    fn retry_policy_provides_backoff_delays() {
+        let policy = RetryPolicy::default();
+        assert!(policy.next_delay(1).is_some());
+        assert!(policy.next_delay(2).is_some());
+        assert!(policy.next_delay(3).is_none(), "no delay after terminal attempt");
+    }
+
+    #[test]
+    fn source_sha256_computed_from_source_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let content = b"pub fn foo() {}";
+        std::fs::write(src_dir.join("lib.rs"), content).unwrap();
+
+        let relative_path = "src/lib.rs";
+        let computed = std::fs::read(dir.path().join(relative_path))
+            .map(|bytes| hex::encode(sha2::Sha256::digest(&bytes)))
+            .unwrap_or_default();
+
+        let expected = hex::encode(sha2::Sha256::digest(content));
+        assert_eq!(computed, expected);
+        assert!(!computed.is_empty());
+    }
+
+    #[test]
+    fn source_sha256_empty_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = std::fs::read(dir.path().join("src/lib.rs"))
+            .map(|bytes| hex::encode(sha2::Sha256::digest(&bytes)))
+            .unwrap_or_default();
+        assert!(result.is_empty(), "missing source file should produce empty sha256");
     }
 
     fn create_tar_zst_for_test(src: &Path) -> Vec<u8> {

--- a/services/expand-worker/src/consumer.rs
+++ b/services/expand-worker/src/consumer.rs
@@ -1,0 +1,570 @@
+//! Kafka consumer loop for `expand-worker`.
+//!
+//! Consumes `IngestRequest` from `rb.ingest.expand.commands`.
+//! The envelope's `blob_ref` points to the clone tar.zst produced by `ingest-clone`.
+//! For each command:
+//!   1. Downloads the clone.tar.zst blob from rb-blob.
+//!   2. Extracts to a temp directory.
+//!   3. Discovers workspace members (Cargo.toml files).
+//!   4. For each member, resolves features via `rb-feature-resolver`.
+//!   5. Runs `cargo expand --package <name> --features <list>`.
+//!   6. Emits `ExpandedFileEvent` per crate (partial=true when cargo expand exits non-zero
+//!      but still produced stdout).
+//!   7. Forwards `IngestRequest` to `rb.ingest.parse.commands`.
+//!   8. Emits `IngestStatusEvent{stage:Expand, status:Done}` to `rb.projector.events`.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use bytes::Bytes;
+use metrics::counter;
+use rb_blob::{BlobRef, BlobStore};
+use rb_kafka::{Consumer, EventEnvelope, Producer};
+use rb_schemas::{
+    ExpandedFileEvent, IngestRequest, IngestStage, IngestStatus, IngestStatusEvent, TenantId,
+    expanded_file_event,
+};
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+pub const TOPIC_EXPAND_COMMANDS: &str = "rb.ingest.expand.commands";
+pub const TOPIC_EXPANDED_FILES: &str = "rb.expanded-files.v1";
+pub const TOPIC_PARSE_COMMANDS: &str = "rb.ingest.parse.commands";
+pub const TOPIC_PROJECTOR_EVENTS: &str = "rb.projector.events";
+
+const INLINE_MAX_BYTES: usize = 512 * 1024;
+
+struct ExpandCtx {
+    blob_store: Arc<dyn BlobStore>,
+    expanded_producer: Arc<Producer<ExpandedFileEvent>>,
+    parse_producer: Arc<Producer<IngestRequest>>,
+    status_producer: Arc<Producer<IngestStatusEvent>>,
+}
+
+pub async fn run(
+    consumer: Consumer<IngestRequest>,
+    blob_store: Arc<dyn BlobStore>,
+    expanded_producer: Arc<Producer<ExpandedFileEvent>>,
+    parse_producer: Arc<Producer<IngestRequest>>,
+    status_producer: Arc<Producer<IngestStatusEvent>>,
+) {
+    let ctx = Arc::new(ExpandCtx {
+        blob_store,
+        expanded_producer,
+        parse_producer,
+        status_producer,
+    });
+
+    loop {
+        match consumer.next().await {
+            None => {
+                tracing::info!("expand_worker: stream ended");
+                break;
+            }
+            Some(Err(e)) => {
+                tracing::error!("expand_worker: kafka error: {e}");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Some(Ok(envelope)) => {
+                let ingest_run_id = envelope.payload.ingest_run_id.clone();
+                let tenant_id = envelope.tenant_id;
+                match process_expand(&ctx, &envelope).await {
+                    Ok(()) => {
+                        counter!("rb_expand_worker_total", "outcome" => "ok").increment(1);
+                        if let Err(e) = consumer.commit(&envelope).await {
+                            tracing::warn!(%ingest_run_id, "expand_worker: commit failed: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            %ingest_run_id,
+                            tenant_id = %tenant_id,
+                            "expand_worker: processing failed: {e:#}"
+                        );
+                        counter!("rb_expand_worker_total", "outcome" => "err").increment(1);
+                        emit_failed_status(
+                            &ctx.status_producer,
+                            tenant_id,
+                            &ingest_run_id,
+                            &format!("expand_failed: {e:#}"),
+                        )
+                        .await;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn process_expand(
+    ctx: &ExpandCtx,
+    envelope: &EventEnvelope<IngestRequest>,
+) -> Result<()> {
+    let req = &envelope.payload;
+    let tenant_id = envelope.tenant_id;
+    let ingest_run_id = &req.ingest_run_id;
+
+    let blob_uri = envelope
+        .blob_ref
+        .as_deref()
+        .context("expand command missing blob_ref (clone tar.zst)")?;
+
+    tracing::info!(%ingest_run_id, "expand_worker: downloading clone blob");
+
+    let blob_ref = BlobRef::from_uri_minimal(blob_uri)
+        .context("invalid blob_ref URI in expand command")?;
+    let archive_bytes = ctx
+        .blob_store
+        .get(&blob_ref)
+        .await
+        .context("failed to download clone blob")?;
+
+    let tmp = tempfile::tempdir().context("failed to create temp dir")?;
+    let clone_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&clone_dir).context("failed to create clone dir")?;
+
+    extract_tar_zst(&archive_bytes, &clone_dir).context("failed to extract clone tar.zst")?;
+
+    tracing::info!(%ingest_run_id, "expand_worker: running cargo expand");
+
+    let members = discover_workspace_members(&clone_dir)?;
+    tracing::info!(%ingest_run_id, count = members.len(), "expand_worker: workspace members found");
+
+    let mut expanded_count = 0usize;
+    let mut partial_count = 0usize;
+
+    for member in &members {
+        match expand_crate(ctx, tenant_id, req, &clone_dir, member).await {
+            Ok(partial) => {
+                expanded_count += 1;
+                if partial {
+                    partial_count += 1;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    %ingest_run_id,
+                    crate_name = %member.name,
+                    "expand_worker: crate expand failed (skipping): {e:#}"
+                );
+                counter!("rb_expand_worker_crate_skip_total").increment(1);
+            }
+        }
+    }
+
+    tracing::info!(
+        %ingest_run_id,
+        expanded_count,
+        partial_count,
+        "expand_worker: expand done"
+    );
+
+    // Forward to parse stage.
+    emit_parse_command(ctx, tenant_id, req, blob_uri).await?;
+
+    emit_done_status(ctx, tenant_id, req).await?;
+
+    Ok(())
+}
+
+/// Expands one workspace member crate. Returns `true` if the event was partial.
+async fn expand_crate(
+    ctx: &ExpandCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+    workspace_root: &Path,
+    member: &WorkspaceMember,
+) -> Result<bool> {
+    let manifest_path = workspace_root.join(&member.manifest_rel_path);
+    let manifest_dir = manifest_path
+        .parent()
+        .context("manifest path has no parent")?;
+
+    let manifest = load_manifest(&manifest_path)?;
+    let requested = rb_feature_resolver::FeatureSet::default();
+    let resolved = rb_feature_resolver::resolve(workspace_root, &manifest, &requested)
+        .context("feature resolution failed")?;
+
+    let feature_list: Vec<String> = resolved.features().iter().cloned().collect();
+    let features_str = feature_list.join(",");
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("expand").arg("--package").arg(&member.name);
+    if !features_str.is_empty() {
+        cmd.arg("--features").arg(&features_str);
+    }
+    cmd.current_dir(manifest_dir);
+
+    let output = tokio::task::spawn_blocking(move || cmd.output())
+        .await
+        .context("spawn_blocking failed")??;
+
+    let stdout = output.stdout;
+    let partial = !output.status.success();
+
+    if partial && stdout.is_empty() {
+        anyhow::bail!(
+            "cargo expand failed with no output: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    if partial {
+        tracing::warn!(
+            ingest_run_id = %req.ingest_run_id,
+            crate_name = %member.name,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "expand_worker: cargo expand exited non-zero — emitting partial event"
+        );
+    }
+
+    let expanded_bytes = Bytes::from(stdout);
+    #[allow(clippy::cast_possible_wrap)]
+    let size_bytes = expanded_bytes.len() as i64;
+    let sha256 = hex::encode(Sha256::digest(&expanded_bytes));
+
+    let relative_path = member
+        .manifest_rel_path
+        .strip_suffix("/Cargo.toml")
+        .unwrap_or(&member.manifest_rel_path)
+        .to_string();
+    let relative_path = if relative_path.is_empty() {
+        "src/lib.rs".to_string()
+    } else {
+        format!("{relative_path}/src/lib.rs")
+    };
+
+    let body = if expanded_bytes.len() <= INLINE_MAX_BYTES {
+        expanded_file_event::Body::InlinePayload(expanded_bytes.to_vec())
+    } else {
+        let blob_ref = store_expanded_blob(ctx, tenant_id, &sha256, expanded_bytes).await?;
+        expanded_file_event::Body::BlobRef(blob_ref)
+    };
+
+    let ev = ExpandedFileEvent {
+        ingest_run_id: req.ingest_run_id.clone(),
+        tenant_id: tenant_id.to_string(),
+        repo_id: req.repo_id.clone(),
+        relative_path,
+        sha256,
+        body: Some(body),
+        size_bytes,
+        emitted_at_ms: chrono::Utc::now().timestamp_millis(),
+        source_sha256: String::new(),
+        features: feature_list,
+        partial,
+    };
+
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = format!("{}.{}", req.tenant_id, req.repo_id);
+    ctx.expanded_producer
+        .publish(TOPIC_EXPANDED_FILES, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish ExpandedFileEvent")?;
+
+    Ok(partial)
+}
+
+async fn store_expanded_blob(
+    ctx: &ExpandCtx,
+    tenant_id: TenantId,
+    sha256: &str,
+    data: Bytes,
+) -> Result<String> {
+    let blob_ref = BlobRef::new(
+        tenant_id.as_uuid(),
+        sha256,
+        "text/x-rust-expanded",
+        data.len() as u64,
+    );
+    ctx.blob_store
+        .put(&blob_ref, data)
+        .await
+        .context("failed to store expanded blob")?;
+    Ok(blob_ref.to_uri())
+}
+
+async fn emit_parse_command(
+    ctx: &ExpandCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+    blob_uri: &str,
+) -> Result<()> {
+    let parse_req = IngestRequest {
+        tenant_id: req.tenant_id.clone(),
+        event_id: Uuid::new_v4().to_string(),
+        source: req.source.clone(),
+        payload: req.payload.clone(),
+        created_at_ms: chrono::Utc::now().timestamp_millis(),
+        repo_id: req.repo_id.clone(),
+        ingest_run_id: req.ingest_run_id.clone(),
+        commit_sha: req.commit_sha.clone(),
+        branch: req.branch.clone(),
+    };
+
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, parse_req).with_blob_ref(blob_uri);
+
+    let key = format!("{}.{}", req.tenant_id, req.repo_id);
+    ctx.parse_producer
+        .publish(TOPIC_PARSE_COMMANDS, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish parse command")?;
+
+    Ok(())
+}
+
+async fn emit_done_status(
+    ctx: &ExpandCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+) -> Result<()> {
+    let ev = IngestStatusEvent {
+        ingest_request_id: req.event_id.clone(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Done as i32,
+        error_message: String::new(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::Expand as i32,
+        stage_seq: 2,
+        ingest_run_id: req.ingest_run_id.clone(),
+        attempt: 0,
+    };
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = tenant_id.to_string();
+    ctx.status_producer
+        .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish done status")?;
+    Ok(())
+}
+
+async fn emit_failed_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: TenantId,
+    ingest_run_id: &str,
+    error_message: &str,
+) {
+    let ev = IngestStatusEvent {
+        ingest_request_id: String::new(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Failed as i32,
+        error_message: error_message.to_owned(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::Expand as i32,
+        stage_seq: 2,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 0,
+    };
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = tenant_id.to_string();
+    if let Err(e) = producer
+        .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
+        .await
+    {
+        tracing::error!("expand_worker: failed to publish failed status: {e}");
+    }
+}
+
+// ── Workspace discovery ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct WorkspaceMember {
+    name: String,
+    manifest_rel_path: String,
+}
+
+fn discover_workspace_members(workspace_root: &Path) -> Result<Vec<WorkspaceMember>> {
+    let root_manifest = workspace_root.join("Cargo.toml");
+    let root_text = std::fs::read_to_string(&root_manifest)
+        .with_context(|| format!("failed to read {}", root_manifest.display()))?;
+    let root_toml: toml::Value =
+        toml::from_str(&root_text).context("failed to parse root Cargo.toml")?;
+
+    if let Some(members) = root_toml
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+    {
+        let mut result = Vec::new();
+        for m in members {
+            let pat = m.as_str().context("workspace member is not a string")?;
+            let member_manifests = glob_manifest_paths(workspace_root, pat);
+            for manifest_path in member_manifests {
+                if let Ok(name) = read_package_name(&manifest_path) {
+                    let rel = manifest_path
+                        .strip_prefix(workspace_root)
+                        .context("manifest outside workspace root")?
+                        .to_string_lossy()
+                        .to_string();
+                    result.push(WorkspaceMember {
+                        name,
+                        manifest_rel_path: rel,
+                    });
+                }
+            }
+        }
+        if !result.is_empty() {
+            return Ok(result);
+        }
+    }
+
+    // Fallback: treat root as a single-crate workspace.
+    let name = read_package_name(&root_manifest)?;
+    Ok(vec![WorkspaceMember {
+        name,
+        manifest_rel_path: "Cargo.toml".to_string(),
+    }])
+}
+
+fn glob_manifest_paths(workspace_root: &Path, pattern: &str) -> Vec<std::path::PathBuf> {
+    let mut paths = Vec::new();
+    // Handle simple "path/*" and "path/**" patterns.
+    let abs_pattern = workspace_root.join(pattern).join("Cargo.toml");
+    let abs_str = abs_pattern.to_string_lossy();
+    if let Ok(entries) = glob::glob(&abs_str) {
+        for entry in entries.flatten() {
+            paths.push(entry);
+        }
+    }
+    // If no glob matches, try direct path.
+    if paths.is_empty() {
+        let direct = workspace_root.join(pattern).join("Cargo.toml");
+        if direct.exists() {
+            paths.push(direct);
+        }
+    }
+    paths
+}
+
+fn read_package_name(manifest_path: &Path) -> Result<String> {
+    let text = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    let toml: toml::Value = toml::from_str(&text)
+        .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
+    toml.get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_owned)
+        .context("Cargo.toml missing [package].name")
+}
+
+fn load_manifest(manifest_path: &Path) -> Result<rb_feature_resolver::CargoManifest> {
+    let text = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    toml::from_str::<rb_feature_resolver::CargoManifest>(&text)
+        .with_context(|| format!("failed to parse manifest {}", manifest_path.display()))
+}
+
+// ── Archive extraction ───────────────────────────────────────────────────────
+
+fn extract_tar_zst(data: &[u8], dest: &Path) -> Result<()> {
+    let decoded = zstd::decode_all(std::io::Cursor::new(data))
+        .context("failed to decompress zstd archive")?;
+    let mut archive = tar::Archive::new(std::io::Cursor::new(decoded));
+    archive.unpack(dest).context("failed to unpack tar archive")?;
+    Ok(())
+}
+
+// ── Topic constant tests ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topic_constants_are_distinct() {
+        let topics = [
+            TOPIC_EXPAND_COMMANDS,
+            TOPIC_EXPANDED_FILES,
+            TOPIC_PARSE_COMMANDS,
+            TOPIC_PROJECTOR_EVENTS,
+        ];
+        let unique: std::collections::HashSet<_> = topics.iter().collect();
+        assert_eq!(unique.len(), topics.len(), "all topic constants must be unique");
+    }
+
+    #[test]
+    fn inline_threshold_is_512kib() {
+        assert_eq!(INLINE_MAX_BYTES, 512 * 1024);
+    }
+
+    #[test]
+    fn extract_tar_zst_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"fn main() {}";
+        std::fs::write(dir.path().join("main.rs"), content).unwrap();
+
+        let compressed = create_tar_zst_for_test(dir.path());
+        let dest = tempfile::tempdir().unwrap();
+        extract_tar_zst(&compressed, dest.path()).unwrap();
+
+        let extracted = std::fs::read(dest.path().join("main.rs")).unwrap();
+        assert_eq!(extracted, content);
+    }
+
+    #[test]
+    fn discover_workspace_members_single_crate() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            b"[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+
+        let members = discover_workspace_members(dir.path()).unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].name, "my-crate");
+    }
+
+    #[test]
+    fn discover_workspace_members_workspace_crate() {
+        let dir = tempfile::tempdir().unwrap();
+        // Root workspace Cargo.toml
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/alpha\"]\n",
+        )
+        .unwrap();
+        // Member
+        std::fs::create_dir_all(dir.path().join("crates/alpha")).unwrap();
+        std::fs::write(
+            dir.path().join("crates/alpha/Cargo.toml"),
+            "[package]\nname = \"alpha\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+
+        let members = discover_workspace_members(dir.path()).unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].name, "alpha");
+        assert!(members[0].manifest_rel_path.ends_with("Cargo.toml"));
+    }
+
+    #[test]
+    fn stage_seq_is_2_for_expand() {
+        // Expand is the second pipeline stage (Clone=1, Expand=2).
+        assert_eq!(IngestStage::Expand as i32, 2);
+    }
+
+    fn create_tar_zst_for_test(src: &Path) -> Vec<u8> {
+        use std::io::Write as _;
+        let mut archive_data = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut archive_data);
+            for entry in walkdir::WalkDir::new(src).min_depth(1) {
+                let entry = entry.unwrap();
+                if entry.file_type().is_file() {
+                    let rel = entry.path().strip_prefix(src).unwrap();
+                    builder.append_path_with_name(entry.path(), rel).unwrap();
+                }
+            }
+            builder.finish().unwrap();
+        }
+        let mut encoder =
+            zstd::Encoder::new(Vec::new(), 3).unwrap();
+        encoder.write_all(&archive_data).unwrap();
+        encoder.finish().unwrap()
+    }
+}

--- a/services/expand-worker/src/consumer.rs
+++ b/services/expand-worker/src/consumer.rs
@@ -4,8 +4,8 @@
 //! The envelope's `blob_ref` points to the clone tar.zst produced by `ingest-clone`.
 //! For each command:
 //!   1. Downloads the clone.tar.zst blob from rb-blob.
-//!   2. Extracts to a temp directory.
-//!   3. Discovers workspace members (Cargo.toml files).
+//!   2. Extracts to a temp directory (see `archive`).
+//!   3. Discovers workspace members (see `workspace`).
 //!   4. For each member, resolves features via `rb-feature-resolver`.
 //!   5. Runs `cargo expand --package <name> --features <list>`.
 //!   6. Emits `ExpandedFileEvent` per crate (partial=true when cargo expand exits non-zero
@@ -16,6 +16,9 @@
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+
+use crate::archive::extract_tar_zst;
+use crate::workspace::{WorkspaceMember, discover_workspace_members, load_manifest};
 
 use anyhow::{Context as _, Result};
 use bytes::Bytes;
@@ -394,111 +397,13 @@ async fn emit_failed_status(
     }
 }
 
-// ── Workspace discovery ──────────────────────────────────────────────────────
-
-#[derive(Debug)]
-struct WorkspaceMember {
-    name: String,
-    manifest_rel_path: String,
-}
-
-fn discover_workspace_members(workspace_root: &Path) -> Result<Vec<WorkspaceMember>> {
-    let root_manifest = workspace_root.join("Cargo.toml");
-    let root_text = std::fs::read_to_string(&root_manifest)
-        .with_context(|| format!("failed to read {}", root_manifest.display()))?;
-    let root_toml: toml::Value =
-        toml::from_str(&root_text).context("failed to parse root Cargo.toml")?;
-
-    if let Some(members) = root_toml
-        .get("workspace")
-        .and_then(|w| w.get("members"))
-        .and_then(|m| m.as_array())
-    {
-        let mut result = Vec::new();
-        for m in members {
-            let pat = m.as_str().context("workspace member is not a string")?;
-            let member_manifests = glob_manifest_paths(workspace_root, pat);
-            for manifest_path in member_manifests {
-                if let Ok(name) = read_package_name(&manifest_path) {
-                    let rel = manifest_path
-                        .strip_prefix(workspace_root)
-                        .context("manifest outside workspace root")?
-                        .to_string_lossy()
-                        .to_string();
-                    result.push(WorkspaceMember {
-                        name,
-                        manifest_rel_path: rel,
-                    });
-                }
-            }
-        }
-        if !result.is_empty() {
-            return Ok(result);
-        }
-    }
-
-    // Fallback: treat root as a single-crate workspace.
-    let name = read_package_name(&root_manifest)?;
-    Ok(vec![WorkspaceMember {
-        name,
-        manifest_rel_path: "Cargo.toml".to_string(),
-    }])
-}
-
-fn glob_manifest_paths(workspace_root: &Path, pattern: &str) -> Vec<std::path::PathBuf> {
-    let mut paths = Vec::new();
-    // Handle simple "path/*" and "path/**" patterns.
-    let abs_pattern = workspace_root.join(pattern).join("Cargo.toml");
-    let abs_str = abs_pattern.to_string_lossy();
-    if let Ok(entries) = glob::glob(&abs_str) {
-        for entry in entries.flatten() {
-            paths.push(entry);
-        }
-    }
-    // If no glob matches, try direct path.
-    if paths.is_empty() {
-        let direct = workspace_root.join(pattern).join("Cargo.toml");
-        if direct.exists() {
-            paths.push(direct);
-        }
-    }
-    paths
-}
-
-fn read_package_name(manifest_path: &Path) -> Result<String> {
-    let text = std::fs::read_to_string(manifest_path)
-        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
-    let toml: toml::Value = toml::from_str(&text)
-        .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
-    toml.get("package")
-        .and_then(|p| p.get("name"))
-        .and_then(|n| n.as_str())
-        .map(str::to_owned)
-        .context("Cargo.toml missing [package].name")
-}
-
-fn load_manifest(manifest_path: &Path) -> Result<rb_feature_resolver::CargoManifest> {
-    let text = std::fs::read_to_string(manifest_path)
-        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
-    toml::from_str::<rb_feature_resolver::CargoManifest>(&text)
-        .with_context(|| format!("failed to parse manifest {}", manifest_path.display()))
-}
-
-// ── Archive extraction ───────────────────────────────────────────────────────
-
-fn extract_tar_zst(data: &[u8], dest: &Path) -> Result<()> {
-    let decoded = zstd::decode_all(std::io::Cursor::new(data))
-        .context("failed to decompress zstd archive")?;
-    let mut archive = tar::Archive::new(std::io::Cursor::new(decoded));
-    archive.unpack(dest).context("failed to unpack tar archive")?;
-    Ok(())
-}
-
 // ── Topic constant tests ─────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::archive::extract_tar_zst;
+    use crate::workspace::discover_workspace_members;
 
     #[test]
     fn topic_constants_are_distinct() {

--- a/services/expand-worker/src/main.rs
+++ b/services/expand-worker/src/main.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rb_blob::store_from_env;
+use rb_kafka::{Consumer, ConsumerCfg, Producer, ProducerCfg};
+use rb_schemas::{ExpandedFileEvent, IngestRequest, IngestStatusEvent};
+
+mod consumer;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = rb_tracing::init("expand-worker")?;
+
+    let blob_store = store_from_env().await.context("failed to init blob store")?;
+
+    let consumer: Consumer<IngestRequest> =
+        Consumer::new(&ConsumerCfg::new("expand-worker"))?;
+    consumer.subscribe(&[consumer::TOPIC_EXPAND_COMMANDS])?;
+
+    let expanded_producer = Arc::new(Producer::<ExpandedFileEvent>::new(&ProducerCfg::default())?);
+    let parse_producer = Arc::new(Producer::<IngestRequest>::new(&ProducerCfg::default())?);
+    let status_producer = Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
+
+    tracing::info!("expand-worker starting");
+
+    let handle = tokio::spawn(consumer::run(
+        consumer,
+        blob_store,
+        expanded_producer,
+        parse_producer,
+        status_producer,
+    ));
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received — stopping consumer");
+    handle.abort();
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    use tokio::signal;
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("failed to listen for Ctrl+C");
+    };
+    #[cfg(unix)]
+    {
+        let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to listen for SIGTERM");
+        tokio::select! {
+            () = ctrl_c => {},
+            _ = sigterm.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    ctrl_c.await;
+}

--- a/services/expand-worker/src/main.rs
+++ b/services/expand-worker/src/main.rs
@@ -5,7 +5,9 @@ use rb_blob::store_from_env;
 use rb_kafka::{Consumer, ConsumerCfg, Producer, ProducerCfg};
 use rb_schemas::{ExpandedFileEvent, IngestRequest, IngestStatusEvent};
 
+mod archive;
 mod consumer;
+mod workspace;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/services/expand-worker/src/workspace.rs
+++ b/services/expand-worker/src/workspace.rs
@@ -1,0 +1,89 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+
+#[derive(Debug)]
+pub struct WorkspaceMember {
+    pub name: String,
+    pub manifest_rel_path: String,
+}
+
+pub fn discover_workspace_members(workspace_root: &Path) -> Result<Vec<WorkspaceMember>> {
+    let root_manifest = workspace_root.join("Cargo.toml");
+    let root_text = std::fs::read_to_string(&root_manifest)
+        .with_context(|| format!("failed to read {}", root_manifest.display()))?;
+    let root_toml: toml::Value =
+        toml::from_str(&root_text).context("failed to parse root Cargo.toml")?;
+
+    if let Some(members) = root_toml
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+    {
+        let mut result = Vec::new();
+        for m in members {
+            let pat = m.as_str().context("workspace member is not a string")?;
+            let member_manifests = glob_manifest_paths(workspace_root, pat);
+            for manifest_path in member_manifests {
+                if let Ok(name) = read_package_name(&manifest_path) {
+                    let rel = manifest_path
+                        .strip_prefix(workspace_root)
+                        .context("manifest outside workspace root")?
+                        .to_string_lossy()
+                        .to_string();
+                    result.push(WorkspaceMember {
+                        name,
+                        manifest_rel_path: rel,
+                    });
+                }
+            }
+        }
+        if !result.is_empty() {
+            return Ok(result);
+        }
+    }
+
+    // Fallback: treat root as a single-crate workspace.
+    let name = read_package_name(&root_manifest)?;
+    Ok(vec![WorkspaceMember {
+        name,
+        manifest_rel_path: "Cargo.toml".to_string(),
+    }])
+}
+
+fn glob_manifest_paths(workspace_root: &Path, pattern: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let abs_pattern = workspace_root.join(pattern).join("Cargo.toml");
+    let abs_str = abs_pattern.to_string_lossy();
+    if let Ok(entries) = glob::glob(&abs_str) {
+        for entry in entries.flatten() {
+            paths.push(entry);
+        }
+    }
+    if paths.is_empty() {
+        let direct = workspace_root.join(pattern).join("Cargo.toml");
+        if direct.exists() {
+            paths.push(direct);
+        }
+    }
+    paths
+}
+
+fn read_package_name(manifest_path: &Path) -> Result<String> {
+    let text = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    let toml: toml::Value = toml::from_str(&text)
+        .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
+    toml.get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_owned)
+        .context("Cargo.toml missing [package].name")
+}
+
+pub fn load_manifest(manifest_path: &Path) -> Result<rb_feature_resolver::CargoManifest> {
+    let text = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    toml::from_str::<rb_feature_resolver::CargoManifest>(&text)
+        .with_context(|| format!("failed to parse manifest {}", manifest_path.display()))
+}

--- a/services/expand-worker/tests/fixtures/feature-flagged-workspace/Cargo.toml
+++ b/services/expand-worker/tests/fixtures/feature-flagged-workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = [
+    "crates/alpha",
+    "crates/beta",
+]

--- a/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/alpha/Cargo.toml
+++ b/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/alpha/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "alpha"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["logging"]
+logging = []
+tracing-support = []

--- a/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/alpha/src/lib.rs
+++ b/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/alpha/src/lib.rs
@@ -1,0 +1,13 @@
+/// Simple feature-flagged fixture crate for expand-worker integration tests.
+
+#[cfg(feature = "logging")]
+pub fn log_message(msg: &str) {
+    println!("[LOG] {msg}");
+}
+
+#[cfg(not(feature = "logging"))]
+pub fn log_message(_msg: &str) {}
+
+pub fn greet(name: &str) -> String {
+    format!("Hello, {name}!")
+}

--- a/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/beta/Cargo.toml
+++ b/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/beta/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "beta"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+extra = []

--- a/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/beta/src/lib.rs
+++ b/services/expand-worker/tests/fixtures/feature-flagged-workspace/crates/beta/src/lib.rs
@@ -1,0 +1,10 @@
+/// Beta crate — no default features, tests feature resolution with default=false.
+
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(feature = "extra")]
+pub fn multiply(a: i32, b: i32) -> i32 {
+    a * b
+}

--- a/services/expand-worker/tests/integration.rs
+++ b/services/expand-worker/tests/integration.rs
@@ -1,0 +1,86 @@
+//! Integration tests for `expand-worker`.
+//!
+//! These tests exercise the workspace-discovery and feature-resolution logic
+//! against the fixture workspace under `tests/fixtures/feature-flagged-workspace/`.
+//! `cargo expand` itself is NOT invoked here — that would require the binary and a
+//! full Cargo build, which is unsuitable for unit-level CI. The integration test
+//! validates the pipeline plumbing (discovery, manifest parsing, feature resolution)
+//! against the fixture.
+
+use std::path::PathBuf;
+
+fn fixture_workspace() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/feature-flagged-workspace")
+}
+
+#[test]
+fn discovers_both_workspace_members() {
+    let root = fixture_workspace();
+    let root_toml = root.join("Cargo.toml");
+    assert!(root_toml.exists(), "fixture workspace root Cargo.toml must exist");
+
+    let text = std::fs::read_to_string(&root_toml).unwrap();
+    let parsed: toml::Value = toml::from_str(&text).unwrap();
+    let members = parsed["workspace"]["members"].as_array().unwrap();
+    assert_eq!(members.len(), 2, "fixture must declare two workspace members");
+}
+
+#[test]
+fn alpha_feature_resolution_includes_logging_by_default() {
+    let root = fixture_workspace();
+    let manifest_path = root.join("crates/alpha/Cargo.toml");
+
+    let text = std::fs::read_to_string(&manifest_path).unwrap();
+    let manifest: rb_feature_resolver::CargoManifest = toml::from_str(&text).unwrap();
+
+    let requested = rb_feature_resolver::FeatureSet::default();
+    let resolved = rb_feature_resolver::resolve(&root, &manifest, &requested).unwrap();
+
+    let features: Vec<_> = resolved.features().iter().cloned().collect();
+    assert!(
+        features.contains(&"logging".to_string()),
+        "default feature set must resolve to include 'logging'; got: {features:?}"
+    );
+    assert!(
+        features.contains(&"default".to_string()),
+        "resolved set must include 'default'; got: {features:?}"
+    );
+}
+
+#[test]
+fn beta_feature_resolution_no_non_default_features() {
+    let root = fixture_workspace();
+    let manifest_path = root.join("crates/beta/Cargo.toml");
+
+    let text = std::fs::read_to_string(&manifest_path).unwrap();
+    let manifest: rb_feature_resolver::CargoManifest = toml::from_str(&text).unwrap();
+
+    let requested = rb_feature_resolver::FeatureSet::default();
+    let resolved = rb_feature_resolver::resolve(&root, &manifest, &requested).unwrap();
+
+    let features: Vec<_> = resolved.features().iter().cloned().collect();
+    // beta declares `default = []` (empty), so "default" may appear but "extra" must not.
+    assert!(
+        !features.contains(&"extra".to_string()),
+        "beta default must not include 'extra'; got: {features:?}"
+    );
+}
+
+#[test]
+fn beta_feature_resolution_respects_no_default_features() {
+    let root = fixture_workspace();
+    let manifest_path = root.join("crates/alpha/Cargo.toml");
+
+    let text = std::fs::read_to_string(&manifest_path).unwrap();
+    let manifest: rb_feature_resolver::CargoManifest = toml::from_str(&text).unwrap();
+
+    let requested = rb_feature_resolver::FeatureSet::default().no_default_features();
+    let resolved = rb_feature_resolver::resolve(&root, &manifest, &requested).unwrap();
+
+    let features: Vec<_> = resolved.features().iter().cloned().collect();
+    assert!(
+        !features.contains(&"logging".to_string()),
+        "no_default_features must suppress 'logging'; got: {features:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements `services/expand-worker/` — Stage 2 of the ingest pipeline (ADR-007 §11.3).

Closes #179

- Consumes `IngestRequest` from `rb.ingest.expand.commands`; `blob_ref` carries the clone tar.zst
- Downloads blob, extracts archive, discovers workspace members, resolves features via `rb-feature-resolver`
- Runs `cargo expand --package <name> --features <list>` per crate root
- Emits `ExpandedFileEvent` per crate to `rb.expanded-files.v1` (partial=true when cargo expand exits non-zero with partial stdout)
- Forwards `IngestRequest` to `rb.ingest.parse.commands`; emits `IngestStatusEvent{Expand,Done}`
- Proto additive change: `bool partial = 12` on `ExpandedFileEvent`
- Retry cap: after `RetryPolicy::MAX_ATTEMPTS` (3) failures, routes to `rb.ingest.expand.commands.dlq` and commits offset
- `source_sha256` populated from pre-expansion `src/lib.rs` hash
- Module split: workspace discovery → `workspace.rs`, archive extraction → `archive.rs`

## Test plan

- [x] `cargo test -p expand-worker` — 14/14 passing (10 unit + 4 integration)
- [x] `cargo clippy -p expand-worker` — clean (pedantic)
- [x] File size check — all files under 600 lines
- [x] Bundle check — single issue, no bundling
- [ ] Runtime smoke: requires Kafka + cargo-expand installed