### PR TITLE
[REQ-IN-08] Stage 6 — Embed Worker + Pipeline UAT Fixes

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -326,7 +326,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
       GITHUB_APP_ID: "${RB_GH_APP_ID:-}"
-      GITHUB_APP_PRIVATE_KEY_PEM: "${RB_GH_APP_PRIVATE_KEY:-}"
+      GITHUB_APP_PRIVATE_KEY_PEM: "${GITHUB_APP_PRIVATE_KEY_PEM:-}"
       GITHUB_WEBHOOK_SECRET: "${RB_GH_APP_WEBHOOK_SECRET:-dev-secret-do-not-use-in-prod}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: ingest-clone
@@ -398,6 +398,27 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: typecheck-worker
       RUST_LOG: "info,typecheck_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
+  ingest-graph:
+    build:
+      context: ..
+      dockerfile: docker/ingest-graph/Dockerfile
+    image: ghcr.io/jarnura/rustacean/ingest-graph:dev
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: ingest-graph
+      RUST_LOG: "info,ingest_graph=debug"
     volumes:
       - blob-data:/data/blobs
     networks:

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -316,6 +316,56 @@ services:
       otel-collector:
         condition: service_started
 
+  ingest-clone:
+    build:
+      context: ..
+      dockerfile: docker/ingest-clone/Dockerfile
+    image: ghcr.io/jarnura/rustacean/ingest-clone:dev
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      GITHUB_APP_ID: "${RB_GH_APP_ID:-}"
+      GITHUB_APP_PRIVATE_KEY_PEM: "${RB_GH_APP_PRIVATE_KEY:-}"
+      GITHUB_WEBHOOK_SECRET: "${RB_GH_APP_WEBHOOK_SECRET:-dev-secret-do-not-use-in-prod}"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: ingest-clone
+      RUST_LOG: "info,ingest_clone=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks:
+      - rb-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
+  expand-worker:
+    build:
+      context: ..
+      dockerfile: docker/expand-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/expand-worker:dev
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: expand-worker
+      RUST_LOG: "info,expand_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
   parse-worker:
     build:
       context: ..
@@ -323,7 +373,7 @@ services:
     image: ghcr.io/jarnura/rustacean/parse-worker:dev
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
-      BLOB_STORE_PATH: /data/blobs
+      RB_BLOB_BASE_PATH: /data/blobs
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: parse-worker
       RUST_LOG: "info,parse_worker=debug"
@@ -344,7 +394,7 @@ services:
     image: ghcr.io/jarnura/rustacean/typecheck-worker:dev
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
-      BLOB_STORE_PATH: /data/blobs
+      RB_BLOB_BASE_PATH: /data/blobs
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: typecheck-worker
       RUST_LOG: "info,typecheck_worker=debug"
@@ -358,6 +408,29 @@ services:
       otel-collector:
         condition: service_started
 
+  projector-neo4j:
+    build:
+      context: ..
+      dockerfile: docker/projector-neo4j/Dockerfile
+    image: ghcr.io/jarnura/rustacean/projector-neo4j:dev
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: rustbrain123
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: projector-neo4j
+      RUST_LOG: "info,projector_neo4j=debug"
+    networks:
+      - rb-net
+    depends_on:
+      neo4j:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+
   embed-worker:
     build:
       context: ..
@@ -365,7 +438,7 @@ services:
     image: ghcr.io/jarnura/rustacean/embed-worker:dev
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
-      BLOB_STORE_PATH: /data/blobs
+      RB_BLOB_BASE_PATH: /data/blobs
       RB_OLLAMA_URL: "http://ollama:11434"
       RB_EMBEDDING_MODEL: "nomic-embed-text"
       RB_EMBEDDING_DIMENSIONS: "768"
@@ -454,3 +527,4 @@ volumes:
   loki_data:
   ollama_data:
   caddy_data:
+  blob-data:

--- a/crates/rb-storage-neo4j/src/injector.rs
+++ b/crates/rb-storage-neo4j/src/injector.rs
@@ -10,13 +10,24 @@ enum ScanState {
     BlockComment,
 }
 
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum PathClauseKind {
+    Match,
+    CreateOrMerge,
+}
+
 fn is_ident_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
 /// Keywords that put us into a path-pattern context (node patterns expected).
-fn is_path_start(upper: &str) -> bool {
-    matches!(upper, "MATCH" | "CREATE" | "MERGE")
+/// Returns the kind of clause so the injector can track bound variables.
+fn path_start_kind(upper: &str) -> Option<PathClauseKind> {
+    match upper {
+        "MATCH" => Some(PathClauseKind::Match),
+        "CREATE" | "MERGE" => Some(PathClauseKind::CreateOrMerge),
+        _ => None,
+    }
 }
 
 /// Keywords that end the current path-pattern context.
@@ -207,6 +218,10 @@ fn splice_label(inner: &str, label: &str) -> String {
 /// Rewrites `cypher` so that every node pattern in a MATCH / MERGE / CREATE / OPTIONAL MATCH
 /// clause has `:<label>` injected after the optional variable and before any existing labels.
 ///
+/// Variables bound by MATCH clauses are tracked. A bare variable reference in MERGE/CREATE
+/// (no labels, no properties) that names an already-bound variable is left as-is so that
+/// Neo4j 5.x `MERGE (a)-[:R]->(b)` patterns work when `a` and `b` were bound by a prior MATCH.
+///
 /// Also rejects queries that contain a bare semicolon outside a string or comment, as those
 /// indicate multi-statement injection attempts.
 ///
@@ -226,8 +241,13 @@ pub fn inject_tenant_label(cypher: &str, label: &str) -> Result<String, CypherEr
     // A `(` that follows an identifier is a function call, not a node pattern.
     let mut last_was_ident = false;
 
-    // Whether the scanner is inside a MATCH/CREATE/MERGE path clause.
+    // Whether the scanner is inside a MATCH/CREATE/MERGE path clause, and which kind.
     let mut in_path_clause = false;
+    let mut path_clause_kind: Option<PathClauseKind> = None;
+
+    // Variables declared by MATCH clauses — skip label injection for bare references to these
+    // in MERGE/CREATE so Neo4j 5.x doesn't reject re-labelling already-bound variables.
+    let mut bound_vars: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     while i < len {
         let b = bytes[i];
@@ -355,13 +375,15 @@ pub fn inject_tenant_label(cypher: &str, label: &str) -> Result<String, CypherEr
                     let word = &cypher[word_start..i];
                     let upper = word.to_ascii_uppercase();
 
-                    if is_path_start(&upper) {
+                    if let Some(kind) = path_start_kind(&upper) {
                         in_path_clause = true;
+                        path_clause_kind = Some(kind);
                         // Allow `MATCH(n)` (no space) — keyword itself is not an identifier
                         // for the purpose of distinguishing function calls.
                         last_was_ident = false;
                     } else if is_path_end(&upper) {
                         in_path_clause = false;
+                        path_clause_kind = None;
                         last_was_ident = true;
                     } else {
                         last_was_ident = true;
@@ -374,10 +396,39 @@ pub fn inject_tenant_label(cypher: &str, label: &str) -> Result<String, CypherEr
                 if b == b'(' && in_path_clause && !last_was_ident {
                     i += 1;
                     let inner = collect_node_pattern(bytes, &mut i)?;
-                    let patched = splice_label(&inner, label);
-                    out.push('(');
-                    out.push_str(&patched);
-                    out.push(')');
+
+                    // Extract the variable name (if any) from the node pattern.
+                    let trimmed = inner.trim_start();
+                    let var_end = trimmed
+                        .find(|c: char| !c.is_alphanumeric() && c != '_')
+                        .unwrap_or(trimmed.len());
+                    let var_name = &trimmed[..var_end];
+                    let rest_after_var = trimmed[var_end..].trim_start();
+
+                    // In MERGE/CREATE, a bare variable reference (no labels, no properties)
+                    // that names an already-bound variable must NOT receive a label injection.
+                    // Neo4j 5.x rejects MERGE/CREATE on already-declared variables with labels.
+                    let is_bound_ref = path_clause_kind == Some(PathClauseKind::CreateOrMerge)
+                        && !var_name.is_empty()
+                        && rest_after_var.is_empty()
+                        && bound_vars.contains(var_name);
+
+                    if is_bound_ref {
+                        // Emit the pattern unchanged.
+                        out.push('(');
+                        out.push_str(&inner);
+                        out.push(')');
+                    } else {
+                        // Track variables declared by MATCH for future MERGE/CREATE checks.
+                        if path_clause_kind == Some(PathClauseKind::Match) && !var_name.is_empty()
+                        {
+                            bound_vars.insert(var_name.to_owned());
+                        }
+                        let patched = splice_label(&inner, label);
+                        out.push('(');
+                        out.push_str(&patched);
+                        out.push(')');
+                    }
                     last_was_ident = false;
                     continue;
                 }

--- a/docker/embed-worker/Dockerfile
+++ b/docker/embed-worker/Dockerfile
@@ -11,6 +11,17 @@ COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
 COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.

--- a/docker/expand-worker/Dockerfile
+++ b/docker/expand-worker/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml                 crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml                 crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml                   crates/rb-kafka/Cargo.toml
+COPY crates/rb-blob/Cargo.toml                    crates/rb-blob/Cargo.toml
+COPY crates/rb-feature-resolver/Cargo.toml        crates/rb-feature-resolver/Cargo.toml
+COPY services/expand-worker/Cargo.toml            services/expand-worker/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/expand-worker/src && \
+    printf 'fn main() {}' > services/expand-worker/src/main.rs && \
+    cargo build --release -p expand-worker 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                    crates/
+COPY services/expand-worker/    services/expand-worker/
+COPY proto/                     proto/
+
+RUN cargo build --release -p expand-worker
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/expand-worker /usr/local/bin/expand-worker
+
+ENTRYPOINT ["/usr/local/bin/expand-worker"]

--- a/docker/expand-worker/Dockerfile
+++ b/docker/expand-worker/Dockerfile
@@ -12,7 +12,18 @@ COPY crates/rb-schemas/Cargo.toml                 crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml                   crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                    crates/rb-blob/Cargo.toml
 COPY crates/rb-feature-resolver/Cargo.toml        crates/rb-feature-resolver/Cargo.toml
-COPY services/expand-worker/Cargo.toml            services/expand-worker/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -13,7 +13,18 @@ COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
 COPY crates/rb-github/Cargo.toml              crates/rb-github/Cargo.toml
 COPY crates/rb-secrets/Cargo.toml             crates/rb-secrets/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
 COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────��───────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
+COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY crates/rb-github/Cargo.toml              crates/rb-github/Cargo.toml
+COPY crates/rb-secrets/Cargo.toml             crates/rb-secrets/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/ingest-clone/src && \
+    printf 'fn main() {}' > services/ingest-clone/src/main.rs && \
+    cargo build --release -p ingest-clone 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                    crates/
+COPY services/ingest-clone/     services/ingest-clone/
+COPY proto/                     proto/
+
+RUN cargo build --release -p ingest-clone
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/ingest-clone /usr/local/bin/ingest-clone
+
+ENTRYPOINT ["/usr/local/bin/ingest-clone"]

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -53,7 +53,7 @@ FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 git && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd --gid 65532 nonroot && \
     useradd --uid 65532 --gid 65532 --no-create-home --system nonroot

--- a/docker/ingest-graph/Dockerfile
+++ b/docker/ingest-graph/Dockerfile
@@ -11,7 +11,18 @@ COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
 COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/parse-worker/Dockerfile
+++ b/docker/parse-worker/Dockerfile
@@ -13,9 +13,18 @@ COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
 COPY crates/rb-parse-syn/Cargo.toml           crates/rb-parse-syn/Cargo.toml
 COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
 COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
 COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-neo4j/Dockerfile
+++ b/docker/projector-neo4j/Dockerfile
@@ -11,7 +11,18 @@ COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
 COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-storage-neo4j/Cargo.toml       crates/rb-storage-neo4j/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-neo4j/Dockerfile
+++ b/docker/projector-neo4j/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
+COPY crates/rb-storage-neo4j/Cargo.toml       crates/rb-storage-neo4j/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/projector-neo4j/src && \
+    printf 'fn main() {}' > services/projector-neo4j/src/main.rs && \
+    cargo build --release -p projector-neo4j 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                      crates/
+COPY services/projector-neo4j/    services/projector-neo4j/
+COPY proto/                       proto/
+
+RUN cargo build --release -p projector-neo4j
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/projector-neo4j /usr/local/bin/projector-neo4j
+
+ENTRYPOINT ["/usr/local/bin/projector-neo4j"]

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -12,10 +12,18 @@ COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
 COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml   crates/rb-storage-pg/Cargo.toml
-COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
-COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml    services/ingest-graph/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -13,9 +13,18 @@ COPY crates/rb-kafka/Cargo.toml          crates/rb-kafka/Cargo.toml
 COPY crates/rb-tenant/Cargo.toml         crates/rb-tenant/Cargo.toml
 COPY crates/rb-storage-pg/Cargo.toml     crates/rb-storage-pg/Cargo.toml
 COPY crates/rb-storage-neo4j/Cargo.toml  crates/rb-storage-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml       services/tombstoner/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml    services/ingest-graph/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/typecheck-worker/Dockerfile
+++ b/docker/typecheck-worker/Dockerfile
@@ -11,8 +11,18 @@ COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
 COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
 COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
 COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
+COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
 COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
 COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/services/control-api/src/ingest_consumer/db.rs
+++ b/services/control-api/src/ingest_consumer/db.rs
@@ -127,7 +127,7 @@ pub(crate) async fn maybe_complete_run(pool: &PgPool, ingest_run_id: &str) -> Re
         sqlx::query(
             "UPDATE control.ingestion_runs \
              SET status = 'succeeded', finished_at = now() \
-             WHERE id = $1 AND status = 'running'",
+             WHERE id = $1 AND status IN ('queued', 'running')",
         )
         .bind(run_id)
         .execute(pool)

--- a/services/embed-worker/src/consumer.rs
+++ b/services/embed-worker/src/consumer.rs
@@ -21,7 +21,7 @@ use metrics::counter;
 use rb_blob::{BlobRef, BlobStore};
 use rb_kafka::{Consumer, EventEnvelope, Producer, RetryPolicy};
 use rb_schemas::{
-    EmbeddingPendingEvent, IngestStage, IngestStatus, IngestStatusEvent, TenantId,
+    IngestStage, IngestStatus, IngestStatusEvent, TenantId,
     TypecheckedItemEvent, typechecked_item_event,
 };
 use uuid::Uuid;
@@ -35,7 +35,6 @@ pub const TOPIC_PROJECTOR_EVENTS: &str = "rb.projector.events";
 struct EmbedCtx {
     blob_store: Arc<dyn BlobStore>,
     status_producer: Arc<Producer<IngestStatusEvent>>,
-    event_producer: Arc<Producer<EmbeddingPendingEvent>>,
     ollama_url: String,
     embedding_model: String,
     embedding_dimensions: u32,
@@ -43,12 +42,10 @@ struct EmbedCtx {
     http: reqwest::Client,
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn run(
     consumer: Consumer<TypecheckedItemEvent>,
     blob_store: Arc<dyn BlobStore>,
     status_producer: Arc<Producer<IngestStatusEvent>>,
-    event_producer: Arc<Producer<EmbeddingPendingEvent>>,
     ollama_url: String,
     embedding_model: String,
     embedding_dimensions: u32,
@@ -57,7 +54,6 @@ pub async fn run(
     let ctx = Arc::new(EmbedCtx {
         blob_store,
         status_producer,
-        event_producer,
         ollama_url,
         embedding_model,
         embedding_dimensions,
@@ -182,7 +178,7 @@ async fn process_item(
     counter!("rb_embed_worker_vectors_total").increment(1);
     tracing::debug!(%ingest_run_id, fqn = %ev.fqn, "embed_worker: vector upserted");
 
-    emit_embedding_pending(ctx, tenant_id, ev).await?;
+    emit_qdrant_done_status(ctx, tenant_id, ev).await?;
     emit_done_status(ctx, tenant_id, ev).await?;
 
     Ok(())
@@ -218,26 +214,28 @@ async fn resolve_body(
 
 // ── Kafka producers ───────────────────────────────────────────────────────────
 
-async fn emit_embedding_pending(
+async fn emit_qdrant_done_status(
     ctx: &EmbedCtx,
     tenant_id: TenantId,
     ev: &TypecheckedItemEvent,
 ) -> Result<()> {
-    let pending_ev = EmbeddingPendingEvent {
-        ingest_run_id: ev.ingest_run_id.clone(),
+    let status_ev = IngestStatusEvent {
+        ingest_request_id: Uuid::new_v4().to_string(),
         tenant_id: tenant_id.to_string(),
-        repo_id: ev.repo_id.clone(),
-        fqn: ev.fqn.clone(),
-        embedding_model: ctx.embedding_model.clone(),
-        dimensions: i32::try_from(ctx.embedding_dimensions).expect("embedding_dimensions fits i32"),
-        emitted_at_ms: chrono::Utc::now().timestamp_millis(),
+        status: IngestStatus::Done as i32,
+        error_message: String::new(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::ProjectQdrant as i32,
+        stage_seq: 9,
+        ingest_run_id: ev.ingest_run_id.clone(),
+        attempt: 0,
     };
-    let envelope = rb_kafka::EventEnvelope::new(tenant_id, pending_ev);
-    let key = format!("{}.{}", ev.tenant_id, ev.repo_id);
-    ctx.event_producer
+    let envelope = rb_kafka::EventEnvelope::new(tenant_id, status_ev);
+    let key = tenant_id.to_string();
+    ctx.status_producer
         .publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), envelope)
         .await
-        .context("failed to publish EmbeddingPendingEvent")?;
+        .context("failed to publish qdrant done status")?;
     Ok(())
 }
 

--- a/services/embed-worker/src/main.rs
+++ b/services/embed-worker/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use rb_blob::store_from_env;
 use rb_kafka::{Consumer, ConsumerCfg, Producer, ProducerCfg};
-use rb_schemas::{EmbeddingPendingEvent, IngestStatusEvent, TypecheckedItemEvent};
+use rb_schemas::{IngestStatusEvent, TypecheckedItemEvent};
 
 mod consumer;
 mod embedder;
@@ -43,8 +43,6 @@ async fn main() -> Result<()> {
 
     let status_producer =
         Arc::new(Producer::<IngestStatusEvent>::new(&ProducerCfg::default())?);
-    let event_producer =
-        Arc::new(Producer::<EmbeddingPendingEvent>::new(&ProducerCfg::default())?);
 
     tracing::info!("embed-worker starting");
 
@@ -52,7 +50,6 @@ async fn main() -> Result<()> {
         item_consumer,
         blob_store,
         status_producer,
-        event_producer,
         ollama_url,
         embedding_model,
         embedding_dimensions,

--- a/services/ingest-clone/src/consumer.rs
+++ b/services/ingest-clone/src/consumer.rs
@@ -233,7 +233,7 @@ async fn git_clone(url: &str, target: &Path) -> Result<()> {
             .env("GIT_HTTP_LOW_SPEED_TIME", CLONE_TIMEOUT_SECS.to_string())
             .env("GIT_CONFIG_NOSYSTEM", "1")
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
             .status(),
     )
     .await

--- a/services/projector-neo4j/src/consumer.rs
+++ b/services/projector-neo4j/src/consumer.rs
@@ -124,6 +124,7 @@ async fn handle_envelope(
                 kind = ev.kind,
                 "projector_neo4j: relation written"
             );
+            emit_done_status(producer, &tenant_id, &ingest_run_id).await;
             if let Err(e) = consumer.commit(&envelope).await {
                 tracing::warn!("projector_neo4j: commit failed: {e}");
             }
@@ -161,6 +162,30 @@ async fn handle_envelope(
             .increment(1);
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
+    }
+}
+
+/// Emit `IngestStatusEvent{stage=ProjectNeo4j, status=Done}` to `rb.projector.events`.
+async fn emit_done_status(
+    producer: &Producer<IngestStatusEvent>,
+    tenant_id: &rb_schemas::TenantId,
+    ingest_run_id: &str,
+) {
+    let status_ev = IngestStatusEvent {
+        ingest_request_id: String::new(),
+        tenant_id: tenant_id.to_string(),
+        status: IngestStatus::Done as i32,
+        error_message: String::new(),
+        occurred_at_ms: chrono::Utc::now().timestamp_millis(),
+        stage: IngestStage::ProjectNeo4j as i32,
+        stage_seq: 0,
+        ingest_run_id: ingest_run_id.to_owned(),
+        attempt: 0,
+    };
+    let env = EventEnvelope::new(*tenant_id, status_ev);
+    let key = tenant_id.to_string();
+    if let Err(e) = producer.publish(TOPIC_PROJECTOR_EVENTS, key.as_bytes(), env).await {
+        tracing::error!("projector_neo4j: failed to publish done status event: {e}");
     }
 }
 


### PR DESCRIPTION
## Summary

- Implements embed-worker service (Stage 6): Kafka consumer → embedding provider → Qdrant vector store
- Fixes 7 UAT bugs found during Wave 5 end-to-end validation (SIGPIPE, volume perms, Neo4j label injection, done-event gaps, completion query, dead event type)
- Adds Dockerfiles for embed-worker, expand-worker, ingest-clone, projector-neo4j with workspace Cargo.toml

## Changes

| Component | Change |
|-----------|--------|
| `services/embed-worker/` | New service: consumer, embedder, qdrant client, metrics tests |
| `services/ingest-clone/` | SIGPIPE fix (Stdio::null) |
| `services/projector-neo4j/` | Neo4j 5.x label injection fix + done event emission |
| `services/ingest-graph/` | project_qdrant done event + stage wiring |
| `services/control-api/` | `maybe_complete_run` WHERE clause fix |
| `crates/rb-storage-neo4j/` | Injector improvements |
| `docker/` | 4 new/updated Dockerfiles with workspace Cargo.toml |
| `compose/dev.yml` | New service definitions |

Closes #192

## Test plan

- [x] QA PASS: all 9 pipeline stages verified across 3 consecutive runs at `e740cb1`
- [x] PostgreSQL: 3 code_files, 19 code_symbols, 11 code_relations
- [x] Neo4j: 14 nodes, 11 relations (BOUNDED_BY / IMPLS / EXTENDS_TRAIT)
- [x] Qdrant: 21 points, vector_size=768
- [x] SSE live stream verified (TC-4)
- [x] Duplicate ingestion guard 409 confirmed (TC-3)
- [x] embed_worker metrics tests pass
- [ ] TC-5: Frontend Ingestion Theatre (board browser demo)