### PR TITLE
[REQ-DP-05] feat(graph): POST /v1/graph/query — raw Cypher endpoint with tenant isolation

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -295,6 +295,36 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/graph/query": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Execute an arbitrary Cypher query against the tenant's Neo4j graph store.
+         * @description The tenant label is automatically injected into every node pattern so queries
+         *     are isolated to the calling tenant's data. Multi-statement queries
+         *     (containing a bare semicolon outside strings/comments) are rejected.
+         *
+         *     When `read_only` is `true` (the default), the query is pre-flight checked
+         *     for Cypher write operators (`CREATE`, `MERGE`, `SET`, `DELETE`, `DETACH`,
+         *     `REMOVE`). Any match causes a `400 cypher_write_denied` response before the
+         *     query reaches Neo4j.
+         *
+         *     Requires an API key with the `admin` scope **or** an active session with the
+         *     `owner` or `admin` tenant role.
+         */
+        readonly post: operations["post_graph_query"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/health/consistency": {
         readonly parameters: {
             readonly query?: never;
@@ -474,28 +504,6 @@ export interface paths {
          *     409 if an ingestion run is already queued or running for this repo.
          */
         readonly post: operations["trigger_ingest"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/v1/repos/{repo_id}/graph/query": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Execute a Cypher query against the tenant's code-intelligence graph.
-         * @description This endpoint is stubbed for RUSAA-78 (health/consistency PR). The
-         *     write-check pre-flight is implemented; the Neo4j execution layer is a
-         *     follow-on task.
-         */
-        readonly post: operations["post_graph_query"];
         readonly delete?: never;
         readonly options?: never;
         readonly head?: never;
@@ -943,16 +951,28 @@ export interface components {
             readonly owner: string;
             readonly slug: string;
         };
-        /** @description Request body for `POST /v1/repos/{repo_id}/graph/query`. */
+        /** @description Request body for `POST /v1/graph/query`. */
         readonly GraphQueryRequest: {
-            /** @description Cypher query string. */
+            /**
+             * @description Raw Cypher statement. The tenant label is injected automatically; multi-statement
+             *     queries (semicolons outside strings) are rejected.
+             */
             readonly cypher: string;
-            /** @description When `true` (default), reject queries that contain write operators. */
+            /** @description Named parameters bound into the query (`$key` → value). */
+            readonly params?: {
+                readonly [key: string]: unknown;
+            };
+            /**
+             * @description When `true` (default), the query is pre-flight checked for write operators
+             *     (CREATE, MERGE, SET, DELETE, DETACH, REMOVE) and rejected with 400 if found.
+             */
             readonly read_only?: boolean;
         };
-        /** @description Placeholder response — full Neo4j integration is a follow-on task. */
+        /** @description Response body for `POST /v1/graph/query`. */
         readonly GraphQueryResponse: {
-            readonly columns: readonly string[];
+            /** @description Number of rows returned. */
+            readonly row_count: number;
+            /** @description Each element is a JSON object mapping column names to their values. */
             readonly rows: readonly unknown[];
         };
         readonly HealthResponse: {
@@ -1896,6 +1916,58 @@ export interface operations {
             };
         };
     };
+    readonly post_graph_query: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["GraphQueryRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Query executed; rows returned */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["GraphQueryResponse"];
+                };
+            };
+            /** @description Malformed query or write operators detected in read-only mode (cypher_write_denied / invalid_input) */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated or session expired */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Insufficient role or scope */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Neo4j graph store not configured (graph_not_configured) */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     readonly consistency_check: {
         readonly parameters: {
             readonly query?: never;
@@ -2261,54 +2333,6 @@ export interface operations {
             };
             /** @description Ingestion run already in-flight (ingest_run_already_in_flight) */
             readonly 409: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly post_graph_query: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                /** @description Repository UUID */
-                readonly repo_id: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody: {
-            readonly content: {
-                readonly "application/json": components["schemas"]["GraphQueryRequest"];
-            };
-        };
-        readonly responses: {
-            /** @description Query results */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content: {
-                    readonly "application/json": components["schemas"]["GraphQueryResponse"];
-                };
-            };
-            /** @description Write operators detected in read-only query (cypher_write_denied) */
-            readonly 400: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Not authenticated */
-            readonly 401: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Neo4j graph store is not configured on this instance */
-            readonly 503: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -578,6 +578,50 @@
         }
       }
     },
+    "/v1/graph/query": {
+      "post": {
+        "tags": [
+          "query"
+        ],
+        "summary": "Execute an arbitrary Cypher query against the tenant's Neo4j graph store.",
+        "description": "The tenant label is automatically injected into every node pattern so queries\nare isolated to the calling tenant's data. Multi-statement queries\n(containing a bare semicolon outside strings/comments) are rejected.\n\nWhen `read_only` is `true` (the default), the query is pre-flight checked\nfor Cypher write operators (`CREATE`, `MERGE`, `SET`, `DELETE`, `DETACH`,\n`REMOVE`). Any match causes a `400 cypher_write_denied` response before the\nquery reaches Neo4j.\n\nRequires an API key with the `admin` scope **or** an active session with the\n`owner` or `admin` tenant role.",
+        "operationId": "post_graph_query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GraphQueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Query executed; rows returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphQueryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed query or write operators detected in read-only mode (cypher_write_denied / invalid_input)"
+          },
+          "401": {
+            "description": "Not authenticated or session expired"
+          },
+          "403": {
+            "description": "Insufficient role or scope"
+          },
+          "503": {
+            "description": "Neo4j graph store not configured (graph_not_configured)"
+          }
+        }
+      }
+    },
     "/v1/health/consistency": {
       "get": {
         "tags": [
@@ -903,59 +947,6 @@
           },
           "409": {
             "description": "Ingestion run already in-flight (ingest_run_already_in_flight)"
-          }
-        }
-      }
-    },
-    "/v1/repos/{repo_id}/graph/query": {
-      "post": {
-        "tags": [
-          "query"
-        ],
-        "summary": "Execute a Cypher query against the tenant's code-intelligence graph.",
-        "description": "This endpoint is stubbed for RUSAA-78 (health/consistency PR). The\nwrite-check pre-flight is implemented; the Neo4j execution layer is a\nfollow-on task.",
-        "operationId": "post_graph_query",
-        "parameters": [
-          {
-            "name": "repo_id",
-            "in": "path",
-            "description": "Repository UUID",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GraphQueryRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Query results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphQueryResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Write operators detected in read-only query (cypher_write_denied)"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "503": {
-            "description": "Neo4j graph store is not configured on this instance"
           }
         }
       }
@@ -2142,38 +2133,46 @@
       },
       "GraphQueryRequest": {
         "type": "object",
-        "description": "Request body for `POST /v1/repos/{repo_id}/graph/query`.",
+        "description": "Request body for `POST /v1/graph/query`.",
         "required": [
           "cypher"
         ],
         "properties": {
           "cypher": {
             "type": "string",
-            "description": "Cypher query string."
+            "description": "Raw Cypher statement. The tenant label is injected automatically; multi-statement\nqueries (semicolons outside strings) are rejected."
+          },
+          "params": {
+            "type": "object",
+            "description": "Named parameters bound into the query (`$key` → value).",
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            }
           },
           "read_only": {
             "type": "boolean",
-            "description": "When `true` (default), reject queries that contain write operators."
+            "description": "When `true` (default), the query is pre-flight checked for write operators\n(CREATE, MERGE, SET, DELETE, DETACH, REMOVE) and rejected with 400 if found."
           }
         }
       },
       "GraphQueryResponse": {
         "type": "object",
-        "description": "Placeholder response — full Neo4j integration is a follow-on task.",
+        "description": "Response body for `POST /v1/graph/query`.",
         "required": [
-          "columns",
-          "rows"
+          "rows",
+          "row_count"
         ],
         "properties": {
-          "columns": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "row_count": {
+            "type": "integer",
+            "description": "Number of rows returned.",
+            "minimum": 0
           },
           "rows": {
             "type": "array",
-            "items": {}
+            "items": {},
+            "description": "Each element is a JSON object mapping column names to their values."
           }
         }
       },

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -75,7 +75,7 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/repos/{repo_id}/items/{fqn_b64}", get(get_item))
         .route("/v1/repos/{repo_id}/items/{fqn_b64}/impls", get(get_trait_impls))
         .route("/v1/repos/{repo_id}/items/{fqn_b64}/usages", get(get_type_usages))
-        .route("/v1/repos/{repo_id}/graph/query", post(post_graph_query))
+        .route("/v1/graph/query", post(post_graph_query))
         .route("/v1/search", post(search))
         .route("/v1/health/consistency", get(consistency_check))
         .route("/v1/ingestions/recent", get(list_recent_runs))

--- a/services/control-api/src/routes/query/graph.rs
+++ b/services/control-api/src/routes/query/graph.rs
@@ -1,33 +1,38 @@
-//! `POST /v1/repos/{repo_id}/graph/query` — raw Cypher query against the
-//! tenant's Neo4j graph (REQ-DP-07 stub; full implementation is out of scope
-//! for this PR — see the health/consistency work in RUSAA-78).
+//! `POST /v1/graph/query` — raw Cypher query with tenant label injection (REQ-DP-05).
 //!
-//! When `read_only = true` the request is pre-flighted through
-//! `rb_storage_neo4j::write_check::has_write_operators` to reject writes
-//! before they reach Neo4j.
+//! Admin scope only: API key with `admin` scope or session with owner/admin role.
+//! When `read_only=true` (default), the query is pre-flight scanned for write
+//! operators and rejected with 400 `cypher_write_denied` if any are found.
 
-use axum::{Json, extract::State};
+use axum::{Json, extract::State, response::IntoResponse};
+use rb_schemas::TenantId;
 use rb_storage_neo4j::has_write_operators;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::{
     error::AppError,
-    middleware::auth::{AuthContext, require_read_auth},
+    middleware::auth::{AuthContext, Scope, require_verified_session},
     state::AppState,
 };
 
 // ---------------------------------------------------------------------------
-// Request / Response types
+// Request / response schemas
 // ---------------------------------------------------------------------------
 
-/// Request body for `POST /v1/repos/{repo_id}/graph/query`.
+/// Request body for `POST /v1/graph/query`.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GraphQueryRequest {
-    /// Cypher query string.
+    /// Raw Cypher statement. The tenant label is injected automatically; multi-statement
+    /// queries (semicolons outside strings) are rejected.
     pub cypher: String,
-    /// When `true` (default), reject queries that contain write operators.
+    /// Named parameters bound into the query (`$key` → value).
+    #[serde(default)]
+    pub params: serde_json::Map<String, Value>,
+    /// When `true` (default), the query is pre-flight checked for write operators
+    /// (CREATE, MERGE, SET, DELETE, DETACH, REMOVE) and rejected with 400 if found.
     #[serde(default = "default_read_only")]
     pub read_only: bool,
 }
@@ -36,51 +41,107 @@ fn default_read_only() -> bool {
     true
 }
 
-/// Placeholder response — full Neo4j integration is a follow-on task.
+/// Response body for `POST /v1/graph/query`.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct GraphQueryResponse {
-    pub columns: Vec<String>,
-    pub rows: Vec<serde_json::Value>,
+    /// Each element is a JSON object mapping column names to their values.
+    pub rows: Vec<Value>,
+    /// Number of rows returned.
+    pub row_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+struct AdminAccess {
+    tenant_id: Uuid,
+}
+
+/// Accept API keys with the `admin` scope **or** verified sessions whose tenant
+/// role is `owner` or `admin`.
+async fn require_admin_access(
+    pool: &sqlx::PgPool,
+    auth: AuthContext,
+) -> Result<AdminAccess, AppError> {
+    match auth {
+        AuthContext::ApiKey(info) => {
+            if info.scopes.contains(&Scope::Admin) {
+                Ok(AdminAccess { tenant_id: info.tenant_id })
+            } else {
+                Err(AppError::InsufficientScope)
+            }
+        }
+        other => {
+            let session = require_verified_session(other)?;
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT role FROM control.tenant_members \
+                 WHERE tenant_id = $1 AND user_id = $2",
+            )
+            .bind(session.tenant_id)
+            .bind(session.user_id)
+            .fetch_optional(pool)
+            .await?;
+
+            match row {
+                None => Err(AppError::NotAMember),
+                Some((role,)) if role == "owner" || role == "admin" => {
+                    Ok(AdminAccess { tenant_id: session.tenant_id })
+                }
+                Some(_) => Err(AppError::InsufficientRole),
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
-/// Execute a Cypher query against the tenant's code-intelligence graph.
+/// Execute an arbitrary Cypher query against the tenant's Neo4j graph store.
 ///
-/// This endpoint is stubbed for RUSAA-78 (health/consistency PR). The
-/// write-check pre-flight is implemented; the Neo4j execution layer is a
-/// follow-on task.
+/// The tenant label is automatically injected into every node pattern so queries
+/// are isolated to the calling tenant's data. Multi-statement queries
+/// (containing a bare semicolon outside strings/comments) are rejected.
+///
+/// When `read_only` is `true` (the default), the query is pre-flight checked
+/// for Cypher write operators (`CREATE`, `MERGE`, `SET`, `DELETE`, `DETACH`,
+/// `REMOVE`). Any match causes a `400 cypher_write_denied` response before the
+/// query reaches Neo4j.
+///
+/// Requires an API key with the `admin` scope **or** an active session with the
+/// `owner` or `admin` tenant role.
 #[utoipa::path(
     post,
-    path = "/v1/repos/{repo_id}/graph/query",
-    params(
-        ("repo_id" = Uuid, Path, description = "Repository UUID"),
-    ),
+    path = "/v1/graph/query",
     request_body = GraphQueryRequest,
     responses(
-        (status = 200, description = "Query results", body = GraphQueryResponse),
-        (status = 400, description = "Write operators detected in read-only query (cypher_write_denied)"),
-        (status = 401, description = "Not authenticated"),
-        (status = 503, description = "Neo4j graph store is not configured on this instance"),
+        (status = 200, description = "Query executed; rows returned", body = GraphQueryResponse),
+        (status = 400, description = "Malformed query or write operators detected in read-only mode (cypher_write_denied / invalid_input)"),
+        (status = 401, description = "Not authenticated or session expired"),
+        (status = 403, description = "Insufficient role or scope"),
+        (status = 503, description = "Neo4j graph store not configured (graph_not_configured)"),
     ),
     tag = "query"
 )]
 pub async fn post_graph_query(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     auth: AuthContext,
-    axum::extract::Path(_repo_id): axum::extract::Path<Uuid>,
-    Json(body): Json<GraphQueryRequest>,
-) -> Result<Json<GraphQueryResponse>, AppError> {
-    let _tenant_id = require_read_auth(auth)?;
+    Json(req): Json<GraphQueryRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let access = require_admin_access(&state.pool, auth).await?;
 
-    if body.read_only && has_write_operators(&body.cypher) {
+    let graph = state.graph.as_ref().ok_or(AppError::GraphNotConfigured)?;
+
+    if req.read_only && has_write_operators(&req.cypher) {
         return Err(AppError::CypherWriteDenied);
     }
 
-    // Neo4j execution is a follow-on task (RUSAA-78 scope: health endpoints).
-    Err(AppError::GraphNotConfigured)
+    let tenant_id = TenantId::from(access.tenant_id);
+    let rows = graph.execute_query(&tenant_id, &req.cypher, &req.params).await?;
+    let row_count = rows.len();
+
+    Ok(Json(GraphQueryResponse { rows, row_count }))
 }
 
 // ---------------------------------------------------------------------------
@@ -90,6 +151,31 @@ pub async fn post_graph_query(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, SessionInfo};
+
+    fn admin_key(tenant_id: Uuid) -> ApiKeyInfo {
+        ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Admin],
+        }
+    }
+
+    fn read_key(tenant_id: Uuid) -> ApiKeyInfo {
+        ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Read],
+        }
+    }
+
+    // ----- require_admin_access (unit, no DB) -----
+    // We can only test the API-key branch synchronously; the session branch
+    // needs a pool so is covered by integration tests.
+
+    // ----- default_read_only -----
 
     #[test]
     fn read_only_defaults_to_true() {
@@ -99,19 +185,87 @@ mod tests {
     }
 
     #[test]
-    fn read_only_can_be_disabled() {
+    fn read_only_can_be_set_false() {
         let req: GraphQueryRequest =
-            serde_json::from_str(r#"{"cypher":"CREATE (n:Foo)","read_only":false}"#).unwrap();
+            serde_json::from_str(r#"{"cypher":"MATCH (n) RETURN n","read_only":false}"#).unwrap();
         assert!(!req.read_only);
     }
 
     #[test]
-    fn write_check_detects_create() {
-        assert!(has_write_operators("CREATE (n:Foo)"));
+    fn params_defaults_to_empty_map() {
+        let req: GraphQueryRequest =
+            serde_json::from_str(r#"{"cypher":"MATCH (n) RETURN n"}"#).unwrap();
+        assert!(req.params.is_empty());
+    }
+
+    // ----- GraphNotConfigured mapping -----
+
+    #[test]
+    fn graph_not_configured_returns_503() {
+        let err = AppError::GraphNotConfigured;
+        let resp = err.into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    // ----- CypherWriteDenied mapping -----
+
+    #[test]
+    fn cypher_write_denied_returns_400() {
+        let err = AppError::CypherWriteDenied;
+        let resp = err.into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    // ----- Response serialisation -----
+
+    #[test]
+    fn graph_query_response_serialises() {
+        let resp = GraphQueryResponse {
+            rows: vec![serde_json::json!({"id": 1, "name": "Foo"})],
+            row_count: 1,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert_eq!(val["row_count"], 1);
+        assert_eq!(val["rows"][0]["name"], "Foo");
+    }
+
+    // ----- write-denied integration with has_write_operators -----
+
+    #[test]
+    fn write_operators_trigger_write_denied_error() {
+        let cypher = "CREATE (n:Foo) RETURN n";
+        let read_only = true;
+        let would_deny = read_only && has_write_operators(cypher);
+        assert!(would_deny, "CREATE must be caught by write-denied guard");
     }
 
     #[test]
-    fn write_check_allows_match() {
-        assert!(!has_write_operators("MATCH (n) RETURN n"));
+    fn read_query_with_read_only_passes_guard() {
+        let cypher = "MATCH (n) RETURN n LIMIT 10";
+        let read_only = true;
+        let would_deny = read_only && has_write_operators(cypher);
+        assert!(!would_deny);
+    }
+
+    #[test]
+    fn write_query_with_read_only_false_passes_guard() {
+        let cypher = "CREATE (n:Foo) RETURN n";
+        let read_only = false;
+        let would_deny = read_only && has_write_operators(cypher);
+        assert!(!would_deny, "read_only=false must bypass the write-denied guard");
+    }
+
+    // ----- Admin scope check (no DB needed) -----
+
+    #[test]
+    fn admin_scope_not_in_read_key() {
+        let key = read_key(Uuid::new_v4());
+        assert!(!key.scopes.contains(&Scope::Admin));
+    }
+
+    #[test]
+    fn admin_scope_in_admin_key() {
+        let key = admin_key(Uuid::new_v4());
+        assert!(key.scopes.contains(&Scope::Admin));
     }
 }


### PR DESCRIPTION
## Summary

- Add `POST /v1/graph/query`: admin-only raw Cypher query endpoint with per-tenant label injection
- Pre-flight write-operator detection (CREATE, MERGE, SET, DELETE, DETACH, REMOVE) when `read_only=true` (default)
- `require_admin_access`: accepts API keys with `admin` scope or verified sessions with `owner`/`admin` tenant role
- `rows` + `row_count` response envelope; OpenAPI spec updated

## Test plan

- [ ] All unit tests pass (`cargo test -p control-api`)
- [ ] `POST /v1/graph/query` with `read_only=true` + write cypher → 400 `cypher_write_denied`
- [ ] `POST /v1/graph/query` without admin scope → 403
- [ ] `POST /v1/graph/query` without `NEO4J_URI` → 503 `graph_not_configured`
- [ ] Valid `MATCH (n) RETURN n` with admin key → 200 with `{rows, row_count}`

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)