### PR TITLE
[REQ-DP-04] feat: trait impls + type usages endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "rb-schemas",
  "rb-secrets",
  "rb-sse",
+ "rb-storage-neo4j",
  "rb-storage-pg",
  "rb-tenant",
  "rb-tracing",
@@ -3819,6 +3820,9 @@ name = "rb-query"
 version = "0.1.0"
 dependencies = [
  "moka",
+ "neo4rs",
+ "rb-schemas",
+ "rb-storage-neo4j",
  "rb-tenant",
  "serde",
  "sqlx",

--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -8,7 +8,10 @@ repository.workspace = true
 
 [dependencies]
 rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+rb-storage-neo4j = { path = "../rb-storage-neo4j", version = "0.1.0" }
 sqlx.workspace = true
+neo4rs.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/rb-query/src/error.rs
+++ b/crates/rb-query/src/error.rs
@@ -4,4 +4,6 @@
 pub enum QueryError {
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
+    #[error("graph error: {0}")]
+    Graph(#[from] rb_storage_neo4j::CypherError),
 }

--- a/crates/rb-query/src/graph/impls.rs
+++ b/crates/rb-query/src/graph/impls.rs
@@ -1,0 +1,83 @@
+//! Trait-impl graph queries (REQ-DP-04 / ADR-008 §3.4).
+//!
+//! Two relationship types target a trait node from the same `repo_id`:
+//!   - `IMPLS`            — direct concrete impls (`impl Display for Foo`)
+//!   - `BLANKET_IMPL_FOR` — blanket impls (`impl<T: Sized> Display for T`)
+
+use rb_schemas::TenantId;
+use rb_storage_neo4j::TenantGraph;
+use uuid::Uuid;
+
+use crate::QueryError;
+
+/// A single impl block that implements the queried trait.
+#[derive(Debug, Clone)]
+pub struct ImplEntry {
+    /// Fully-qualified name of the impl block.
+    pub fqn: String,
+    /// `"direct"` for `IMPLS` edges; `"blanket"` for `BLANKET_IMPL_FOR` edges.
+    pub impl_kind: String,
+}
+
+/// Fetch all impl blocks for trait `fqn` within `repo_id`.
+///
+/// Returns direct impls (`IMPLS` edge) and blanket impls (`BLANKET_IMPL_FOR`
+/// edge).  Both are represented as `Item` nodes in the graph.  Rows are
+/// de-duplicated by Neo4j's `UNION` (no blanket impl counts as direct or
+/// vice-versa for the same fqn).
+///
+/// Returns an empty `Vec` when the graph holds no impls for the given trait.
+///
+/// # Errors
+///
+/// Propagates [`QueryError::Graph`] on driver or injection failure.
+pub async fn fetch_trait_impls(
+    graph: &TenantGraph,
+    tenant_id: &TenantId,
+    repo_id: Uuid,
+    fqn: &str,
+) -> Result<Vec<ImplEntry>, QueryError> {
+    let repo_str = repo_id.to_string();
+
+    // UNION deduplicates; direct and blanket sets should never overlap for a
+    // single impl block, but the dedup is a safety net.
+    let cypher = "\
+        MATCH (impl:Item {repo_id: $repo_id})-[:IMPLS]->(t:Item {fqn: $fqn, repo_id: $repo_id}) \
+        RETURN impl.fqn AS fqn, 'direct' AS impl_kind \
+        UNION \
+        MATCH (impl:Item {repo_id: $repo_id})-[:BLANKET_IMPL_FOR]->(t:Item {fqn: $fqn, repo_id: $repo_id}) \
+        RETURN impl.fqn AS fqn, 'blanket' AS impl_kind";
+
+    let rows = graph
+        .execute_read(tenant_id, cypher, &[("fqn", fqn), ("repo_id", &repo_str)])
+        .await?;
+
+    let mut entries = Vec::with_capacity(rows.len());
+    for row in rows {
+        let Some(fqn_val) = row.get::<String>("fqn").ok() else {
+            continue;
+        };
+        let impl_kind = row.get::<String>("impl_kind").unwrap_or_else(|_| "direct".to_owned());
+        entries.push(ImplEntry { fqn: fqn_val, impl_kind });
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn impl_entry_fields_are_accessible() {
+        let entry = ImplEntry { fqn: "my_crate::Foo".to_owned(), impl_kind: "direct".to_owned() };
+        assert_eq!(entry.fqn, "my_crate::Foo");
+        assert_eq!(entry.impl_kind, "direct");
+    }
+
+    #[test]
+    fn impl_entry_blanket_kind() {
+        let entry =
+            ImplEntry { fqn: "my_crate::GenericFoo".to_owned(), impl_kind: "blanket".to_owned() };
+        assert_eq!(entry.impl_kind, "blanket");
+    }
+}

--- a/crates/rb-query/src/graph/mod.rs
+++ b/crates/rb-query/src/graph/mod.rs
@@ -1,0 +1,4 @@
+//! Neo4j graph read queries — tenant-isolated via [`TenantGraph::execute_read`].
+
+pub mod impls;
+pub mod usages;

--- a/crates/rb-query/src/graph/mod.rs
+++ b/crates/rb-query/src/graph/mod.rs
@@ -1,4 +1,4 @@
 //! Neo4j graph read queries — tenant-isolated via [`TenantGraph::execute_read`].
 
-pub mod impls;
-pub mod usages;
+pub(crate) mod impls;
+pub(crate) mod usages;

--- a/crates/rb-query/src/graph/usages.rs
+++ b/crates/rb-query/src/graph/usages.rs
@@ -1,0 +1,95 @@
+//! Type-usage graph queries (REQ-DP-04 / ADR-008 §3.4).
+//!
+//! Two sources of usage for a type `fqn`:
+//!   - Textual (`USES_TYPE` edge)     — items that directly reference the type
+//!     by name in their source (an `Item → Item` edge in the graph).
+//!   - Monomorphized (`MONOMORPHIZED_FROM` edge) — concrete `TypeInstance`
+//!     nodes that were instantiated from this `TypeDef`.
+
+use rb_schemas::TenantId;
+use rb_storage_neo4j::TenantGraph;
+use uuid::Uuid;
+
+use crate::QueryError;
+
+/// A single item that uses the queried type.
+#[derive(Debug, Clone)]
+pub struct UsageEntry {
+    /// Fully-qualified name of the using item or type instance.
+    pub fqn: String,
+    /// `"textual"` for `USES_TYPE` edges; `"monomorphized"` for
+    /// `MONOMORPHIZED_FROM` edges from a `TypeInstance` node.
+    pub usage_kind: String,
+}
+
+/// Fetch all usages of type `fqn` within `repo_id`.
+///
+/// Returns two disjoint sets:
+/// - **Textual** usages: `Item` nodes connected by `USES_TYPE` to the `Item`
+///   node for `fqn`.
+/// - **Monomorphized** usages: `TypeInstance` nodes connected by
+///   `MONOMORPHIZED_FROM` to the `TypeDef` node for `fqn`.
+///
+/// The two sets are combined with `UNION` so the caller receives a single
+/// flat list.  Duplicates across the two result sets are removed by Neo4j.
+///
+/// Returns an empty `Vec` when the graph holds no recorded usages.
+///
+/// # Errors
+///
+/// Propagates [`QueryError::Graph`] on driver or injection failure.
+pub async fn fetch_type_usages(
+    graph: &TenantGraph,
+    tenant_id: &TenantId,
+    repo_id: Uuid,
+    fqn: &str,
+) -> Result<Vec<UsageEntry>, QueryError> {
+    let repo_str = repo_id.to_string();
+
+    // UNION deduplicates rows that appear in both branches (defensive — in
+    // practice textual Item usages and TypeInstance monomorphizations are
+    // disjoint sets).
+    let cypher = "\
+        MATCH (user:Item {repo_id: $repo_id})-[:USES_TYPE]->(t:Item {fqn: $fqn, repo_id: $repo_id}) \
+        RETURN user.fqn AS fqn, 'textual' AS usage_kind \
+        UNION \
+        MATCH (inst:TypeInstance {repo_id: $repo_id})-[:MONOMORPHIZED_FROM]->(t:TypeDef {fqn: $fqn, repo_id: $repo_id}) \
+        RETURN inst.fqn AS fqn, 'monomorphized' AS usage_kind";
+
+    let rows = graph
+        .execute_read(tenant_id, cypher, &[("fqn", fqn), ("repo_id", &repo_str)])
+        .await?;
+
+    let mut entries = Vec::with_capacity(rows.len());
+    for row in rows {
+        let Some(fqn_val) = row.get::<String>("fqn").ok() else {
+            continue;
+        };
+        let usage_kind =
+            row.get::<String>("usage_kind").unwrap_or_else(|_| "textual".to_owned());
+        entries.push(UsageEntry { fqn: fqn_val, usage_kind });
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_entry_textual_kind() {
+        let entry =
+            UsageEntry { fqn: "my_crate::uses_foo".to_owned(), usage_kind: "textual".to_owned() };
+        assert_eq!(entry.fqn, "my_crate::uses_foo");
+        assert_eq!(entry.usage_kind, "textual");
+    }
+
+    #[test]
+    fn usage_entry_monomorphized_kind() {
+        let entry = UsageEntry {
+            fqn: "my_crate::Foo<i32>".to_owned(),
+            usage_kind: "monomorphized".to_owned(),
+        };
+        assert_eq!(entry.usage_kind, "monomorphized");
+    }
+}

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -7,9 +7,11 @@
 //! [`rb_storage_neo4j::TenantGraph`] for tenant isolation (ADR-007 §3.4).
 
 mod error;
-pub mod graph;
+mod graph;
 mod pg;
 
 pub use error::QueryError;
+pub use graph::impls::{ImplEntry, fetch_trait_impls};
+pub use graph::usages::{UsageEntry, fetch_type_usages};
 pub use pg::items;
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -2,8 +2,12 @@
 //!
 //! Provides SQL helpers that operate against per-tenant schemas via
 //! fully-qualified table names (`TenantCtx::qualify`). Never mutates data.
+//!
+//! The `graph` module provides Neo4j read queries routed through
+//! [`rb_storage_neo4j::TenantGraph`] for tenant isolation (ADR-007 §3.4).
 
 mod error;
+pub mod graph;
 mod pg;
 
 pub use error::QueryError;

--- a/crates/rb-storage-neo4j/src/graph.rs
+++ b/crates/rb-storage-neo4j/src/graph.rs
@@ -113,6 +113,37 @@ impl TenantGraph {
         self.run(tenant_id, "MATCH (n) DETACH DELETE n", &[]).await
     }
 
+    /// Execute a read Cypher query with string parameters, injecting the tenant label.
+    ///
+    /// Returns all matching rows collected in memory.  Use this for all read
+    /// queries so that tenant-label isolation (ADR-007 §3.4) is enforced on the
+    /// read path too — callers must not hold a raw `neo4rs::Graph` reference.
+    ///
+    /// # Errors
+    ///
+    /// - [`CypherError::MultiStatement`] — semicolon found outside a string/comment.
+    /// - [`CypherError::UnclosedNodePattern`] — unbalanced `(` in a path clause.
+    /// - [`CypherError::Neo4j`] — driver or network failure.
+    pub async fn execute_read(
+        &self,
+        tenant_id: &TenantId,
+        cypher: &str,
+        params: &[(&str, &str)],
+    ) -> Result<Vec<neo4rs::Row>, CypherError> {
+        let label = tenant_label(tenant_id);
+        let injected = inject_tenant_label(cypher, &label)?;
+        let mut q = neo4rs::query(&injected);
+        for (k, v) in params {
+            q = q.param(k, *v);
+        }
+        let mut stream = self.inner.execute(q).await?;
+        let mut rows = Vec::new();
+        while let Some(row) = stream.next().await? {
+            rows.push(row);
+        }
+        Ok(rows)
+    }
+
     /// Count `TypeInstance` nodes scoped to `tenant_id`.
     ///
     /// Used by projector-neo4j to enforce the `RB_MONOMORPH_NODE_CAP` per ADR-007 §13.7.

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -507,6 +507,57 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/repos/{repo_id}/items/{fqn_b64}/impls": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * List all impl blocks for the trait identified by `fqn_b64` within a repository.
+         * @description Returns both direct impls (`impl Trait for Type`) and blanket impls
+         *     (`impl<T: Bound> Trait for T`) found in the graph.
+         *
+         *     `fqn_b64` must be URL-safe base64 (no padding) of the trait's FQN.
+         *     Requires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.
+         */
+        readonly get: operations["get_trait_impls"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/repos/{repo_id}/items/{fqn_b64}/usages": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * List all usages of the type identified by `fqn_b64` within a repository.
+         * @description Returns two categories of usage combined in a flat list:
+         *     - **Textual** (`usage_kind = "textual"`)  — items that reference the type
+         *       by name (`USES_TYPE` edge).
+         *     - **Monomorphized** (`usage_kind = "monomorphized"`) — `TypeInstance` nodes
+         *       derived from this type via a `MONOMORPHIZED_FROM` edge.
+         *
+         *     `fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.
+         *     Requires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.
+         */
+        readonly get: operations["get_type_usages"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/repos/{repo_id}/modules": {
         readonly parameters: {
             readonly query?: never;
@@ -762,6 +813,25 @@ export interface components {
             readonly app_id: number;
             readonly owner: string;
             readonly slug: string;
+        };
+        /** @description One impl block that implements the queried trait. */
+        readonly ImplEntry: {
+            /** @description Fully-qualified name of the impl block. */
+            readonly fqn: string;
+            /** @description `"direct"` for concrete impls; `"blanket"` for blanket impls. */
+            readonly impl_kind: string;
+        };
+        /** @description Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/impls`. */
+        readonly ImplsResponse: {
+            /** @description Impl blocks found in the graph. */
+            readonly impls: readonly components["schemas"]["ImplEntry"][];
+            /**
+             * Format: uuid
+             * @description Repository UUID.
+             */
+            readonly repo_id: string;
+            /** @description FQN of the queried trait. */
+            readonly trait_fqn: string;
         };
         readonly InstallUrlResponse: {
             /** @description The raw opaque state token embedded in the URL. */
@@ -1036,6 +1106,28 @@ export interface components {
             readonly role: string;
             /** Format: uuid */
             readonly user_id: string;
+        };
+        /** @description One item that references the queried type. */
+        readonly UsageEntry: {
+            /** @description Fully-qualified name of the using item or type instance. */
+            readonly fqn: string;
+            /**
+             * @description `"textual"` — item uses the type by name in its source.
+             *     `"monomorphized"` — `TypeInstance` instantiated from this type's `TypeDef`.
+             */
+            readonly usage_kind: string;
+        };
+        /** @description Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/usages`. */
+        readonly UsagesResponse: {
+            /**
+             * Format: uuid
+             * @description Repository UUID.
+             */
+            readonly repo_id: string;
+            /** @description FQN of the queried type. */
+            readonly type_fqn: string;
+            /** @description All usages found in the graph, combining textual and monomorphized. */
+            readonly usages: readonly components["schemas"]["UsageEntry"][];
         };
         /** @description Public profile of the authenticated user. */
         readonly UserInfo: {
@@ -2027,6 +2119,126 @@ export interface operations {
             };
             /** @description Repository or item not found (not_found) */
             readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_trait_impls: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Repository UUID */
+                readonly repo_id: string;
+                /** @description URL-safe base64 (no padding) encoded trait FQN */
+                readonly fqn_b64: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Impl list */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ImplsResponse"];
+                };
+            };
+            /** @description Malformed fqn_b64 */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified or insufficient scope */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Repository not found or belongs to another tenant */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Neo4j graph not configured on this instance */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_type_usages: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Repository UUID */
+                readonly repo_id: string;
+                /** @description URL-safe base64 (no padding) encoded type FQN */
+                readonly fqn_b64: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Usage list */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["UsagesResponse"];
+                };
+            };
+            /** @description Malformed fqn_b64 */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified or insufficient scope */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Repository not found or belongs to another tenant */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Neo4j graph not configured on this instance */
+            readonly 503: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -993,6 +993,122 @@
         }
       }
     },
+    "/v1/repos/{repo_id}/items/{fqn_b64}/impls": {
+      "get": {
+        "tags": [
+          "query"
+        ],
+        "summary": "List all impl blocks for the trait identified by `fqn_b64` within a repository.",
+        "description": "Returns both direct impls (`impl Trait for Type`) and blanket impls\n(`impl<T: Bound> Trait for T`) found in the graph.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the trait's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
+        "operationId": "get_trait_impls",
+        "parameters": [
+          {
+            "name": "repo_id",
+            "in": "path",
+            "description": "Repository UUID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fqn_b64",
+            "in": "path",
+            "description": "URL-safe base64 (no padding) encoded trait FQN",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Impl list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImplsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed fqn_b64"
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified or insufficient scope"
+          },
+          "404": {
+            "description": "Repository not found or belongs to another tenant"
+          },
+          "503": {
+            "description": "Neo4j graph not configured on this instance"
+          }
+        }
+      }
+    },
+    "/v1/repos/{repo_id}/items/{fqn_b64}/usages": {
+      "get": {
+        "tags": [
+          "query"
+        ],
+        "summary": "List all usages of the type identified by `fqn_b64` within a repository.",
+        "description": "Returns two categories of usage combined in a flat list:\n- **Textual** (`usage_kind = \"textual\"`)  — items that reference the type\n  by name (`USES_TYPE` edge).\n- **Monomorphized** (`usage_kind = \"monomorphized\"`) — `TypeInstance` nodes\n  derived from this type via a `MONOMORPHIZED_FROM` edge.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
+        "operationId": "get_type_usages",
+        "parameters": [
+          {
+            "name": "repo_id",
+            "in": "path",
+            "description": "Repository UUID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fqn_b64",
+            "in": "path",
+            "description": "URL-safe base64 (no padding) encoded type FQN",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsagesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed fqn_b64"
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Email not verified or insufficient scope"
+          },
+          "404": {
+            "description": "Repository not found or belongs to another tenant"
+          },
+          "503": {
+            "description": "Neo4j graph not configured on this instance"
+          }
+        }
+      }
+    },
     "/v1/repos/{repo_id}/modules": {
       "get": {
         "tags": [
@@ -1678,6 +1794,51 @@
           },
           "slug": {
             "type": "string"
+          }
+        }
+      },
+      "ImplEntry": {
+        "type": "object",
+        "description": "One impl block that implements the queried trait.",
+        "required": [
+          "fqn",
+          "impl_kind"
+        ],
+        "properties": {
+          "fqn": {
+            "type": "string",
+            "description": "Fully-qualified name of the impl block."
+          },
+          "impl_kind": {
+            "type": "string",
+            "description": "`\"direct\"` for concrete impls; `\"blanket\"` for blanket impls."
+          }
+        }
+      },
+      "ImplsResponse": {
+        "type": "object",
+        "description": "Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/impls`.",
+        "required": [
+          "repo_id",
+          "trait_fqn",
+          "impls"
+        ],
+        "properties": {
+          "impls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImplEntry"
+            },
+            "description": "Impl blocks found in the graph."
+          },
+          "repo_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Repository UUID."
+          },
+          "trait_fqn": {
+            "type": "string",
+            "description": "FQN of the queried trait."
           }
         }
       },
@@ -2451,6 +2612,51 @@
           "user_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "UsageEntry": {
+        "type": "object",
+        "description": "One item that references the queried type.",
+        "required": [
+          "fqn",
+          "usage_kind"
+        ],
+        "properties": {
+          "fqn": {
+            "type": "string",
+            "description": "Fully-qualified name of the using item or type instance."
+          },
+          "usage_kind": {
+            "type": "string",
+            "description": "`\"textual\"` — item uses the type by name in its source.\n`\"monomorphized\"` — `TypeInstance` instantiated from this type's `TypeDef`."
+          }
+        }
+      },
+      "UsagesResponse": {
+        "type": "object",
+        "description": "Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/usages`.",
+        "required": [
+          "repo_id",
+          "type_fqn",
+          "usages"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Repository UUID."
+          },
+          "type_fqn": {
+            "type": "string",
+            "description": "FQN of the queried type."
+          },
+          "usages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UsageEntry"
+            },
+            "description": "All usages found in the graph, combining textual and monomorphized."
           }
         }
       },

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -32,6 +32,7 @@ rb-tenant = { path = "../../crates/rb-tenant", version = "0.1.0" }
 rb-schemas = { path = "../../crates/rb-schemas", version = "0.1.0" }
 rb-storage-pg = { path = "../../crates/rb-storage-pg", version = "0.1.0" }
 rb-query = { path = "../../crates/rb-query", version = "0.1.0" }
+rb-storage-neo4j = { path = "../../crates/rb-storage-neo4j", version = "0.1.0" }
 rb-tracing = { path = "../../crates/rb-tracing", version = "0.1.0" }
 opentelemetry.workspace = true
 tokio.workspace = true

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -30,6 +30,15 @@ pub struct Config {
     /// signature verification.
     pub gh_app_webhook_secret: Option<String>,
 
+    // --- Neo4j (REQ-DP-04) ---
+    /// `RB_NEO4J_URI` — bolt URI for the Neo4j instance (e.g. `bolt://neo4j:7687`).
+    /// Optional; graph endpoints return 503 when absent.
+    pub neo4j_uri: Option<String>,
+    /// `RB_NEO4J_USER` — Neo4j username.  Defaults to `"neo4j"` when URI is set.
+    pub neo4j_user: String,
+    /// `RB_NEO4J_PASSWORD` — Neo4j password.
+    pub neo4j_password: Option<String>,
+
     // --- Kafka / SSE (REQ-DP-08) ---
     /// `KAFKA_BOOTSTRAP_SERVERS` — broker list for the ingest consumer.
     /// Defaults to `kafka:9092` (dev compose alias).
@@ -98,6 +107,9 @@ impl Config {
             gh_app_webhook_secret: env::var("RB_GH_APP_WEBHOOK_SECRET")
                 .ok()
                 .filter(|s| !s.is_empty()),
+            neo4j_uri: env::var("RB_NEO4J_URI").ok().filter(|s| !s.is_empty()),
+            neo4j_user: env::var("RB_NEO4J_USER").unwrap_or_else(|_| "neo4j".to_owned()),
+            neo4j_password: env::var("RB_NEO4J_PASSWORD").ok().filter(|s| !s.is_empty()),
             kafka_bootstrap_servers: env::var("KAFKA_BOOTSTRAP_SERVERS")
                 .unwrap_or_else(|_| "kafka:9092".to_owned()),
             dev_test_routes: env::var("RB_DEV_TEST_ROUTES")
@@ -127,6 +139,9 @@ impl Config {
             gh_app_id: None,
             gh_app_private_key_b64: None,
             gh_app_webhook_secret: None,
+            neo4j_uri: None,
+            neo4j_user: "neo4j".to_owned(),
+            neo4j_password: None,
             kafka_bootstrap_servers: "localhost:9092".to_owned(),
             dev_test_routes: false,
             migrations_root: None,

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -56,6 +56,8 @@ pub enum AppError {
     IngestRunAlreadyInFlight,
     #[error("X-Confirm header must match the tenant slug exactly")]
     ConfirmationMismatch,
+    #[error("Neo4j graph is not configured on this instance")]
+    GraphUnavailable,
     #[error("Kafka producer is not configured on this instance")]
     KafkaNotConfigured,
     #[error("Kafka brokers are not reachable")]
@@ -135,6 +137,11 @@ impl IntoResponse for AppError {
             AppError::ConfirmationMismatch => (
                 StatusCode::BAD_REQUEST,
                 "confirmation_mismatch",
+                self.to_string(),
+            ),
+            AppError::GraphUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "graph_unavailable",
                 self.to_string(),
             ),
             AppError::KafkaNotConfigured => (

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -42,6 +42,8 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
         ingest::trigger::trigger_ingestion,
         query::items::get_item,
         query::modules::get_module_tree,
+        query::impls::get_trait_impls,
+        query::usages::get_type_usages,
     ),
     components(
         schemas(
@@ -92,6 +94,10 @@ use crate::routes::{api_keys, audit, auth, auth_logout, auth_verify, github, hea
             query::modules::NodeSource,
             query::modules::ModuleNodeItem,
             query::modules::ModuleTreeResponse,
+            query::impls::ImplEntry,
+            query::impls::ImplsResponse,
+            query::usages::UsageEntry,
+            query::usages::UsagesResponse,
         )
     ),
     info(

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -30,8 +30,10 @@ use crate::routes::{
     ingest::test_publish::test_publish,
     ingest::trigger::trigger_ingestion,
     me::{get_me, switch_tenant},
+    query::impls::get_trait_impls,
     query::items::get_item,
     query::modules::get_module_tree,
+    query::usages::get_type_usages,
     repos::{connect_repo, list_repos, trigger_ingest},
     tenants::{delete_tenant, invite_member, list_members, remove_member, transfer_ownership, update_member_role},
 };
@@ -68,6 +70,8 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/repos/{id}/ingest", post(trigger_ingest))
         .route("/v1/repos/{repo_id}/ingestions", post(trigger_ingestion))
         .route("/v1/repos/{repo_id}/items/{fqn_b64}", get(get_item))
+        .route("/v1/repos/{repo_id}/items/{fqn_b64}/impls", get(get_trait_impls))
+        .route("/v1/repos/{repo_id}/items/{fqn_b64}/usages", get(get_type_usages))
         .route("/v1/ingestions/recent", get(list_recent_runs))
         .route("/v1/ingestions/{ingestion_run_id}/stages", get(get_stage_timeline))
         .route("/v1/ingest/events", get(events_stream))

--- a/services/control-api/src/routes/query/impls.rs
+++ b/services/control-api/src/routes/query/impls.rs
@@ -1,0 +1,214 @@
+//! `GET /v1/repos/{repo_id}/items/{fqn_b64}/impls` — trait impl lookup (REQ-DP-04 / ADR-008 §3.4).
+//!
+//! Returns direct and blanket impl blocks for the given trait FQN within a
+//! repository.  Queries are tenant-isolated via `TenantGraph::execute_read`.
+
+use axum::{Json, extract::State, response::IntoResponse};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rb_query::graph::impls::fetch_trait_impls;
+use rb_schemas::TenantId;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_read_auth},
+    state::AppState,
+};
+
+// ---------------------------------------------------------------------------
+// Response schema
+// ---------------------------------------------------------------------------
+
+/// One impl block that implements the queried trait.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImplEntry {
+    /// Fully-qualified name of the impl block.
+    pub fqn: String,
+    /// `"direct"` for concrete impls; `"blanket"` for blanket impls.
+    pub impl_kind: String,
+}
+
+/// Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/impls`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImplsResponse {
+    /// Repository UUID.
+    pub repo_id: Uuid,
+    /// FQN of the queried trait.
+    pub trait_fqn: String,
+    /// Impl blocks found in the graph.
+    pub impls: Vec<ImplEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// List all impl blocks for the trait identified by `fqn_b64` within a repository.
+///
+/// Returns both direct impls (`impl Trait for Type`) and blanket impls
+/// (`impl<T: Bound> Trait for T`) found in the graph.
+///
+/// `fqn_b64` must be URL-safe base64 (no padding) of the trait's FQN.
+/// Requires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.
+#[utoipa::path(
+    get,
+    path = "/v1/repos/{repo_id}/items/{fqn_b64}/impls",
+    params(
+        ("repo_id" = Uuid, Path, description = "Repository UUID"),
+        ("fqn_b64" = String, Path, description = "URL-safe base64 (no padding) encoded trait FQN"),
+    ),
+    responses(
+        (status = 200, description = "Impl list", body = ImplsResponse),
+        (status = 400, description = "Malformed fqn_b64"),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified or insufficient scope"),
+        (status = 404, description = "Repository not found or belongs to another tenant"),
+        (status = 503, description = "Neo4j graph not configured on this instance"),
+    ),
+    tag = "query"
+)]
+pub async fn get_trait_impls(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    axum::extract::Path((repo_id, fqn_b64)): axum::extract::Path<(Uuid, String)>,
+) -> Result<impl IntoResponse, AppError> {
+    let tenant_id = require_read_auth(auth)?;
+
+    let graph = state.graph.as_deref().ok_or(AppError::GraphUnavailable)?;
+
+    let fqn_bytes =
+        URL_SAFE_NO_PAD.decode(fqn_b64.as_bytes()).map_err(|_| AppError::InvalidInput)?;
+    let fqn = String::from_utf8(fqn_bytes).map_err(|_| AppError::InvalidInput)?;
+
+    // Verify the repo belongs to this tenant.
+    let owned: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM control.repos \
+         WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+    owned.ok_or(AppError::NotFound)?;
+
+    let tid = TenantId::from(tenant_id);
+    let entries = fetch_trait_impls(graph, &tid, repo_id, &fqn).await?;
+
+    tracing::debug!(
+        %repo_id,
+        fqn = %fqn,
+        count = entries.len(),
+        tenant_id = %tenant_id,
+        "trait impls lookup"
+    );
+
+    Ok(Json(ImplsResponse {
+        repo_id,
+        trait_fqn: fqn,
+        impls: entries
+            .into_iter()
+            .map(|e| ImplEntry { fqn: e.fqn, impl_kind: e.impl_kind })
+            .collect(),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, Scope, SessionInfo};
+
+    fn verified_session(tenant_id: Uuid) -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id,
+            email_verified: true,
+        }
+    }
+
+    #[test]
+    fn require_read_auth_accepts_verified_session() {
+        let tid = Uuid::new_v4();
+        let result = require_read_auth(AuthContext::Session(verified_session(tid)));
+        assert_eq!(result.unwrap(), tid);
+    }
+
+    #[test]
+    fn require_read_auth_accepts_api_key_read_scope() {
+        let tid = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: tid,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Read],
+        };
+        assert_eq!(require_read_auth(AuthContext::ApiKey(key)).unwrap(), tid);
+    }
+
+    #[test]
+    fn require_read_auth_rejects_anonymous() {
+        assert!(matches!(
+            require_read_auth(AuthContext::Anonymous),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn valid_fqn_b64_roundtrips() {
+        let fqn = "my_crate::module::MyTrait";
+        let encoded = URL_SAFE_NO_PAD.encode(fqn.as_bytes());
+        let decoded = URL_SAFE_NO_PAD.decode(encoded.as_bytes()).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), fqn);
+    }
+
+    #[test]
+    fn invalid_base64_maps_to_invalid_input() {
+        let err = URL_SAFE_NO_PAD.decode(b"not-valid!@#").map_err(|_| AppError::InvalidInput);
+        assert!(matches!(err, Err(AppError::InvalidInput)));
+    }
+
+    #[test]
+    fn impls_response_serializes_correctly() {
+        let resp = ImplsResponse {
+            repo_id: Uuid::new_v4(),
+            trait_fqn: "my_crate::MyTrait".to_owned(),
+            impls: vec![
+                ImplEntry { fqn: "my_crate::Foo".to_owned(), impl_kind: "direct".to_owned() },
+                ImplEntry {
+                    fqn: "my_crate::GenericFoo".to_owned(),
+                    impl_kind: "blanket".to_owned(),
+                },
+            ],
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert_eq!(val["trait_fqn"], "my_crate::MyTrait");
+        let impls = val["impls"].as_array().unwrap();
+        assert_eq!(impls.len(), 2);
+        assert_eq!(impls[0]["impl_kind"], "direct");
+        assert_eq!(impls[1]["impl_kind"], "blanket");
+    }
+
+    #[test]
+    fn empty_impls_response_serializes_correctly() {
+        let resp = ImplsResponse {
+            repo_id: Uuid::new_v4(),
+            trait_fqn: "my_crate::UnimplementedTrait".to_owned(),
+            impls: vec![],
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["impls"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn graph_unavailable_returns_503() {
+        let err = AppError::GraphUnavailable;
+        let resp = err.into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/services/control-api/src/routes/query/impls.rs
+++ b/services/control-api/src/routes/query/impls.rs
@@ -5,7 +5,7 @@
 
 use axum::{Json, extract::State, response::IntoResponse};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use rb_query::graph::impls::fetch_trait_impls;
+use rb_query::fetch_trait_impls;
 use rb_schemas::TenantId;
 use serde::Serialize;
 use utoipa::ToSchema;

--- a/services/control-api/src/routes/query/mod.rs
+++ b/services/control-api/src/routes/query/mod.rs
@@ -1,4 +1,6 @@
 //! Query endpoints — read-only access to the code graph.
 
+pub mod impls;
 pub mod items;
 pub mod modules;
+pub mod usages;

--- a/services/control-api/src/routes/query/usages.rs
+++ b/services/control-api/src/routes/query/usages.rs
@@ -1,0 +1,216 @@
+//! `GET /v1/repos/{repo_id}/items/{fqn_b64}/usages` — type usage lookup (REQ-DP-04 / ADR-008 §3.4).
+//!
+//! Returns both textual usages (`USES_TYPE` edges) and monomorphized instances
+//! (`MONOMORPHIZED_FROM` edges from `TypeInstance` nodes).  The response
+//! distinguishes the two by the `usage_kind` field.
+
+use axum::{Json, extract::State, response::IntoResponse};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rb_query::graph::usages::fetch_type_usages;
+use rb_schemas::TenantId;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_read_auth},
+    state::AppState,
+};
+
+// ---------------------------------------------------------------------------
+// Response schema
+// ---------------------------------------------------------------------------
+
+/// One item that references the queried type.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct UsageEntry {
+    /// Fully-qualified name of the using item or type instance.
+    pub fqn: String,
+    /// `"textual"` — item uses the type by name in its source.
+    /// `"monomorphized"` — `TypeInstance` instantiated from this type's `TypeDef`.
+    pub usage_kind: String,
+}
+
+/// Response for `GET /v1/repos/{repo_id}/items/{fqn_b64}/usages`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct UsagesResponse {
+    /// Repository UUID.
+    pub repo_id: Uuid,
+    /// FQN of the queried type.
+    pub type_fqn: String,
+    /// All usages found in the graph, combining textual and monomorphized.
+    pub usages: Vec<UsageEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// List all usages of the type identified by `fqn_b64` within a repository.
+///
+/// Returns two categories of usage combined in a flat list:
+/// - **Textual** (`usage_kind = "textual"`)  — items that reference the type
+///   by name (`USES_TYPE` edge).
+/// - **Monomorphized** (`usage_kind = "monomorphized"`) — `TypeInstance` nodes
+///   derived from this type via a `MONOMORPHIZED_FROM` edge.
+///
+/// `fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.
+/// Requires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.
+#[utoipa::path(
+    get,
+    path = "/v1/repos/{repo_id}/items/{fqn_b64}/usages",
+    params(
+        ("repo_id" = Uuid, Path, description = "Repository UUID"),
+        ("fqn_b64" = String, Path, description = "URL-safe base64 (no padding) encoded type FQN"),
+    ),
+    responses(
+        (status = 200, description = "Usage list", body = UsagesResponse),
+        (status = 400, description = "Malformed fqn_b64"),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Email not verified or insufficient scope"),
+        (status = 404, description = "Repository not found or belongs to another tenant"),
+        (status = 503, description = "Neo4j graph not configured on this instance"),
+    ),
+    tag = "query"
+)]
+pub async fn get_type_usages(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    axum::extract::Path((repo_id, fqn_b64)): axum::extract::Path<(Uuid, String)>,
+) -> Result<impl IntoResponse, AppError> {
+    let tenant_id = require_read_auth(auth)?;
+
+    let graph = state.graph.as_deref().ok_or(AppError::GraphUnavailable)?;
+
+    let fqn_bytes =
+        URL_SAFE_NO_PAD.decode(fqn_b64.as_bytes()).map_err(|_| AppError::InvalidInput)?;
+    let fqn = String::from_utf8(fqn_bytes).map_err(|_| AppError::InvalidInput)?;
+
+    // Verify the repo belongs to this tenant.
+    let owned: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM control.repos \
+         WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+    owned.ok_or(AppError::NotFound)?;
+
+    let tid = TenantId::from(tenant_id);
+    let entries = fetch_type_usages(graph, &tid, repo_id, &fqn).await?;
+
+    tracing::debug!(
+        %repo_id,
+        fqn = %fqn,
+        count = entries.len(),
+        tenant_id = %tenant_id,
+        "type usages lookup"
+    );
+
+    Ok(Json(UsagesResponse {
+        repo_id,
+        type_fqn: fqn,
+        usages: entries
+            .into_iter()
+            .map(|e| UsageEntry { fqn: e.fqn, usage_kind: e.usage_kind })
+            .collect(),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, Scope, SessionInfo};
+
+    fn verified_session(tenant_id: Uuid) -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id,
+            email_verified: true,
+        }
+    }
+
+    #[test]
+    fn require_read_auth_accepts_verified_session() {
+        let tid = Uuid::new_v4();
+        let result = require_read_auth(AuthContext::Session(verified_session(tid)));
+        assert_eq!(result.unwrap(), tid);
+    }
+
+    #[test]
+    fn require_read_auth_accepts_api_key_any_scope() {
+        let tid = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: tid,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Admin],
+        };
+        assert_eq!(require_read_auth(AuthContext::ApiKey(key)).unwrap(), tid);
+    }
+
+    #[test]
+    fn require_read_auth_rejects_expired_session() {
+        assert!(matches!(
+            require_read_auth(AuthContext::ExpiredSession),
+            Err(AppError::SessionExpired)
+        ));
+    }
+
+    #[test]
+    fn valid_fqn_b64_roundtrips() {
+        let fqn = "std::vec::Vec";
+        let encoded = URL_SAFE_NO_PAD.encode(fqn.as_bytes());
+        let decoded = URL_SAFE_NO_PAD.decode(encoded.as_bytes()).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), fqn);
+    }
+
+    #[test]
+    fn usages_response_serializes_correctly() {
+        let resp = UsagesResponse {
+            repo_id: Uuid::new_v4(),
+            type_fqn: "my_crate::MyType".to_owned(),
+            usages: vec![
+                UsageEntry {
+                    fqn: "my_crate::uses_it".to_owned(),
+                    usage_kind: "textual".to_owned(),
+                },
+                UsageEntry {
+                    fqn: "my_crate::MyType<i32>".to_owned(),
+                    usage_kind: "monomorphized".to_owned(),
+                },
+            ],
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert_eq!(val["type_fqn"], "my_crate::MyType");
+        let usages = val["usages"].as_array().unwrap();
+        assert_eq!(usages.len(), 2);
+        assert_eq!(usages[0]["usage_kind"], "textual");
+        assert_eq!(usages[1]["usage_kind"], "monomorphized");
+    }
+
+    #[test]
+    fn empty_usages_serializes_correctly() {
+        let resp = UsagesResponse {
+            repo_id: Uuid::new_v4(),
+            type_fqn: "my_crate::Unused".to_owned(),
+            usages: vec![],
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["usages"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn graph_unavailable_returns_503() {
+        let err = AppError::GraphUnavailable;
+        let resp = err.into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/services/control-api/src/routes/query/usages.rs
+++ b/services/control-api/src/routes/query/usages.rs
@@ -6,7 +6,7 @@
 
 use axum::{Json, extract::State, response::IntoResponse};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use rb_query::graph::usages::fetch_type_usages;
+use rb_query::fetch_type_usages;
 use rb_schemas::TenantId;
 use serde::Serialize;
 use utoipa::ToSchema;

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -9,6 +9,7 @@ use rb_email::{SmtpConfig, from_transport};
 use rb_github::{GhApp, Secret};
 use rb_kafka::{ConsumerCfg, Producer, ProducerCfg};
 use rb_sse::{EventBus, SseConfig};
+use rb_storage_neo4j::TenantGraph;
 use sqlx::postgres::PgPoolOptions;
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -95,6 +96,25 @@ pub async fn run(config: Config) -> Result<()> {
         }
     };
 
+    // Connect to Neo4j.  Failure is non-fatal — graph endpoints degrade to 503.
+    let graph = if let (Some(uri), Some(password)) =
+        (config.neo4j_uri.as_deref(), config.neo4j_password.as_deref())
+    {
+        match TenantGraph::connect(uri, &config.neo4j_user, password).await {
+            Ok(g) => {
+                tracing::info!("neo4j connected at {uri}");
+                Some(Arc::new(g))
+            }
+            Err(e) => {
+                tracing::warn!("neo4j connection failed (graph endpoints disabled): {e}");
+                None
+            }
+        }
+    } else {
+        tracing::info!("RB_NEO4J_URI / RB_NEO4J_PASSWORD not set — graph endpoints disabled");
+        None
+    };
+
     let state = AppState {
         pool,
         email_sender: Arc::from(email_sender),
@@ -106,6 +126,7 @@ pub async fn run(config: Config) -> Result<()> {
         ingest_producer,
         tombstone_producer,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph,
     };
 
     // Spawn the Kafka → SSE fan-out consumer.  Errors here are logged but do

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -73,8 +73,8 @@ pub async fn run(config: Config) -> Result<()> {
         bootstrap_servers: config.kafka_bootstrap_servers.clone(),
         ..ProducerCfg::default()
     };
-    let ingest_producer = build_producer(&producer_cfg, "ingest_producer");
-    let tombstone_producer = build_producer(&producer_cfg, "tombstone_producer");
+    let ingest_producer = build_producer(Producer::new(&producer_cfg), "ingest_producer");
+    let tombstone_producer = build_producer(Producer::new(&producer_cfg), "tombstone_producer");
 
     // Connect to Neo4j.  Failure is non-fatal — graph endpoints degrade to 503.
     let graph = if let (Some(uri), Some(password)) =
@@ -140,8 +140,11 @@ pub async fn run(config: Config) -> Result<()> {
     Ok(())
 }
 
-fn build_producer(cfg: &ProducerCfg, name: &str) -> Option<Arc<Producer>> {
-    match Producer::new(cfg) {
+fn build_producer<P, Err: std::fmt::Display>(
+    result: Result<P, Err>,
+    name: &str,
+) -> Option<Arc<P>> {
+    match result {
         Ok(p) => {
             tracing::info!("{name} connected to Kafka");
             Some(Arc::new(p))

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -68,33 +68,13 @@ pub async fn run(config: Config) -> Result<()> {
 
     let sse_bus = Arc::new(EventBus::new(SseConfig::default()));
 
-    // Build the Kafka ingestion producer.  Failure is non-fatal — the route
-    // returns 503 when the producer is absent (graceful degradation).
+    // Build the Kafka producers.  Failure is non-fatal — routes degrade to 503.
     let producer_cfg = ProducerCfg {
         bootstrap_servers: config.kafka_bootstrap_servers.clone(),
         ..ProducerCfg::default()
     };
-    let ingest_producer = match Producer::new(&producer_cfg) {
-        Ok(p) => {
-            tracing::info!("ingest_producer connected to Kafka");
-            Some(Arc::new(p))
-        }
-        Err(e) => {
-            tracing::warn!("ingest_producer failed to connect (Kafka unavailable?): {e}");
-            None
-        }
-    };
-
-    let tombstone_producer = match Producer::new(&producer_cfg) {
-        Ok(p) => {
-            tracing::info!("tombstone_producer connected to Kafka");
-            Some(Arc::new(p))
-        }
-        Err(e) => {
-            tracing::warn!("tombstone_producer failed to connect (Kafka unavailable?): {e}");
-            None
-        }
-    };
+    let ingest_producer = build_producer(&producer_cfg, "ingest_producer");
+    let tombstone_producer = build_producer(&producer_cfg, "tombstone_producer");
 
     // Connect to Neo4j.  Failure is non-fatal — graph endpoints degrade to 503.
     let graph = if let (Some(uri), Some(password)) =
@@ -158,6 +138,19 @@ pub async fn run(config: Config) -> Result<()> {
         .await?;
 
     Ok(())
+}
+
+fn build_producer(cfg: &ProducerCfg, name: &str) -> Option<Arc<Producer>> {
+    match Producer::new(cfg) {
+        Ok(p) => {
+            tracing::info!("{name} connected to Kafka");
+            Some(Arc::new(p))
+        }
+        Err(e) => {
+            tracing::warn!("{name} failed to connect (Kafka unavailable?): {e}");
+            None
+        }
+    }
 }
 
 /// Constructs a [`GhApp`] from config, or returns `None` when the GitHub App

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -7,6 +7,7 @@ use rb_kafka::Producer;
 use rb_query::ModuleTreeCache;
 use rb_schemas::{IngestRequest, Tombstone};
 use rb_sse::EventBus;
+use rb_storage_neo4j::TenantGraph;
 use sqlx::PgPool;
 
 use crate::config::Config;
@@ -33,4 +34,7 @@ pub struct AppState {
     /// 60-second in-process cache for `GET /v1/repos/{id}/modules` (ADR-008 §3.6 / AC3).
     /// Keyed by `(repo_id, last_succeeded_ingest_run_id)`.
     pub module_tree_cache: ModuleTreeCache,
+    /// Neo4j tenant-graph handle.  `None` when `RB_NEO4J_URI` is not configured;
+    /// graph endpoints (`/impls`, `/usages`) return 503 in that case.
+    pub graph: Option<Arc<TenantGraph>>,
 }

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -109,6 +109,7 @@ fn state_with_gh(secret: &[u8]) -> AppState {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     }
 }
 
@@ -125,6 +126,7 @@ fn state_without_gh() -> AppState {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     }
 }
 

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -62,6 +62,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
         kafka_bootstrap_servers: "127.0.0.1:19999".to_owned(),
         dev_test_routes: false,
         migrations_root: std::env::var("RB_MIGRATIONS_ROOT").ok().map(std::path::PathBuf::from),
@@ -77,6 +80,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -45,6 +45,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
@@ -60,6 +63,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -58,6 +58,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
@@ -73,6 +76,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -41,6 +41,7 @@ fn test_state() -> AppState {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     }
 }
 
@@ -319,6 +320,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
@@ -334,6 +338,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         ingest_producer: None,
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
     };
     Some((state, pool))
 }


### PR DESCRIPTION
## Summary

- **`GET /v1/repos/{repo_id}/items/{fqn_b64}/impls`** — returns direct (`IMPLS`) and blanket (`BLANKET_IMPL_FOR`) impl blocks for a trait FQN within a repo
- **`GET /v1/repos/{repo_id}/items/{fqn_b64}/usages`** — returns textual (`USES_TYPE`) and monomorphized (`MONOMORPHIZED_FROM` from `TypeInstance`) usages of a type
- Both endpoints are tenant-isolated via `TenantGraph::execute_read` (ADR-007 §3.4) and degrade gracefully to 503 when `RB_NEO4J_URI` is not configured

## Changes

| Crate / Service | What changed |
|---|---|
| `rb-storage-neo4j` | Added `TenantGraph::execute_read` — injects tenant label, executes read Cypher, collects all rows |
| `rb-query` | New `graph` module: `impls::fetch_trait_impls` + `usages::fetch_type_usages` |
| `control-api` | `AppError::GraphUnavailable` (503); Neo4j config fields (`RB_NEO4J_URI/USER/PASSWORD`); `AppState::graph`; route handlers + OpenAPI docs; integration test fixture fixes |

## Graph schema note

Queries match against `Item` nodes (what `projector-neo4j` currently writes for IMPLS, BLANKET_IMPL_FOR, USES_TYPE relations) and `TypeInstance`/`TypeDef` nodes (for MONOMORPHIZED_FROM). The ADR-008 §3.4 reference to `IMPL_BLOCK` and `Trait` node labels can be addressed by a follow-up to projector-neo4j that emits specialized labels.

## Test plan

- [x] `cargo test -p rb-storage-neo4j -p rb-query -p control-api` — all pass (196 + others)
- [ ] End-to-end: spin up Neo4j, run an ingestion, call `/impls` and `/usages`
- [ ] QA sign-off

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)