### PR TITLE
[REQ-IN-08] feat(embed-worker): Stage 6 — Embed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
+name = "embed-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "metrics",
+ "metrics-util 0.18.0",
+ "rb-blob",
+ "rb-kafka",
+ "rb-schemas",
+ "rb-tracing",
+ "reqwest",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "services/projector-pg",
     "services/projector-neo4j",
     "services/tombstoner",
+    "services/embed-worker",
 ]
 
 [workspace.package]

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -358,6 +358,35 @@ services:
       otel-collector:
         condition: service_started
 
+  embed-worker:
+    build:
+      context: ..
+      dockerfile: docker/embed-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/embed-worker:dev
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      BLOB_STORE_PATH: /data/blobs
+      RB_OLLAMA_URL: "http://ollama:11434"
+      RB_EMBEDDING_MODEL: "nomic-embed-text"
+      RB_EMBEDDING_DIMENSIONS: "768"
+      QDRANT_URL: "http://qdrant:6333"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: embed-worker
+      RUST_LOG: "info,embed_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+      qdrant:
+        condition: service_started
+      ollama:
+        condition: service_started
+      otel-collector:
+        condition: service_started
+
   caddy:
     image: caddy:2-alpine
     volumes:

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -29,6 +29,7 @@ COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.
 COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
 COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/embed-worker/Dockerfile
+++ b/docker/embed-worker/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
+COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/embed-worker/src && \
+    printf 'fn main() {}' > services/embed-worker/src/main.rs && \
+    cargo build --release -p embed-worker 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                   crates/
+COPY services/embed-worker/    services/embed-worker/
+COPY proto/                    proto/
+
+RUN cargo build --release -p embed-worker
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/embed-worker /usr/local/bin/embed-worker
+
+ENTRYPOINT ["/usr/local/bin/embed-worker"]

--- a/services/embed-worker/Cargo.toml
+++ b/services/embed-worker/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "embed-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "embed-worker"
+path = "src/main.rs"
+
+[dependencies]
+rb-blob    = { path = "../../crates/rb-blob",    version = "0.1.0" }
+rb-kafka   = { path = "../../crates/rb-kafka",   version = "0.1.0" }
+rb-schemas = { path = "../../crates/rb-schemas", version = "0.1.0" }
+rb-tracing = { path = "../../crates/rb-tracing", version = "0.1.0" }
+
+anyhow.workspace    = true
+chrono.workspace    = true
+metrics.workspace   = true
+reqwest.workspace   = true
+serde_json.workspace = true
+sha2 = { workspace = true }
+tokio.workspace     = true
+tracing.workspace   = true
+uuid.workspace      = true
+
+[dev-dependencies]
+metrics-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/services/embed-worker/src/consumer.rs
+++ b/services/embed-worker/src/consumer.rs
@@ -1,16 +1,17 @@
-//! Kafka consumer loop for `ingest-graph`.
+//! Kafka consumer loop for `embed-worker`.
 //!
-//! Consumes `TypecheckedItemEvent` from `rb.typechecked-items.v1`.
+//! Consumes `TypecheckedItemEvent` from `rb.ingest.embed.commands`.
 //! For each event:
 //!   1. Resolves the item body (inline bytes or blob download).
-//!   2. Calls [`extract_relations`] to derive graph edges.
-//!   3. Emits one `GraphRelationEvent` per relation to `rb.ingest.graph.commands`.
-//!   4. Forwards the `TypecheckedItemEvent` to `rb.ingest.embed.commands` (Stage 6 cascade).
-//!   5. Emits `IngestStatusEvent{stage:Extract, status:Done}` to `rb.projector.events`.
-//!   6. Commits the consumer offset.
+//!   2. Builds the §3.5.7 composite embedding input.
+//!   3. Calls Ollama to produce a float vector.
+//!   4. Upserts the vector to Qdrant `rb_embeddings` (point id = sha256(tenant:repo:fqn)).
+//!   5. Emits `EmbeddingPendingEvent` to `rb.projector.events`.
+//!   6. Emits `IngestStatusEvent{stage:Embed, status:Done}` to `rb.projector.events`.
+//!   7. Commits the Kafka offset.
 //!
-//! On transient errors the consumer sleeps and redelivers (no DLQ for per-item
-//! events; a single bad item is skipped after max retries via a DLQ nack).
+//! On transient errors the consumer sleeps and redelivers.  Persistent failures
+//! after max retries go to the DLQ via `consumer.nack_to_dlq`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,42 +21,58 @@ use metrics::counter;
 use rb_blob::{BlobRef, BlobStore};
 use rb_kafka::{Consumer, EventEnvelope, Producer, RetryPolicy};
 use rb_schemas::{
-    GraphRelationEvent, IngestStage, IngestStatus, IngestStatusEvent, TenantId,
+    EmbeddingPendingEvent, IngestStage, IngestStatus, IngestStatusEvent, TenantId,
     TypecheckedItemEvent, typechecked_item_event,
 };
 use uuid::Uuid;
 
-use crate::extractor::extract_relations;
+use crate::embedder::build_composite;
+use crate::qdrant::upsert_vector;
 
-pub const TOPIC_TYPECHECKED_ITEMS: &str = "rb.typechecked-items.v1";
-pub const TOPIC_GRAPH_COMMANDS: &str = "rb.ingest.graph.commands";
 pub const TOPIC_EMBED_COMMANDS: &str = "rb.ingest.embed.commands";
 pub const TOPIC_PROJECTOR_EVENTS: &str = "rb.projector.events";
 
-struct GraphCtx {
+struct EmbedCtx {
     blob_store: Arc<dyn BlobStore>,
-    relation_producer: Arc<Producer<GraphRelationEvent>>,
-    embed_producer: Arc<Producer<TypecheckedItemEvent>>,
     status_producer: Arc<Producer<IngestStatusEvent>>,
+    event_producer: Arc<Producer<EmbeddingPendingEvent>>,
+    ollama_url: String,
+    embedding_model: String,
+    embedding_dimensions: u32,
+    qdrant_url: String,
+    http: reqwest::Client,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     consumer: Consumer<TypecheckedItemEvent>,
     blob_store: Arc<dyn BlobStore>,
-    relation_producer: Arc<Producer<GraphRelationEvent>>,
-    embed_producer: Arc<Producer<TypecheckedItemEvent>>,
     status_producer: Arc<Producer<IngestStatusEvent>>,
+    event_producer: Arc<Producer<EmbeddingPendingEvent>>,
+    ollama_url: String,
+    embedding_model: String,
+    embedding_dimensions: u32,
+    qdrant_url: String,
 ) {
-    let ctx = Arc::new(GraphCtx { blob_store, relation_producer, embed_producer, status_producer });
+    let ctx = Arc::new(EmbedCtx {
+        blob_store,
+        status_producer,
+        event_producer,
+        ollama_url,
+        embedding_model,
+        embedding_dimensions,
+        qdrant_url,
+        http: reqwest::Client::new(),
+    });
 
     loop {
         match consumer.next().await {
             None => {
-                tracing::info!("ingest_graph: stream ended");
+                tracing::info!("embed_worker: stream ended");
                 break;
             }
             Some(Err(e)) => {
-                tracing::error!("ingest_graph: kafka error: {e}");
+                tracing::error!("embed_worker: kafka error: {e}");
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
             Some(Ok(envelope)) => {
@@ -64,9 +81,9 @@ pub async fn run(
 
                 match process_item(&ctx, &envelope).await {
                     Ok(()) => {
-                        counter!("rb_ingest_graph_total", "outcome" => "ok").increment(1);
+                        counter!("rb_embed_worker_total", "outcome" => "ok").increment(1);
                         if let Err(e) = consumer.commit(&envelope).await {
-                            tracing::warn!(%ingest_run_id, "ingest_graph: commit failed: {e}");
+                            tracing::warn!(%ingest_run_id, "embed_worker: commit failed: {e}");
                         }
                     }
                     Err(e) => {
@@ -75,15 +92,15 @@ pub async fn run(
                             attempt,
                             %ingest_run_id,
                             tenant_id = %tenant_id,
-                            "ingest_graph: processing failed: {e:#}"
+                            "embed_worker: processing failed: {e:#}"
                         );
-                        counter!("rb_ingest_graph_total", "outcome" => "err").increment(1);
+                        counter!("rb_embed_worker_total", "outcome" => "err").increment(1);
                         emit_failed_status(
                             &ctx.status_producer,
                             tenant_id,
                             &ingest_run_id,
                             &envelope.payload.fqn,
-                            &format!("extract_failed: {e:#}"),
+                            &format!("embed_failed: {e:#}"),
                         )
                         .await;
                         let policy = RetryPolicy::default();
@@ -91,21 +108,21 @@ pub async fn run(
                             tracing::warn!(
                                 attempt,
                                 %ingest_run_id,
-                                "ingest_graph: max retries exceeded — routing to DLQ"
+                                "embed_worker: max retries exceeded — routing to DLQ"
                             );
-                            counter!("rb_ingest_graph_dlq_total").increment(1);
+                            counter!("rb_embed_worker_dlq_total").increment(1);
                             if let Err(dlq_err) =
                                 consumer.nack_to_dlq(&envelope, &format!("{e:#}")).await
                             {
                                 tracing::error!(
                                     %ingest_run_id,
-                                    "ingest_graph: nack_to_dlq failed: {dlq_err}"
+                                    "embed_worker: nack_to_dlq failed: {dlq_err}"
                                 );
                             }
                             if let Err(ce) = consumer.commit(&envelope).await {
                                 tracing::warn!(
                                     %ingest_run_id,
-                                    "ingest_graph: commit after DLQ failed: {ce}"
+                                    "embed_worker: commit after DLQ failed: {ce}"
                                 );
                             }
                         } else {
@@ -121,41 +138,51 @@ pub async fn run(
 }
 
 async fn process_item(
-    ctx: &GraphCtx,
+    ctx: &EmbedCtx,
     envelope: &EventEnvelope<TypecheckedItemEvent>,
 ) -> Result<()> {
     let ev = &envelope.payload;
     let tenant_id = envelope.tenant_id;
     let ingest_run_id = &ev.ingest_run_id;
 
-    tracing::debug!(%ingest_run_id, fqn = %ev.fqn, "ingest_graph: processing item");
+    tracing::debug!(%ingest_run_id, fqn = %ev.fqn, "embed_worker: processing item");
 
-    let body = resolve_body(ctx, ev.body.as_ref()).await?;
+    let source_text = resolve_body(ctx, ev.body.as_ref()).await?;
 
-    let relations = extract_relations(
+    let composite = build_composite(
         &ev.fqn,
         &ev.resolved_type_signature,
         &ev.trait_bounds,
-        &body,
+        source_text.as_deref(),
     );
 
-    let relation_count = relations.len();
+    let vector = crate::embedder::call_ollama(
+        &ctx.http,
+        &ctx.ollama_url,
+        &ctx.embedding_model,
+        &composite,
+    )
+    .await
+    .context("Ollama embedding call failed")?;
 
-    for rel in relations {
-        emit_relation(ctx, tenant_id, ev, rel).await?;
-    }
+    upsert_vector(
+        &ctx.http,
+        &ctx.qdrant_url,
+        tenant_id,
+        &ev.repo_id,
+        &ev.fqn,
+        &ev.ingest_run_id,
+        &ctx.embedding_model,
+        ctx.embedding_dimensions,
+        vector,
+    )
+    .await
+    .context("Qdrant upsert failed")?;
 
-    counter!("rb_ingest_graph_relations_total").increment(relation_count as u64);
-    tracing::debug!(
-        %ingest_run_id,
-        fqn = %ev.fqn,
-        relation_count,
-        "ingest_graph: extraction done"
-    );
+    counter!("rb_embed_worker_vectors_total").increment(1);
+    tracing::debug!(%ingest_run_id, fqn = %ev.fqn, "embed_worker: vector upserted");
 
-    // Cascade to Stage 6: forward the original item to embed-worker.
-    emit_embed_command(ctx, tenant_id, ev).await?;
-
+    emit_embedding_pending(ctx, tenant_id, ev).await?;
     emit_done_status(ctx, tenant_id, ev).await?;
 
     Ok(())
@@ -164,14 +191,15 @@ async fn process_item(
 // ── Body resolution ───────────────────────────────────────────────────────────
 
 async fn resolve_body(
-    ctx: &GraphCtx,
+    ctx: &EmbedCtx,
     body: Option<&typechecked_item_event::Body>,
-) -> Result<String> {
+) -> Result<Option<String>> {
     match body {
-        None => Ok(String::new()),
+        None => Ok(None),
         Some(typechecked_item_event::Body::InlinePayload(bytes)) => {
-            String::from_utf8(bytes.clone())
-                .context("inline item body is not valid UTF-8")
+            let text = String::from_utf8(bytes.clone())
+                .context("inline item body is not valid UTF-8")?;
+            Ok(Some(text))
         }
         Some(typechecked_item_event::Body::BlobRef(uri)) => {
             let blob_ref = BlobRef::from_uri_minimal(uri)
@@ -181,54 +209,40 @@ async fn resolve_body(
                 .get(&blob_ref)
                 .await
                 .context("failed to download item body blob")?;
-            String::from_utf8(data.to_vec())
-                .context("blob item body is not valid UTF-8")
+            let text = String::from_utf8(data.to_vec())
+                .context("blob item body is not valid UTF-8")?;
+            Ok(Some(text))
         }
     }
 }
 
 // ── Kafka producers ───────────────────────────────────────────────────────────
 
-async fn emit_relation(
-    ctx: &GraphCtx,
+async fn emit_embedding_pending(
+    ctx: &EmbedCtx,
     tenant_id: TenantId,
     ev: &TypecheckedItemEvent,
-    rel: crate::extractor::Relation,
 ) -> Result<()> {
-    let graph_ev = GraphRelationEvent {
+    let pending_ev = EmbeddingPendingEvent {
         ingest_run_id: ev.ingest_run_id.clone(),
         tenant_id: tenant_id.to_string(),
         repo_id: ev.repo_id.clone(),
-        from_fqn: rel.from_fqn,
-        to_fqn: rel.to_fqn,
-        kind: rel.kind as i32,
+        fqn: ev.fqn.clone(),
+        embedding_model: ctx.embedding_model.clone(),
+        dimensions: ctx.embedding_dimensions as i32,
         emitted_at_ms: chrono::Utc::now().timestamp_millis(),
     };
-    let envelope = rb_kafka::EventEnvelope::new(tenant_id, graph_ev);
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, pending_ev);
     let key = format!("{}.{}", ev.tenant_id, ev.repo_id);
-    ctx.relation_producer
-        .publish(TOPIC_GRAPH_COMMANDS, key.as_bytes(), envelope)
+    ctx.event_producer
+        .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
         .await
-        .context("failed to publish graph relation event")?;
-    Ok(())
-}
-
-async fn emit_embed_command(
-    ctx: &GraphCtx,
-    tenant_id: TenantId,
-    ev: &TypecheckedItemEvent,
-) -> Result<()> {
-    let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev.clone());
-    let key = format!("{}.{}", ev.tenant_id, ev.repo_id);
-    ctx.embed_producer
-        .publish(TOPIC_EMBED_COMMANDS, key.as_bytes(), envelope)
-        .await
-        .context("failed to forward item to embed commands")?;
+        .context("failed to publish EmbeddingPendingEvent")?;
     Ok(())
 }
 
 async fn emit_done_status(
-    ctx: &GraphCtx,
+    ctx: &EmbedCtx,
     tenant_id: TenantId,
     ev: &TypecheckedItemEvent,
 ) -> Result<()> {
@@ -238,8 +252,8 @@ async fn emit_done_status(
         status: IngestStatus::Done as i32,
         error_message: String::new(),
         occurred_at_ms: chrono::Utc::now().timestamp_millis(),
-        stage: IngestStage::Extract as i32,
-        stage_seq: 5,
+        stage: IngestStage::Embed as i32,
+        stage_seq: 6,
         ingest_run_id: ev.ingest_run_id.clone(),
         attempt: 0,
     };
@@ -265,15 +279,15 @@ async fn emit_failed_status(
         status: IngestStatus::Failed as i32,
         error_message: error_message.to_owned(),
         occurred_at_ms: chrono::Utc::now().timestamp_millis(),
-        stage: IngestStage::Extract as i32,
-        stage_seq: 5,
+        stage: IngestStage::Embed as i32,
+        stage_seq: 6,
         ingest_run_id: ingest_run_id.to_owned(),
         attempt: 0,
     };
     let envelope = rb_kafka::EventEnvelope::new(tenant_id, ev);
     let key = tenant_id.to_string();
     if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope).await {
-        tracing::error!("ingest_graph: failed to publish failed status: {e}");
+        tracing::error!("embed_worker: failed to publish failed status: {e}");
     }
 }
 
@@ -282,23 +296,18 @@ async fn emit_failed_status(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rb_schemas::RelationKind;
+    use rb_schemas::IngestStage;
 
     #[test]
     fn topic_constants_are_distinct() {
-        let topics = [
-            TOPIC_TYPECHECKED_ITEMS,
-            TOPIC_GRAPH_COMMANDS,
-            TOPIC_EMBED_COMMANDS,
-            TOPIC_PROJECTOR_EVENTS,
-        ];
+        let topics = [TOPIC_EMBED_COMMANDS, TOPIC_PROJECTOR_EVENTS];
         let unique: std::collections::HashSet<_> = topics.iter().collect();
-        assert_eq!(unique.len(), topics.len(), "all topic constants must be unique");
+        assert_eq!(unique.len(), topics.len(), "topic constants must be unique");
     }
 
     #[test]
-    fn stage_seq_is_5_for_extract() {
-        assert_eq!(IngestStage::Extract as i32, 5);
+    fn stage_seq_is_6_for_embed() {
+        assert_eq!(IngestStage::Embed as i32, 6);
     }
 
     #[test]
@@ -306,20 +315,5 @@ mod tests {
         let policy = RetryPolicy::default();
         assert!(!policy.is_terminal(1));
         assert!(policy.is_terminal(3));
-    }
-
-    #[test]
-    fn graph_relation_event_fields_accessible() {
-        let ev = GraphRelationEvent {
-            ingest_run_id: "run-1".to_string(),
-            tenant_id: "tenant-1".to_string(),
-            repo_id: "repo-1".to_string(),
-            from_fqn: "src_lib::Foo".to_string(),
-            to_fqn: "Display".to_string(),
-            kind: RelationKind::Impls as i32,
-            emitted_at_ms: 0,
-        };
-        assert_eq!(ev.from_fqn, "src_lib::Foo");
-        assert_eq!(ev.kind, RelationKind::Impls as i32);
     }
 }

--- a/services/embed-worker/src/consumer.rs
+++ b/services/embed-worker/src/consumer.rs
@@ -229,7 +229,7 @@ async fn emit_embedding_pending(
         repo_id: ev.repo_id.clone(),
         fqn: ev.fqn.clone(),
         embedding_model: ctx.embedding_model.clone(),
-        dimensions: ctx.embedding_dimensions as i32,
+        dimensions: i32::try_from(ctx.embedding_dimensions).expect("embedding_dimensions fits i32"),
         emitted_at_ms: chrono::Utc::now().timestamp_millis(),
     };
     let envelope = rb_kafka::EventEnvelope::new(tenant_id, pending_ev);

--- a/services/embed-worker/src/consumer.rs
+++ b/services/embed-worker/src/consumer.rs
@@ -99,7 +99,7 @@ pub async fn run(
                             &ctx.status_producer,
                             tenant_id,
                             &ingest_run_id,
-                            &envelope.payload.fqn,
+                            &Uuid::new_v4().to_string(),
                             &format!("embed_failed: {e:#}"),
                         )
                         .await;

--- a/services/embed-worker/src/embedder.rs
+++ b/services/embed-worker/src/embedder.rs
@@ -1,7 +1,7 @@
 //! Ollama HTTP client and composite embedding input builder.
 //!
 //! The composite prompt follows ADR-007 §3.5.7:
-//!   fqn / resolved_type_signature / trait_bounds / source text
+//!   fqn / `resolved_type_signature` / `trait_bounds` / source text
 //!
 //! All fields are best-effort: missing fields are omitted rather than erroring
 //! (PARTIAL_* quality items per ADR-007 §13.4).
@@ -44,6 +44,7 @@ pub(crate) fn build_composite(
 /// POST to `{ollama_url}/api/embeddings` and return the embedding vector.
 ///
 /// Ollama response: `{"embedding": [f64, ...]}`
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) async fn call_ollama(
     http: &reqwest::Client,
     ollama_url: &str,

--- a/services/embed-worker/src/embedder.rs
+++ b/services/embed-worker/src/embedder.rs
@@ -1,0 +1,140 @@
+//! Ollama HTTP client and composite embedding input builder.
+//!
+//! The composite prompt follows ADR-007 §3.5.7:
+//!   fqn / resolved_type_signature / trait_bounds / source text
+//!
+//! All fields are best-effort: missing fields are omitted rather than erroring
+//! (PARTIAL_* quality items per ADR-007 §13.4).
+
+use anyhow::{Context as _, Result};
+use serde_json::json;
+
+/// Build the §3.5.7 composite embedding prompt for one item.
+///
+/// Fields that are empty or absent are omitted to avoid polluting the
+/// embedding with uninformative whitespace lines.
+pub(crate) fn build_composite(
+    fqn: &str,
+    type_signature: &str,
+    trait_bounds: &[String],
+    source_text: Option<&str>,
+) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(5);
+
+    parts.push(format!("fqn: {fqn}"));
+
+    if !type_signature.is_empty() {
+        parts.push(format!("signature: {type_signature}"));
+    }
+
+    if !trait_bounds.is_empty() {
+        parts.push(format!("bounds: {}", trait_bounds.join(", ")));
+    }
+
+    if let Some(src) = source_text {
+        let trimmed = src.trim();
+        if !trimmed.is_empty() {
+            parts.push(format!("source:\n{trimmed}"));
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// POST to `{ollama_url}/api/embeddings` and return the embedding vector.
+///
+/// Ollama response: `{"embedding": [f64, ...]}`
+pub(crate) async fn call_ollama(
+    http: &reqwest::Client,
+    ollama_url: &str,
+    model: &str,
+    prompt: &str,
+) -> Result<Vec<f32>> {
+    let url = format!("{ollama_url}/api/embeddings");
+    let body = json!({ "model": model, "prompt": prompt });
+
+    let resp = http
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("Ollama request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Ollama returned HTTP {status}: {text}");
+    }
+
+    let json: serde_json::Value = resp.json().await.context("Ollama response is not JSON")?;
+
+    let embedding = json
+        .get("embedding")
+        .and_then(|v| v.as_array())
+        .context("Ollama response missing 'embedding' array")?;
+
+    let vector: Vec<f32> = embedding
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            v.as_f64()
+                .map(|f| f as f32)
+                .with_context(|| format!("embedding[{i}] is not a number"))
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(vector)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_includes_all_non_empty_fields() {
+        let composite = build_composite(
+            "src_lib::Foo",
+            "impl Display for Foo",
+            &["T: Clone".to_owned()],
+            Some("pub struct Foo;"),
+        );
+        assert!(composite.contains("fqn: src_lib::Foo"));
+        assert!(composite.contains("signature: impl Display for Foo"));
+        assert!(composite.contains("bounds: T: Clone"));
+        assert!(composite.contains("source:\npub struct Foo;"));
+    }
+
+    #[test]
+    fn composite_omits_empty_fields() {
+        let composite = build_composite("src_lib::Bar", "", &[], None);
+        assert_eq!(composite, "fqn: src_lib::Bar");
+        assert!(!composite.contains("signature"));
+        assert!(!composite.contains("bounds"));
+        assert!(!composite.contains("source"));
+    }
+
+    #[test]
+    fn composite_multiple_bounds() {
+        let composite = build_composite(
+            "my_mod::process",
+            "fn process<T>()",
+            &["T: Clone".to_owned(), "T: Send".to_owned()],
+            None,
+        );
+        assert!(composite.contains("bounds: T: Clone, T: Send"));
+    }
+
+    #[test]
+    fn composite_trims_source_whitespace() {
+        let composite = build_composite("x::y", "", &[], Some("  fn foo() {}  "));
+        assert!(composite.contains("source:\nfn foo() {}"));
+    }
+
+    #[test]
+    fn composite_skips_whitespace_only_source() {
+        let composite = build_composite("x::y", "", &[], Some("   \n  "));
+        assert!(!composite.contains("source"));
+    }
+}

--- a/services/embed-worker/src/main.rs
+++ b/services/embed-worker/src/main.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rb_blob::store_from_env;
+use rb_kafka::{Consumer, ConsumerCfg, Producer, ProducerCfg};
+use rb_schemas::{EmbeddingPendingEvent, IngestStatusEvent, TypecheckedItemEvent};
+
+mod consumer;
+mod embedder;
+mod qdrant;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = rb_tracing::init("embed-worker")?;
+
+    let ollama_url = std::env::var("RB_OLLAMA_URL")
+        .unwrap_or_else(|_| "http://ollama:11434".to_owned());
+    let embedding_model = std::env::var("RB_EMBEDDING_MODEL")
+        .unwrap_or_else(|_| "nomic-embed-text".to_owned());
+    let embedding_dimensions: u32 = std::env::var("RB_EMBEDDING_DIMENSIONS")
+        .unwrap_or_else(|_| "768".to_owned())
+        .parse()
+        .context("RB_EMBEDDING_DIMENSIONS must be a positive integer")?;
+    let qdrant_url = std::env::var("QDRANT_URL")
+        .unwrap_or_else(|_| "http://qdrant:6333".to_owned());
+
+    // Fail fast: validate that Qdrant collection dimensions match our config.
+    qdrant::ensure_collection(&qdrant_url, embedding_dimensions)
+        .await
+        .context("Qdrant startup check failed")?;
+
+    tracing::info!(
+        embedding_model,
+        embedding_dimensions,
+        "embed-worker: Qdrant collection validated"
+    );
+
+    let blob_store = store_from_env().await.context("failed to init blob store")?;
+
+    let item_consumer: Consumer<TypecheckedItemEvent> =
+        Consumer::new(&ConsumerCfg::new("embed-worker"))?;
+    item_consumer.subscribe(&[consumer::TOPIC_EMBED_COMMANDS])?;
+
+    let status_producer =
+        Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
+    let event_producer =
+        Arc::new(Producer::<EmbeddingPendingEvent>::new(&ProducerCfg::default())?);
+
+    tracing::info!("embed-worker starting");
+
+    let handle = tokio::spawn(consumer::run(
+        item_consumer,
+        blob_store,
+        status_producer,
+        event_producer,
+        ollama_url,
+        embedding_model,
+        embedding_dimensions,
+        qdrant_url,
+    ));
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received — stopping consumer");
+    handle.abort();
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}

--- a/services/embed-worker/src/qdrant.rs
+++ b/services/embed-worker/src/qdrant.rs
@@ -1,0 +1,251 @@
+//! Qdrant REST client helpers for `embed-worker`.
+//!
+//! Uses a single `rb_embeddings` collection with payload multi-tenancy per
+//! ADR-007 §13.2.  Every point carries `tenant_id` in its payload so
+//! per-tenant filtering is possible without per-tenant collections.
+//!
+//! Point ID = first 16 bytes of SHA-256( "{tenant}:{repo}:{fqn}" ) interpreted
+//! as a UUID.  This gives stable, idempotent IDs (upsert semantics).
+
+use anyhow::{Context as _, Result};
+use rb_schemas::TenantId;
+use serde_json::json;
+use sha2::{Digest as _, Sha256};
+
+/// Qdrant collection used for all embeddings.
+pub(crate) const COLLECTION: &str = "rb_embeddings";
+
+/// Ensure the `rb_embeddings` collection exists with the expected vector size.
+///
+/// If the collection does not exist it is created.  If it exists but has a
+/// different vector size the function returns an error so the binary exits
+/// fast (startup guard per ADR-007 §11.8).
+pub(crate) async fn ensure_collection(qdrant_url: &str, dimensions: u32) -> Result<()> {
+    let http = reqwest::Client::new();
+    let info_url = format!("{qdrant_url}/collections/{COLLECTION}");
+
+    let resp = http
+        .get(&info_url)
+        .send()
+        .await
+        .context("failed to reach Qdrant")?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        create_collection(&http, qdrant_url, dimensions).await?;
+        tracing::info!(dimensions, "embed_worker: created Qdrant collection {COLLECTION}");
+        return Ok(());
+    }
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Qdrant GET /collections/{COLLECTION} returned {status}: {body}");
+    }
+
+    let body: serde_json::Value = resp.json().await.context("Qdrant info response is not JSON")?;
+    let actual_dims = body
+        .pointer("/result/config/params/vectors/size")
+        .and_then(|v| v.as_u64())
+        .context("could not read vectors.size from Qdrant collection info")?;
+
+    if actual_dims != u64::from(dimensions) {
+        anyhow::bail!(
+            "Qdrant collection '{COLLECTION}' has vector size {actual_dims} but \
+             RB_EMBEDDING_DIMENSIONS={dimensions}; fix the mismatch before starting"
+        );
+    }
+
+    tracing::info!(
+        dimensions,
+        "embed_worker: Qdrant collection {COLLECTION} validated (size={actual_dims})"
+    );
+    Ok(())
+}
+
+/// Upsert one embedding vector into `rb_embeddings`.
+///
+/// `point_id` is a UUID derived from SHA-256 of `"{tenant}:{repo}:{fqn}"`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn upsert_vector(
+    http: &reqwest::Client,
+    qdrant_url: &str,
+    tenant_id: TenantId,
+    repo_id: &str,
+    fqn: &str,
+    ingest_run_id: &str,
+    embedding_model: &str,
+    dimensions: u32,
+    vector: Vec<f32>,
+) -> Result<()> {
+    if vector.len() != dimensions as usize {
+        anyhow::bail!(
+            "vector length {} does not match expected dimensions {}",
+            vector.len(),
+            dimensions
+        );
+    }
+
+    let point_id = point_id_for(tenant_id, repo_id, fqn);
+
+    let url = format!("{qdrant_url}/collections/{COLLECTION}/points?wait=true");
+    let body = json!({
+        "points": [{
+            "id": point_id,
+            "vector": vector,
+            "payload": {
+                "tenant_id": tenant_id.to_string(),
+                "repo_id": repo_id,
+                "fqn": fqn,
+                "ingest_run_id": ingest_run_id,
+                "embedding_model": embedding_model,
+            }
+        }]
+    });
+
+    let resp = http
+        .put(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("Qdrant upsert request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Qdrant upsert returned HTTP {status}: {text}");
+    }
+
+    Ok(())
+}
+
+/// Create the `rb_embeddings` collection with a flat vector config.
+async fn create_collection(
+    http: &reqwest::Client,
+    qdrant_url: &str,
+    dimensions: u32,
+) -> Result<()> {
+    let url = format!("{qdrant_url}/collections/{COLLECTION}");
+    let body = json!({
+        "vectors": {
+            "size": dimensions,
+            "distance": "Cosine"
+        }
+    });
+
+    let resp = http
+        .put(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("Qdrant create collection request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Qdrant create collection returned HTTP {status}: {text}");
+    }
+
+    // Create the tenant_id payload index for efficient per-tenant filtering.
+    create_tenant_index(http, qdrant_url).await?;
+
+    Ok(())
+}
+
+/// Create a payload index on `tenant_id` for per-tenant filtering performance.
+async fn create_tenant_index(http: &reqwest::Client, qdrant_url: &str) -> Result<()> {
+    let url = format!("{qdrant_url}/collections/{COLLECTION}/index");
+    let body = json!({
+        "field_name": "tenant_id",
+        "field_schema": "keyword"
+    });
+
+    let resp = http
+        .put(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("Qdrant create index request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Qdrant create index returned HTTP {status}: {text}");
+    }
+
+    Ok(())
+}
+
+/// Derive a stable UUID point ID from `"{tenant}:{repo}:{fqn}"`.
+///
+/// Takes the first 16 bytes of SHA-256 and constructs a version-4-style UUID.
+/// This gives per-item idempotency: re-embedding the same item overwrites the
+/// existing point rather than creating a duplicate.
+fn point_id_for(tenant_id: TenantId, repo_id: &str, fqn: &str) -> String {
+    let raw = format!("{tenant_id}:{repo_id}:{fqn}");
+    let hash = Sha256::digest(raw.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&hash[..16]);
+    // Stamp as UUID v4 (random) layout — the content is a hash but the version
+    // bits need not be semantically correct; what matters is uniqueness.
+    let uuid = uuid::Uuid::from_bytes(bytes);
+    uuid.to_string()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn point_id_is_stable() {
+        let tid: TenantId = "00000000-0000-0000-0000-000000000001"
+            .parse::<uuid::Uuid>()
+            .unwrap()
+            .into();
+        let id1 = point_id_for(tid, "repo-a", "src_lib::Foo");
+        let id2 = point_id_for(tid, "repo-a", "src_lib::Foo");
+        assert_eq!(id1, id2, "same inputs must produce the same point ID");
+    }
+
+    #[test]
+    fn point_id_differs_for_different_fqn() {
+        let tid: TenantId = "00000000-0000-0000-0000-000000000001"
+            .parse::<uuid::Uuid>()
+            .unwrap()
+            .into();
+        let id1 = point_id_for(tid, "repo-a", "src_lib::Foo");
+        let id2 = point_id_for(tid, "repo-a", "src_lib::Bar");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn point_id_differs_for_different_tenant() {
+        let t1: TenantId = "00000000-0000-0000-0000-000000000001"
+            .parse::<uuid::Uuid>()
+            .unwrap()
+            .into();
+        let t2: TenantId = "00000000-0000-0000-0000-000000000002"
+            .parse::<uuid::Uuid>()
+            .unwrap()
+            .into();
+        let id1 = point_id_for(t1, "repo-a", "src_lib::Foo");
+        let id2 = point_id_for(t2, "repo-a", "src_lib::Foo");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn point_id_is_valid_uuid_string() {
+        let tid: TenantId = "00000000-0000-0000-0000-000000000001"
+            .parse::<uuid::Uuid>()
+            .unwrap()
+            .into();
+        let id = point_id_for(tid, "repo", "mod::fn");
+        assert!(uuid::Uuid::parse_str(&id).is_ok(), "point id must be a valid UUID");
+    }
+
+    #[test]
+    fn collection_constant() {
+        assert_eq!(COLLECTION, "rb_embeddings");
+    }
+}

--- a/services/embed-worker/src/qdrant.rs
+++ b/services/embed-worker/src/qdrant.rs
@@ -45,7 +45,7 @@ pub(crate) async fn ensure_collection(qdrant_url: &str, dimensions: u32) -> Resu
     let body: serde_json::Value = resp.json().await.context("Qdrant info response is not JSON")?;
     let actual_dims = body
         .pointer("/result/config/params/vectors/size")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .context("could not read vectors.size from Qdrant collection info")?;
 
     if actual_dims != u64::from(dimensions) {

--- a/services/embed-worker/tests/metrics_emitted.rs
+++ b/services/embed-worker/tests/metrics_emitted.rs
@@ -1,0 +1,81 @@
+//! Value-asserting tests for all `rb_embed_worker_*` metrics.
+//!
+//! Uses `metrics_util::debugging::DebuggingRecorder` as the in-process backend.
+//! Metrics are emitted directly (matching the `counter!` call-sites in
+//! `consumer.rs`) and asserted against the snapshot.
+
+use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+fn counter_value(
+    entries: &[(
+        metrics_util::CompositeKey,
+        Option<metrics::Unit>,
+        Option<metrics::SharedString>,
+        DebugValue,
+    )],
+    name: &str,
+    labels: &[(&str, &str)],
+) -> u64 {
+    entries
+        .iter()
+        .filter(|(key, _, _, _)| key.key().name() == name)
+        .filter_map(|(key, _, _, value)| {
+            let key_labels: std::collections::HashMap<&str, &str> =
+                key.key().labels().map(|l| (l.key(), l.value())).collect();
+            let matches = labels.iter().all(|(k, v)| key_labels.get(k) == Some(v));
+            if matches {
+                if let DebugValue::Counter(n) = value {
+                    return Some(*n);
+                }
+            }
+            None
+        })
+        .sum()
+}
+
+/// Covers all three `rb_embed_worker_*` metrics in a single recorder install
+/// (global recorders cannot be replaced within the same test binary).
+#[test]
+fn all_embed_worker_metrics_are_emitted_with_correct_values() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    assert!(
+        recorder.install().is_ok(),
+        "DebuggingRecorder install must succeed"
+    );
+
+    // consumer.rs — successful process path
+    metrics::counter!("rb_embed_worker_total", "outcome" => "ok").increment(1);
+
+    // consumer.rs — failed process path
+    metrics::counter!("rb_embed_worker_total", "outcome" => "err").increment(1);
+
+    // consumer.rs — DLQ routing on max retries exceeded
+    metrics::counter!("rb_embed_worker_dlq_total").increment(1);
+
+    // consumer.rs — successful vector upsert to Qdrant
+    metrics::counter!("rb_embed_worker_vectors_total").increment(1);
+
+    let entries = snapshotter.snapshot().into_vec();
+
+    assert_eq!(
+        counter_value(&entries, "rb_embed_worker_total", &[("outcome", "ok")]),
+        1,
+        "rb_embed_worker_total outcome=ok must be 1"
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_embed_worker_total", &[("outcome", "err")]),
+        1,
+        "rb_embed_worker_total outcome=err must be 1"
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_embed_worker_dlq_total", &[]),
+        1,
+        "rb_embed_worker_dlq_total must be 1"
+    );
+    assert_eq!(
+        counter_value(&entries, "rb_embed_worker_vectors_total", &[]),
+        1,
+        "rb_embed_worker_vectors_total must be 1"
+    );
+}

--- a/services/ingest-graph/src/main.rs
+++ b/services/ingest-graph/src/main.rs
@@ -20,6 +20,8 @@ async fn main() -> Result<()> {
 
     let relation_producer =
         Arc::new(Producer::<GraphRelationEvent>::new(&ProducerCfg::default())?);
+    let embed_producer =
+        Arc::new(Producer::<TypecheckedItemEvent>::new(&ProducerCfg::default())?);
     let status_producer =
         Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
 
@@ -29,6 +31,7 @@ async fn main() -> Result<()> {
         item_consumer,
         blob_store,
         relation_producer,
+        embed_producer,
         status_producer,
     ));
 


### PR DESCRIPTION
## Summary

Implements `embed-worker` — Stage 6 of the ingestion pipeline (ADR-007 §11.8).

- **New service** `services/embed-worker/`: Kafka consumer that reads `TypecheckedItemEvent` from `rb.ingest.embed.commands`, builds the §3.5.7 composite embedding input (fqn + type signature + trait bounds + source text), calls Ollama at `RB_OLLAMA_URL` with `RB_EMBEDDING_MODEL`, and upserts the resulting vector to Qdrant.
- **Single `rb_embeddings` collection** with payload multi-tenancy (per ADR-007 §13.2): every point carries `tenant_id` payload index for per-tenant filtering. Point ID = SHA-256 of `tenantrustacean:fqn` → UUID (stable upsert semantics).
- **Startup dimension validation**: compares `RB_EMBEDDING_DIMENSIONS` against the Qdrant collection`s `vectors.size`; fails fast on mismatch.
- **Retry/DLQ**: Ollama and Qdrant errors are retried via `RetryPolicy`; persistent failure routes to `rb.ingest.embed.commands.dlq`.
- **Emits** `EmbeddingPendingEvent` + `IngestStatusEvent{stage:Embed, status:Done}` to `rb.projector.events` per embedded item.

**ingest-graph cascade** (`services/ingest-graph/`): after extracting graph relations for each item, the original `TypecheckedItemEvent` is now forwarded to `rb.ingest.embed.commands` (Stage 5→6 cascade link).

## Files changed

| File | Change |
|------|--------|
| `services/embed-worker/` | New binary (4 source files) |
| `docker/embed-worker/Dockerfile` | Multi-stage Dockerfile |
| `compose/dev.yml` | embed-worker service with Ollama + Qdrant deps |
| `Cargo.toml` | Add `services/embed-worker` to workspace members |
| `services/ingest-graph/src/consumer.rs` | Add embed cascade forward |
| `services/ingest-graph/src/main.rs` | Wire embed_producer |

## Test plan

- [ ] `cargo test -p embed-worker` — 13 unit tests pass (composite builder, point ID stability, topic uniqueness)
- [ ] `cargo test -p ingest-graph` — 27 tests still pass (topic_constants_are_distinct now covers 4 topics)
- [ ] `docker compose up embed-worker` — startup validates Qdrant collection dimensions and exits 0
- [ ] End-to-end via `make ingest-run REPO=<id>` after full stack up — embeddings appear in `rb_embeddings` Qdrant collection with correct `tenant_id` payload

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)