### PR TITLE
fix(ingest-clone): make GitHub App auth optional

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -339,6 +339,7 @@ services:
       dockerfile: docker/ingest-clone/Dockerfile
     image: ghcr.io/jarnura/rustacean/ingest-clone:dev
     pull_policy: never
+    restart: on-failure
     environment:
       DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"

--- a/services/ingest-clone/src/consumer.rs
+++ b/services/ingest-clone/src/consumer.rs
@@ -43,7 +43,7 @@ const CLONE_TIMEOUT_SECS: u64 = 300;
 
 struct CloneCtx {
     pool: Arc<PgPool>,
-    gh_app: Arc<GhApp>,
+    gh_app: Option<Arc<GhApp>>,
     blob_store: Arc<dyn BlobStore>,
     source_producer: Arc<Producer<SourceFileEvent>>,
     expand_producer: Arc<Producer<IngestRequest>>,
@@ -53,7 +53,7 @@ struct CloneCtx {
 pub async fn run(
     consumer: Consumer<IngestRequest>,
     pool: Arc<PgPool>,
-    gh_app: Arc<GhApp>,
+    gh_app: Option<Arc<GhApp>>,
     blob_store: Arc<dyn BlobStore>,
     source_producer: Arc<Producer<SourceFileEvent>>,
     expand_producer: Arc<Producer<IngestRequest>>,
@@ -163,16 +163,21 @@ async fn process_clone(
     Ok(())
 }
 
-/// Resolves a GitHub HTTPS clone URL with embedded installation access token.
+/// Resolves a GitHub HTTPS clone URL.
+///
+/// When GitHub App credentials are configured (`ctx.gh_app` is `Some`), embeds an
+/// installation access token. Otherwise falls back to a `GITHUB_PAT` env var or,
+/// if that is also absent, a plain unauthenticated URL (public repos only).
 async fn resolve_clone_url(
     ctx: &CloneCtx,
     tenant_id: TenantId,
     repo_id: Uuid,
 ) -> Result<String> {
-    let row: (String, i64) = sqlx::query_as(
+    // LEFT JOIN so the query succeeds even when no installation row exists (PAT/public path).
+    let row: (String, Option<i64>) = sqlx::query_as(
         "SELECT r.full_name, gi.github_installation_id \
          FROM control.repos r \
-         JOIN control.github_installations gi ON gi.id = r.installation_id \
+         LEFT JOIN control.github_installations gi ON gi.id = r.installation_id \
          WHERE r.id = $1 AND r.tenant_id = $2 AND r.archived_at IS NULL",
     )
     .bind(repo_id)
@@ -183,18 +188,32 @@ async fn resolve_clone_url(
 
     let (full_name, installation_id) = row;
 
-    let token = ctx
-        .gh_app
-        .installation_token(installation_id)
-        .await
-        .context("failed to get GitHub installation token")?;
+    if let Some(app) = &ctx.gh_app {
+        let inst_id = installation_id
+            .context("repo has no GitHub installation; cannot obtain clone token")?;
+        let token = app
+            .installation_token(inst_id)
+            .await
+            .context("failed to get GitHub installation token")?;
+        // Embed the token as a URL credential so git authenticates without prompts.
+        return Ok(format!(
+            "https://x-access-token:{}@github.com/{}.git",
+            token.expose(),
+            full_name
+        ));
+    }
 
-    // Embed the token as a URL credential so git authenticates without prompts.
-    Ok(format!(
-        "https://x-access-token:{}@github.com/{}.git",
-        token.expose(),
-        full_name
-    ))
+    // GH App not configured — try a personal access token, then fall back to public HTTPS.
+    let pat = std::env::var("GITHUB_PAT").unwrap_or_default();
+    if pat.is_empty() {
+        Ok(format!("https://github.com/{}.git", full_name))
+    } else {
+        Ok(format!(
+            "https://x-access-token:{}@github.com/{}.git",
+            pat,
+            full_name
+        ))
+    }
 }
 
 /// Removes the embedded token from a clone URL for safe logging.

--- a/services/ingest-clone/src/consumer.rs
+++ b/services/ingest-clone/src/consumer.rs
@@ -199,13 +199,9 @@ async fn resolve_clone_url(
 
     let pat = std::env::var("GITHUB_PAT").unwrap_or_default();
     if pat.is_empty() {
-        Ok(format!("https://github.com/{}.git", full_name))
+        Ok(format!("https://github.com/{full_name}.git"))
     } else {
-        Ok(format!(
-            "https://x-access-token:{}@github.com/{}.git",
-            pat,
-            full_name
-        ))
+        Ok(format!("https://x-access-token:{pat}@github.com/{full_name}.git"))
     }
 }
 

--- a/services/ingest-clone/src/consumer.rs
+++ b/services/ingest-clone/src/consumer.rs
@@ -163,17 +163,12 @@ async fn process_clone(
     Ok(())
 }
 
-/// Resolves a GitHub HTTPS clone URL.
-///
-/// When GitHub App credentials are configured (`ctx.gh_app` is `Some`), embeds an
-/// installation access token. Otherwise falls back to a `GITHUB_PAT` env var or,
-/// if that is also absent, a plain unauthenticated URL (public repos only).
+/// Resolves a clone URL: GH App token when configured, `GITHUB_PAT` or plain HTTPS otherwise.
 async fn resolve_clone_url(
     ctx: &CloneCtx,
     tenant_id: TenantId,
     repo_id: Uuid,
 ) -> Result<String> {
-    // LEFT JOIN so the query succeeds even when no installation row exists (PAT/public path).
     let row: (String, Option<i64>) = sqlx::query_as(
         "SELECT r.full_name, gi.github_installation_id \
          FROM control.repos r \
@@ -195,7 +190,6 @@ async fn resolve_clone_url(
             .installation_token(inst_id)
             .await
             .context("failed to get GitHub installation token")?;
-        // Embed the token as a URL credential so git authenticates without prompts.
         return Ok(format!(
             "https://x-access-token:{}@github.com/{}.git",
             token.expose(),
@@ -203,7 +197,6 @@ async fn resolve_clone_url(
         ));
     }
 
-    // GH App not configured — try a personal access token, then fall back to public HTTPS.
     let pat = std::env::var("GITHUB_PAT").unwrap_or_default();
     if pat.is_empty() {
         Ok(format!("https://github.com/{}.git", full_name))
@@ -493,12 +486,6 @@ async fn emit_failed_status(
         tracing::error!("ingest_clone: failed to publish failed status: {e}");
     }
 }
-
-// ── Topic constant consistency note ─────────────────────────────────────────
-// projector-pg currently has `TOPIC_SOURCE_FILE = "rb.ingest.clone.commands"`.
-// That is a placeholder from early scaffolding. The authoritative source-file
-// topic is `rb.source-files.v1` (emitted here). projector-pg will be updated
-// in its own PR to consume from `rb.source-files.v1`.
 
 #[cfg(test)]
 mod tests {

--- a/services/ingest-clone/src/main.rs
+++ b/services/ingest-clone/src/main.rs
@@ -25,8 +25,7 @@ async fn main() -> Result<()> {
             .context("failed to connect to Postgres")?,
     );
 
-    let gh_app = build_gh_app()?;
-    let gh_app = Arc::new(gh_app);
+    let gh_app = build_gh_app()?.map(Arc::new);
 
     let blob_store = store_from_env().await.context("failed to init blob store")?;
 
@@ -43,7 +42,7 @@ async fn main() -> Result<()> {
     let handle: JoinHandle<()> = tokio::spawn(consumer::run(
         consumer,
         pool,
-        gh_app,
+        gh_app,  // Option<Arc<GhApp>>
         blob_store,
         source_producer,
         expand_producer,
@@ -57,14 +56,19 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn build_gh_app() -> Result<GhApp> {
-    let app_id: i64 = std::env::var("GITHUB_APP_ID")
-        .context("GITHUB_APP_ID is required")?
+fn build_gh_app() -> Result<Option<GhApp>> {
+    let app_id_str = std::env::var("GITHUB_APP_ID").unwrap_or_default();
+    if app_id_str.is_empty() {
+        tracing::info!("GITHUB_APP_ID is unset — GitHub App auth disabled; using PAT or public clone");
+        return Ok(None);
+    }
+
+    let app_id: i64 = app_id_str
         .parse()
         .context("GITHUB_APP_ID must be a number")?;
 
     let private_key_pem = std::env::var("GITHUB_APP_PRIVATE_KEY_PEM")
-        .context("GITHUB_APP_PRIVATE_KEY_PEM is required")?;
+        .context("GITHUB_APP_PRIVATE_KEY_PEM is required when GITHUB_APP_ID is set")?;
 
     let encoding_key = EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
         .context("invalid GITHUB_APP_PRIVATE_KEY_PEM")?;
@@ -73,11 +77,34 @@ fn build_gh_app() -> Result<GhApp> {
         .unwrap_or_default()
         .into_bytes();
 
-    Ok(GhApp::new(
+    Ok(Some(GhApp::new(
         app_id,
         encoding_key,
         rb_github::Secret::new(webhook_secret_raw),
-    ))
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_gh_app_returns_none_when_app_id_absent() {
+        // SAFETY: single-threaded test binary; no other thread reads GITHUB_APP_ID.
+        unsafe { std::env::remove_var("GITHUB_APP_ID") };
+        let result = build_gh_app()
+            .expect("build_gh_app must not error when GITHUB_APP_ID is absent");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn build_gh_app_returns_none_when_app_id_empty_string() {
+        // SAFETY: single-threaded test binary; no other thread reads GITHUB_APP_ID.
+        unsafe { std::env::set_var("GITHUB_APP_ID", "") };
+        let result = build_gh_app()
+            .expect("build_gh_app must not error when GITHUB_APP_ID is empty");
+        assert!(result.is_none());
+    }
 }
 
 async fn shutdown_signal() {


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `build_gh_app()` in `services/ingest-clone/src/main.rs` unconditionally parsed `GITHUB_APP_ID` as `i64`, crashing the container when the env var was empty (the compose default). Now returns `Option<GhApp>` — `None` when the var is absent or empty, skipping all App-auth setup entirely.
- **Fallback auth**: `resolve_clone_url` in `consumer.rs` uses a `LEFT JOIN` so the DB query succeeds without an installation row. Falls back to `GITHUB_PAT` env var, then plain HTTPS.
- **Compose restart policy**: Added `restart: on-failure` to `ingest-clone` in `compose/dev.yml`.
- **Unit tests**: Two new tests verify `build_gh_app` returns `None` when `GITHUB_APP_ID` is absent and when it is an empty string.

## Test plan

- [ ] `cargo test -p ingest-clone` — 13 tests green (12 unit + 1 metrics integration)
- [ ] Start dev stack with `RB_GH_APP_ID` unset — `ingest-clone` container should stay up
- [ ] Start dev stack with `RB_GH_APP_ID` set to a valid app ID — existing GH App code path unchanged
- [ ] CI green at HEAD

Closes #263