### PR TITLE
[REQ-DP-01] feat(data-plane): semantic search via Ollama + Qdrant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,11 +1076,12 @@ dependencies = [
  "rb-schemas",
  "rb-secrets",
  "rb-sse",
- "rb-storage-neo4j",
  "rb-storage-pg",
+ "rb-storage-qdrant",
  "rb-tenant",
  "rb-tracing",
  "rdkafka",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3820,9 +3821,8 @@ name = "rb-query"
 version = "0.1.0"
 dependencies = [
  "moka",
- "neo4rs",
  "rb-schemas",
- "rb-storage-neo4j",
+ "rb-storage-qdrant",
  "rb-tenant",
  "serde",
  "sqlx",
@@ -3890,6 +3890,19 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "rb-storage-qdrant"
+version = "0.1.0"
+dependencies = [
+ "rb-schemas",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ members = [
     "crates/rb-query",
     "crates/rb-audit-cli",
     "crates/rb-storage-neo4j",
+    "crates/rb-storage-qdrant",
     "services/projector-pg",
     "services/projector-neo4j",
     "services/tombstoner",
     "services/embed-worker",
-    "crates/rb-query",
 ]
 
 [workspace.package]

--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -8,10 +8,9 @@ repository.workspace = true
 
 [dependencies]
 rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+rb-storage-neo4j = { path = "../rb-storage-neo4j", version = "0.1.0" }
 rb-storage-qdrant = { path = "../rb-storage-qdrant", version = "0.1.0" }
 rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
-rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
-rb-storage-neo4j = { path = "../rb-storage-neo4j", version = "0.1.0" }
 sqlx.workspace = true
 neo4rs.workspace = true
 uuid.workspace = true

--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+rb-storage-qdrant = { path = "../rb-storage-qdrant", version = "0.1.0" }
 rb-tenant = { path = "../rb-tenant", version = "0.1.0" }
 rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
 rb-storage-neo4j = { path = "../rb-storage-neo4j", version = "0.1.0" }

--- a/crates/rb-query/src/error.rs
+++ b/crates/rb-query/src/error.rs
@@ -6,4 +6,6 @@ pub enum QueryError {
     Database(#[from] sqlx::Error),
     #[error("graph error: {0}")]
     Graph(#[from] rb_storage_neo4j::CypherError),
+    #[error("vector store error: {0}")]
+    Qdrant(#[from] rb_storage_qdrant::QdrantError),
 }

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -5,13 +5,19 @@
 //!
 //! The `graph` module provides Neo4j read queries routed through
 //! [`rb_storage_neo4j::TenantGraph`] for tenant isolation (ADR-007 §3.4).
+//! The `vector` module provides semantic search via [`rb_storage_qdrant::TenantVectorStore`]
+//! with mandatory per-tenant isolation (ADR-007 §13.2).
 
 mod error;
 mod graph;
 mod pg;
+mod vector;
 
 pub use error::QueryError;
 pub use graph::impls::{ImplEntry, fetch_trait_impls};
 pub use graph::usages::{UsageEntry, fetch_type_usages};
 pub use pg::items;
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};
+pub use vector::search::{
+    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, SemanticHit, semantic_search,
+};

--- a/crates/rb-query/src/vector/mod.rs
+++ b/crates/rb-query/src/vector/mod.rs
@@ -1,0 +1,1 @@
+pub mod search;

--- a/crates/rb-query/src/vector/search.rs
+++ b/crates/rb-query/src/vector/search.rs
@@ -57,7 +57,7 @@ pub async fn semantic_search(
     vector: &[f32],
     opts: SearchOptions,
 ) -> Result<Vec<SemanticHit>, QueryError> {
-    let limit = opts.limit.min(MAX_SEARCH_LIMIT).max(1);
+    let limit = opts.limit.clamp(1, MAX_SEARCH_LIMIT);
     let hits = store.search(tenant_id, vector, limit, opts.repo_id).await?;
     Ok(hits.into_iter().map(SemanticHit::from).collect())
 }

--- a/crates/rb-query/src/vector/search.rs
+++ b/crates/rb-query/src/vector/search.rs
@@ -1,0 +1,99 @@
+//! Semantic search query — embed query via Ollama, search Qdrant `rb_embeddings`.
+//!
+//! Entry point: [`semantic_search`].  Callers supply a pre-validated tenant
+//! context; this module enforces per-tenant isolation by delegating to
+//! [`TenantVectorStore::search`] which injects the mandatory `tenant_id` filter.
+
+use rb_schemas::TenantId;
+use rb_storage_qdrant::{SearchHit, TenantVectorStore};
+use uuid::Uuid;
+
+use crate::QueryError;
+
+/// Options controlling a semantic search request.
+pub struct SearchOptions {
+    /// Maximum number of results to return (capped at [`MAX_SEARCH_LIMIT`]).
+    pub limit: u32,
+    /// When set, restricts results to a single repository.
+    pub repo_id: Option<Uuid>,
+}
+
+/// Maximum allowed `limit` for a single search request.
+pub const MAX_SEARCH_LIMIT: u32 = 50;
+
+/// Default result limit when the caller does not specify one.
+pub const DEFAULT_SEARCH_LIMIT: u32 = 10;
+
+/// A ranked semantic search result.
+#[derive(Debug, Clone)]
+pub struct SemanticHit {
+    /// Fully-qualified name of the matched code symbol.
+    pub fqn: String,
+    /// Repository UUID this symbol belongs to.
+    pub repo_id: String,
+    /// Cosine similarity score in `[0, 1]`.
+    pub score: f32,
+}
+
+impl From<SearchHit> for SemanticHit {
+    fn from(h: SearchHit) -> Self {
+        Self { fqn: h.fqn, repo_id: h.repo_id, score: h.score }
+    }
+}
+
+/// Search `rb_embeddings` for the `limit` most similar code symbols.
+///
+/// `vector` must be the Ollama embedding of the user's query (produced by the
+/// caller via [`call_ollama`](crate::vector::search) or equivalent).  The
+/// `must` tenant filter is injected by [`TenantVectorStore`] — this function
+/// never forwards cross-tenant data.
+///
+/// # Errors
+///
+/// Returns [`QueryError::Qdrant`] on Qdrant communication failure.
+pub async fn semantic_search(
+    store: &TenantVectorStore,
+    tenant_id: &TenantId,
+    vector: &[f32],
+    opts: SearchOptions,
+) -> Result<Vec<SemanticHit>, QueryError> {
+    let limit = opts.limit.min(MAX_SEARCH_LIMIT).max(1);
+    let hits = store.search(tenant_id, vector, limit, opts.repo_id).await?;
+    Ok(hits.into_iter().map(SemanticHit::from).collect())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_storage_qdrant::SearchHit;
+
+    #[test]
+    fn semantic_hit_from_search_hit() {
+        let hit = SearchHit { fqn: "my::Fn".to_owned(), repo_id: "r1".to_owned(), score: 0.9 };
+        let sh: SemanticHit = hit.into();
+        assert_eq!(sh.fqn, "my::Fn");
+        assert_eq!(sh.repo_id, "r1");
+        assert!((sh.score - 0.9).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn limit_is_capped_at_max() {
+        // Verify the cap formula: min(limit, MAX) works.
+        let capped = 200_u32.min(MAX_SEARCH_LIMIT).max(1);
+        assert_eq!(capped, MAX_SEARCH_LIMIT);
+    }
+
+    #[test]
+    fn limit_zero_becomes_one() {
+        let capped = 0_u32.min(MAX_SEARCH_LIMIT).max(1);
+        assert_eq!(capped, 1);
+    }
+
+    #[test]
+    fn default_limit_is_within_max() {
+        assert!(DEFAULT_SEARCH_LIMIT <= MAX_SEARCH_LIMIT);
+        assert!(DEFAULT_SEARCH_LIMIT > 0);
+    }
+}

--- a/crates/rb-storage-qdrant/Cargo.toml
+++ b/crates/rb-storage-qdrant/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rb-storage-qdrant"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+rb-schemas = { path = "../rb-schemas", version = "0.1.0" }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-storage-qdrant/src/error.rs
+++ b/crates/rb-storage-qdrant/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum QdrantError {
+    #[error("tenant_id filter is required — refusing to execute an unscoped query")]
+    MissingTenantFilter,
+
+    #[error("Qdrant HTTP error {status}: {body}")]
+    Http { status: u16, body: String },
+
+    #[error("Qdrant request failed: {0}")]
+    Request(#[from] reqwest::Error),
+
+    #[error("Qdrant response parse error: {0}")]
+    Parse(String),
+}

--- a/crates/rb-storage-qdrant/src/lib.rs
+++ b/crates/rb-storage-qdrant/src/lib.rs
@@ -1,0 +1,15 @@
+//! `rb-storage-qdrant` — tenant-scoped Qdrant vector search wrapper.
+//!
+//! Provides [`TenantVectorStore`] as the sole entry point for searching
+//! the `rb_embeddings` Qdrant collection.  Every search injects a mandatory
+//! `tenant_id` `must` filter (ADR-007 §13.2) so cross-tenant data is never
+//! reachable even if a call site contains a bug.
+//!
+//! No code outside this crate may issue raw Qdrant REST requests — CI lint
+//! enforces this boundary (analogous to `rb-storage-neo4j`).
+
+mod error;
+mod store;
+
+pub use error::QdrantError;
+pub use store::{SearchHit, TenantVectorStore};

--- a/crates/rb-storage-qdrant/src/store.rs
+++ b/crates/rb-storage-qdrant/src/store.rs
@@ -1,0 +1,175 @@
+//! Tenant-scoped Qdrant vector search.
+//!
+//! Every search injects a `must` filter on `tenant_id` (ADR-007 §13.2) so
+//! cross-tenant data is never reachable even on bugs in call sites.
+//!
+//! No caller outside `rb-storage-qdrant` may issue raw Qdrant requests —
+//! use this type as the sole search path.
+
+use rb_schemas::TenantId;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::error::QdrantError;
+
+/// Qdrant collection used for all code embeddings.
+const COLLECTION: &str = "rb_embeddings";
+
+/// A single ranked result from a Qdrant nearest-neighbour search.
+#[derive(Debug, Clone)]
+pub struct SearchHit {
+    /// Fully-qualified name of the matched code symbol.
+    pub fqn: String,
+    /// Repository UUID string from the point payload.
+    pub repo_id: String,
+    /// Cosine similarity score in `[0, 1]` (higher is more similar).
+    pub score: f32,
+}
+
+/// Tenant-scoped Qdrant client.
+///
+/// All search queries must pass through [`Self::search`]; the method injects a
+/// mandatory `tenant_id` `must` filter before forwarding to Qdrant so that
+/// per-tenant isolation (ADR-007 §13.2) is enforced at the driver level.
+pub struct TenantVectorStore {
+    client: reqwest::Client,
+    url: String,
+}
+
+impl TenantVectorStore {
+    /// Build a store pointing at `qdrant_url` (e.g. `http://qdrant:6333`).
+    #[must_use]
+    pub fn new(qdrant_url: &str) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url: qdrant_url.trim_end_matches('/').to_owned(),
+        }
+    }
+
+    /// Search `rb_embeddings` for the `k` nearest neighbours of `vector`.
+    ///
+    /// Always injects a `must` filter on `tenant_id` — refusing to execute
+    /// when the tenant is somehow invalid is safer than silently returning
+    /// cross-tenant results.  An additional optional `repo_id` filter narrows
+    /// results to a single repository.
+    ///
+    /// # Errors
+    ///
+    /// - [`QdrantError::MissingTenantFilter`] — internal guard (should never
+    ///   fire; present to make the invariant explicit in the type system).
+    /// - [`QdrantError::Http`] — Qdrant returned a non-2xx status.
+    /// - [`QdrantError::Request`] — network-level failure.
+    /// - [`QdrantError::Parse`] — unexpected response shape.
+    pub async fn search(
+        &self,
+        tenant_id: &TenantId,
+        vector: &[f32],
+        limit: u32,
+        repo_id: Option<Uuid>,
+    ) -> Result<Vec<SearchHit>, QdrantError> {
+        let tenant_str = tenant_id.to_string();
+        if tenant_str.is_empty() {
+            return Err(QdrantError::MissingTenantFilter);
+        }
+
+        // Build must-filter conditions.
+        let mut must_conditions = vec![json!({
+            "key": "tenant_id",
+            "match": { "value": tenant_str }
+        })];
+
+        if let Some(rid) = repo_id {
+            must_conditions.push(json!({
+                "key": "repo_id",
+                "match": { "value": rid.to_string() }
+            }));
+        }
+
+        let body = json!({
+            "vector": vector,
+            "limit": limit,
+            "with_payload": true,
+            "filter": {
+                "must": must_conditions
+            }
+        });
+
+        let url = format!("{}/collections/{}/points/search", self.url, COLLECTION);
+        let resp = self.client.post(&url).json(&body).send().await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(QdrantError::Http {
+                status: status.as_u16(),
+                body: body_text,
+            });
+        }
+
+        let json: serde_json::Value =
+            resp.json().await.map_err(|e| QdrantError::Parse(e.to_string()))?;
+
+        let results = json
+            .get("result")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| QdrantError::Parse("missing 'result' array".into()))?;
+
+        let mut hits = Vec::with_capacity(results.len());
+        for item in results {
+            let score = item
+                .get("score")
+                .and_then(serde_json::Value::as_f64)
+                .map(|f| f as f32)
+                .ok_or_else(|| QdrantError::Parse("missing 'score' field".into()))?;
+
+            let payload = item.get("payload").ok_or_else(|| {
+                QdrantError::Parse("missing 'payload' field".into())
+            })?;
+
+            let fqn = payload
+                .get("fqn")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| QdrantError::Parse("missing payload.fqn".into()))?
+                .to_owned();
+
+            let repo_id_str = payload
+                .get("repo_id")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| QdrantError::Parse("missing payload.repo_id".into()))?
+                .to_owned();
+
+            hits.push(SearchHit { fqn, repo_id: repo_id_str, score });
+        }
+
+        Ok(hits)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_trims_trailing_slash_from_url() {
+        let store = TenantVectorStore::new("http://qdrant:6333/");
+        assert_eq!(store.url, "http://qdrant:6333");
+    }
+
+    #[test]
+    fn search_hit_fields_accessible() {
+        let hit = SearchHit {
+            fqn: "my_crate::Foo".to_owned(),
+            repo_id: "repo-uuid".to_owned(),
+            score: 0.95,
+        };
+        assert_eq!(hit.fqn, "my_crate::Foo");
+        assert!((hit.score - 0.95).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn collection_constant_matches_embed_worker() {
+        assert_eq!(COLLECTION, "rb_embeddings");
+    }
+}

--- a/crates/rb-storage-qdrant/src/store.rs
+++ b/crates/rb-storage-qdrant/src/store.rs
@@ -60,6 +60,7 @@ impl TenantVectorStore {
     /// - [`QdrantError::Http`] — Qdrant returned a non-2xx status.
     /// - [`QdrantError::Request`] — network-level failure.
     /// - [`QdrantError::Parse`] — unexpected response shape.
+    #[allow(clippy::cast_possible_truncation)]
     pub async fn search(
         &self,
         tenant_id: &TenantId,

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -33,7 +33,9 @@ rb-schemas = { path = "../../crates/rb-schemas", version = "0.1.0" }
 rb-storage-pg = { path = "../../crates/rb-storage-pg", version = "0.1.0" }
 rb-query = { path = "../../crates/rb-query", version = "0.1.0" }
 rb-storage-neo4j = { path = "../../crates/rb-storage-neo4j", version = "0.1.0" }
+rb-storage-qdrant = { path = "../../crates/rb-storage-qdrant", version = "0.1.0" }
 rb-tracing = { path = "../../crates/rb-tracing", version = "0.1.0" }
+reqwest = { workspace = true }
 opentelemetry.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -53,6 +53,17 @@ pub struct Config {
     /// Defaults to `/migrations` (the standard mount point in Docker).
     /// Set to `None` (env var absent) to disable automatic tenant migration.
     pub migrations_root: Option<PathBuf>,
+
+    // --- Semantic search (REQ-DP-01) ---
+    /// `RB_QDRANT_URL` — Qdrant REST base URL (e.g. `http://qdrant:6333`).
+    /// Optional; `POST /v1/search` returns 503 when absent.
+    pub qdrant_url: Option<String>,
+    /// `RB_OLLAMA_URL` — Ollama HTTP base URL (e.g. `http://ollama:11434`).
+    /// Optional; `POST /v1/search` returns 503 when absent.
+    pub ollama_url: Option<String>,
+    /// `RB_EMBEDDING_MODEL` — model name passed to Ollama for query embedding.
+    /// Defaults to `nomic-embed-text`.
+    pub embedding_model: String,
 }
 
 impl Config {
@@ -115,6 +126,10 @@ impl Config {
             dev_test_routes: env::var("RB_DEV_TEST_ROUTES")
                 .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")),
             migrations_root: env::var("RB_MIGRATIONS_ROOT").ok().map(PathBuf::from),
+            qdrant_url: env::var("RB_QDRANT_URL").ok().filter(|s| !s.is_empty()),
+            ollama_url: env::var("RB_OLLAMA_URL").ok().filter(|s| !s.is_empty()),
+            embedding_model: env::var("RB_EMBEDDING_MODEL")
+                .unwrap_or_else(|_| "nomic-embed-text".to_owned()),
         })
     }
 
@@ -145,6 +160,9 @@ impl Config {
             kafka_bootstrap_servers: "localhost:9092".to_owned(),
             dev_test_routes: false,
             migrations_root: None,
+            qdrant_url: None,
+            ollama_url: None,
+            embedding_model: "nomic-embed-text".to_owned(),
         }
     }
 }

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -58,6 +58,8 @@ pub enum AppError {
     ConfirmationMismatch,
     #[error("Neo4j graph is not configured on this instance")]
     GraphUnavailable,
+    #[error("required upstream service is not available")]
+    ServiceUnavailable,
     #[error("Kafka producer is not configured on this instance")]
     KafkaNotConfigured,
     #[error("Kafka brokers are not reachable")]
@@ -142,6 +144,11 @@ impl IntoResponse for AppError {
             AppError::GraphUnavailable => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "graph_unavailable",
+                self.to_string(),
+            ),
+            AppError::ServiceUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_unavailable",
                 self.to_string(),
             ),
             AppError::KafkaNotConfigured => (

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -33,6 +33,7 @@ use crate::routes::{
     query::impls::get_trait_impls,
     query::items::get_item,
     query::modules::get_module_tree,
+    query::search::search,
     query::usages::get_type_usages,
     repos::{connect_repo, list_repos, trigger_ingest},
     tenants::{delete_tenant, invite_member, list_members, remove_member, transfer_ownership, update_member_role},
@@ -72,6 +73,7 @@ pub fn build(state: AppState) -> Router {
         .route("/v1/repos/{repo_id}/items/{fqn_b64}", get(get_item))
         .route("/v1/repos/{repo_id}/items/{fqn_b64}/impls", get(get_trait_impls))
         .route("/v1/repos/{repo_id}/items/{fqn_b64}/usages", get(get_type_usages))
+        .route("/v1/search", post(search))
         .route("/v1/ingestions/recent", get(list_recent_runs))
         .route("/v1/ingestions/{ingestion_run_id}/stages", get(get_stage_timeline))
         .route("/v1/ingest/events", get(events_stream))

--- a/services/control-api/src/routes/query/mod.rs
+++ b/services/control-api/src/routes/query/mod.rs
@@ -3,4 +3,5 @@
 pub mod impls;
 pub mod items;
 pub mod modules;
+pub mod search;
 pub mod usages;

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -1,0 +1,330 @@
+//! `POST /v1/search` — semantic code search (REQ-DP-01).
+//!
+//! Embeds the caller's query via Ollama, searches the `rb_embeddings` Qdrant
+//! collection within the caller's tenant scope, and returns ranked code symbols.
+//!
+//! Multi-tenancy is enforced at two layers:
+//!   1. [`TenantVectorStore::search`] injects a `must` tenant_id filter so
+//!      Qdrant never returns cross-tenant points.
+//!   2. Optional `repo_id` filter further narrows to a single repository that
+//!      must belong to the caller's tenant (validated against Postgres).
+
+use axum::{Json, extract::State, response::IntoResponse};
+use rb_query::{DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, semantic_search};
+use rb_schemas::TenantId;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, Scope},
+    state::AppState,
+};
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Optional filters applied on top of the vector similarity ranking.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SearchFilters {
+    /// Restrict results to a single repository UUID.
+    pub repo_id: Option<Uuid>,
+}
+
+/// Body for `POST /v1/search`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SearchRequest {
+    /// Natural-language query to embed and search.
+    pub q: String,
+    /// Maximum number of results to return (default 10, max 50).
+    pub limit: Option<u32>,
+    /// Optional result filters.
+    pub filters: Option<SearchFilters>,
+}
+
+/// A single ranked result returned by `/v1/search`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResult {
+    /// Fully-qualified name (e.g. `my_crate::module::my_fn`).
+    pub fqn: String,
+    /// Top-level crate name extracted from the FQN.
+    pub crate_name: String,
+    /// Repository UUID this symbol belongs to.
+    pub repo_id: String,
+    /// Cosine similarity score in `[0, 1]`.
+    pub score: f32,
+}
+
+/// Response body for `POST /v1/search`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResponse {
+    pub results: Vec<SearchResult>,
+}
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+fn require_read_access(auth: AuthContext) -> Result<Uuid, AppError> {
+    match auth {
+        AuthContext::Session(info) if info.email_verified => Ok(info.tenant_id),
+        AuthContext::Session(_) => Err(AppError::EmailNotVerified),
+        AuthContext::ExpiredSession => Err(AppError::SessionExpired),
+        AuthContext::ApiKey(info) if info.scopes.contains(&Scope::Read) => Ok(info.tenant_id),
+        AuthContext::ApiKey(_) => Err(AppError::InsufficientScope),
+        AuthContext::Anonymous => Err(AppError::Unauthorized),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ollama embedding
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::cast_possible_truncation)]
+async fn embed_query(
+    http: &reqwest::Client,
+    ollama_url: &str,
+    model: &str,
+    query: &str,
+) -> Result<Vec<f32>, AppError> {
+    let url = format!("{}/api/embeddings", ollama_url.trim_end_matches('/'));
+    let body = serde_json::json!({ "model": model, "prompt": query });
+
+    let resp = http
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!("Ollama request failed: {e}");
+            AppError::ServiceUnavailable
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        tracing::warn!("Ollama returned HTTP {status}: {text}");
+        return Err(AppError::ServiceUnavailable);
+    }
+
+    let json: serde_json::Value = resp.json().await.map_err(|e| {
+        tracing::warn!("Ollama response parse error: {e}");
+        AppError::ServiceUnavailable
+    })?;
+
+    let embedding = json
+        .get("embedding")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            tracing::warn!("Ollama response missing 'embedding' array");
+            AppError::ServiceUnavailable
+        })?;
+
+    embedding
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .map(|f| f as f32)
+                .ok_or(AppError::ServiceUnavailable)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// Semantic search across embedded code symbols within the caller's tenant.
+///
+/// Embeds `q` via Ollama, performs approximate nearest-neighbour search in
+/// the Qdrant `rb_embeddings` collection filtered by `tenant_id`, and returns
+/// ranked results with their fully-qualified names and crate context.
+///
+/// Returns 503 when either Qdrant (`RB_QDRANT_URL`) or Ollama (`RB_OLLAMA_URL`)
+/// are not configured on this instance.
+#[utoipa::path(
+    post,
+    path = "/v1/search",
+    request_body = SearchRequest,
+    responses(
+        (status = 200, description = "Ranked search results", body = SearchResponse),
+        (status = 400, description = "Invalid request (query empty or limit out of range)"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Email not verified or API key lacks read scope"),
+        (status = 503, description = "Qdrant or Ollama not configured on this instance"),
+    ),
+    tag = "search"
+)]
+pub async fn search(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Json(req): Json<SearchRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let tenant_id_uuid = require_read_access(auth)?;
+
+    if req.q.trim().is_empty() {
+        return Err(AppError::InvalidInput);
+    }
+
+    let qdrant = state.qdrant.as_deref().ok_or(AppError::ServiceUnavailable)?;
+    let ollama_url =
+        state.config.ollama_url.as_deref().ok_or(AppError::ServiceUnavailable)?;
+
+    let limit = req
+        .limit
+        .unwrap_or(DEFAULT_SEARCH_LIMIT)
+        .min(MAX_SEARCH_LIMIT)
+        .max(1);
+
+    let repo_id_filter = req.filters.as_ref().and_then(|f| f.repo_id);
+
+    // Validate repo ownership when a repo_id filter is supplied.
+    if let Some(rid) = repo_id_filter {
+        let owned: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM control.repos \
+             WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+        )
+        .bind(rid)
+        .bind(tenant_id_uuid)
+        .fetch_optional(&state.pool)
+        .await?;
+        owned.ok_or(AppError::NotFound)?;
+    }
+
+    let http = reqwest::Client::new();
+    let vector = embed_query(&http, ollama_url, &state.config.embedding_model, &req.q).await?;
+
+    let tenant_id = TenantId::from(tenant_id_uuid);
+    let opts = SearchOptions { limit, repo_id: repo_id_filter };
+    let hits = semantic_search(qdrant, &tenant_id, &vector, opts).await?;
+
+    let results: Vec<SearchResult> = hits
+        .into_iter()
+        .map(|h| {
+            let crate_name = h
+                .fqn
+                .split("::")
+                .next()
+                .unwrap_or(&h.fqn)
+                .to_owned();
+            SearchResult {
+                fqn: h.fqn,
+                crate_name,
+                repo_id: h.repo_id,
+                score: h.score,
+            }
+        })
+        .collect();
+
+    tracing::debug!(
+        tenant_id = %tenant_id_uuid,
+        query = %req.q,
+        result_count = results.len(),
+        "semantic search completed"
+    );
+
+    Ok(Json(SearchResponse { results }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, SessionInfo};
+
+    fn verified_session(tenant_id: Uuid) -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id,
+            email_verified: true,
+        }
+    }
+
+    #[test]
+    fn anonymous_rejected() {
+        assert!(matches!(
+            require_read_access(AuthContext::Anonymous),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn expired_session_rejected() {
+        assert!(matches!(
+            require_read_access(AuthContext::ExpiredSession),
+            Err(AppError::SessionExpired)
+        ));
+    }
+
+    #[test]
+    fn unverified_session_rejected() {
+        let mut info = verified_session(Uuid::new_v4());
+        info.email_verified = false;
+        assert!(matches!(
+            require_read_access(AuthContext::Session(info)),
+            Err(AppError::EmailNotVerified)
+        ));
+    }
+
+    #[test]
+    fn verified_session_accepted() {
+        let tid = Uuid::new_v4();
+        let result = require_read_access(AuthContext::Session(verified_session(tid)));
+        assert_eq!(result.unwrap(), tid);
+    }
+
+    #[test]
+    fn api_key_with_read_scope_accepted() {
+        let tid = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: tid,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Read],
+        };
+        assert_eq!(require_read_access(AuthContext::ApiKey(key)).unwrap(), tid);
+    }
+
+    #[test]
+    fn api_key_without_read_scope_rejected() {
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Write],
+        };
+        assert!(matches!(
+            require_read_access(AuthContext::ApiKey(key)),
+            Err(AppError::InsufficientScope)
+        ));
+    }
+
+    #[test]
+    fn crate_name_extracted_from_fqn() {
+        let fqn = "my_crate::module::MyStruct";
+        let crate_name = fqn.split("::").next().unwrap_or(fqn).to_owned();
+        assert_eq!(crate_name, "my_crate");
+    }
+
+    #[test]
+    fn crate_name_for_bare_fqn() {
+        let fqn = "bare_crate";
+        let crate_name = fqn.split("::").next().unwrap_or(fqn).to_owned();
+        assert_eq!(crate_name, "bare_crate");
+    }
+
+    #[test]
+    fn limit_defaults_and_cap() {
+        let applied = None::<u32>.unwrap_or(DEFAULT_SEARCH_LIMIT).min(MAX_SEARCH_LIMIT).max(1);
+        assert_eq!(applied, DEFAULT_SEARCH_LIMIT);
+
+        let over = 200_u32.min(MAX_SEARCH_LIMIT).max(1);
+        assert_eq!(over, MAX_SEARCH_LIMIT);
+    }
+}

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -4,7 +4,7 @@
 //! collection within the caller's tenant scope, and returns ranked code symbols.
 //!
 //! Multi-tenancy is enforced at two layers:
-//!   1. [`TenantVectorStore::search`] injects a `must` tenant_id filter so
+//!   1. [`TenantVectorStore::search`] injects a `must` `tenant_id` filter so
 //!      Qdrant never returns cross-tenant points.
 //!   2. Optional `repo_id` filter further narrows to a single repository that
 //!      must belong to the caller's tenant (validated against Postgres).
@@ -172,11 +172,7 @@ pub async fn search(
     let ollama_url =
         state.config.ollama_url.as_deref().ok_or(AppError::ServiceUnavailable)?;
 
-    let limit = req
-        .limit
-        .unwrap_or(DEFAULT_SEARCH_LIMIT)
-        .min(MAX_SEARCH_LIMIT)
-        .max(1);
+    let limit = req.limit.unwrap_or(DEFAULT_SEARCH_LIMIT).clamp(1, MAX_SEARCH_LIMIT);
 
     let repo_id_filter = req.filters.as_ref().and_then(|f| f.repo_id);
 

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -10,6 +10,7 @@ use rb_github::{GhApp, Secret};
 use rb_kafka::{ConsumerCfg, Producer, ProducerCfg};
 use rb_sse::{EventBus, SseConfig};
 use rb_storage_neo4j::TenantGraph;
+use rb_storage_qdrant::TenantVectorStore;
 use sqlx::postgres::PgPoolOptions;
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -95,6 +96,13 @@ pub async fn run(config: Config) -> Result<()> {
         None
     };
 
+    // Build the Qdrant vector store.  Failure is non-fatal — `/v1/search`
+    // returns 503 when Qdrant is not configured.
+    let qdrant = config.qdrant_url.as_deref().map(|url| {
+        tracing::info!("qdrant configured at {url}");
+        Arc::new(TenantVectorStore::new(url))
+    });
+
     let state = AppState {
         pool,
         email_sender: Arc::from(email_sender),
@@ -107,6 +115,7 @@ pub async fn run(config: Config) -> Result<()> {
         tombstone_producer,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph,
+        qdrant,
     };
 
     // Spawn the Kafka → SSE fan-out consumer.  Errors here are logged but do

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -8,6 +8,7 @@ use rb_query::ModuleTreeCache;
 use rb_schemas::{IngestRequest, Tombstone};
 use rb_sse::EventBus;
 use rb_storage_neo4j::TenantGraph;
+use rb_storage_qdrant::TenantVectorStore;
 use sqlx::PgPool;
 
 use crate::config::Config;
@@ -37,4 +38,7 @@ pub struct AppState {
     /// Neo4j tenant-graph handle.  `None` when `RB_NEO4J_URI` is not configured;
     /// graph endpoints (`/impls`, `/usages`) return 503 in that case.
     pub graph: Option<Arc<TenantGraph>>,
+    /// Qdrant vector store for semantic search (REQ-DP-01). `None` when
+    /// `RB_QDRANT_URL` is not configured; `POST /v1/search` returns 503.
+    pub qdrant: Option<Arc<TenantVectorStore>>,
 }

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -110,6 +110,7 @@ fn state_with_gh(secret: &[u8]) -> AppState {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     }
 }
 
@@ -127,6 +128,7 @@ fn state_without_gh() -> AppState {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     }
 }
 

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -68,6 +68,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         kafka_bootstrap_servers: "127.0.0.1:19999".to_owned(),
         dev_test_routes: false,
         migrations_root: std::env::var("RB_MIGRATIONS_ROOT").ok().map(std::path::PathBuf::from),
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
     };
     let state = AppState {
         pool: pool.clone(),
@@ -81,6 +84,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -51,6 +51,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
     };
     let state = AppState {
         pool: pool.clone(),
@@ -64,6 +67,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -64,6 +64,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
     };
     let state = AppState {
         pool: pool.clone(),
@@ -77,6 +80,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -42,6 +42,7 @@ fn test_state() -> AppState {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     }
 }
 
@@ -326,6 +327,9 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         kafka_bootstrap_servers: "localhost:9092".to_owned(),
         dev_test_routes: false,
         migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
     };
     let state = AppState {
         pool: pool.clone(),
@@ -339,6 +343,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         tombstone_producer: None,
         module_tree_cache: rb_query::new_module_tree_cache(),
         graph: None,
+        qdrant: None,
     };
     Some((state, pool))
 }


### PR DESCRIPTION
## Summary

- Introduces `crates/rb-storage-qdrant` — new tenant-scoped Qdrant wrapper that enforces a mandatory `tenant_id` `must` filter on every search (ADR-007 §13.2). Refuses unscoped queries at the driver level, analogous to `rb-storage-neo4j`.
- Adds `rb-query::vector::search` — `semantic_search` function delegating to `TenantVectorStore` with configurable limit (default 10, max 50).
- Implements `POST /v1/search` in `control-api`: embeds query via Ollama, searches `rb_embeddings` scoped to caller's tenant, returns ranked `{fqn, crate_name, repo_id, score}`. Optional `filters.repo_id` narrows to a single repo (validated against `control.repos`). Returns 503 when `RB_QDRANT_URL` or `RB_OLLAMA_URL` are absent.

**New env vars:** `RB_QDRANT_URL`, `RB_OLLAMA_URL`, `RB_EMBEDDING_MODEL` (default: `nomic-embed-text`).

## GitHub Issue
Closes #224

## Paperclip

## Checklist
- [x] All unit tests pass (206 control-api, 13 rb-query, 3 rb-storage-qdrant)
- [x] No internal Paperclip references in code or commits
- [x] Docs updated if architecture changed
- [x] Tenant isolation enforced at Qdrant driver level