### PR TITLE
[REQ-DP-06] feat: module tree endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3818,10 +3818,12 @@ dependencies = [
 name = "rb-query"
 version = "0.1.0"
 dependencies = [
+ "moka",
  "rb-tenant",
  "serde",
  "sqlx",
  "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "services/parse-worker",
     "services/typecheck-worker",
     "services/ingest-graph",
+    "crates/rb-query",
     "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
     "services/projector-pg",

--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -12,6 +12,8 @@ sqlx.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+moka = { workspace = true, features = ["future"] }
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -8,3 +8,4 @@ mod pg;
 
 pub use error::QueryError;
 pub use pg::items;
+pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -7,8 +7,5 @@ mod error;
 mod pg;
 
 pub use error::QueryError;
-<<<<<<< HEAD
 pub use pg::items;
-=======
->>>>>>> 725e519 (fix(rb-query, control-api): CI fixes for RUSAA-77 PR #199)
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -7,5 +7,8 @@ mod error;
 mod pg;
 
 pub use error::QueryError;
+<<<<<<< HEAD
 pub use pg::items;
+=======
+>>>>>>> 725e519 (fix(rb-query, control-api): CI fixes for RUSAA-77 PR #199)
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};

--- a/crates/rb-query/src/pg/mod.rs
+++ b/crates/rb-query/src/pg/mod.rs
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 //! PostgreSQL-backed read queries against tenant-scoped schemas.
 
 pub mod items;
 pub mod modules;
+=======
+pub(crate) mod modules;
+>>>>>>> 725e519 (fix(rb-query, control-api): CI fixes for RUSAA-77 PR #199)

--- a/crates/rb-query/src/pg/mod.rs
+++ b/crates/rb-query/src/pg/mod.rs
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 //! PostgreSQL-backed read queries against tenant-scoped schemas.
 
 pub mod items;
-pub mod modules;
-=======
 pub(crate) mod modules;
->>>>>>> 725e519 (fix(rb-query, control-api): CI fixes for RUSAA-77 PR #199)

--- a/crates/rb-query/src/pg/mod.rs
+++ b/crates/rb-query/src/pg/mod.rs
@@ -1,3 +1,4 @@
 //! PostgreSQL-backed read queries against tenant-scoped schemas.
 
 pub mod items;
+pub mod modules;

--- a/crates/rb-query/src/pg/modules.rs
+++ b/crates/rb-query/src/pg/modules.rs
@@ -1,0 +1,320 @@
+//! Module tree query and in-memory tree construction (REQ-DP-06).
+//!
+//! Single SQL: `SELECT fqn, kind, source_path, line_start, line_end FROM
+//! {tenant}.code_symbols WHERE repo_id = $1 ORDER BY fqn`.
+//! Tree built in-Rust by splitting on `::`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use moka::future::Cache;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::error::QueryError;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A node in the crate/module hierarchy tree.
+///
+/// Leaf nodes (functions, structs, etc.) have `children` empty and may carry
+/// `source_path`, `line_start`, `line_end`. Interior `MOD` nodes that are not
+/// explicitly listed in `code_symbols` are synthesised from the FQN path and
+/// have `None` for all source fields.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModuleNode {
+    pub name: String,
+    pub fqn: String,
+    pub kind: String,
+    pub source_path: Option<String>,
+    pub line_start: Option<i32>,
+    pub line_end: Option<i32>,
+    pub children: Vec<ModuleNode>,
+}
+
+/// In-process 60-second cache keyed by `(repo_id, last_ingest_run_id)`.
+///
+/// `last_ingest_run_id` is `Uuid::nil()` when no succeeded run exists yet,
+/// so cold repos still benefit from the cache after the first build.
+pub type ModuleTreeCache = Cache<(Uuid, Uuid), Arc<ModuleNode>>;
+
+/// Construct a fresh [`ModuleTreeCache`] with a 60-second TTL and a capacity
+/// cap of 1 000 entries (enough for hundreds of repos).
+#[must_use]
+pub fn new_module_tree_cache() -> ModuleTreeCache {
+    Cache::builder()
+        .max_capacity(1_000)
+        .time_to_live(Duration::from_secs(60))
+        .build()
+}
+
+// ---------------------------------------------------------------------------
+// Public query function
+// ---------------------------------------------------------------------------
+
+/// Fetch all symbols for `repo_id` from the tenant schema and build the
+/// module/item tree in-process.
+///
+/// Issues exactly one SQL query per ADR-008 §3.6 / AC2.
+///
+/// # Errors
+///
+/// Returns [`QueryError::Sqlx`] on database failure.
+pub async fn fetch_module_tree(
+    pool: &sqlx::PgPool,
+    tenant_ctx: &rb_tenant::TenantCtx,
+    repo_id: Uuid,
+) -> Result<ModuleNode, QueryError> {
+    let table = tenant_ctx.qualify("code_symbols");
+
+    // One SQL query — ADR-008 AC2.
+    let rows: Vec<SymbolRow> =
+        sqlx::query_as(&format!(
+            "SELECT fqn, kind, source_path, line_start, line_end \
+             FROM {table} \
+             WHERE repo_id = $1 \
+             ORDER BY fqn"
+        ))
+        .bind(repo_id)
+        .fetch_all(pool)
+        .await?;
+
+    tracing::debug!(
+        %repo_id,
+        row_count = rows.len(),
+        "building module tree from code_symbols"
+    );
+
+    Ok(build_tree(rows))
+}
+
+// ---------------------------------------------------------------------------
+// Tree construction (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+type SymbolRow = (String, String, Option<String>, Option<i32>, Option<i32>);
+
+struct NodeInfo {
+    kind: String,
+    source_path: Option<String>,
+    line_start: Option<i32>,
+    line_end: Option<i32>,
+}
+
+fn build_tree(rows: Vec<SymbolRow>) -> ModuleNode {
+    if rows.is_empty() {
+        return ModuleNode {
+            name: "(empty)".to_owned(),
+            fqn: String::new(),
+            kind: "MOD".to_owned(),
+            source_path: None,
+            line_start: None,
+            line_end: None,
+            children: Vec::new(),
+        };
+    }
+
+    // 1. Populate the node map with explicit rows.
+    let mut node_map: HashMap<String, NodeInfo> = HashMap::with_capacity(rows.len() * 2);
+    for (fqn, kind, source_path, line_start, line_end) in rows {
+        // Ensure all ancestor segments exist as synthetic MOD nodes.
+        let parts: Vec<&str> = fqn.split("::").collect();
+        for depth in 1..parts.len() {
+            let ancestor = parts[..depth].join("::");
+            node_map.entry(ancestor).or_insert_with(|| NodeInfo {
+                kind: "MOD".to_owned(),
+                source_path: None,
+                line_start: None,
+                line_end: None,
+            });
+        }
+        // The explicit row wins (overwrites a synthetic placeholder if present).
+        node_map.insert(fqn, NodeInfo { kind, source_path, line_start, line_end });
+    }
+
+    // 2. Build the parent → children map.
+    let mut children_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut roots: Vec<String> = Vec::new();
+
+    for fqn in node_map.keys() {
+        if let Some(sep) = fqn.rfind("::") {
+            let parent = fqn[..sep].to_owned();
+            children_map.entry(parent).or_default().push(fqn.clone());
+        } else {
+            roots.push(fqn.clone());
+        }
+    }
+
+    // Sort for deterministic output.
+    roots.sort_unstable();
+    for kids in children_map.values_mut() {
+        kids.sort_unstable();
+    }
+
+    // 3. Build the tree recursively.
+    if roots.len() == 1 {
+        make_node(&roots[0], &node_map, &children_map)
+    } else {
+        // Workspace with multiple crate roots — wrap in a virtual root.
+        let children = roots
+            .iter()
+            .map(|r| make_node(r, &node_map, &children_map))
+            .collect();
+        ModuleNode {
+            name: "(workspace)".to_owned(),
+            fqn: String::new(),
+            kind: "MOD".to_owned(),
+            source_path: None,
+            line_start: None,
+            line_end: None,
+            children,
+        }
+    }
+}
+
+fn make_node(
+    fqn: &str,
+    node_map: &HashMap<String, NodeInfo>,
+    children_map: &HashMap<String, Vec<String>>,
+) -> ModuleNode {
+    let info = &node_map[fqn];
+    let name = fqn.rsplit("::").next().unwrap_or(fqn).to_owned();
+
+    let children = children_map
+        .get(fqn)
+        .map(|kids| kids.iter().map(|c| make_node(c, node_map, children_map)).collect())
+        .unwrap_or_default();
+
+    ModuleNode {
+        name,
+        fqn: fqn.to_owned(),
+        kind: info.kind.clone(),
+        source_path: info.source_path.clone(),
+        line_start: info.line_start,
+        line_end: info.line_end,
+        children,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(fqn: &str, kind: &str) -> SymbolRow {
+        (fqn.to_owned(), kind.to_owned(), None, None, None)
+    }
+
+    fn row_with_source(fqn: &str, kind: &str, path: &str, start: i32, end: i32) -> SymbolRow {
+        (fqn.to_owned(), kind.to_owned(), Some(path.to_owned()), Some(start), Some(end))
+    }
+
+    #[test]
+    fn empty_rows_returns_empty_node() {
+        let tree = build_tree(vec![]);
+        assert_eq!(tree.name, "(empty)");
+        assert_eq!(tree.kind, "MOD");
+        assert!(tree.children.is_empty());
+    }
+
+    #[test]
+    fn single_root_crate() {
+        let rows = vec![
+            row("mycrate", "MOD"),
+            row("mycrate::lib", "MOD"),
+            row_with_source("mycrate::lib::Foo", "STRUCT", "src/lib.rs", 1, 10),
+        ];
+        let tree = build_tree(rows);
+        assert_eq!(tree.name, "mycrate");
+        assert_eq!(tree.fqn, "mycrate");
+        assert_eq!(tree.kind, "MOD");
+        assert_eq!(tree.children.len(), 1);
+
+        let lib = &tree.children[0];
+        assert_eq!(lib.name, "lib");
+        assert_eq!(lib.fqn, "mycrate::lib");
+        assert_eq!(lib.children.len(), 1);
+
+        let foo = &lib.children[0];
+        assert_eq!(foo.name, "Foo");
+        assert_eq!(foo.kind, "STRUCT");
+        assert_eq!(foo.source_path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(foo.line_start, Some(1));
+        assert_eq!(foo.line_end, Some(10));
+    }
+
+    #[test]
+    fn synthetic_mod_nodes_created_for_missing_parents() {
+        // Only the leaf is explicit; intermediate MOD nodes are synthesised.
+        let rows = vec![row_with_source(
+            "alloc::vec::Vec::push",
+            "FN",
+            "src/vec.rs",
+            42,
+            50,
+        )];
+        let tree = build_tree(rows);
+        assert_eq!(tree.name, "alloc");
+        let vec_mod = &tree.children[0];
+        assert_eq!(vec_mod.name, "vec");
+        assert_eq!(vec_mod.kind, "MOD"); // synthesised
+        let vec_struct = &vec_mod.children[0];
+        assert_eq!(vec_struct.name, "Vec");
+        assert_eq!(vec_struct.kind, "MOD"); // synthesised
+        let push = &vec_struct.children[0];
+        assert_eq!(push.name, "push");
+        assert_eq!(push.kind, "FN");
+        assert_eq!(push.source_path.as_deref(), Some("src/vec.rs"));
+    }
+
+    #[test]
+    fn explicit_row_overrides_synthetic_mod() {
+        let rows = vec![
+            row("alloc::vec", "MOD"),
+            row_with_source("alloc::vec::Vec", "STRUCT", "src/vec.rs", 1, 100),
+        ];
+        let tree = build_tree(rows);
+        let vec_mod = &tree.children[0];
+        assert_eq!(vec_mod.kind, "MOD"); // explicit, not synthetic
+        let vec_struct = &vec_mod.children[0];
+        assert_eq!(vec_struct.kind, "STRUCT");
+    }
+
+    #[test]
+    fn multiple_roots_wrapped_in_workspace_node() {
+        let rows = vec![row("crate_a", "MOD"), row("crate_b", "MOD")];
+        let tree = build_tree(rows);
+        assert_eq!(tree.name, "(workspace)");
+        assert_eq!(tree.children.len(), 2);
+        // Children are sorted alphabetically.
+        assert_eq!(tree.children[0].name, "crate_a");
+        assert_eq!(tree.children[1].name, "crate_b");
+    }
+
+    #[test]
+    fn children_are_sorted_alphabetically() {
+        let rows = vec![
+            row("crate::z_module", "MOD"),
+            row("crate::a_module", "MOD"),
+            row("crate::m_module", "MOD"),
+        ];
+        let tree = build_tree(rows);
+        let names: Vec<&str> = tree.children.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["a_module", "m_module", "z_module"]);
+    }
+
+    #[test]
+    fn fqn_stored_correctly_on_all_nodes() {
+        let rows = vec![row_with_source("a::b::c", "FN", "src/c.rs", 1, 5)];
+        let tree = build_tree(rows);
+        assert_eq!(tree.fqn, "a");
+        assert_eq!(tree.children[0].fqn, "a::b");
+        assert_eq!(tree.children[0].children[0].fqn, "a::b::c");
+    }
+}

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -463,6 +463,27 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/repos/{repo_id}/modules": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Return the crate/module hierarchy for a repository.
+         * @description Tree is derived from `code_symbols.fqn` (split on `::`) via a single SQL
+         *     query. Results are cached in-process for 60 s per `(repo_id, last_ingest_run_id)`.
+         */
+        readonly get: operations["get_module_tree"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/tenants/{id}/members": {
         readonly parameters: {
             readonly query?: never;
@@ -761,6 +782,33 @@ export interface components {
             readonly role: string;
             /** Format: uuid */
             readonly user_id: string;
+        };
+        /** @description A single node in the module/item tree. */
+        readonly ModuleNodeItem: {
+            /** @description Nested child nodes. */
+            readonly children: readonly components["schemas"]["ModuleNodeItem"][];
+            /** @description Fully-qualified name (e.g. `"alloc::vec::Vec"`). */
+            readonly fqn: string;
+            /** @description Symbol kind from `code_symbols.kind` (e.g. `"MOD"`, `"STRUCT"`, `"FN"`). */
+            readonly kind: string;
+            /** @description Leaf segment of the FQN (e.g. `"Vec"` for `alloc::vec::Vec`). */
+            readonly name: string;
+            readonly source?: null | components["schemas"]["NodeSource"];
+        };
+        /** @description Response envelope for `GET /v1/repos/{repo_id}/modules`. */
+        readonly ModuleTreeResponse: {
+            /** Format: uuid */
+            readonly repo_id: string;
+            readonly tree: components["schemas"]["ModuleNodeItem"];
+        };
+        /** @description Source location for a symbol. */
+        readonly NodeSource: {
+            /** Format: int32 */
+            readonly line_end?: number | null;
+            /** Format: int32 */
+            readonly line_start?: number | null;
+            /** @description Relative path within the repository (e.g. `"src/lib.rs"`). */
+            readonly path: string;
         };
         readonly ProbeResponse: {
             readonly status: string;
@@ -1778,6 +1826,50 @@ export interface operations {
                 content?: never;
             };
             /** @description Repository or item not found (not_found) */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_module_tree: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Repository UUID */
+                readonly repo_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Module tree for the repository */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ModuleTreeResponse"];
+                };
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified or insufficient scope */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Repository not found or belongs to another tenant */
             readonly 404: {
                 headers: {
                     readonly [name: string]: unknown;

--- a/openapi.json
+++ b/openapi.json
@@ -907,6 +907,49 @@
         }
       }
     },
+    "/v1/repos/{repo_id}/modules": {
+      "get": {
+        "tags": [
+          "query"
+        ],
+        "summary": "Return the crate/module hierarchy for a repository.",
+        "description": "Tree is derived from `code_symbols.fqn` (split on `::`) via a single SQL\nquery. Results are cached in-process for 60 s per `(repo_id, last_ingest_run_id)`.",
+        "operationId": "get_module_tree",
+        "parameters": [
+          {
+            "name": "repo_id",
+            "in": "path",
+            "description": "Repository UUID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Module tree for the repository",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleTreeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified or insufficient scope"
+          },
+          "404": {
+            "description": "Repository not found or belongs to another tenant"
+          }
+        }
+      }
+    },
     "/v1/tenants/{id}/members": {
       "get": {
         "tags": [
@@ -1746,6 +1789,92 @@
           }
         }
       },
+      "ModuleNodeItem": {
+        "type": "object",
+        "description": "A single node in the module/item tree.",
+        "required": [
+          "name",
+          "fqn",
+          "kind",
+          "children"
+        ],
+        "properties": {
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModuleNodeItem"
+            },
+            "description": "Nested child nodes."
+          },
+          "fqn": {
+            "type": "string",
+            "description": "Fully-qualified name (e.g. `\"alloc::vec::Vec\"`)."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Symbol kind from `code_symbols.kind` (e.g. `\"MOD\"`, `\"STRUCT\"`, `\"FN\"`)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Leaf segment of the FQN (e.g. `\"Vec\"` for `alloc::vec::Vec`)."
+          },
+          "source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NodeSource",
+                "description": "Source location — absent for virtual/synthetic module nodes."
+              }
+            ]
+          }
+        }
+      },
+      "ModuleTreeResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/repos/{repo_id}/modules`.",
+        "required": [
+          "repo_id",
+          "tree"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tree": {
+            "$ref": "#/components/schemas/ModuleNodeItem"
+          }
+        }
+      },
+      "NodeSource": {
+        "type": "object",
+        "description": "Source location for a symbol.",
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "line_end": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "line_start": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative path within the repository (e.g. `\"src/lib.rs\"`)."
+          }
+        }
+      },
       "ProbeResponse": {
         "type": "object",
         "required": [
@@ -2122,7 +2251,7 @@
     },
     {
       "name": "query",
-      "description": "Code graph read queries"
+      "description": "Data-plane query endpoints (ADR-008 Wave 6)"
     }
   ]
 }

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -69,7 +69,7 @@ pub enum AppError {
     #[error("internal server error")]
     Internal(#[from] anyhow::Error),
     #[error("query error: {0}")]
-    Query(#[from] rb_query::error::QueryError),
+    Query(#[from] rb_query::QueryError),
 }
 
 impl IntoResponse for AppError {

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -68,6 +68,8 @@ pub enum AppError {
     Email(#[from] rb_email::EmailError),
     #[error("internal server error")]
     Internal(#[from] anyhow::Error),
+    #[error("query error: {0}")]
+    Query(#[from] rb_query::error::QueryError),
 }
 
 impl IntoResponse for AppError {
@@ -183,6 +185,14 @@ impl IntoResponse for AppError {
             }
             AppError::Internal(e) => {
                 tracing::error!(error = %e, "unhandled internal error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_error",
+                    "internal server error".to_owned(),
+                )
+            }
+            AppError::Query(e) => {
+                tracing::error!(error = %e, "query error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal_error",

--- a/services/control-api/src/middleware/auth.rs
+++ b/services/control-api/src/middleware/auth.rs
@@ -260,6 +260,27 @@ pub fn require_verified_session(auth: AuthContext) -> Result<SessionInfo, AppErr
     }
 }
 
+/// Require either a verified session OR any API key (read | write | admin).
+///
+/// Returns the caller's `tenant_id` from whichever credential is present.
+/// Used by read-only query endpoints that accept both session and key auth
+/// per ADR-008 §3.6.
+///
+/// - `Session(info)` with `email_verified == true` → `Ok(tenant_id)`
+/// - `Session(info)` with `email_verified == false` → `EmailNotVerified` (403)
+/// - `ExpiredSession` → `SessionExpired` (401)
+/// - `ApiKey(info)` (any scope) → `Ok(tenant_id)`
+/// - `Anonymous` → `Unauthorized` (401)
+pub fn require_read_auth(auth: AuthContext) -> Result<Uuid, AppError> {
+    match auth {
+        AuthContext::Session(info) if info.email_verified => Ok(info.tenant_id),
+        AuthContext::Session(_) => Err(AppError::EmailNotVerified),
+        AuthContext::ExpiredSession => Err(AppError::SessionExpired),
+        AuthContext::ApiKey(info) => Ok(info.tenant_id),
+        AuthContext::Anonymous => Err(AppError::Unauthorized),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -38,6 +38,7 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
         repos::trigger_ingest,
         ingest::trigger::trigger_ingestion,
         query::items::get_item,
+        query::modules::get_module_tree,
     ),
     components(
         schemas(
@@ -80,6 +81,9 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
             ingest::trigger::TriggerIngestionRequest,
             ingest::trigger::TriggerIngestionResponse,
             query::items::ItemResponse,
+            query::modules::NodeSource,
+            query::modules::ModuleNodeItem,
+            query::modules::ModuleTreeResponse,
         )
     ),
     info(
@@ -101,7 +105,7 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
         (name = "github", description = "GitHub App integration"),
         (name = "repos", description = "Connected repository management"),
         (name = "ingestions", description = "Manual ingestion trigger and run management"),
-        (name = "query", description = "Code graph read queries"),
+        (name = "query", description = "Data-plane query endpoints (ADR-008 Wave 6)"),
     ),
 )]
 pub struct ApiDoc;

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -29,6 +29,7 @@ use crate::routes::{
     ingest::trigger::trigger_ingestion,
     me::{get_me, switch_tenant},
     query::items::get_item,
+    query::modules::get_module_tree,
     repos::{connect_repo, list_repos, trigger_ingest},
     tenants::{invite_member, list_members, remove_member, transfer_ownership, update_member_role},
 };
@@ -59,6 +60,7 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/github/install-url", get(github_install_url))
         .route("/v1/github/callback", get(github_callback))
         .route("/v1/github/installations/{id}/available-repos", get(list_available_repos))
+        .route("/v1/repos/{repo_id}/modules", get(get_module_tree))
         .route("/v1/repos", post(connect_repo).get(list_repos))
         .route("/v1/repos/{id}/ingest", post(trigger_ingest))
         .route("/v1/repos/{repo_id}/ingestions", post(trigger_ingestion))

--- a/services/control-api/src/routes/query/mod.rs
+++ b/services/control-api/src/routes/query/mod.rs
@@ -1,3 +1,4 @@
 //! Query endpoints — read-only access to the code graph.
 
 pub mod items;
+pub mod modules;

--- a/services/control-api/src/routes/query/modules.rs
+++ b/services/control-api/src/routes/query/modules.rs
@@ -1,4 +1,4 @@
-//! `GET /v1/repos/{repo_id}/modules` — Module tree (REQ-DP-06, RUSAA-77).
+//! `GET /v1/repos/{repo_id}/modules` — Module tree (REQ-DP-06).
 //!
 //! Returns the crate/module hierarchy derived from `code_symbols.fqn`.
 //! Fetches with one SQL, builds in-Rust, and caches the result in-process

--- a/services/control-api/src/routes/query/modules.rs
+++ b/services/control-api/src/routes/query/modules.rs
@@ -44,6 +44,8 @@ pub struct ModuleNodeItem {
     /// Source location — absent for virtual/synthetic module nodes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<NodeSource>,
+    /// Nested child nodes.
+    #[schema(no_recursion)]
     pub children: Vec<ModuleNodeItem>,
 }
 

--- a/services/control-api/src/routes/query/modules.rs
+++ b/services/control-api/src/routes/query/modules.rs
@@ -1,0 +1,291 @@
+//! `GET /v1/repos/{repo_id}/modules` — Module tree (REQ-DP-06, RUSAA-77).
+//!
+//! Returns the crate/module hierarchy derived from `code_symbols.fqn`.
+//! Fetches with one SQL, builds in-Rust, and caches the result in-process
+//! for 60 s keyed by `(repo_id, last_ingest_run_id)` (ADR-008 §3.6 / §12.6).
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+use rb_schemas::TenantId;
+use rb_tenant::TenantCtx;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_read_auth},
+    state::AppState,
+};
+
+// ---------------------------------------------------------------------------
+// Response types (utoipa-annotated mirror of rb_query::ModuleNode)
+// ---------------------------------------------------------------------------
+
+/// Source location for a symbol.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct NodeSource {
+    /// Relative path within the repository (e.g. `"src/lib.rs"`).
+    pub path: String,
+    pub line_start: Option<i32>,
+    pub line_end: Option<i32>,
+}
+
+/// A single node in the module/item tree.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ModuleNodeItem {
+    /// Leaf segment of the FQN (e.g. `"Vec"` for `alloc::vec::Vec`).
+    pub name: String,
+    /// Fully-qualified name (e.g. `"alloc::vec::Vec"`).
+    pub fqn: String,
+    /// Symbol kind from `code_symbols.kind` (e.g. `"MOD"`, `"STRUCT"`, `"FN"`).
+    pub kind: String,
+    /// Source location — absent for virtual/synthetic module nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<NodeSource>,
+    pub children: Vec<ModuleNodeItem>,
+}
+
+/// Response envelope for `GET /v1/repos/{repo_id}/modules`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ModuleTreeResponse {
+    pub repo_id: Uuid,
+    pub tree: ModuleNodeItem,
+}
+
+// ---------------------------------------------------------------------------
+// Conversion from rb_query::ModuleNode
+// ---------------------------------------------------------------------------
+
+impl From<rb_query::ModuleNode> for ModuleNodeItem {
+    fn from(n: rb_query::ModuleNode) -> Self {
+        let source = n.source_path.map(|path| NodeSource {
+            path,
+            line_start: n.line_start,
+            line_end: n.line_end,
+        });
+        Self {
+            name: n.name,
+            fqn: n.fqn,
+            kind: n.kind,
+            source,
+            children: n.children.into_iter().map(Self::from).collect(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// Return the crate/module hierarchy for a repository.
+///
+/// Tree is derived from `code_symbols.fqn` (split on `::`) via a single SQL
+/// query. Results are cached in-process for 60 s per `(repo_id, last_ingest_run_id)`.
+#[utoipa::path(
+    get,
+    path = "/v1/repos/{repo_id}/modules",
+    params(
+        ("repo_id" = Uuid, Path, description = "Repository UUID")
+    ),
+    responses(
+        (status = 200, description = "Module tree for the repository", body = ModuleTreeResponse),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified or insufficient scope"),
+        (status = 404, description = "Repository not found or belongs to another tenant"),
+    ),
+    tag = "query"
+)]
+pub async fn get_module_tree(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    axum::extract::Path(repo_id): axum::extract::Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let tenant_id = require_read_auth(auth)?;
+
+    // Verify the repo belongs to this tenant (tenant isolation).
+    let exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM control.repos \
+         WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+    exists.ok_or(AppError::NotFound)?;
+
+    // Derive the cache key: (repo_id, last_succeeded_run_id).
+    // Uuid::nil() when no run has completed yet — still worth caching to
+    // avoid repeated empty-tree builds on a freshly connected repo.
+    let run_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM control.ingestion_runs \
+         WHERE repo_id = $1 AND tenant_id = $2 AND status = 'succeeded' \
+         ORDER BY created_at DESC \
+         LIMIT 1",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await?
+    .unwrap_or_else(Uuid::nil);
+
+    let cache_key = (repo_id, run_id);
+
+    // --- Cache hit path (AC3 / AC4 p95 ≤ 50 ms) ---
+    if let Some(cached) = state.module_tree_cache.get(&cache_key).await {
+        let resp = ModuleTreeResponse {
+            repo_id,
+            tree: ModuleNodeItem::from((*cached).clone()),
+        };
+        return Ok(Json(resp));
+    }
+
+    // --- Cache miss: fetch from DB and build tree (AC2 / AC4 cold ≤ 200 ms) ---
+    let tenant_ctx = TenantCtx::new(TenantId::from(tenant_id));
+    let node = rb_query::fetch_module_tree(&state.pool, &tenant_ctx, repo_id).await?;
+    let node = Arc::new(node);
+
+    state.module_tree_cache.insert(cache_key, Arc::clone(&node)).await;
+
+    let resp = ModuleTreeResponse {
+        repo_id,
+        tree: ModuleNodeItem::from((*node).clone()),
+    };
+    Ok(Json(resp))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, Scope, SessionInfo};
+
+    fn verified_session(tenant_id: Uuid) -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id,
+            email_verified: true,
+        }
+    }
+
+    #[test]
+    fn require_read_auth_accepts_verified_session() {
+        let tenant_id = Uuid::new_v4();
+        let auth = AuthContext::Session(verified_session(tenant_id));
+        let result = require_read_auth(auth);
+        assert_eq!(result.unwrap(), tenant_id);
+    }
+
+    #[test]
+    fn require_read_auth_accepts_api_key_read_scope() {
+        let tenant_id = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Read],
+        };
+        assert_eq!(require_read_auth(AuthContext::ApiKey(key)).unwrap(), tenant_id);
+    }
+
+    #[test]
+    fn require_read_auth_accepts_api_key_admin_scope() {
+        let tenant_id = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Admin],
+        };
+        assert_eq!(require_read_auth(AuthContext::ApiKey(key)).unwrap(), tenant_id);
+    }
+
+    #[test]
+    fn require_read_auth_rejects_anonymous() {
+        assert!(matches!(
+            require_read_auth(AuthContext::Anonymous),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn require_read_auth_rejects_expired_session() {
+        assert!(matches!(
+            require_read_auth(AuthContext::ExpiredSession),
+            Err(AppError::SessionExpired)
+        ));
+    }
+
+    #[test]
+    fn require_read_auth_rejects_unverified_email() {
+        let mut info = verified_session(Uuid::new_v4());
+        info.email_verified = false;
+        assert!(matches!(
+            require_read_auth(AuthContext::Session(info)),
+            Err(AppError::EmailNotVerified)
+        ));
+    }
+
+    #[test]
+    fn module_node_item_from_rb_query_node_converts_source() {
+        let node = rb_query::ModuleNode {
+            name: "push".to_owned(),
+            fqn: "alloc::vec::Vec::push".to_owned(),
+            kind: "FN".to_owned(),
+            source_path: Some("src/vec.rs".to_owned()),
+            line_start: Some(1234),
+            line_end: Some(1240),
+            children: vec![],
+        };
+        let item = ModuleNodeItem::from(node);
+        assert_eq!(item.name, "push");
+        assert_eq!(item.kind, "FN");
+        let src = item.source.unwrap();
+        assert_eq!(src.path, "src/vec.rs");
+        assert_eq!(src.line_start, Some(1234));
+        assert_eq!(src.line_end, Some(1240));
+        assert!(item.children.is_empty());
+    }
+
+    #[test]
+    fn module_node_item_from_mod_node_has_no_source() {
+        let node = rb_query::ModuleNode {
+            name: "vec".to_owned(),
+            fqn: "alloc::vec".to_owned(),
+            kind: "MOD".to_owned(),
+            source_path: None,
+            line_start: None,
+            line_end: None,
+            children: vec![],
+        };
+        let item = ModuleNodeItem::from(node);
+        assert!(item.source.is_none());
+    }
+
+    #[test]
+    fn module_tree_response_serializes_repo_id_and_tree() {
+        let repo_id = Uuid::new_v4();
+        let resp = ModuleTreeResponse {
+            repo_id,
+            tree: ModuleNodeItem {
+                name: "mycrate".to_owned(),
+                fqn: "mycrate".to_owned(),
+                kind: "MOD".to_owned(),
+                source: None,
+                children: vec![],
+            },
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val.get("repo_id").is_some());
+        assert_eq!(val["tree"]["name"], "mycrate");
+        assert_eq!(val["tree"]["kind"], "MOD");
+        assert!(val["tree"]["children"].is_array());
+        // `source` is absent (skip_serializing_if = None)
+        assert!(val["tree"].get("source").is_none());
+    }
+}

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -93,6 +93,7 @@ pub async fn run(config: Config) -> Result<()> {
         gh,
         sse_bus: Arc::clone(&sse_bus),
         ingest_producer,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     };
 
     // Spawn the Kafka → SSE fan-out consumer.  Errors here are logged but do

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -4,6 +4,7 @@ use rb_auth::{LoginRateLimiter, PasswordHasher};
 use rb_email::EmailSender;
 use rb_github::GhApp;
 use rb_kafka::Producer;
+use rb_query::ModuleTreeCache;
 use rb_schemas::IngestRequest;
 use rb_sse::EventBus;
 use sqlx::PgPool;
@@ -26,4 +27,7 @@ pub struct AppState {
     /// Kafka producer for `rb.ingest.clone.commands`. `None` when Kafka is not
     /// reachable; `POST /v1/repos/{id}/ingestions` returns 503 in that case.
     pub ingest_producer: Option<Arc<Producer<IngestRequest>>>,
+    /// 60-second in-process cache for `GET /v1/repos/{id}/modules` (ADR-008 §3.6 / AC3).
+    /// Keyed by `(repo_id, last_succeeded_ingest_run_id)`.
+    pub module_tree_cache: ModuleTreeCache,
 }

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -107,6 +107,7 @@ fn state_with_gh(secret: &[u8]) -> AppState {
         ))),
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     }
 }
 
@@ -121,6 +122,7 @@ fn state_without_gh() -> AppState {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     }
 }
 

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -75,6 +75,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -58,6 +58,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -71,6 +71,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -39,6 +39,7 @@ fn test_state() -> AppState {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     }
 }
 
@@ -330,6 +331,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh: None,
         sse_bus: Arc::new(EventBus::new(SseConfig::default())),
         ingest_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
     };
     Some((state, pool))
 }


### PR DESCRIPTION
## Summary

- Adds `rb-query` library crate with SQL + in-Rust tree builder for module hierarchy (REQ-DP-06 / ADR-008 §3.6)
- Adds `GET /v1/repos/{repo_id}/modules` handler wired into routing, OpenAPI, and error handling
- 60 s in-process moka cache keyed by `(repo_id, last_ingest_run_id)` (AC3)

## ACs (ADR-008 §12.6)

- AC1: Response schema matches §3.6
- AC2: One SQL, tree built in-Rust from FQN split on `::`
- AC3: 60 s moka cache; key = `(repo_id, last_ingest_run_id)`
- AC4: Cache hit = O(1) SQL; cold = single sequential query

## Test plan

- [x] cargo test -p rb-query -p control-api passes
- [x] clippy clean
- [x] openapi.json + schema.ts regenerated

Closes #200