### PR TITLE
fix(compose): add pull_policy: never for custom images; document local-build-only on mars

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -238,6 +238,7 @@ services:
       context: ..
       dockerfile: docker/control-api/Dockerfile
     image: ghcr.io/jarnura/rustacean/control-api:dev
+    pull_policy: never
     environment:
       RB_DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       RB_LISTEN_ADDR: "0.0.0.0:8080"
@@ -283,6 +284,7 @@ services:
       context: ..
       dockerfile: docker/projector-pg/Dockerfile
     image: ghcr.io/jarnura/rustacean/projector-pg:dev
+    pull_policy: never
     environment:
       DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
@@ -306,6 +308,7 @@ services:
       context: ..
       dockerfile: docker/tombstoner/Dockerfile
     image: ghcr.io/jarnura/rustacean/tombstoner:dev
+    pull_policy: never
     environment:
       DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       NEO4J_URI: "bolt://neo4j:7687"
@@ -335,6 +338,7 @@ services:
       context: ..
       dockerfile: docker/ingest-clone/Dockerfile
     image: ghcr.io/jarnura/rustacean/ingest-clone:dev
+    pull_policy: never
     environment:
       DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
@@ -364,6 +368,7 @@ services:
       context: ..
       dockerfile: docker/expand-worker/Dockerfile
     image: ghcr.io/jarnura/rustacean/expand-worker:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
@@ -385,6 +390,7 @@ services:
       context: ..
       dockerfile: docker/parse-worker/Dockerfile
     image: ghcr.io/jarnura/rustacean/parse-worker:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
@@ -406,6 +412,7 @@ services:
       context: ..
       dockerfile: docker/typecheck-worker/Dockerfile
     image: ghcr.io/jarnura/rustacean/typecheck-worker:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
@@ -427,6 +434,7 @@ services:
       context: ..
       dockerfile: docker/ingest-graph/Dockerfile
     image: ghcr.io/jarnura/rustacean/ingest-graph:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
@@ -448,6 +456,7 @@ services:
       context: ..
       dockerfile: docker/projector-neo4j/Dockerfile
     image: ghcr.io/jarnura/rustacean/projector-neo4j:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       NEO4J_URI: "bolt://neo4j:7687"
@@ -471,6 +480,7 @@ services:
       context: ..
       dockerfile: docker/embed-worker/Dockerfile
     image: ghcr.io/jarnura/rustacean/embed-worker:dev
+    pull_policy: never
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_BLOB_BASE_PATH: /data/blobs
@@ -540,6 +550,7 @@ services:
       context: ..
       dockerfile: docker/frontend/Dockerfile
     image: rustbrain/frontend:dev
+    pull_policy: never
     ports:
       - "${FRONTEND_HOST_PORT:-15173}:80"
     networks:

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -33,6 +33,16 @@ After restart the script waits 15 s then probes:
 
 Results are written to the rebuild log and optionally posted as a GitHub commit status.
 
+## Image strategy on mars (local-build-only)
+
+All custom service images (`ghcr.io/jarnura/rustacean/*:dev`, `rustbrain/frontend:dev`) are built
+from source on mars. GHCR pull is never used — `compose/dev.yml` sets `pull_policy: never` on
+every custom service so Docker will not attempt a registry pull. Third-party images
+(postgres, neo4j, kafka, …) are still pulled from their public registries as normal.
+
+**Why**: mars has no GHCR credentials. The `image:` tags in the compose file serve only to
+name the locally-built artifact consistently; they are not treated as pull targets.
+
 ## Setup on mars
 
 ### 1. Clone or pull the repo
@@ -48,7 +58,20 @@ git pull
 chmod +x scripts/dev-stack-watch.sh scripts/dev-stack-auto-rebuild.sh
 ```
 
-### 3. Create the systemd service
+### 3. Build all custom images (first time only)
+
+Because `pull_policy: never` is set, Docker will not pull custom images from a registry.
+You must build them locally before the first `docker compose up`:
+
+```bash
+export COMPOSE_CMD="docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+$COMPOSE_CMD build
+```
+
+This tags all 11 custom images locally. Subsequent rebuilds are handled automatically by
+`dev-stack-watch.sh` (control-api and frontend only) or manually for other services.
+
+### 4. Create the systemd service
 
 ```bash
 sudo tee /etc/systemd/system/rustbrain-dev-watch.service <<'EOF'
@@ -85,7 +108,7 @@ EOF
 
 Adjust `User=` and `WorkingDirectory=` / `ExecStart=` paths to match your actual mars layout.
 
-### 4. Enable and start
+### 5. Enable and start
 
 ```bash
 sudo systemctl daemon-reload
@@ -93,7 +116,7 @@ sudo systemctl enable --now rustbrain-dev-watch
 sudo systemctl status rustbrain-dev-watch
 ```
 
-### 5. Verify
+### 6. Verify
 
 Tail the service log:
 ```bash


### PR DESCRIPTION
## Summary

- Add `pull_policy: never` to all 11 custom service definitions in `compose/dev.yml` (10 GHCR services + `rustbrain/frontend:dev`). Docker Compose no longer attempts a registry pull for these images; they must exist locally (built from source).
- Update `docs/dev-stack-auto-rebuild.md` with an **Image strategy on mars** section and a first-time **Step 3: Build all custom images** (`docker compose build`) before the first `docker compose up`.

**Root cause**: `compose/dev.yml` sets `image: ghcr.io/jarnura/rustacean/*:dev` without `pull_policy`, so `docker compose up` attempts a GHCR pull on mars — which fails with "denied" since mars has no GHCR credentials. The `dev-stack-auto-rebuild.sh` script only auto-rebuilds `control-api` and `frontend`, so the other 8 services had no locally-built image and triggered a pull every time.

## GitHub Issue
Closes #251

## Checklist
- [x] `pull_policy: never` added to all 11 custom service definitions
- [x] Documentation updated with image strategy and first-time build step
- [x] Only compose/dev.yml and docs changed — no logic or schema changes