### PR TITLE
fix(e2e): enable screenshots for all Playwright tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   use: {
     baseURL: "http://localhost:4173",
     trace: "on-first-retry",
+    screenshot: "on",
   },
   webServer: {
     command: "npm run preview",


### PR DESCRIPTION
## Summary

Closes #250

- Set `screenshot: "on"` in `frontend/playwright.config.ts` so every Playwright test captures a screenshot in CI artifacts, not just axe-dispatch tests.

## Changes

- `frontend/playwright.config.ts`: add `screenshot: 'on'` to the reporter config

## Test plan

- [ ] CI Playwright runs produce screenshot artifacts for all tests
- [ ] No existing tests broken by screenshot capture