### PR TITLE
ci: add GITLEAKS_LICENSE env var to gitleaks-action step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   # ── Reviewer checklist ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}` to the `gitleaks/gitleaks-action@v2` step in `.github/workflows/ci.yml`
- The `f-crop` org requires a paid license for gitleaks-action v2; without it the secret scan job fails on every PR
- Cross-cutting CI fix — no application code changed

## Checklist
- [x] Single-line YAML change, no logic impact
- [x] Secret referenced from GitHub org secrets (`GITLEAKS_LICENSE`), not hardcoded
- [x] Unblocks all PRs blocked by the failing secret-scan check (incl. PR #223)

Closes #228