### PR TITLE
feat(infra): add dev-stack liveness monitor (systemd timer + issue alerting)

### DIFF
--- a/docs/dev-stack-health-alerting.md
+++ b/docs/dev-stack-health-alerting.md
@@ -1,0 +1,127 @@
+# Dev-stack Health Alerting
+
+The `rustbrain-dev-health` systemd timer runs `scripts/dev-health-check.sh` every 5 minutes on mars. If critical containers or health endpoints are down it creates a Paperclip issue (priority: high) as an alert.
+
+## What is checked
+
+| Check | Detail |
+|-------|--------|
+| `postgres` container running | `docker ps` label filter on project `rustbrain-dev` |
+| `control-api` container running | same |
+| `frontend` container running | same |
+| `kafka` container running | same |
+| control-api `/health` | `GET http://localhost:18080/health` → expects 200 |
+| frontend | `GET http://localhost:15173/` → expects 200 |
+| Loki `/ready` | `GET http://localhost:13300/ready` → expects 200 |
+
+Ports resolve from `compose/tailscale.env` (`CONTROL_API_HOST_PORT`, `FRONTEND_HOST_PORT`, `LOKI_HOST_PORT`).
+
+## Alert behaviour
+
+- On first failure: creates a Paperclip issue (priority: high, status: todo).
+- Cooldown: 30 minutes. Subsequent failures within the cooldown window are logged but do not create duplicate issues.
+- Recovery: when all checks pass again, the cooldown state is cleared so the next failure alerts immediately.
+
+## Setup on mars
+
+### 1. Pull the repo
+
+```bash
+cd /opt/rustbrain
+git pull
+```
+
+### 2. Make the script executable
+
+```bash
+chmod +x scripts/dev-health-check.sh
+```
+
+### 3. Create the Paperclip credentials file
+
+```bash
+sudo tee /etc/rustbrain-dev-health.env <<'EOF'
+PAPERCLIP_API_URL=http://localhost:3100
+PAPERCLIP_API_KEY=<long-lived-token-or-agent-key>
+PAPERCLIP_COMPANY_ID=e69fd970-615f-4c94-85f4-f46aa2da8f03
+EOF
+sudo chmod 600 /etc/rustbrain-dev-health.env
+```
+
+> **Note:** The `PAPERCLIP_API_URL` above uses the host port for Paperclip (port 3100 per `docs/PORT_MAP.md`). Use a long-lived API key that has permission to create issues. Never commit credentials to the repo.
+
+### 4. Install the systemd units
+
+```bash
+sudo cp infra/systemd/rustbrain-dev-health.service /etc/systemd/system/
+sudo cp infra/systemd/rustbrain-dev-health.timer   /etc/systemd/system/
+```
+
+Edit `User=` and `WorkingDirectory=` / `ExecStart=` in the `.service` file if the repo is not at `/opt/rustbrain`:
+
+```bash
+sudo sed -i 's|/opt/rustbrain|/actual/path|g' /etc/systemd/system/rustbrain-dev-health.service
+```
+
+### 5. Enable and start
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now rustbrain-dev-health.timer
+sudo systemctl status rustbrain-dev-health.timer
+```
+
+### 6. Verify
+
+Run the check once manually:
+
+```bash
+sudo systemctl start rustbrain-dev-health.service
+journalctl -u rustbrain-dev-health.service --no-pager
+```
+
+Expected healthy output:
+
+```
+[dev-health-check] 2026-05-06T10:00:00Z: all healthy
+```
+
+Expected output when a service is down:
+
+```
+[dev-health-check] 2026-05-06T10:00:00Z: ALERT — failures detected:
+  - container 'control-api' is not running (project: rustbrain-dev)
+  - control-api /health returned HTTP 000 (expected 200) at http://localhost:18080/health
+[dev-health-check] Paperclip alert posted (issue: <uuid>)
+```
+
+## Monitoring the timer
+
+```bash
+# Check timer schedule
+systemctl list-timers rustbrain-dev-health.timer
+
+# Tail live logs
+journalctl -fu rustbrain-dev-health.service
+
+# Last 20 runs
+journalctl -u rustbrain-dev-health.service -n 100 --no-pager
+```
+
+## Adjusting parameters
+
+Override via `EnvironmentFile` or `Environment=` in the service unit:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COMPOSE_ENV_FILE` | (none) | Path to tailscale.env for port overrides |
+| `ALERT_COOLDOWN_SECS` | `1800` | Minimum seconds between Paperclip alerts |
+| `RB_STATE_DIR` | `~/.local/state/rustbrain` | State directory for cooldown tracking |
+
+## Disabling temporarily
+
+```bash
+sudo systemctl stop rustbrain-dev-health.timer
+# ... maintenance ...
+sudo systemctl start rustbrain-dev-health.timer
+```

--- a/infra/systemd/rustbrain-dev-health.service
+++ b/infra/systemd/rustbrain-dev-health.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Rustbrain dev-stack health check
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# Adjust User= and WorkingDirectory= to match the actual clone path on mars.
+User=jarnura
+WorkingDirectory=/opt/rustbrain
+
+ExecStart=/opt/rustbrain/scripts/dev-health-check.sh
+
+# Exit 0 = healthy, exit 1 = failures detected (alert posted or cooldown active).
+# Both are expected outcomes — treat as success so the timer keeps firing.
+SuccessExitStatus=0 1
+
+# Source tailscale port overrides into the health-check shell so
+# CONTROL_API_HOST_PORT=18080, LOKI_HOST_PORT=13300, etc. resolve correctly.
+# docker compose --env-file only exports vars to containers, not to this shell.
+Environment="COMPOSE_ENV_FILE=/opt/rustbrain/compose/tailscale.env"
+
+# Paperclip alerting credentials.
+# Create /etc/rustbrain-dev-health.env on mars with:
+#   PAPERCLIP_API_URL=https://<your-paperclip-host>
+#   PAPERCLIP_API_KEY=<short-lived or long-lived token>
+#   PAPERCLIP_COMPANY_ID=<uuid>
+# The leading '-' means systemd ignores a missing file rather than failing.
+EnvironmentFile=-/etc/rustbrain-dev-health.env
+
+StandardOutput=journal
+StandardError=journal

--- a/infra/systemd/rustbrain-dev-health.timer
+++ b/infra/systemd/rustbrain-dev-health.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run Rustbrain dev-stack health check every 5 minutes
+Requires=rustbrain-dev-health.service
+
+[Timer]
+# Fire at :00, :05, :10, ... every hour, every day.
+OnCalendar=*:0/5
+# Run a missed check immediately after a reboot (in case the system was down
+# during a scheduled window).
+Persistent=true
+Unit=rustbrain-dev-health.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/dev-health-check.sh
+++ b/scripts/dev-health-check.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Checks the rustbrain dev stack on mars and posts a Paperclip alert issue on failure.
+# Run every 5 minutes via rustbrain-dev-health.timer.
+#
+# Usage:
+#   scripts/dev-health-check.sh
+#
+# Environment:
+#   COMPOSE_ENV_FILE         Path to compose env-file to source for port overrides.
+#                            Required on mars so CONTROL_API_HOST_PORT etc. resolve
+#                            to tailscale-remapped ports (e.g. 18080/15173/13300).
+#                            Example: "/opt/rustbrain/compose/tailscale.env"
+#   PAPERCLIP_API_URL        Paperclip API base URL (required for alerting)
+#   PAPERCLIP_API_KEY        Paperclip API key (required for alerting)
+#   PAPERCLIP_COMPANY_ID     Paperclip company ID (required for alerting)
+#   ALERT_COOLDOWN_SECS      Minimum seconds between repeated alerts (default: 1800)
+#   RB_STATE_DIR             State directory for cooldown tracking
+#                            (default: $HOME/.local/state/rustbrain)
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed (alert posted or suppressed by cooldown)
+#
+# See docs/dev-stack-health-alerting.md for setup instructions.
+
+set -euo pipefail
+
+# -- Source compose env-file for host port overrides -------------------------
+
+if [[ -n "${COMPOSE_ENV_FILE:-}" && -f "$COMPOSE_ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$COMPOSE_ENV_FILE"
+  set +a
+fi
+
+CONTROL_API_PORT="${CONTROL_API_HOST_PORT:-8080}"
+FRONTEND_PORT="${FRONTEND_HOST_PORT:-15173}"
+LOKI_PORT="${LOKI_HOST_PORT:-3100}"
+ALERT_COOLDOWN_SECS="${ALERT_COOLDOWN_SECS:-1800}"
+STATE_DIR="${RB_STATE_DIR:-"$HOME/.local/state/rustbrain"}"
+STATE_FILE="$STATE_DIR/dev-health-alert.last"
+COMPOSE_PROJECT="rustbrain-dev"
+
+mkdir -p "$STATE_DIR"
+
+FAILURES=()
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+
+# -- Check: critical Docker containers are running ---------------------------
+
+check_compose_services() {
+  local critical_services=("postgres" "control-api" "frontend" "kafka")
+
+  for svc in "${critical_services[@]}"; do
+    if ! docker ps \
+        --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+        --filter "label=com.docker.compose.service=${svc}" \
+        --filter "status=running" \
+        --format "{{.Names}}" 2>/dev/null | grep -q .; then
+      FAILURES+=("container '${svc}' is not running (project: ${COMPOSE_PROJECT})")
+    fi
+  done
+}
+
+# -- Check: HTTP health endpoints --------------------------------------------
+
+check_http() {
+  local name="$1" url="$2"
+  local code
+  code=$(curl -sf -o /dev/null -w "%{http_code}" \
+    --connect-timeout 5 --max-time 10 "$url" 2>/dev/null || echo "000")
+  if [[ "$code" != "200" ]]; then
+    FAILURES+=("${name} returned HTTP ${code} (expected 200) at ${url}")
+  fi
+}
+
+# -- Run all checks ----------------------------------------------------------
+
+check_compose_services
+check_http "control-api /health" "http://localhost:${CONTROL_API_PORT}/health"
+check_http "frontend"             "http://localhost:${FRONTEND_PORT}/"
+check_http "loki /ready"          "http://localhost:${LOKI_PORT}/ready"
+
+# -- All healthy -------------------------------------------------------------
+
+if [[ ${#FAILURES[@]} -eq 0 ]]; then
+  echo "[dev-health-check] $(ts): all healthy"
+  # Clear stale cooldown state when stack recovers so next failure alerts immediately.
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# -- Failures detected — apply cooldown to suppress alert spam ---------------
+
+NOW=$(date +%s)
+
+if [[ -f "$STATE_FILE" ]]; then
+  LAST_ALERT=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+  ELAPSED=$(( NOW - LAST_ALERT ))
+  if (( ELAPSED < ALERT_COOLDOWN_SECS )); then
+    echo "[dev-health-check] $(ts): failures detected, cooldown active (${ELAPSED}s < ${ALERT_COOLDOWN_SECS}s) — skipping alert"
+    for f in "${FAILURES[@]}"; do
+      echo "  - $f"
+    done
+    exit 1
+  fi
+fi
+
+echo "$NOW" > "$STATE_FILE"
+
+echo "[dev-health-check] $(ts): ALERT — failures detected:"
+for f in "${FAILURES[@]}"; do
+  echo "  - $f"
+done
+
+# -- Post Paperclip alert issue ----------------------------------------------
+
+if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_COMPANY_ID:-}" ]]; then
+  echo "[dev-health-check] PAPERCLIP_API_URL/KEY/COMPANY_ID not set — skipping Paperclip alert" >&2
+  exit 1
+fi
+
+FAILURE_BULLETS=""
+for f in "${FAILURES[@]}"; do
+  FAILURE_BULLETS+="- ${f}\n"
+done
+
+PAYLOAD=$(jq -n \
+  --arg title "alert: dev stack failure on mars — $(date -u '+%Y-%m-%d %H:%M UTC')" \
+  --arg desc "## Dev stack health alert
+
+**Host:** mars (100.87.157.74)
+**Time:** $(date -u)
+
+### Failures
+
+${FAILURE_BULLETS}
+### Remediation
+
+\`\`\`bash
+# Check container status
+docker compose -p rustbrain-dev ps
+
+# Restart the stack
+docker compose --env-file /opt/rustbrain/compose/tailscale.env \\
+  -f /opt/rustbrain/compose/dev.yml \\
+  -f /opt/rustbrain/compose/tailscale.yml up -d
+
+# Check logs for a failing service
+docker compose -p rustbrain-dev logs --tail=100 control-api
+\`\`\`" \
+  '{"title": $title, "description": $desc, "priority": "high", "status": "todo"}')
+
+HTTP_CODE=$(curl -s -o /tmp/rb-dev-health-alert.json -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${PAPERCLIP_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  "${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues" 2>/dev/null || echo "000")
+
+if [[ "$HTTP_CODE" == "200" || "$HTTP_CODE" == "201" ]]; then
+  ISSUE_ID=$(jq -r '.id // "unknown"' /tmp/rb-dev-health-alert.json 2>/dev/null || echo "unknown")
+  echo "[dev-health-check] Paperclip alert posted (issue: ${ISSUE_ID})"
+else
+  echo "[dev-health-check] failed to post Paperclip alert (HTTP ${HTTP_CODE})" >&2
+  cat /tmp/rb-dev-health-alert.json >&2 2>/dev/null || true
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

Adds a `rustbrain-dev-health` systemd timer that fires every 5 minutes and probes the dev stack. On failure it creates an alert issue (priority: high) so the board sees it without manually checking. Adds liveness monitoring after the silent stack-down incident.

### What is checked

| Check | Detail |
|-------|--------|
| `postgres` container running | `docker ps` label filter |
| `control-api` container running | same |
| `frontend` container running | same |
| `kafka` container running | same |
| `GET /health` → 200 | control-api on port 18080 (tailscale) |
| `GET /` → 200 | frontend on port 15173 |
| `GET /ready` → 200 | Loki on port 13300 |

### Alert behaviour

- Creates an alert issue (priority: high) on first failure.
- 30-minute cooldown suppresses duplicate issues while stack stays down.
- Cooldown clears on recovery so the next failure always fires immediately.
- All failures + suppressions logged to journald.

### Files added

| File | Purpose |
|------|---------|
| `scripts/dev-health-check.sh` | Health check + alert script |
| `infra/systemd/rustbrain-dev-health.service` | Oneshot service unit |
| `infra/systemd/rustbrain-dev-health.timer` | 5-minute timer unit |
| `docs/dev-stack-health-alerting.md` | Setup instructions for mars |

## GitHub Issue
Closes #253

## Setup on mars

After merge, on mars:
```bash
chmod +x scripts/dev-health-check.sh
sudo cp infra/systemd/rustbrain-dev-health.{service,timer} /etc/systemd/system/
# create /etc/rustbrain-dev-health.env with API credentials
sudo systemctl daemon-reload && sudo systemctl enable --now rustbrain-dev-health.timer
```

## Checklist
- [x] `bash -n scripts/dev-health-check.sh` passes (syntax check)
- [x] Script is executable (`chmod +x`)
- [x] Systemd units have `SuccessExitStatus=0 1` so timer continues on check failure
- [x] `Persistent=true` on timer so a missed check runs on reboot
- [x] No hardcoded secrets — credentials go in `/etc/rustbrain-dev-health.env`
- [x] Docs updated (`docs/dev-stack-health-alerting.md`)
- [x] No changes to existing services