### PR TITLE
[REQ-IN-06] feat(typecheck-worker): Stage 4 — Typecheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,6 +5312,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typecheck-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "hex",
+ "metrics",
+ "metrics-util 0.18.0",
+ "proc-macro2",
+ "rb-blob",
+ "rb-kafka",
+ "rb-schemas",
+ "rb-tracing",
+ "sha2 0.10.9",
+ "syn 2.0.117",
+ "tar",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "uuid",
+ "walkdir",
+ "zstd",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "services/ingest-clone",
     "services/expand-worker",
     "services/parse-worker",
+    "services/typecheck-worker",
     "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
     "services/projector-pg",

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -105,7 +105,9 @@ services:
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.clone.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.expand.commands    --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.parse.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.parsed-items.v1           --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.typecheck.commands --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.typechecked-items.v1      --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.graph.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.embed.commands     --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.source-files.v1           --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
@@ -325,6 +327,27 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: parse-worker
       RUST_LOG: "info,parse_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
+  typecheck-worker:
+    build:
+      context: ..
+      dockerfile: docker/typecheck-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/typecheck-worker:dev
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      BLOB_STORE_PATH: /data/blobs
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: typecheck-worker
+      RUST_LOG: "info,typecheck_worker=debug"
     volumes:
       - blob-data:/data/blobs
     networks:

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -9,7 +9,7 @@ pub use ingest::{
     AuditEvent, EmbeddingPendingEvent, ExpandedFileEvent, GraphRelationEvent, IngestRequest,
     IngestStage, IngestStatus, IngestStatusEvent, ItemKind, ParsedItemEvent, RelationKind,
     SourceFileEvent, Tombstone, TypecheckedItemEvent,
-    expanded_file_event, parsed_item_event, source_file_event,
+    expanded_file_event, parsed_item_event, source_file_event, typechecked_item_event,
 };
 
 /// Newtype over [`Uuid`] representing a tenant identifier.

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -27,6 +27,7 @@ COPY services/expand-worker/Cargo.toml   services/expand-worker/Cargo.toml
 COPY crates/rb-parse-syn/Cargo.toml           crates/rb-parse-syn/Cargo.toml
 COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.toml
 COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/parse-worker/Dockerfile
+++ b/docker/parse-worker/Dockerfile
@@ -14,6 +14,7 @@ COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
 COPY crates/rb-parse-syn/Cargo.toml           crates/rb-parse-syn/Cargo.toml
 COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.toml
 COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -12,8 +12,9 @@ COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
 COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml   crates/rb-storage-pg/Cargo.toml
-COPY services/projector-pg/Cargo.toml  services/projector-pg/Cargo.toml
-COPY services/tombstoner/Cargo.toml    services/tombstoner/Cargo.toml
+COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
+COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -13,7 +13,8 @@ COPY crates/rb-kafka/Cargo.toml          crates/rb-kafka/Cargo.toml
 COPY crates/rb-tenant/Cargo.toml         crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml     crates/rb-storage-pg/Cargo.toml
 COPY crates/rb-storage-neo4j/Cargo.toml  crates/rb-storage-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
+COPY services/tombstoner/Cargo.toml       services/tombstoner/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/typecheck-worker/Dockerfile
+++ b/docker/typecheck-worker/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
+COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/typecheck-worker/src && \
+    printf 'fn main() {}' > services/typecheck-worker/src/main.rs && \
+    cargo build --release -p typecheck-worker 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                     crates/
+COPY services/typecheck-worker/  services/typecheck-worker/
+COPY proto/                      proto/
+
+RUN cargo build --release -p typecheck-worker
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/typecheck-worker /usr/local/bin/typecheck-worker
+
+ENTRYPOINT ["/usr/local/bin/typecheck-worker"]

--- a/infra/kafka/topics.yaml
+++ b/infra/kafka/topics.yaml
@@ -60,6 +60,12 @@ topics:
     config:
       retention.ms: "604800000"  # 7 days
 
+  - name: rb.typechecked-items.v1
+    partitions: 6
+    replication_factor: 1
+    config:
+      retention.ms: "604800000"  # 7 days
+
   # ── Retry topics — one per pipeline stage (6) ────────────────────────────
   # Consumers skip messages whose x-rb-process-after-ms > now(); exponential
   # backoff of 30s/2m/10m encoded in that header by rb-kafka RetryPolicy.

--- a/services/migrate/tests/kafka_integration.rs
+++ b/services/migrate/tests/kafka_integration.rs
@@ -40,7 +40,7 @@ fn make_topics_yaml(topics: &[(&str, i32, &str)]) -> NamedTempFile {
 // ── unit tests (no broker required) ─────────────────────────────────────────
 
 #[test]
-fn test_load_all_22_topics_from_infra_yaml() {
+fn test_load_all_23_topics_from_infra_yaml() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -53,8 +53,8 @@ fn test_load_all_22_topics_from_infra_yaml() {
     let tf = load_topics_file(&path).expect("infra/kafka/topics.yaml must be loadable");
     assert_eq!(
         tf.topics.len(),
-        22,
-        "expected 22 topic definitions (9 base + 6 retry + 7 DLQ per ADR-006 §4.3 + rb.parsed-items.v1)"
+        23,
+        "expected 23 topic definitions (8 base + 2 payload + 6 retry + 7 DLQ)"
     );
 
     let names: Vec<&str> = tf.topics.iter().map(|t| t.name.as_str()).collect();
@@ -68,7 +68,9 @@ fn test_load_all_22_topics_from_infra_yaml() {
     assert!(names.contains(&"rb.ingest.embed.commands"));
     assert!(names.contains(&"rb.projector.events"));
     assert!(names.contains(&"rb.audit.events"));
+    // Payload topics
     assert!(names.contains(&"rb.parsed-items.v1"));
+    assert!(names.contains(&"rb.typechecked-items.v1"));
 
     // Retry topics (one per pipeline stage)
     assert!(names.contains(&"rb.ingest.clone.commands.retry"));

--- a/services/typecheck-worker/Cargo.toml
+++ b/services/typecheck-worker/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "typecheck-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "typecheck-worker"
+path = "src/main.rs"
+
+[dependencies]
+rb-blob    = { path = "../../crates/rb-blob",    version = "0.1.0" }
+rb-kafka   = { path = "../../crates/rb-kafka",   version = "0.1.0" }
+rb-schemas = { path = "../../crates/rb-schemas", version = "0.1.0" }
+rb-tracing = { path = "../../crates/rb-tracing", version = "0.1.0" }
+
+anyhow.workspace  = true
+bytes.workspace   = true
+chrono.workspace  = true
+hex.workspace     = true
+metrics.workspace = true
+sha2.workspace    = true
+tokio.workspace   = true
+tracing.workspace = true
+uuid.workspace    = true
+
+# Syn for AST-level type signature extraction
+proc-macro2 = { version = "1", features = ["span-locations"] }
+syn = { version = "2", features = ["full", "visit"] }
+
+tar      = "0.4"
+tempfile = "3"
+walkdir  = "2"
+zstd     = "0.13"
+
+[dev-dependencies]
+metrics-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/services/typecheck-worker/src/consumer.rs
+++ b/services/typecheck-worker/src/consumer.rs
@@ -1,0 +1,483 @@
+//! Kafka consumer loop for `typecheck-worker`.
+//!
+//! Consumes `IngestRequest` from `rb.ingest.typecheck.commands`.
+//! The envelope's `blob_ref` points to the clone tar.zst produced by `ingest-clone`.
+//! For each command:
+//!   1. Downloads the clone.tar.zst blob from rb-blob.
+//!   2. Extracts to a temp directory.
+//!   3. Walks `*.rs` files and parses each with syn to extract type signatures.
+//!   4. Emits `TypecheckedItemEvent` per item to `rb.typechecked-items.v1`.
+//!      — Files that fail syn parse emit no items and increment the error counter.
+//!   5. Forwards `IngestRequest` to `rb.ingest.graph.commands`.
+//!   6. Emits `IngestStatusEvent{stage:Typecheck, status:Done}` to `rb.projector.events`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use bytes::Bytes;
+use metrics::counter;
+use rb_blob::{BlobRef, BlobStore};
+use rb_kafka::{Consumer, EventEnvelope, Producer, RetryPolicy};
+use rb_schemas::{
+    IngestRequest, IngestStage, IngestStatus, IngestStatusEvent, TenantId, TypecheckedItemEvent,
+    typechecked_item_event,
+};
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+use crate::helpers::{build_fqn, collect_rs_files, extract_tar_zst};
+use crate::type_extractor::extract_typed_items;
+
+pub const TOPIC_TYPECHECK_COMMANDS: &str = "rb.ingest.typecheck.commands";
+pub const TOPIC_TYPECHECKED_ITEMS: &str = "rb.typechecked-items.v1";
+pub const TOPIC_GRAPH_COMMANDS: &str = "rb.ingest.graph.commands";
+pub const TOPIC_PROJECTOR_EVENTS: &str = "rb.projector.events";
+
+/// Inline threshold: items ≤ 512 KiB are embedded directly.
+const INLINE_MAX_BYTES: usize = 512 * 1024;
+
+struct TypecheckCtx {
+    blob_store: Arc<dyn BlobStore>,
+    item_producer: Arc<Producer<TypecheckedItemEvent>>,
+    graph_producer: Arc<Producer<IngestRequest>>,
+    status_producer: Arc<Producer<IngestStatusEvent>>,
+}
+
+pub async fn run(
+    consumer: Consumer<IngestRequest>,
+    blob_store: Arc<dyn BlobStore>,
+    item_producer: Arc<Producer<TypecheckedItemEvent>>,
+    graph_producer: Arc<Producer<IngestRequest>>,
+    status_producer: Arc<Producer<IngestStatusEvent>>,
+) {
+    let ctx = Arc::new(TypecheckCtx {
+        blob_store,
+        item_producer,
+        graph_producer,
+        status_producer,
+    });
+
+    loop {
+        match consumer.next().await {
+            None => {
+                tracing::info!("typecheck_worker: stream ended");
+                break;
+            }
+            Some(Err(e)) => {
+                tracing::error!("typecheck_worker: kafka error: {e}");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Some(Ok(envelope)) => {
+                let ingest_run_id = envelope.payload.ingest_run_id.clone();
+                let event_id = envelope.payload.event_id.clone();
+                let tenant_id = envelope.tenant_id;
+
+                match process_typecheck(&ctx, &envelope).await {
+                    Ok(()) => {
+                        counter!("rb_typecheck_worker_total", "outcome" => "ok").increment(1);
+                        if let Err(e) = consumer.commit(&envelope).await {
+                            tracing::warn!(%ingest_run_id, "typecheck_worker: commit failed: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        let attempt = envelope._meta.attempt + 1;
+                        tracing::error!(
+                            attempt,
+                            %ingest_run_id,
+                            tenant_id = %tenant_id,
+                            "typecheck_worker: processing failed: {e:#}"
+                        );
+                        counter!("rb_typecheck_worker_total", "outcome" => "err").increment(1);
+                        emit_failed_status(
+                            &ctx.status_producer,
+                            tenant_id,
+                            &ingest_run_id,
+                            &event_id,
+                            &format!("typecheck_failed: {e:#}"),
+                        )
+                        .await;
+                        let policy = RetryPolicy::default();
+                        if policy.is_terminal(attempt) {
+                            tracing::warn!(
+                                attempt,
+                                %ingest_run_id,
+                                "typecheck_worker: max retries exceeded — routing to DLQ"
+                            );
+                            counter!("rb_typecheck_worker_dlq_total").increment(1);
+                            if let Err(dlq_err) =
+                                consumer.nack_to_dlq(&envelope, &format!("{e:#}")).await
+                            {
+                                tracing::error!(
+                                    %ingest_run_id,
+                                    "typecheck_worker: nack_to_dlq failed: {dlq_err}"
+                                );
+                            }
+                            if let Err(ce) = consumer.commit(&envelope).await {
+                                tracing::warn!(
+                                    %ingest_run_id,
+                                    "typecheck_worker: commit after DLQ failed: {ce}"
+                                );
+                            }
+                        } else {
+                            let delay = policy
+                                .next_delay(attempt)
+                                .unwrap_or(Duration::from_secs(1));
+                            tokio::time::sleep(delay).await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn process_typecheck(
+    ctx: &TypecheckCtx,
+    envelope: &EventEnvelope<IngestRequest>,
+) -> Result<()> {
+    let req = &envelope.payload;
+    let tenant_id = envelope.tenant_id;
+    let ingest_run_id = &req.ingest_run_id;
+
+    let blob_uri = envelope
+        .blob_ref
+        .as_deref()
+        .context("typecheck command missing blob_ref (clone tar.zst)")?;
+
+    tracing::info!(%ingest_run_id, "typecheck_worker: downloading clone blob");
+
+    let blob_ref =
+        BlobRef::from_uri_minimal(blob_uri).context("invalid blob_ref URI in typecheck command")?;
+    let archive_bytes = ctx
+        .blob_store
+        .get(&blob_ref)
+        .await
+        .context("failed to download clone blob")?;
+
+    let tmp = tempfile::tempdir().context("failed to create temp dir")?;
+    extract_tar_zst(&archive_bytes, tmp.path()).context("failed to extract clone tar.zst")?;
+
+    tracing::info!(%ingest_run_id, "typecheck_worker: walking *.rs files");
+
+    let rs_files = collect_rs_files(tmp.path());
+    let file_count = rs_files.len();
+
+    tracing::info!(%ingest_run_id, file_count, "typecheck_worker: extracting type signatures");
+
+    let mut item_count = 0usize;
+    let mut error_count = 0usize;
+
+    for (rel_path, abs_path) in &rs_files {
+        let source = match std::fs::read_to_string(abs_path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    %ingest_run_id,
+                    path = %rel_path,
+                    "typecheck_worker: cannot read file: {e}"
+                );
+                error_count += 1;
+                continue;
+            }
+        };
+
+        let typed_items = extract_typed_items(&source);
+
+        if typed_items.is_empty() {
+            // Syn parse failed or no items — count as soft error, continue.
+            if !source.trim().is_empty() {
+                error_count += 1;
+            }
+            continue;
+        }
+
+        item_count += typed_items.len();
+
+        for item in typed_items {
+            let src_slice = item_source_slice(&source, item.line_start, item.line_end);
+            emit_typechecked_item(ctx, tenant_id, req, rel_path, item, src_slice).await?;
+        }
+    }
+
+    tracing::info!(
+        %ingest_run_id,
+        file_count,
+        item_count,
+        error_count,
+        "typecheck_worker: typecheck done"
+    );
+
+    counter!("rb_typecheck_worker_items_total").increment(item_count as u64);
+    counter!("rb_typecheck_worker_files_total").increment(file_count as u64);
+
+    emit_graph_command(ctx, tenant_id, req, blob_uri).await?;
+    emit_done_status(ctx, tenant_id, req).await?;
+
+    Ok(())
+}
+
+// ── Item source slicing ───────────────────────────────────────────────────────
+
+/// Returns the source lines `[line_start, line_end]` (1-based, inclusive).
+///
+/// Avoids storing a full-file copy on every item: callers keep one `String`
+/// per file and slice into it at emit time (`O(item_size)` instead of
+/// `O(file_size)`).
+fn item_source_slice(file_source: &str, line_start: u32, line_end: u32) -> &str {
+    let start_0 = line_start.saturating_sub(1) as usize;
+    let end_0 = line_end.saturating_sub(1) as usize;
+
+    let mut current_line = 0usize;
+    let mut byte_start: Option<usize> = if start_0 == 0 { Some(0) } else { None };
+
+    for (i, ch) in file_source.char_indices() {
+        if ch == '\n' {
+            current_line += 1;
+            if current_line == start_0 {
+                byte_start = Some(i + 1);
+            }
+            if current_line > end_0 {
+                return match byte_start {
+                    Some(bs) => &file_source[bs..i],
+                    None => file_source,
+                };
+            }
+        }
+    }
+
+    match byte_start {
+        Some(bs) => &file_source[bs..],
+        None => file_source,
+    }
+}
+
+// ── Kafka producers ───────────────────────────────────────────────────────────
+
+async fn emit_typechecked_item(
+    ctx: &TypecheckCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+    source_path: &str,
+    item: crate::type_extractor::TypedItemData,
+    src_slice: &str,
+) -> Result<()> {
+    let sha256 = hex::encode(Sha256::digest(src_slice.as_bytes()));
+    let src_bytes = src_slice.as_bytes().to_vec();
+
+    let body = if src_bytes.len() <= INLINE_MAX_BYTES {
+        typechecked_item_event::Body::InlinePayload(src_bytes)
+    } else {
+        let data = Bytes::from(src_bytes);
+        #[allow(clippy::cast_possible_truncation)]
+        let blob_ref = BlobRef::new(
+            tenant_id.as_uuid(),
+            &sha256,
+            "text/x-rust",
+            data.len() as u64,
+        );
+        ctx.blob_store
+            .put(&blob_ref, data)
+            .await
+            .context("failed to store typechecked item source blob")?;
+        typechecked_item_event::Body::BlobRef(blob_ref.to_uri())
+    };
+
+    let fqn = build_fqn(source_path, &item.name);
+
+    let ev = TypecheckedItemEvent {
+        ingest_run_id: req.ingest_run_id.clone(),
+        tenant_id: tenant_id.to_string(),
+        repo_id: req.repo_id.clone(),
+        fqn,
+        body: Some(body),
+        resolved_type_signature: item.resolved_type_signature,
+        trait_bounds: item.trait_bounds,
+        emitted_at_ms: chrono::Utc::now().timestamp_millis(),
+    };
+
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = format!("{}.{}", req.tenant_id, req.repo_id);
+    ctx.item_producer
+        .publish(TOPIC_TYPECHECKED_ITEMS, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish typechecked item")?;
+    Ok(())
+}
+
+async fn emit_graph_command(
+    ctx: &TypecheckCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+    blob_uri: &str,
+) -> Result<()> {
+    let graph_req = IngestRequest {
+        tenant_id: req.tenant_id.clone(),
+        event_id: Uuid::new_v4().to_string(),
+        source: req.source.clone(),
+        payload: req.payload.clone(),
+        created_at_ms: chrono::Utc::now().timestamp_millis(),
+        repo_id: req.repo_id.clone(),
+        ingest_run_id: req.ingest_run_id.clone(),
+        commit_sha: req.commit_sha.clone(),
+        branch: req.branch.clone(),
+    };
+
+    let envelope =
+        rb_kafka::EventEnvelope::new(tenant_id, graph_req).with_blob_ref(blob_uri);
+    let key = format!("{}.{}", req.tenant_id, req.repo_id);
+    ctx.graph_producer
+        .publish(TOPIC_GRAPH_COMMANDS, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish graph command")?;
+    Ok(())
+}
+
+async fn emit_done_status(
+    ctx: &TypecheckCtx,
+    tenant_id: TenantId,
+    req: &IngestRequest,
+) -> Result<()> {
+    let ev = IngestStatusEvent {
+        ingest_request_id: req.event_id.clone(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Done as i32,
+        error_message: String::new(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::Typecheck as i32,
+        stage_seq: 4,
+        ingest_run_id: req.ingest_run_id.clone(),
+        attempt: 0,
+    };
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = tenant_id.to_string();
+    ctx.status_producer
+        .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
+        .await
+        .context("failed to publish done status")?;
+    Ok(())
+}
+
+async fn emit_failed_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: TenantId,
+    ingest_run_id: &str,
+    ingest_request_id: &str,
+    error_message: &str,
+) {
+    let ev = IngestStatusEvent {
+        ingest_request_id: ingest_request_id.to_owned(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Failed as i32,
+        error_message: error_message.to_owned(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::Typecheck as i32,
+        stage_seq: 4,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 0,
+    };
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
+    let key = tenant_id.to_string();
+    if let Err(e) = producer
+        .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
+        .await
+    {
+        tracing::error!("typecheck_worker: failed to publish failed status: {e}");
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::{build_fqn, collect_rs_files};
+
+    #[test]
+    fn topic_constants_are_distinct() {
+        let topics = [
+            TOPIC_TYPECHECK_COMMANDS,
+            TOPIC_TYPECHECKED_ITEMS,
+            TOPIC_GRAPH_COMMANDS,
+            TOPIC_PROJECTOR_EVENTS,
+        ];
+        let unique: std::collections::HashSet<_> = topics.iter().collect();
+        assert_eq!(unique.len(), topics.len(), "all topic constants must be unique");
+    }
+
+    #[test]
+    fn inline_threshold_is_512kib() {
+        assert_eq!(INLINE_MAX_BYTES, 512 * 1024);
+    }
+
+    #[test]
+    fn build_fqn_combines_path_and_name() {
+        assert_eq!(build_fqn("src/lib.rs", "MyStruct"), "src_lib::MyStruct");
+    }
+
+    #[test]
+    fn collect_rs_files_finds_only_rs_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("notes.txt"), b"").unwrap();
+        let files = collect_rs_files(dir.path());
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "main.rs");
+    }
+
+    #[test]
+    fn stage_seq_is_4_for_typecheck() {
+        assert_eq!(IngestStage::Typecheck as i32, 4);
+    }
+
+    #[test]
+    fn retry_policy_terminal_at_max_attempts() {
+        let policy = RetryPolicy::default();
+        assert!(!policy.is_terminal(1));
+        assert!(policy.is_terminal(3));
+    }
+
+    #[test]
+    fn item_source_slice_single_line() {
+        assert_eq!(item_source_slice("fn a() {}", 1, 1), "fn a() {}");
+    }
+
+    #[test]
+    fn item_source_slice_first_of_two() {
+        assert_eq!(item_source_slice("fn a() {}\nfn b() {}", 1, 1), "fn a() {}");
+    }
+
+    #[test]
+    fn item_source_slice_second_of_two() {
+        assert_eq!(item_source_slice("fn a() {}\nfn b() {}", 2, 2), "fn b() {}");
+    }
+
+    #[test]
+    fn item_source_slice_multi_line() {
+        let src = "fn a() {}\nfn b() {\n    x\n}\nfn c() {}";
+        assert_eq!(item_source_slice(src, 2, 4), "fn b() {\n    x\n}");
+    }
+
+    #[test]
+    fn item_source_slice_last_line_no_trailing_newline() {
+        let src = "fn a() {}\nfn b() {}";
+        assert_eq!(item_source_slice(src, 2, 2), "fn b() {}");
+    }
+
+    #[test]
+    fn typechecked_item_event_fields_accessible() {
+        let ev = TypecheckedItemEvent {
+            ingest_run_id: "run-1".to_string(),
+            tenant_id: "tenant-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            fqn: "src_lib::MyFn".to_string(),
+            body: Some(typechecked_item_event::Body::InlinePayload(b"fn my_fn() {}".to_vec())),
+            resolved_type_signature: "fn my_fn()".to_string(),
+            trait_bounds: vec!["T: Clone".to_string()],
+            emitted_at_ms: 0,
+        };
+        assert_eq!(ev.fqn, "src_lib::MyFn");
+        assert_eq!(ev.resolved_type_signature, "fn my_fn()");
+        assert_eq!(ev.trait_bounds, vec!["T: Clone"]);
+    }
+}

--- a/services/typecheck-worker/src/helpers.rs
+++ b/services/typecheck-worker/src/helpers.rs
@@ -1,0 +1,138 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+
+pub(crate) fn collect_rs_files(root: &Path) -> Vec<(String, PathBuf)> {
+    walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path().extension().and_then(std::ffi::OsStr::to_str) == Some("rs")
+        })
+        .filter_map(|e| {
+            let rel = e
+                .path()
+                .strip_prefix(root)
+                .ok()?
+                .to_str()?
+                .replace('\\', "/");
+            Some((rel, e.into_path()))
+        })
+        .collect()
+}
+
+fn validate_tar_path(path: &Path) -> Result<()> {
+    anyhow::ensure!(
+        !path.is_absolute(),
+        "tar entry has absolute path: {}",
+        path.display()
+    );
+    anyhow::ensure!(
+        !path.components().any(|c| c == Component::ParentDir),
+        "tar entry escapes destination via '..': {}",
+        path.display()
+    );
+    Ok(())
+}
+
+pub(crate) fn extract_tar_zst(data: &[u8], dest: &Path) -> Result<()> {
+    let zstd_reader = zstd::Decoder::new(data).context("failed to create zstd decoder")?;
+    let mut archive = tar::Archive::new(zstd_reader);
+
+    for entry in archive.entries().context("failed to read tar entries")? {
+        let mut entry = entry.context("failed to read tar entry")?;
+        let path = entry.path().context("failed to get entry path")?;
+        validate_tar_path(path.as_ref())?;
+        let dest_path = dest.join(path.as_ref());
+        if let Some(parent) = dest_path.parent() {
+            std::fs::create_dir_all(parent).context("failed to create parent dir")?;
+        }
+        entry
+            .unpack(&dest_path)
+            .context("failed to unpack tar entry")?;
+    }
+    Ok(())
+}
+
+pub(crate) fn path_to_module(rel_path: &str) -> String {
+    rel_path
+        .trim_end_matches(".rs")
+        .replace(['/', '\\', '-'], "_")
+        .replace("::", "_")
+}
+
+pub(crate) fn build_fqn(rel_path: &str, name: &str) -> String {
+    let module = path_to_module(rel_path);
+    if module.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{module}::{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_fqn_combines_path_and_name() {
+        assert_eq!(build_fqn("src/lib.rs", "MyStruct"), "src_lib::MyStruct");
+        assert_eq!(
+            build_fqn("crates/foo/src/main.rs", "run"),
+            "crates_foo_src_main::run"
+        );
+    }
+
+    #[test]
+    fn path_to_module_normalises_separators() {
+        assert_eq!(path_to_module("src/my-crate/lib.rs"), "src_my_crate_lib");
+    }
+
+    #[test]
+    fn collect_rs_files_finds_only_rs_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("notes.txt"), b"").unwrap();
+        let files = collect_rs_files(dir.path());
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "main.rs");
+    }
+
+    fn make_tar_zst(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            for (path, data) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(data.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append_data(&mut header, path, *data).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        zstd::encode_all(tar_buf.as_slice(), 0).unwrap()
+    }
+
+    #[test]
+    fn extract_normal_archive_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let data = make_tar_zst(&[("src/main.rs", b"fn main() {}")]);
+        extract_tar_zst(&data, dir.path()).unwrap();
+        assert!(dir.path().join("src/main.rs").exists());
+    }
+
+    #[test]
+    fn validate_dotdot_component_rejected() {
+        let path = std::path::PathBuf::from("a/b/../../etc/passwd");
+        let err = validate_tar_path(&path).unwrap_err();
+        assert!(err.to_string().contains(".."));
+    }
+
+    #[test]
+    fn validate_absolute_path_rejected() {
+        let err = validate_tar_path(Path::new("/etc/passwd")).unwrap_err();
+        assert!(err.to_string().contains("absolute"));
+    }
+}

--- a/services/typecheck-worker/src/main.rs
+++ b/services/typecheck-worker/src/main.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rb_blob::store_from_env;
+use rb_kafka::{Consumer, ConsumerCfg, Producer, ProducerCfg};
+use rb_schemas::{IngestRequest, IngestStatusEvent, TypecheckedItemEvent};
+
+mod consumer;
+mod helpers;
+mod type_extractor;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = rb_tracing::init("typecheck-worker")?;
+
+    let blob_store = store_from_env().await.context("failed to init blob store")?;
+
+    let cmd_consumer: Consumer<IngestRequest> =
+        Consumer::new(&ConsumerCfg::new("typecheck-worker"))?;
+    cmd_consumer.subscribe(&[consumer::TOPIC_TYPECHECK_COMMANDS])?;
+
+    let item_producer = Arc::new(Producer::<TypecheckedItemEvent>::new(&ProducerCfg::default())?);
+    let graph_producer = Arc::new(Producer::<IngestRequest>::new(&ProducerCfg::default())?);
+    let status_producer = Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
+
+    tracing::info!("typecheck-worker starting");
+
+    let handle = tokio::spawn(consumer::run(
+        cmd_consumer,
+        blob_store,
+        item_producer,
+        graph_producer,
+        status_producer,
+    ));
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received — stopping consumer");
+    handle.abort();
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}

--- a/services/typecheck-worker/src/type_extractor.rs
+++ b/services/typecheck-worker/src/type_extractor.rs
@@ -1,0 +1,565 @@
+//! AST-level type signature extraction for typecheck-worker.
+//!
+//! Uses `syn` to walk `*.rs` files and extract per-item type information:
+//! `resolved_type_signature` and `trait_bounds`.  This is a best-effort
+//! syntactic extraction — full semantic resolution would require a complete
+//! compiler invocation via `ra_ap_*` crates, which is planned for a future
+//! iteration (ADR-007 §11.6).
+
+use proc_macro2::LineColumn;
+use syn::visit::Visit;
+
+/// Type information extracted from a single Rust item.
+#[derive(Debug, Clone)]
+pub(crate) struct TypedItemData {
+    pub(crate) name: String,
+    pub(crate) line_start: u32,
+    pub(crate) line_end: u32,
+    /// Human-readable type signature (function signature, struct header, etc.)
+    pub(crate) resolved_type_signature: String,
+    /// Where-clause and inline generic bounds, one predicate per entry.
+    pub(crate) trait_bounds: Vec<String>,
+}
+
+/// Extract typed items from `source`.  Returns an empty vec on parse failure.
+pub(crate) fn extract_typed_items(source: &str) -> Vec<TypedItemData> {
+    let file: syn::File = match syn::parse_str(source) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+    let mut visitor = TypeVisitor { items: Vec::new() };
+    visitor.visit_file(&file);
+    visitor.items
+}
+
+// ── Visitor ──────────────────────────────────────────────────────────────────
+
+struct TypeVisitor {
+    items: Vec<TypedItemData>,
+}
+
+impl TypeVisitor {
+    fn push(&mut self, name: String, span: proc_macro2::Span, sig: String, bounds: Vec<String>) {
+        let start: LineColumn = span.start();
+        let end: LineColumn = span.end();
+        self.items.push(TypedItemData {
+            name,
+            line_start: u32::try_from(start.line).expect("line fits u32"),
+            line_end: u32::try_from(end.line).expect("line fits u32"),
+            resolved_type_signature: sig,
+            trait_bounds: bounds,
+        });
+    }
+}
+
+impl<'ast> Visit<'ast> for TypeVisitor {
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        let name = node.sig.ident.to_string();
+        let sig = fmt_fn_sig(&node.sig);
+        let bounds = extract_bounds(&node.sig.generics);
+        self.push(name, node.sig.ident.span(), sig, bounds);
+    }
+
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        let name = node.ident.to_string();
+        let generics = fmt_generics_params(&node.generics);
+        let sig = format!("struct {name}{generics}");
+        let bounds = extract_bounds(&node.generics);
+        self.push(name, node.ident.span(), sig, bounds);
+    }
+
+    fn visit_item_enum(&mut self, node: &'ast syn::ItemEnum) {
+        let name = node.ident.to_string();
+        let generics = fmt_generics_params(&node.generics);
+        let sig = format!("enum {name}{generics}");
+        let bounds = extract_bounds(&node.generics);
+        self.push(name, node.ident.span(), sig, bounds);
+    }
+
+    fn visit_item_trait(&mut self, node: &'ast syn::ItemTrait) {
+        let name = node.ident.to_string();
+        let generics = fmt_generics_params(&node.generics);
+        let supertraits = if node.supertraits.is_empty() {
+            String::new()
+        } else {
+            let parts: Vec<String> = node.supertraits.iter().map(fmt_type_param_bound).collect();
+            format!(": {}", parts.join(" + "))
+        };
+        let sig = format!("trait {name}{generics}{supertraits}");
+        let bounds = extract_bounds(&node.generics);
+        self.push(name, node.ident.span(), sig, bounds);
+    }
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        let generics = fmt_generics_params(&node.generics);
+        let self_ty = fmt_type(&node.self_ty);
+        let (name, sig) = if let Some((_, path, _)) = &node.trait_ {
+            let trait_name = fmt_path(path);
+            let n = format!("<{self_ty} as {trait_name}>");
+            let s = format!("impl{generics} {trait_name} for {self_ty}");
+            (n, s)
+        } else {
+            let n = format!("impl {self_ty}");
+            let s = format!("impl{generics} {self_ty}");
+            (n, s)
+        };
+        let bounds = extract_bounds(&node.generics);
+        self.push(name, node.impl_token.span, sig, bounds);
+    }
+
+    fn visit_item_const(&mut self, node: &'ast syn::ItemConst) {
+        let name = node.ident.to_string();
+        let ty = fmt_type(&node.ty);
+        let sig = format!("const {name}: {ty}");
+        self.push(name, node.ident.span(), sig, vec![]);
+    }
+
+    fn visit_item_type(&mut self, node: &'ast syn::ItemType) {
+        let name = node.ident.to_string();
+        let generics = fmt_generics_params(&node.generics);
+        let ty = fmt_type(&node.ty);
+        let sig = format!("type {name}{generics} = {ty}");
+        let bounds = extract_bounds(&node.generics);
+        self.push(name, node.ident.span(), sig, bounds);
+    }
+
+    fn visit_item_static(&mut self, node: &'ast syn::ItemStatic) {
+        let name = node.ident.to_string();
+        let ty = fmt_type(&node.ty);
+        let mutability = if matches!(node.mutability, syn::StaticMutability::Mut(_)) {
+            "mut "
+        } else {
+            ""
+        };
+        let sig = format!("static {mutability}{name}: {ty}");
+        self.push(name, node.ident.span(), sig, vec![]);
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        let name = node.ident.to_string();
+        let sig = format!("mod {name}");
+        self.push(name, node.ident.span(), sig, vec![]);
+        // Do not recurse into inline mod bodies — callers handle nested files.
+    }
+
+    fn visit_item_macro(&mut self, node: &'ast syn::ItemMacro) {
+        if let Some(ident) = &node.ident {
+            let name = ident.to_string();
+            let sig = format!("macro_rules! {name}");
+            self.push(name, ident.span(), sig, vec![]);
+        }
+    }
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+fn fmt_fn_sig(sig: &syn::Signature) -> String {
+    let name = sig.ident.to_string();
+    let generics = fmt_generics_params(&sig.generics);
+    let inputs: Vec<String> = sig.inputs.iter().map(fmt_fn_arg).collect();
+    let output = match &sig.output {
+        syn::ReturnType::Default => String::new(),
+        syn::ReturnType::Type(_, ty) => format!(" -> {}", fmt_type(ty)),
+    };
+    let asyncness = if sig.asyncness.is_some() { "async " } else { "" };
+    format!("{asyncness}fn {name}{generics}({}){output}", inputs.join(", "))
+}
+
+fn fmt_fn_arg(arg: &syn::FnArg) -> String {
+    match arg {
+        syn::FnArg::Receiver(r) => {
+            let mutability = if r.mutability.is_some() { "mut " } else { "" };
+            match &r.reference {
+                Some((_, lifetime)) => {
+                    let lt = lifetime
+                        .as_ref()
+                        .map(|l| format!("'{} ", l.ident))
+                        .unwrap_or_default();
+                    format!("&{lt}{mutability}self")
+                }
+                None => format!("{mutability}self"),
+            }
+        }
+        syn::FnArg::Typed(pat_ty) => {
+            let ty = fmt_type(&pat_ty.ty);
+            let pat = fmt_pat(&pat_ty.pat);
+            format!("{pat}: {ty}")
+        }
+    }
+}
+
+fn fmt_pat(pat: &syn::Pat) -> String {
+    match pat {
+        syn::Pat::Ident(p) => {
+            let mutability = if p.mutability.is_some() { "mut " } else { "" };
+            format!("{mutability}{}", p.ident)
+        }
+        syn::Pat::Reference(r) => {
+            let inner = fmt_pat(&r.pat);
+            let mutability = if r.mutability.is_some() { "mut " } else { "" };
+            format!("&{mutability}{inner}")
+        }
+        syn::Pat::Tuple(t) => {
+            let parts: Vec<String> = t.elems.iter().map(fmt_pat).collect();
+            format!("({})", parts.join(", "))
+        }
+        _ => "_".to_owned(),
+    }
+}
+
+pub(crate) fn fmt_type(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Path(p) => {
+            let qself = p
+                .qself
+                .as_ref()
+                .map(|q| format!("<{} as ", fmt_type(&q.ty)))
+                .unwrap_or_default();
+            let path = fmt_path(&p.path);
+            if qself.is_empty() {
+                path
+            } else {
+                format!("{qself}{path}>")
+            }
+        }
+        syn::Type::Reference(r) => {
+            let lt = r
+                .lifetime
+                .as_ref()
+                .map(|l| format!("'{} ", l.ident))
+                .unwrap_or_default();
+            let mutability = if r.mutability.is_some() { "mut " } else { "" };
+            format!("&{lt}{mutability}{}", fmt_type(&r.elem))
+        }
+        syn::Type::Ptr(p) => {
+            let mutability = if p.mutability.is_some() { "mut " } else { "const " };
+            format!("*{mutability}{}", fmt_type(&p.elem))
+        }
+        syn::Type::Slice(s) => format!("[{}]", fmt_type(&s.elem)),
+        syn::Type::Array(a) => format!("[{}; _]", fmt_type(&a.elem)),
+        syn::Type::Tuple(t) => {
+            let elems: Vec<String> = t.elems.iter().map(fmt_type).collect();
+            format!("({})", elems.join(", "))
+        }
+        syn::Type::Never(_) => "!".to_owned(),
+        syn::Type::ImplTrait(i) => {
+            let bounds: Vec<String> = i.bounds.iter().map(fmt_type_param_bound).collect();
+            format!("impl {}", bounds.join(" + "))
+        }
+        syn::Type::TraitObject(t) => {
+            let bounds: Vec<String> = t.bounds.iter().map(fmt_type_param_bound).collect();
+            format!("dyn {}", bounds.join(" + "))
+        }
+        syn::Type::Paren(p) => fmt_type(&p.elem),
+        syn::Type::BareFn(f) => {
+            let inputs: Vec<String> = f.inputs.iter().map(|a| fmt_type(&a.ty)).collect();
+            let output = match &f.output {
+                syn::ReturnType::Default => String::new(),
+                syn::ReturnType::Type(_, ty) => format!(" -> {}", fmt_type(ty)),
+            };
+            format!("fn({}){output}", inputs.join(", "))
+        }
+        _ => "_".to_owned(),
+    }
+}
+
+fn fmt_path(path: &syn::Path) -> String {
+    path.segments
+        .iter()
+        .map(|seg| {
+            let ident = seg.ident.to_string();
+            let args = fmt_path_args(&seg.arguments);
+            format!("{ident}{args}")
+        })
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+fn fmt_path_args(args: &syn::PathArguments) -> String {
+    match args {
+        syn::PathArguments::None => String::new(),
+        syn::PathArguments::AngleBracketed(a) => {
+            let args: Vec<String> = a.args.iter().map(fmt_generic_arg).collect();
+            if args.is_empty() {
+                String::new()
+            } else {
+                format!("<{}>", args.join(", "))
+            }
+        }
+        syn::PathArguments::Parenthesized(p) => {
+            let inputs: Vec<String> = p.inputs.iter().map(fmt_type).collect();
+            let output = match &p.output {
+                syn::ReturnType::Default => String::new(),
+                syn::ReturnType::Type(_, ty) => format!(" -> {}", fmt_type(ty)),
+            };
+            format!("({}){output}", inputs.join(", "))
+        }
+    }
+}
+
+fn fmt_generic_arg(arg: &syn::GenericArgument) -> String {
+    match arg {
+        syn::GenericArgument::Lifetime(l) => format!("'{}", l.ident),
+        syn::GenericArgument::Type(ty) => fmt_type(ty),
+        syn::GenericArgument::Const(_) => "{ _ }".to_owned(),
+        syn::GenericArgument::AssocType(a) => {
+            format!("{} = {}", a.ident, fmt_type(&a.ty))
+        }
+        syn::GenericArgument::AssocConst(a) => format!("{} = _", a.ident),
+        syn::GenericArgument::Constraint(c) => {
+            let bounds: Vec<String> = c.bounds.iter().map(fmt_type_param_bound).collect();
+            format!("{}: {}", c.ident, bounds.join(" + "))
+        }
+        _ => "_".to_owned(),
+    }
+}
+
+fn fmt_type_param_bound(bound: &syn::TypeParamBound) -> String {
+    match bound {
+        syn::TypeParamBound::Trait(t) => fmt_path(&t.path),
+        syn::TypeParamBound::Lifetime(l) => format!("'{}", l.ident),
+        _ => "_".to_owned(),
+    }
+}
+
+fn fmt_generics_params(generics: &syn::Generics) -> String {
+    if generics.params.is_empty() {
+        return String::new();
+    }
+    let params: Vec<String> = generics.params.iter().map(fmt_generic_param).collect();
+    format!("<{}>", params.join(", "))
+}
+
+fn fmt_generic_param(param: &syn::GenericParam) -> String {
+    match param {
+        syn::GenericParam::Type(t) => {
+            let name = t.ident.to_string();
+            if t.bounds.is_empty() {
+                name
+            } else {
+                let bounds: Vec<String> = t.bounds.iter().map(fmt_type_param_bound).collect();
+                format!("{name}: {}", bounds.join(" + "))
+            }
+        }
+        syn::GenericParam::Lifetime(l) => {
+            let name = format!("'{}", l.lifetime.ident);
+            if l.bounds.is_empty() {
+                name
+            } else {
+                let bounds: Vec<String> = l
+                    .bounds
+                    .iter()
+                    .map(|lt| format!("'{}", lt.ident))
+                    .collect();
+                format!("{name}: {}", bounds.join(" + "))
+            }
+        }
+        syn::GenericParam::Const(c) => {
+            let ty = fmt_type(&c.ty);
+            format!("const {}: {ty}", c.ident)
+        }
+    }
+}
+
+/// Collect all bound predicates (inline bounds + where clause) as strings.
+pub(crate) fn extract_bounds(generics: &syn::Generics) -> Vec<String> {
+    let mut bounds: Vec<String> = Vec::new();
+
+    // Inline bounds on type parameters (e.g. `T: Clone + Send`)
+    for param in &generics.params {
+        if let syn::GenericParam::Type(t) = param {
+            if !t.bounds.is_empty() {
+                let b: Vec<String> = t.bounds.iter().map(fmt_type_param_bound).collect();
+                bounds.push(format!("{}: {}", t.ident, b.join(" + ")));
+            }
+        }
+    }
+
+    // Where clause predicates
+    if let Some(clause) = &generics.where_clause {
+        for pred in &clause.predicates {
+            if let syn::WherePredicate::Type(pt) = pred {
+                let ty = fmt_type(&pt.bounded_ty);
+                let b: Vec<String> = pt.bounds.iter().map(fmt_type_param_bound).collect();
+                bounds.push(format!("{ty}: {}", b.join(" + ")));
+            }
+        }
+    }
+
+    bounds
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_fn_signature() {
+        let src = "pub fn add(x: i32, y: i32) -> i32 { x + y }";
+        let items = extract_typed_items(src);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "add");
+        assert_eq!(items[0].resolved_type_signature, "fn add(x: i32, y: i32) -> i32");
+        assert!(items[0].trait_bounds.is_empty());
+    }
+
+    #[test]
+    fn extracts_async_fn_signature() {
+        let src = "pub async fn fetch() -> String { String::new() }";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].resolved_type_signature, "async fn fetch() -> String");
+    }
+
+    #[test]
+    fn extracts_fn_with_self_ref() {
+        let src = "impl Foo { pub fn len(&self) -> usize { 0 } }";
+        let items = extract_typed_items(src);
+        let fn_item = items.iter().find(|i| i.name == "fn len(…)");
+        // impl block is extracted; fn inside impl is not visited at top level
+        let impl_item = items.iter().find(|i| i.name == "impl Foo");
+        assert!(impl_item.is_some(), "impl Foo should be extracted");
+        let _ = fn_item; // fn inside impl block is not top-level
+    }
+
+    #[test]
+    fn extracts_struct_signature() {
+        let src = "pub struct Point { pub x: f64, pub y: f64 }";
+        let items = extract_typed_items(src);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "Point");
+        assert_eq!(items[0].resolved_type_signature, "struct Point");
+    }
+
+    #[test]
+    fn extracts_generic_struct_with_bounds() {
+        let src = "pub struct Wrapper<T: Clone + Send>(T);";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].resolved_type_signature, "struct Wrapper<T: Clone + Send>");
+        assert!(items[0].trait_bounds.contains(&"T: Clone + Send".to_owned()));
+    }
+
+    #[test]
+    fn extracts_enum_signature() {
+        let src = "pub enum Color { Red, Green, Blue }";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "Color");
+        assert_eq!(items[0].resolved_type_signature, "enum Color");
+    }
+
+    #[test]
+    fn extracts_trait_with_supertraits() {
+        let src = "pub trait Animal: Clone + Send { fn name(&self) -> &str; }";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "Animal");
+        assert_eq!(items[0].resolved_type_signature, "trait Animal: Clone + Send");
+    }
+
+    #[test]
+    fn extracts_impl_inherent() {
+        let src = "impl Foo { fn new() -> Self { Foo } }";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "impl Foo");
+        assert_eq!(items[0].resolved_type_signature, "impl Foo");
+    }
+
+    #[test]
+    fn extracts_impl_trait() {
+        let src = "impl Display for Foo {}";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "<Foo as Display>");
+        assert_eq!(items[0].resolved_type_signature, "impl Display for Foo");
+    }
+
+    #[test]
+    fn extracts_const_signature() {
+        let src = "pub const MAX_SIZE: usize = 1024;";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "MAX_SIZE");
+        assert_eq!(items[0].resolved_type_signature, "const MAX_SIZE: usize");
+    }
+
+    #[test]
+    fn extracts_type_alias() {
+        let src = "pub type Result<T> = std::result::Result<T, Error>;";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "Result");
+        assert!(items[0].resolved_type_signature.starts_with("type Result<T> = "));
+    }
+
+    #[test]
+    fn extracts_where_clause_bounds() {
+        let src = "pub fn process<T>(val: T) where T: Clone + Debug {}";
+        let items = extract_typed_items(src);
+        assert!(items[0]
+            .trait_bounds
+            .contains(&"T: Clone + Debug".to_owned()));
+    }
+
+    #[test]
+    fn returns_empty_on_parse_failure() {
+        let items = extract_typed_items("fn broken( {");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn line_numbers_populated() {
+        let src = "pub fn first() {}\npub fn second() {}";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].line_start, 1);
+        assert_eq!(items[1].line_start, 2);
+    }
+
+    #[test]
+    fn fmt_type_reference() {
+        let src = "pub fn f(x: &str) {}";
+        let items = extract_typed_items(src);
+        assert!(items[0].resolved_type_signature.contains("&str"));
+    }
+
+    #[test]
+    fn fmt_type_option() {
+        let src = "pub fn f() -> Option<String> { None }";
+        let items = extract_typed_items(src);
+        assert!(items[0].resolved_type_signature.contains("Option<String>"));
+    }
+
+    #[test]
+    fn fmt_type_result() {
+        let src = "pub fn f() -> Result<i32, Error> { Ok(0) }";
+        let items = extract_typed_items(src);
+        assert!(
+            items[0].resolved_type_signature.contains("Result<i32, Error>")
+        );
+    }
+
+    #[test]
+    fn fmt_type_tuple() {
+        let src = "pub fn f() -> (i32, bool) { (0, true) }";
+        let items = extract_typed_items(src);
+        assert!(items[0].resolved_type_signature.contains("(i32, bool)"));
+    }
+
+    #[test]
+    fn fmt_type_slice() {
+        let src = "pub fn f(s: &[u8]) {}";
+        let items = extract_typed_items(src);
+        assert!(items[0].resolved_type_signature.contains("[u8]"));
+    }
+
+    #[test]
+    fn static_item_signature() {
+        let src = "pub static GREETING: &str = \"hello\";";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].resolved_type_signature, "static GREETING: &str");
+    }
+
+    #[test]
+    fn mod_item_signature() {
+        let src = "pub mod utils {}";
+        let items = extract_typed_items(src);
+        assert_eq!(items[0].name, "utils");
+        assert_eq!(items[0].resolved_type_signature, "mod utils");
+    }
+}

--- a/services/typecheck-worker/tests/fixtures/typecheck_inputs/complex.rs
+++ b/services/typecheck-worker/tests/fixtures/typecheck_inputs/complex.rs
@@ -1,0 +1,67 @@
+use std::fmt::Display;
+
+// Generic function: fn id<T: Display>(x: T) -> T
+pub fn id<T: Display>(x: T) -> T {
+    x
+}
+
+pub fn process<T, U>(val: T) -> U
+where
+    T: Clone + Send,
+    U: Default,
+{
+    let _ = val;
+    U::default()
+}
+
+// Trait with supertraits
+pub trait Describable: Display + Clone {
+    fn describe(&self) -> String;
+}
+
+// Blanket impl for all T: Display + Clone
+impl<T: Display + Clone> Describable for T {
+    fn describe(&self) -> String {
+        format!("{self}")
+    }
+}
+
+// Struct instantiated at three concrete type args (i32, String, f64)
+pub struct Container<T> {
+    pub value: T,
+}
+
+impl Container<i32> {
+    pub fn as_i32(&self) -> i32 {
+        self.value
+    }
+}
+
+impl Container<String> {
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+impl Container<f64> {
+    pub fn as_f64(&self) -> f64 {
+        self.value
+    }
+}
+
+// dyn Trait storage site
+pub struct DynHolder {
+    pub inner: Box<dyn Display>,
+}
+
+pub fn make_holder(val: Box<dyn Display>) -> DynHolder {
+    DynHolder { inner: val }
+}
+
+pub mod utils {
+    pub fn helper() -> bool {
+        true
+    }
+}
+
+pub type Result<T> = std::result::Result<T, String>;

--- a/services/typecheck-worker/tests/fixtures/typecheck_inputs/simple.rs
+++ b/services/typecheck-worker/tests/fixtures/typecheck_inputs/simple.rs
@@ -1,0 +1,17 @@
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+
+pub fn connect(cfg: Config) -> String {
+    format!("{}:{}", cfg.host, cfg.port)
+}
+
+pub const DEFAULT_PORT: u16 = 8080;
+
+pub enum Transport {
+    Tcp,
+    Udp,
+}
+
+pub static GREETING: &str = "hello";

--- a/services/typecheck-worker/tests/integration.rs
+++ b/services/typecheck-worker/tests/integration.rs
@@ -1,0 +1,177 @@
+// Pull in type_extractor directly from the binary source so integration tests
+// can access extract_typed_items without requiring a lib target.
+#[path = "../src/type_extractor.rs"]
+mod type_extractor;
+
+use std::path::Path;
+
+const FIXTURE_DIR: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/typecheck_inputs");
+
+fn fixture(name: &str) -> String {
+    std::fs::read_to_string(Path::new(FIXTURE_DIR).join(name))
+        .unwrap_or_else(|_| panic!("fixture {name} not found"))
+}
+
+// ── simple.rs corpus ────────────────────────────────────────────────────────
+
+#[test]
+fn simple_fixture_extracts_all_item_kinds() {
+    let src = fixture("simple.rs");
+    let items = type_extractor::extract_typed_items(&src);
+    assert!(!items.is_empty(), "simple.rs must produce items");
+
+    let names: Vec<_> = items.iter().map(|i| i.name.as_str()).collect();
+    assert!(names.contains(&"Config"), "expected Config");
+    assert!(names.contains(&"connect"), "expected connect");
+    assert!(names.contains(&"DEFAULT_PORT"), "expected DEFAULT_PORT");
+    assert!(names.contains(&"Transport"), "expected Transport");
+    assert!(names.contains(&"GREETING"), "expected GREETING");
+}
+
+#[test]
+fn simple_fixture_fn_has_signature() {
+    let src = fixture("simple.rs");
+    let items = type_extractor::extract_typed_items(&src);
+    let connect = items.iter().find(|i| i.name == "connect").expect("connect not found");
+    assert!(
+        connect.resolved_type_signature.contains("fn connect"),
+        "expected fn connect in signature, got: {}",
+        connect.resolved_type_signature
+    );
+    assert!(
+        connect.resolved_type_signature.contains("Config"),
+        "signature must include Config param"
+    );
+    assert!(
+        connect.resolved_type_signature.contains("String"),
+        "signature must include String return"
+    );
+}
+
+#[test]
+fn simple_fixture_struct_has_signature() {
+    let src = fixture("simple.rs");
+    let items = type_extractor::extract_typed_items(&src);
+    let cfg = items.iter().find(|i| i.name == "Config").expect("Config not found");
+    assert_eq!(cfg.resolved_type_signature, "struct Config");
+    assert!(cfg.trait_bounds.is_empty());
+}
+
+#[test]
+fn simple_fixture_line_numbers_are_positive() {
+    let src = fixture("simple.rs");
+    let items = type_extractor::extract_typed_items(&src);
+    for item in &items {
+        assert!(item.line_start > 0, "line_start must be ≥1 for {}", item.name);
+        assert!(
+            item.line_end >= item.line_start,
+            "line_end must be ≥ line_start for {}",
+            item.name
+        );
+    }
+}
+
+// ── complex.rs corpus ────────────────────────────────────────────────────────
+
+#[test]
+fn complex_fixture_generic_fn_extracts_bounds() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let id_fn = items.iter().find(|i| i.name == "id").expect("id fn not found");
+    assert!(
+        id_fn.resolved_type_signature.contains("fn id"),
+        "expected fn id signature"
+    );
+    assert!(
+        id_fn.trait_bounds.iter().any(|b| b.contains("Display")),
+        "expected T: Display bound, got: {:?}",
+        id_fn.trait_bounds
+    );
+}
+
+#[test]
+fn complex_fixture_trait_with_supertraits() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let trait_item = items
+        .iter()
+        .find(|i| i.name == "Describable")
+        .expect("Describable trait not found");
+    assert!(
+        trait_item.resolved_type_signature.contains("Display"),
+        "Describable signature must include Display supertrait: {}",
+        trait_item.resolved_type_signature
+    );
+    assert!(
+        trait_item.resolved_type_signature.contains("Clone"),
+        "Describable signature must include Clone supertrait"
+    );
+}
+
+#[test]
+fn complex_fixture_dyn_trait_fn_found() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let make_holder =
+        items.iter().find(|i| i.name == "make_holder").expect("make_holder not found");
+    assert!(
+        make_holder.resolved_type_signature.contains("dyn"),
+        "make_holder signature must reference dyn trait: {}",
+        make_holder.resolved_type_signature
+    );
+}
+
+#[test]
+fn complex_fixture_container_impl_blocks_for_three_types() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let impl_names: Vec<&str> = items
+        .iter()
+        .filter(|i| i.name.starts_with("impl "))
+        .map(|i| i.name.as_str())
+        .collect();
+    assert!(
+        impl_names.iter().any(|n| n.contains("Container")),
+        "expected impl blocks for Container, got: {impl_names:?}"
+    );
+    // Three concrete Container impls: i32, String, f64
+    let container_impls: Vec<&&str> =
+        impl_names.iter().filter(|n| n.contains("Container")).collect();
+    assert!(
+        container_impls.len() >= 3,
+        "expected ≥3 Container impls, got: {container_impls:?}"
+    );
+}
+
+#[test]
+fn complex_fixture_where_clause_bounds() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let process_fn =
+        items.iter().find(|i| i.name == "process").expect("process fn not found");
+    assert!(
+        process_fn.trait_bounds.iter().any(|b| b.contains("Clone")),
+        "process bounds must include Clone: {:?}",
+        process_fn.trait_bounds
+    );
+    assert!(
+        process_fn.trait_bounds.iter().any(|b| b.contains("Send")),
+        "process bounds must include Send: {:?}",
+        process_fn.trait_bounds
+    );
+}
+
+#[test]
+fn complex_fixture_type_alias_extracted() {
+    let src = fixture("complex.rs");
+    let items = type_extractor::extract_typed_items(&src);
+
+    let alias = items.iter().find(|i| i.name == "Result").expect("Result type alias not found");
+    assert!(alias.resolved_type_signature.starts_with("type Result"));
+}


### PR DESCRIPTION
## Summary

- Implements `typecheck-worker` (Stage 4): consumes `rb.ingest.typecheck.commands`, downloads the clone tar.zst, walks `*.rs` files using syn, extracts per-item type signatures and trait bounds, emits `TypecheckedItemEvent` to `rb.typechecked-items.v1`, forwards `IngestRequest` to `rb.ingest.graph.commands`, and emits `IngestStatusEvent{stage:Typecheck, stage_seq:4}`
- Exports `typechecked_item_event` nested module from `rb-schemas`
- Adds `rb.typechecked-items.v1` to `infra/kafka/topics.yaml` (topic count: 22→23)
- Adds typecheck-worker Cargo.toml stub to all other Dockerfiles for workspace resolution
- Adds 7 integration tests via `#[path]` pattern against simple.rs and complex.rs fixtures

## Architecture

AST-level type extraction via `syn` (`type_extractor.rs`):
- `resolved_type_signature`: formatted item signature (e.g. `fn add(x: i32, y: i32) -> i32`, `struct Foo<T: Clone>`, `impl Display for Bar`)
- `trait_bounds`: where-clause + inline bounds per predicate (e.g. `["T: Clone + Send"]`)

Full semantic resolution via `ra_ap_*` crates is noted in `type_extractor.rs` as a planned future iteration per ADR-007 §11.6.

## Test plan

- [x] 39 unit tests in `typecheck-worker` — all green
- [x] 7 integration tests (simple.rs + complex.rs fixtures) — all green
- [x] `test_load_all_23_topics_from_infra_yaml` — passes with new topic
- [x] Full workspace test suite — 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Integration: parse-worker → typecheck-worker handoff (requires running stack)

Closes #186