### PR TITLE
ci: remove cargo-check, chain clippy after test, coordinate frontend jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,6 @@ jobs:
 
   # ── Real Rust jobs ─────────────────────────────────────────────────────────
 
-  cargo-check:
-    name: cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/setup-rdkafka
-      - run: cargo check --workspace
-
   cargo-test:
     name: cargo test
     runs-on: ubuntu-latest
@@ -60,6 +50,7 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    needs: [cargo-test]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -133,6 +124,7 @@ jobs:
   frontend-typecheck:
     name: frontend typecheck
     runs-on: ubuntu-latest
+    needs: [codegen-drift]
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
## Summary

- **Remove `cargo-check` job** — `cargo test --workspace` includes a full check pass; the standalone job was pure redundancy.
- **`clippy` now has `needs: [cargo-test]`** — Swatinem/rust-cache@v2 shares artifacts between jobs, so clippy no longer rebuilds from scratch.
- **`frontend-typecheck` now has `needs: [codegen-drift]`** — if generated artefacts are stale, `npm ci` + `tsc` + `eslint` are skipped entirely.
- **Removed `cargo check` from branch protection required status checks** (API PATCH applied; no longer in the required list).

## GitHub Issue
Closes #234

## Checklist
- [x] CI workflow edits applied
- [x] Branch protection `cargo check` entry removed via API
- [x] No new jobs added; two existing jobs gain a `needs:` only
- [x] Acceptance: one full workspace compilation (cargo-test), clippy reuses artifacts, typecheck skips on drift failure