### PR TITLE
feat: dev-stack-watch cold start when stack is fully stopped

### DIFF
--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -166,9 +166,23 @@ To trigger a rebuild outside the watch loop (e.g. after a manual `git pull` or t
 
 ```bash
 export COMPOSE_CMD="docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
-scripts/dev-stack-auto-rebuild.sh          # diffs HEAD vs HEAD^1
-scripts/dev-stack-auto-rebuild.sh <prev_sha> <new_sha>   # explicit range
+scripts/dev-stack-auto-rebuild.sh                        # diffs HEAD vs HEAD^1
+scripts/dev-stack-auto-rebuild.sh <prev_sha> <new_sha>  # explicit range
 ```
+
+### Cold start (stack fully stopped)
+
+If the stack has zero running containers (e.g. after `docker compose down` or a machine reboot), use `--cold-start` to skip the diff and bring up the entire stack including infrastructure services:
+
+```bash
+export COMPOSE_CMD="docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+scripts/dev-stack-auto-rebuild.sh --cold-start                        # builds both services, full up -d
+scripts/dev-stack-auto-rebuild.sh --cold-start <prev_sha> <new_sha>  # with explicit SHA range
+```
+
+`--cold-start` forces both `control-api` and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so databases, queues, and all other infrastructure services start alongside the application containers.
+
+The watcher (`dev-stack-watch.sh`) automatically detects a stopped stack at startup and on each new-commit cycle, and passes `--cold-start` to the rebuild script when needed. The `COMPOSE_CMD` environment variable must be set (or accept the default) for cold-start detection to work correctly.
 
 ## Troubleshooting
 
@@ -185,3 +199,8 @@ scripts/dev-stack-auto-rebuild.sh <prev_sha> <new_sha>   # explicit range
 **Build fails**
 - Docker build errors are printed inline and recorded in the NDJSON log.
 - Run `docker compose -f compose/dev.yml build control-api` manually to see the full output.
+
+**Stack was stopped and watcher didn't bring it back**
+- The watcher checks for a cold stack at startup and on each new commit. If no commit landed while the stack was down, trigger manually: `scripts/dev-stack-auto-rebuild.sh --cold-start`
+- Check `journalctl -fu rustbrain-dev-watch` to see if the cold-start detection fired at startup.
+- Ensure `COMPOSE_CMD` in the systemd unit matches the actual compose file set — the watcher uses this to query running containers.

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -2,10 +2,11 @@
 # Rebuilds and restarts dev-stack services whose source paths changed between two git SHAs.
 #
 # Usage:
-#   scripts/dev-stack-auto-rebuild.sh [PREV_SHA [NEW_SHA]]
+#   scripts/dev-stack-auto-rebuild.sh [--cold-start] [PREV_SHA [NEW_SHA]]
 #   scripts/dev-stack-auto-rebuild.sh --logs [N]    # show last N rebuild records (default: 10)
 #
 # If SHAs are omitted, detects PREV_SHA=HEAD^1 and NEW_SHA=HEAD from the repo.
+# --cold-start forces a full up -d of the entire stack regardless of which paths changed.
 #
 # Environment:
 #   COMPOSE_CMD      Full docker compose invocation (default: "docker compose -f <repo>/compose/dev.yml")
@@ -77,6 +78,14 @@ print(json.dumps({'state': sys.argv[1], 'description': sys.argv[2], 'context': '
     "https://api.github.com/repos/${GITHUB_REPO}/statuses/${NEW_SHA}" || true
 }
 
+# -- Flag parsing ------------------------------------------------------------
+
+COLD_START=false
+if [[ "${1:-}" == "--cold-start" ]]; then
+  COLD_START=true
+  shift
+fi
+
 # -- Logs mode ---------------------------------------------------------------
 
 if [[ "${1:-}" == "--logs" ]]; then
@@ -129,38 +138,44 @@ if [[ -f "$BYPASS_FILE" ]]; then
   exit 0
 fi
 
-# -- Detect changed paths ----------------------------------------------------
-
-CHANGED_FILES="$(git diff --name-only "$PREV_SHA" "$NEW_SHA" 2>/dev/null || true)"
-
-if [[ -z "$CHANGED_FILES" ]]; then
-  echo "[dev-stack-auto-rebuild] no changed files — nothing to do"
-  log_record "skipped" "" "[]" "no changed files"
-  exit 0
-fi
+# -- Detect changed paths (skipped in cold-start mode) -----------------------
 
 REBUILD_CONTROL_API=false
 REBUILD_FRONTEND=false
 
-while IFS= read -r f; do
-  case "$f" in
-    # control-api source: Rust crates, Dockerfiles, migrations, proto
-    services/control-api/*|crates/*|Cargo.toml|Cargo.lock|docker/control-api/*|migrations/*|proto/*)
-      REBUILD_CONTROL_API=true ;;
-    # frontend source
-    frontend/*|docker/frontend/*)
-      REBUILD_FRONTEND=true ;;
-    # compose config changes affect all built services
-    compose/dev.yml|compose/full.yml|compose/tailscale.yml|compose/tailscale.env|compose/scripts/*)
-      REBUILD_CONTROL_API=true
-      REBUILD_FRONTEND=true ;;
-  esac
-done <<< "$CHANGED_FILES"
+if [[ "$COLD_START" == "true" ]]; then
+  echo "[dev-stack-auto-rebuild] cold start — forcing rebuild of all services"
+  REBUILD_CONTROL_API=true
+  REBUILD_FRONTEND=true
+else
+  CHANGED_FILES="$(git diff --name-only "$PREV_SHA" "$NEW_SHA" 2>/dev/null || true)"
 
-if [[ "$REBUILD_CONTROL_API" == "false" && "$REBUILD_FRONTEND" == "false" ]]; then
-  echo "[dev-stack-auto-rebuild] no service paths changed — skipping"
-  log_record "skipped" "" "[]" "no service paths changed"
-  exit 0
+  if [[ -z "$CHANGED_FILES" ]]; then
+    echo "[dev-stack-auto-rebuild] no changed files — nothing to do"
+    log_record "skipped" "" "[]" "no changed files"
+    exit 0
+  fi
+
+  while IFS= read -r f; do
+    case "$f" in
+      # control-api source: Rust crates, Dockerfiles, migrations, proto
+      services/control-api/*|crates/*|Cargo.toml|Cargo.lock|docker/control-api/*|migrations/*|proto/*)
+        REBUILD_CONTROL_API=true ;;
+      # frontend source
+      frontend/*|docker/frontend/*)
+        REBUILD_FRONTEND=true ;;
+      # compose config changes affect all built services
+      compose/dev.yml|compose/full.yml|compose/tailscale.yml|compose/tailscale.env|compose/scripts/*)
+        REBUILD_CONTROL_API=true
+        REBUILD_FRONTEND=true ;;
+    esac
+  done <<< "$CHANGED_FILES"
+
+  if [[ "$REBUILD_CONTROL_API" == "false" && "$REBUILD_FRONTEND" == "false" ]]; then
+    echo "[dev-stack-auto-rebuild] no service paths changed — skipping"
+    log_record "skipped" "" "[]" "no service paths changed"
+    exit 0
+  fi
 fi
 
 # -- Build -------------------------------------------------------------------
@@ -195,32 +210,51 @@ fi
 
 # -- Restart -----------------------------------------------------------------
 
-if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
-  echo "[dev-stack-auto-rebuild] re-running migrations..."
-  # Blocks until rb-migrations exits (restart: "no"). Idempotent — skips applied versions.
+if [[ "$COLD_START" == "true" ]]; then
+  # Cold start: run migrations then bring up the entire stack (infra + app services).
+  # --no-deps is intentionally omitted so dependencies (postgres, neo4j, qdrant, etc.) start too.
+  echo "[dev-stack-auto-rebuild] cold start: running migrations..."
   if ! $COMPOSE_CMD up --force-recreate rb-migrations 2>&1; then
     echo "[dev-stack-auto-rebuild] rb-migrations FAILED"
-    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "migrations failed"
-    post_gh_status "failure" "rb-migrations failed"
+    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "cold start migrations failed"
+    post_gh_status "failure" "Cold start rb-migrations failed"
     exit 1
   fi
-
-  echo "[dev-stack-auto-rebuild] restarting control-api..."
-  if ! $COMPOSE_CMD up -d --no-deps --force-recreate control-api 2>&1; then
-    echo "[dev-stack-auto-rebuild] control-api restart FAILED"
-    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "control-api compose up error"
-    post_gh_status "failure" "control-api restart failed"
+  echo "[dev-stack-auto-rebuild] cold start: bringing up full stack..."
+  if ! $COMPOSE_CMD up -d 2>&1; then
+    echo "[dev-stack-auto-rebuild] full stack up FAILED"
+    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "cold start compose up -d error"
+    post_gh_status "failure" "Cold start compose up -d failed"
     exit 1
   fi
-fi
+else
+  if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+    echo "[dev-stack-auto-rebuild] re-running migrations..."
+    # Blocks until rb-migrations exits (restart: "no"). Idempotent — skips applied versions.
+    if ! $COMPOSE_CMD up --force-recreate rb-migrations 2>&1; then
+      echo "[dev-stack-auto-rebuild] rb-migrations FAILED"
+      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "migrations failed"
+      post_gh_status "failure" "rb-migrations failed"
+      exit 1
+    fi
 
-if [[ "$REBUILD_FRONTEND" == "true" ]]; then
-  echo "[dev-stack-auto-rebuild] restarting frontend..."
-  if ! $COMPOSE_CMD up -d --no-deps --force-recreate frontend 2>&1; then
-    echo "[dev-stack-auto-rebuild] frontend restart FAILED"
-    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "frontend compose up error"
-    post_gh_status "failure" "frontend restart failed"
-    exit 1
+    echo "[dev-stack-auto-rebuild] restarting control-api..."
+    if ! $COMPOSE_CMD up -d --no-deps --force-recreate control-api 2>&1; then
+      echo "[dev-stack-auto-rebuild] control-api restart FAILED"
+      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "control-api compose up error"
+      post_gh_status "failure" "control-api restart failed"
+      exit 1
+    fi
+  fi
+
+  if [[ "$REBUILD_FRONTEND" == "true" ]]; then
+    echo "[dev-stack-auto-rebuild] restarting frontend..."
+    if ! $COMPOSE_CMD up -d --no-deps --force-recreate frontend 2>&1; then
+      echo "[dev-stack-auto-rebuild] frontend restart FAILED"
+      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "frontend compose up error"
+      post_gh_status "failure" "frontend restart failed"
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -9,7 +9,7 @@
 #   POLL_INTERVAL   Seconds between git fetch polls (default: 60)
 #   REMOTE          Remote name to poll (default: origin)
 #   BRANCH          Branch to track (default: main)
-#   COMPOSE_CMD     Passed through to dev-stack-auto-rebuild.sh
+#   COMPOSE_CMD     Used locally to detect running containers; also passed through to dev-stack-auto-rebuild.sh
 #
 # Logs: journald captures stdout/stderr when run as a systemd service.
 # Rebuild records are written by dev-stack-auto-rebuild.sh to
@@ -26,6 +26,17 @@ REMOTE="${REMOTE:-origin}"
 BRANCH="${BRANCH:-main}"
 
 REBUILD_SCRIPT="$SCRIPT_DIR/dev-stack-auto-rebuild.sh"
+
+# Resolve COMPOSE_CMD with the same default as dev-stack-auto-rebuild.sh uses.
+# This is needed to inspect running container counts for cold-start detection.
+COMPOSE_CMD="${COMPOSE_CMD:-docker compose -f $REPO_ROOT/compose/dev.yml}"
+
+# Returns exit code 0 when zero compose services are currently running.
+stack_is_cold() {
+  local running_ids
+  running_ids="$($COMPOSE_CMD ps --quiet --status running 2>/dev/null)" || true
+  [[ -z "$running_ids" ]]
+}
 
 # Persist LAST_KNOWN_SHA across restarts so commits that land during an outage
 # are not silently dropped when the service comes back up.
@@ -53,6 +64,17 @@ fi
 
 echo "[dev-stack-watch] tracking from $LAST_KNOWN_SHA"
 
+# Cold-start check on startup: if the stack is fully stopped, bring it up immediately
+# without waiting for the next commit. This handles the case where the watcher restarts
+# after an outage that also stopped the compose stack.
+if stack_is_cold; then
+  echo "[dev-stack-watch] stack is not running — triggering cold start"
+  "$REBUILD_SCRIPT" --cold-start "$LAST_KNOWN_SHA" "$LAST_KNOWN_SHA" || \
+    echo "[dev-stack-watch] cold start failed — see rebuild logs for details" >&2
+else
+  echo "[dev-stack-watch] stack is running — entering poll loop"
+fi
+
 while true; do
   sleep "$POLL_INTERVAL"
 
@@ -79,8 +101,15 @@ while true; do
   LAST_KNOWN_SHA="$NEW_SHA"
   echo "$LAST_KNOWN_SHA" > "$SHA_STATE_FILE"
 
-  echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
-  # Never let a rebuild failure crash the watch loop.
-  "$REBUILD_SCRIPT" "$PREV_SHA" "$NEW_SHA" || \
-    echo "[dev-stack-watch] rebuild exited non-zero — see logs for details" >&2
+  # If the stack is fully stopped, force a cold start so infra services come up too.
+  if stack_is_cold; then
+    echo "[dev-stack-watch] stack is not running — triggering cold start: $PREV_SHA → $NEW_SHA"
+    "$REBUILD_SCRIPT" --cold-start "$PREV_SHA" "$NEW_SHA" || \
+      echo "[dev-stack-watch] cold start exited non-zero — see logs for details" >&2
+  else
+    echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
+    # Never let a rebuild failure crash the watch loop.
+    "$REBUILD_SCRIPT" "$PREV_SHA" "$NEW_SHA" || \
+      echo "[dev-stack-watch] rebuild exited non-zero — see logs for details" >&2
+  fi
 done

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -6,10 +6,12 @@
 #   scripts/dev-stack-watch.sh [REPO_PATH]
 #
 # Environment:
-#   POLL_INTERVAL   Seconds between git fetch polls (default: 60)
-#   REMOTE          Remote name to poll (default: origin)
-#   BRANCH          Branch to track (default: main)
-#   COMPOSE_CMD     Used locally to detect running containers; also passed through to dev-stack-auto-rebuild.sh
+#   POLL_INTERVAL          Seconds between git fetch polls (default: 60)
+#   REMOTE                 Remote name to poll (default: origin)
+#   BRANCH                 Branch to track (default: main)
+#   COMPOSE_CMD            Used locally to detect running containers; also passed through to dev-stack-auto-rebuild.sh
+#   COLD_START_MAX_ATTEMPTS  Max cold-start attempts on startup before exiting for systemd retry (default: 5)
+#   COLD_START_RETRY_DELAY   Initial seconds between cold-start retry attempts; doubles each attempt (default: 30)
 #
 # Logs: journald captures stdout/stderr when run as a systemd service.
 # Rebuild records are written by dev-stack-auto-rebuild.sh to
@@ -64,13 +66,32 @@ fi
 
 echo "[dev-stack-watch] tracking from $LAST_KNOWN_SHA"
 
-# Cold-start check on startup: if the stack is fully stopped, bring it up immediately
-# without waiting for the next commit. This handles the case where the watcher restarts
-# after an outage that also stopped the compose stack.
+# Cold-start on startup: if the stack is fully stopped, bring it up immediately without
+# waiting for the next commit. Retries with exponential backoff so transient failures
+# (e.g. Docker daemon not yet ready) self-heal. Exits non-zero after all attempts so
+# systemd Restart=on-failure can take over rather than leaving the stack down indefinitely.
 if stack_is_cold; then
   echo "[dev-stack-watch] stack is not running — triggering cold start"
-  "$REBUILD_SCRIPT" --cold-start "$LAST_KNOWN_SHA" "$LAST_KNOWN_SHA" || \
-    echo "[dev-stack-watch] cold start failed — see rebuild logs for details" >&2
+  _cs_attempt=1
+  _cs_delay="${COLD_START_RETRY_DELAY:-30}"
+  _cs_max="${COLD_START_MAX_ATTEMPTS:-5}"
+  while [[ $_cs_attempt -le $_cs_max ]]; do
+    if "$REBUILD_SCRIPT" --cold-start "$LAST_KNOWN_SHA" "$LAST_KNOWN_SHA"; then
+      echo "[dev-stack-watch] cold start succeeded on attempt $_cs_attempt"
+      break
+    fi
+    echo "[dev-stack-watch] cold start failed (attempt $_cs_attempt/$_cs_max) — see rebuild logs" >&2
+    if [[ $_cs_attempt -lt $_cs_max ]]; then
+      echo "[dev-stack-watch] retrying in ${_cs_delay}s" >&2
+      sleep "$_cs_delay"
+      _cs_delay=$(( _cs_delay * 2 ))
+    fi
+    _cs_attempt=$(( _cs_attempt + 1 ))
+  done
+  if [[ $_cs_attempt -gt $_cs_max ]]; then
+    echo "[dev-stack-watch] cold start failed after $_cs_max attempts — exiting for systemd restart" >&2
+    exit 1
+  fi
 else
   echo "[dev-stack-watch] stack is running — entering poll loop"
 fi


### PR DESCRIPTION
## Summary

- `dev-stack-auto-rebuild.sh` gains `--cold-start` flag: skips diff detection, forces both `control-api` and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so all infrastructure services (postgres, neo4j, qdrant, ollama) start alongside the app containers.
- `dev-stack-watch.sh` resolves `COMPOSE_CMD` locally to query running containers, and uses a `stack_is_cold()` helper to detect a fully stopped stack at startup and on each new-commit cycle — passing `--cold-start` to the rebuild script when needed.
- Docs updated with cold start usage, manual invocation examples, and a new troubleshooting entry.

## GitHub Issue
Closes #252

## Context
Discovered during the dev-stack redeploy (PRs #244 and #249) — the stack was fully stopped so the auto-rebuild never fired.

## Checklist
- [x] All three requirements implemented
- [x] `--cold-start` skips diff, forces both services, runs full `up -d`
- [x] Watcher detects cold stack at startup and on new-commit detection
- [x] No new env vars required — reuses existing `COMPOSE_CMD`
- [x] Documentation updated