### PR TITLE
ci: path-filter docker-build, drop playwright stub, composite rdkafka action

### DIFF
--- a/.github/actions/setup-rdkafka/action.yml
+++ b/.github/actions/setup-rdkafka/action.yml
@@ -1,0 +1,9 @@
+name: Setup rdkafka build dependencies
+description: Install apt packages required to build the rdkafka-sys crate on ubuntu-latest runners.
+
+runs:
+  using: composite
+  steps:
+    - name: Install rdkafka build dependencies
+      shell: bash
+      run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,27 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # ── Path filter (drives conditional jobs) ─────────────────────────────────
+
+  changes:
+    name: detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'Dockerfile*'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'services/**'
+              - 'crates/**'
+
   # ── Real Rust jobs ─────────────────────────────────────────────────────────
 
   cargo-check:
@@ -23,8 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - run: cargo check --workspace
 
   cargo-test:
@@ -34,8 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - run: cargo test --workspace
 
   clippy:
@@ -47,8 +66,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - run: cargo clippy --workspace -- -D warnings
 
   # ── Script-backed jobs ─────────────────────────────────────────────────────
@@ -76,8 +94,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - run: bash scripts/check-openapi-sync.sh
 
   codegen-drift:
@@ -87,8 +104,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -187,8 +203,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install rdkafka build dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev
+      - uses: ./.github/actions/setup-rdkafka
       - name: Run reviewer checklist (skip docker smoke in CI)
         run: SKIP_DOCKER=1 WAIVER_FILE=tests/review-checklist/baseline-waivers.txt make review-checklist
 
@@ -205,6 +220,8 @@ jobs:
   docker-build:
     name: docker build + push
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'push'
     permissions:
       contents: read
       packages: write
@@ -228,15 +245,6 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/control-api:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  playwright-e2e:
-    name: playwright e2e
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Playwright suite
-        # Full wiring against compose/test.yml happens in Wave 8
-        run: echo "playwright-e2e stub — wired in Wave 8"
 
   frontend-e2e:
     name: frontend e2e


### PR DESCRIPTION
## Summary

Three independent CI quick wins:

- **Path-filter docker-build**: Added a `changes` job (`dorny/paths-filter@v3`) that detects changes in `docker/**`, `Dockerfile*`, `Cargo.toml`, `Cargo.lock`, `services/**`, `crates/**`. `docker-build` now has `needs: changes` + `if: needs.changes.outputs.docker == 'true' || github.event_name == 'push'` — skipped on frontend-only PRs, always runs on push-to-main.
- **Remove playwright-e2e stub**: Deleted the job that printed `"playwright-e2e stub — wired in Wave 8"`. Wave 8 will add the real job.
- **Composite rdkafka action**: Extracted the 6 repeated `apt-get install cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev` blocks into `.github/actions/setup-rdkafka/action.yml`. Affected jobs (`cargo-check`, `cargo-test`, `clippy`, `openapi-sync`, `codegen-drift`, `review-checklist`) now use `uses: ./.github/actions/setup-rdkafka`.

## GitHub Issue
Closes #229

## Checklist
- [ ] CI passes on this PR
- [ ] `docker-build` skips on a frontend-only PR
- [ ] No duplicate apt-get blocks remain in ci.yml