### PR TITLE
fix(control-api): write trace_id to ingestion_runs on creation

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1340,6 +1340,8 @@ export interface components {
         readonly TriggerIngestionResponse: {
             /** Format: uuid */
             readonly ingest_run_id: string;
+            /** @description 32-hex OpenTelemetry trace ID for this run. `null` when no active trace context. */
+            readonly trace_id?: string | null;
         };
         readonly UpdateRoleRequest: {
             /** @description Target role: `member` or `admin`. Cannot set `owner` via this endpoint. */

--- a/openapi.json
+++ b/openapi.json
@@ -3218,6 +3218,13 @@
           "ingest_run_id": {
             "type": "string",
             "format": "uuid"
+          },
+          "trace_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "32-hex OpenTelemetry trace ID for this run. `null` when no active trace context."
           }
         }
       },

--- a/services/control-api/src/routes/ingest/trigger.rs
+++ b/services/control-api/src/routes/ingest/trigger.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use opentelemetry::trace::TraceContextExt as _;
 use rb_kafka::EventEnvelope;
 use rb_schemas::{IngestRequest, TenantId};
 use serde::{Deserialize, Serialize};
@@ -51,6 +52,8 @@ pub struct TriggerIngestionRequest {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TriggerIngestionResponse {
     pub ingest_run_id: Uuid,
+    /// 32-hex OpenTelemetry trace ID for this run. `null` when no active trace context.
+    pub trace_id: Option<String>,
 }
 
 /// Trigger a manual ingestion run for a connected repository.
@@ -126,6 +129,13 @@ pub async fn trigger_ingestion(
     let run_id = Uuid::new_v4();
     let event_id = Uuid::new_v4();
 
+    // Capture the active OTel trace ID so Grafana/Tempo links work.
+    // Returns None when no HTTP middleware has established a trace context.
+    let trace_id: Option<String> = {
+        let span_ctx = opentelemetry::Context::current().span().span_context().clone();
+        span_ctx.is_valid().then(|| span_ctx.trace_id().to_string())
+    };
+
     // 3. Build the Kafka envelope before opening the transaction (pure in-memory,
     //    no I/O). This lets us publish to Kafka while still inside the transaction
     //    and rollback cleanly if the broker is unavailable.
@@ -151,13 +161,14 @@ pub async fn trigger_ingestion(
 
     sqlx::query(
         "INSERT INTO control.ingestion_runs \
-         (id, tenant_id, repo_id, status, requested_by) \
-         VALUES ($1, $2, $3, 'queued', $4)",
+         (id, tenant_id, repo_id, status, requested_by, trace_id) \
+         VALUES ($1, $2, $3, 'queued', $4, $5)",
     )
     .bind(run_id)
     .bind(session.tenant_id)
     .bind(repo_id)
     .bind(session.user_id)
+    .bind(&trace_id)
     .execute(&mut *txn)
     .await?;
 
@@ -196,7 +207,7 @@ pub async fn trigger_ingestion(
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(TriggerIngestionResponse { ingest_run_id: run_id }),
+        Json(TriggerIngestionResponse { ingest_run_id: run_id, trace_id }),
     ))
 }
 
@@ -232,11 +243,24 @@ mod tests {
     }
 
     #[test]
-    fn trigger_ingestion_response_serializes() {
+    fn trigger_ingestion_response_serializes_with_trace_id() {
         let run_id = Uuid::new_v4();
-        let resp = TriggerIngestionResponse { ingest_run_id: run_id };
+        let resp = TriggerIngestionResponse {
+            ingest_run_id: run_id,
+            trace_id: Some("abcdef0123456789abcdef0123456789".to_owned()),
+        };
         let val = serde_json::to_value(&resp).unwrap();
         assert!(val.get("ingest_run_id").is_some());
+        assert_eq!(val["trace_id"], "abcdef0123456789abcdef0123456789");
+    }
+
+    #[test]
+    fn trigger_ingestion_response_serializes_null_trace_id() {
+        let run_id = Uuid::new_v4();
+        let resp = TriggerIngestionResponse { ingest_run_id: run_id, trace_id: None };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val.get("ingest_run_id").is_some());
+        assert!(val["trace_id"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Captures the active OTel trace ID (`opentelemetry::Context::current().span().span_context().trace_id()`) when `POST /v1/repos/{repo_id}/ingestions` creates a new run
- Persists it to `control.ingestion_runs.trace_id` in the same atomic transaction
- Exposes `trace_id` in the 202 Accepted response so the frontend can link to Tempo/Grafana

Fixes the dead-code column identified during the ingestion-trace root-cause analysis (the column existed but no code path populated it). Returns `null` when no OTel middleware has established a trace context.

Closes #257

## Test plan

- [ ] `cargo test -p control-api --lib routes::ingest::trigger` — 12/12 pass locally
- [ ] Integration test: trigger an ingestion via the API and verify `ingestion_runs.trace_id` is populated in Postgres
- [ ] Verify `trace_id` appears in the 202 response JSON
- [ ] Verify `GET /v1/ingestions/recent` and `GET /v1/ingestions/{id}/stages` surface the stored trace_id