### PR TITLE
[REQ-IN-05] refactor(parse-worker): eliminate source_text per-item duplication

### DIFF
--- a/crates/rb-parse-syn/src/lib.rs
+++ b/crates/rb-parse-syn/src/lib.rs
@@ -33,8 +33,6 @@ pub struct ExtractedItem {
     /// Simple ident name (e.g. `"my_fn"`).
     pub name: String,
     pub kind: Kind,
-    /// Verbatim source text of the item (used as `inline_payload`).
-    pub source_text: String,
     pub line_start: u32,
     pub line_end: u32,
 }
@@ -49,35 +47,29 @@ pub struct ExtractedItem {
 /// Returns [`ParseSynError::Syn`] if `source` cannot be parsed as a Rust file.
 pub fn extract_items(source: &str) -> Result<Vec<ExtractedItem>, ParseSynError> {
     let file: syn::File = syn::parse_str(source)?;
-    let mut visitor = ItemVisitor {
-        source,
-        items: Vec::new(),
-    };
+    let mut visitor = ItemVisitor { items: Vec::new() };
     visitor.visit_file(&file);
     Ok(visitor.items)
 }
 
-struct ItemVisitor<'src> {
-    source: &'src str,
+struct ItemVisitor {
     items: Vec<ExtractedItem>,
 }
 
-impl ItemVisitor<'_> {
+impl ItemVisitor {
     fn push(&mut self, name: String, kind: Kind, span: proc_macro2::Span) {
         let start: LineColumn = span.start();
         let end: LineColumn = span.end();
-        let source_text = self.source.to_owned();
         self.items.push(ExtractedItem {
             name,
             kind,
-            source_text,
             line_start: u32::try_from(start.line).expect("line number fits u32"),
             line_end: u32::try_from(end.line).expect("line number fits u32"),
         });
     }
 }
 
-impl<'ast> Visit<'ast> for ItemVisitor<'_> {
+impl<'ast> Visit<'ast> for ItemVisitor {
     fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
         self.push(node.sig.ident.to_string(), Kind::Fn, node.sig.ident.span());
     }

--- a/services/parse-worker/src/consumer.rs
+++ b/services/parse-worker/src/consumer.rs
@@ -196,7 +196,7 @@ async fn process_parse(
         error_count += usize::from(extracted.had_error);
 
         for item in extracted.items {
-            emit_parsed_item(ctx, tenant_id, req, rel_path, item).await?;
+            emit_parsed_item(ctx, tenant_id, req, rel_path, item, &source).await?;
         }
 
         if extracted.had_error && extracted_is_empty {
@@ -230,15 +230,50 @@ async fn process_parse(
 
 // ── Kafka producers ──────────────────────────────────────────────────────────
 
+/// Returns the source lines `[line_start, line_end]` (1-based, inclusive) as a
+/// borrowed slice of `file_source`, without trailing newline.
+///
+/// This avoids storing a full-file copy on every item: callers keep one `String`
+/// per file and slice into it at emit time (O(item_size) instead of O(file_size)).
+fn item_source_slice(file_source: &str, line_start: u32, line_end: u32) -> &str {
+    let start_0 = line_start.saturating_sub(1) as usize;
+    let end_0 = line_end.saturating_sub(1) as usize;
+
+    let mut current_line = 0usize;
+    let mut byte_start: Option<usize> = if start_0 == 0 { Some(0) } else { None };
+
+    for (i, ch) in file_source.char_indices() {
+        if ch == '\n' {
+            current_line += 1;
+            if current_line == start_0 {
+                byte_start = Some(i + 1);
+            }
+            if current_line > end_0 {
+                return match byte_start {
+                    Some(bs) => &file_source[bs..i],
+                    None => file_source,
+                };
+            }
+        }
+    }
+
+    match byte_start {
+        Some(bs) => &file_source[bs..],
+        None => file_source,
+    }
+}
+
 async fn emit_parsed_item(
     ctx: &ParseCtx,
     tenant_id: TenantId,
     req: &IngestRequest,
     source_path: &str,
     item: ExtractedItemData,
+    file_source: &str,
 ) -> Result<()> {
-    let src_bytes = item.source_text.into_bytes();
-    let sha256 = hex::encode(Sha256::digest(&src_bytes));
+    let src_slice = item_source_slice(file_source, item.line_start, item.line_end);
+    let sha256 = hex::encode(Sha256::digest(src_slice.as_bytes()));
+    let src_bytes = src_slice.as_bytes().to_vec();
 
     let body = if src_bytes.len() <= INLINE_MAX_BYTES {
         parsed_item_event::Body::InlinePayload(src_bytes)
@@ -450,5 +485,32 @@ mod tests {
         let policy = RetryPolicy::default();
         assert!(!policy.is_terminal(1));
         assert!(policy.is_terminal(3));
+    }
+
+    #[test]
+    fn item_source_slice_single_line_only_item() {
+        assert_eq!(item_source_slice("fn a() {}", 1, 1), "fn a() {}");
+    }
+
+    #[test]
+    fn item_source_slice_first_of_two() {
+        assert_eq!(item_source_slice("fn a() {}\nfn b() {}", 1, 1), "fn a() {}");
+    }
+
+    #[test]
+    fn item_source_slice_second_of_two() {
+        assert_eq!(item_source_slice("fn a() {}\nfn b() {}", 2, 2), "fn b() {}");
+    }
+
+    #[test]
+    fn item_source_slice_multi_line_item() {
+        let src = "fn a() {}\nfn b() {\n    x\n}\nfn c() {}";
+        assert_eq!(item_source_slice(src, 2, 4), "fn b() {\n    x\n}");
+    }
+
+    #[test]
+    fn item_source_slice_last_line_no_trailing_newline() {
+        let src = "fn a() {}\nfn b() {}";
+        assert_eq!(item_source_slice(src, 2, 2), "fn b() {}");
     }
 }

--- a/services/parse-worker/src/consumer.rs
+++ b/services/parse-worker/src/consumer.rs
@@ -234,7 +234,7 @@ async fn process_parse(
 /// borrowed slice of `file_source`, without trailing newline.
 ///
 /// This avoids storing a full-file copy on every item: callers keep one `String`
-/// per file and slice into it at emit time (O(item_size) instead of O(file_size)).
+/// per file and slice into it at emit time (`O(item_size)` instead of `O(file_size)`).
 fn item_source_slice(file_source: &str, line_start: u32, line_end: u32) -> &str {
     let start_0 = line_start.saturating_sub(1) as usize;
     let end_0 = line_end.saturating_sub(1) as usize;

--- a/services/parse-worker/src/parse_strategy.rs
+++ b/services/parse-worker/src/parse_strategy.rs
@@ -11,7 +11,6 @@ pub(crate) struct Extraction {
 pub(crate) struct ExtractedItemData {
     pub(crate) name: String,
     pub(crate) kind: ItemKind,
-    pub(crate) source_text: String,
     pub(crate) line_start: u32,
     pub(crate) line_end: u32,
 }
@@ -25,7 +24,6 @@ pub(crate) fn parse_file(source: &str, rel_path: &str, ingest_run_id: &str) -> E
                 .map(|i| ExtractedItemData {
                     name: i.name,
                     kind: syn_kind_to_proto(i.kind),
-                    source_text: i.source_text,
                     line_start: i.line_start,
                     line_end: i.line_end,
                 })
@@ -62,7 +60,6 @@ pub(crate) fn parse_file(source: &str, rel_path: &str, ingest_run_id: &str) -> E
         .map(|i| ExtractedItemData {
             name: i.name,
             kind: ts_kind_to_proto(i.kind),
-            source_text: source.to_owned(),
             line_start: i.line_start,
             line_end: i.line_end,
         })


### PR DESCRIPTION
## Summary

Fixes the HIGH memory-pressure finding from PR #180 review.

Each parsed item was carrying a full copy of the source file text. A file with N items allocated N × file_size bytes simultaneously in the `items` Vec before any Kafka emission happened. For large repos this multiplied Kafka topic payload size proportionally.

**Root cause:** `ItemVisitor::push()` in `rb-parse-syn` called `self.source.to_owned()` — cloning the entire file per item, not the item's own slice. The tree-sitter fallback path in `parse_strategy.rs` did the same.

**Fix:** Remove `source_text` from `ExtractedItem` and `ExtractedItemData`. Add `item_source_slice(file_source, line_start, line_end)` in `consumer.rs` that borrows only the item's lines from the already-held file `String` at emit time.

**Memory change:** O(N × file_size) → O(file_size + item_size) per file.

**Protocol note:** `ParsedItemEvent.body` now correctly carries the item's own source text rather than the full file — this is what downstream consumers should have been receiving all along.

## Changes

- `crates/rb-parse-syn/src/lib.rs` — remove `source_text: String` from `ExtractedItem`; `ItemVisitor` no longer holds a source reference
- `services/parse-worker/src/parse_strategy.rs` — remove `source_text` from `ExtractedItemData`; strip both mapping paths
- `services/parse-worker/src/consumer.rs` — add `item_source_slice` helper (borrows item lines by 1-based offset); thread `file_source: &str` into `emit_parsed_item`; 5 new unit tests

## Test plan

- [x] `cargo test --package rb-parse-syn --package rb-parse-tree-sitter --package parse-worker` — 44 tests, all pass
- [x] New unit tests for `item_source_slice`: single-line, first/last of two, multi-line span, no-trailing-newline edge case
- [ ] Integration benchmark on a representative large repo (follow-up — see issue description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #183