### PR TITLE
feat(frontend): show explanation when callers/callees data unavailable

### DIFF
--- a/frontend/src/components/code-intel/RelationsPanel.tsx
+++ b/frontend/src/components/code-intel/RelationsPanel.tsx
@@ -130,9 +130,15 @@ function TraversalGraph({ data, onSelect, direction }: TraversalGraphProps): JSX
       </div>
 
       {related.length === 0 ? (
-        <p className="px-3 pb-3 text-xs text-muted-foreground">
-          No {label} found.
-        </p>
+        <div className="px-3 pb-3">
+          <p className="text-xs text-muted-foreground">
+            Call graph analysis is not yet available for this repository.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground/70">
+            {label.charAt(0).toUpperCase() + label.slice(1)} will appear here once call graph
+            extraction has been completed for this codebase.
+          </p>
+        </div>
       ) : (
         <ul
           aria-label={`${direction} list`}


### PR DESCRIPTION
## Summary

- Replace generic "No callers found." / "No callees found." with a contextual explanation when the callers/callees API returns 0 edges.
- Message: "Call graph analysis is not yet available for this repository." with a secondary line: "Callers/Callees will appear here once call graph extraction has been completed for this codebase."
- Addresses the known gap where CALLS extraction is deferred (ADR-007 §11.6) but was not communicated to users.

## GitHub Issue

Closes #258

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR