### PR TITLE
test(ci): add E2E pipeline smoke test

### DIFF
--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -5,9 +5,12 @@ name: Pipeline E2E Smoke Test
 # Skipped automatically on fork PRs (secrets are unavailable there).
 
 on:
+  # Runs after merge to main (secrets available) and on manual triggers.
+  # Intentionally NOT on pull_request: the test requires GitHub App secrets
+  # that are unavailable on PRs, takes up to 10 minutes, and is not a merge
+  # gate (regular CI — cargo test, clippy, etc. — gates PRs instead).
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -18,15 +21,6 @@ jobs:
   pipeline-e2e:
     name: pipeline e2e smoke
     runs-on: ubuntu-latest
-
-    # Skip the job on fork PRs: they cannot access repository secrets, so
-    # SMOKE_GH_APP_ID will be empty and the test cannot clone the fixture repo.
-    # The condition evaluates to true for all pushes to main and for PRs opened
-    # from the same repository (i.e. branches pushed by collaborators).
-    if: >
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -1,0 +1,76 @@
+name: Pipeline E2E Smoke Test
+
+# Full 9-stage pipeline integration test (RUSAA-645).
+# Requires real GitHub App credentials stored as repository secrets.
+# Skipped automatically on fork PRs (secrets are unavailable there).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipeline-e2e:
+    name: pipeline e2e smoke
+    runs-on: ubuntu-latest
+
+    # Skip the job on fork PRs: they cannot access repository secrets, so
+    # SMOKE_GH_APP_ID will be empty and the test cannot clone the fixture repo.
+    # The condition evaluates to true for all pushes to main and for PRs opened
+    # from the same repository (i.e. branches pushed by collaborators).
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify required secrets are present
+        env:
+          SMOKE_GH_APP_ID: ${{ secrets.SMOKE_GH_APP_ID }}
+        run: |
+          if [ -z "$SMOKE_GH_APP_ID" ]; then
+            echo "::error::Secret SMOKE_GH_APP_ID is not configured."
+            echo "::error::Set SMOKE_GH_APP_ID, SMOKE_GH_PRIVATE_KEY_PEM_B64,"
+            echo "::error::SMOKE_INSTALLATION_ID, SMOKE_GITHUB_REPO_ID, and"
+            echo "::error::SMOKE_GITHUB_REPO_FULL_NAME as repository secrets."
+            exit 1
+          fi
+          echo "Secrets present — proceeding with E2E test."
+
+      - name: Decode GitHub App private key
+        env:
+          SMOKE_GH_PRIVATE_KEY_PEM_B64: ${{ secrets.SMOKE_GH_PRIVATE_KEY_PEM_B64 }}
+        run: |
+          # The PEM is stored base64-encoded to survive GitHub's secret masking.
+          echo "$SMOKE_GH_PRIVATE_KEY_PEM_B64" | base64 -d > /tmp/smoke-gh-key.pem
+          echo "GITHUB_APP_PRIVATE_KEY_PEM<<EOF" >> "$GITHUB_ENV"
+          cat /tmp/smoke-gh-key.pem >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+          rm -f /tmp/smoke-gh-key.pem
+
+      - name: Run E2E pipeline smoke test
+        env:
+          SMOKE_GH_APP_ID: ${{ secrets.SMOKE_GH_APP_ID }}
+          SMOKE_INSTALLATION_ID: ${{ secrets.SMOKE_INSTALLATION_ID }}
+          SMOKE_GITHUB_REPO_ID: ${{ secrets.SMOKE_GITHUB_REPO_ID }}
+          SMOKE_GITHUB_REPO_FULL_NAME: ${{ secrets.SMOKE_GITHUB_REPO_FULL_NAME }}
+          SMOKE_TIMEOUT_SECS: "600"
+        run: bash scripts/e2e-smoke-test.sh
+
+      - name: Upload compose logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-compose-logs-${{ github.run_id }}
+          path: /tmp/smoke-compose-logs/
+          retention-days: 7

--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -37,15 +37,20 @@ jobs:
       - name: Verify required secrets are present
         env:
           SMOKE_GH_APP_ID: ${{ secrets.SMOKE_GH_APP_ID }}
+          SMOKE_GH_PRIVATE_KEY_PEM_B64: ${{ secrets.SMOKE_GH_PRIVATE_KEY_PEM_B64 }}
         run: |
-          if [ -z "$SMOKE_GH_APP_ID" ]; then
-            echo "::error::Secret SMOKE_GH_APP_ID is not configured."
-            echo "::error::Set SMOKE_GH_APP_ID, SMOKE_GH_PRIVATE_KEY_PEM_B64,"
-            echo "::error::SMOKE_INSTALLATION_ID, SMOKE_GITHUB_REPO_ID, and"
-            echo "::error::SMOKE_GITHUB_REPO_FULL_NAME as repository secrets."
+          missing=()
+          [ -n "$SMOKE_GH_APP_ID" ]             || missing+=("SMOKE_GH_APP_ID")
+          [ -n "$SMOKE_GH_PRIVATE_KEY_PEM_B64" ] || missing+=("SMOKE_GH_PRIVATE_KEY_PEM_B64")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            for s in "${missing[@]}"; do
+              echo "::error::Required secret $s is not configured."
+            done
+            echo "::error::Also ensure SMOKE_INSTALLATION_ID, SMOKE_GITHUB_REPO_ID,"
+            echo "::error::and SMOKE_GITHUB_REPO_FULL_NAME are set as repository secrets."
             exit 1
           fi
-          echo "Secrets present — proceeding with E2E test."
+          echo "All required secrets present — proceeding with E2E test."
 
       - name: Decode GitHub App private key
         env:
@@ -53,9 +58,13 @@ jobs:
         run: |
           # The PEM is stored base64-encoded to survive GitHub's secret masking.
           echo "$SMOKE_GH_PRIVATE_KEY_PEM_B64" | base64 -d > /tmp/smoke-gh-key.pem
-          echo "GITHUB_APP_PRIVATE_KEY_PEM<<EOF" >> "$GITHUB_ENV"
+          [ -s /tmp/smoke-gh-key.pem ] \
+            || { echo "::error::Decoded PEM is empty — SMOKE_GH_PRIVATE_KEY_PEM_B64 may be corrupt"; exit 1; }
+          # Use a unique sentinel to prevent accidental heredoc truncation if the PEM
+          # body somehow contains a bare "EOF" line (e.g. a manually-pasted corrupt key).
+          echo "GITHUB_APP_PRIVATE_KEY_PEM<<SMOKE_PEM_HEREDOC_END" >> "$GITHUB_ENV"
           cat /tmp/smoke-gh-key.pem >> "$GITHUB_ENV"
-          echo "EOF" >> "$GITHUB_ENV"
+          echo "SMOKE_PEM_HEREDOC_END" >> "$GITHUB_ENV"
           rm -f /tmp/smoke-gh-key.pem
 
       - name: Run E2E pipeline smoke test

--- a/compose/e2e.yml
+++ b/compose/e2e.yml
@@ -1,0 +1,346 @@
+name: rustbrain-e2e
+
+# Lightweight stack for the pipeline E2E smoke test (RUSAA-645).
+# Differences from dev.yml:
+#   - No observability stack (loki/tempo/prometheus/grafana/otel-collector)
+#   - Neo4j uses a tiny heap/pagecache to fit within CI runner memory (~7 GB)
+#   - ollama-stub replaces the real Ollama so embed-worker can run without GPU
+#   - Kafka uses 1 partition per topic (no need for multi-partition parallelism)
+#   - Memory limits on each service so the runner doesn't OOM
+#
+# Required env vars (set in the smoke-test workflow via GitHub Secrets):
+#   SMOKE_GH_APP_ID           — GitHub App numeric ID
+#   GITHUB_APP_PRIVATE_KEY_PEM — raw RSA PEM private key for ingest-clone
+#   SMOKE_INSTALLATION_ID     — numeric GitHub installation ID for the test repo
+#   SMOKE_GITHUB_REPO_ID      — numeric GitHub repo ID
+#   SMOKE_GITHUB_REPO_FULL_NAME — e.g. "jarnura/rb-smoke-fixture"
+
+services:
+
+  # ── Infrastructure ──────────────────────────────────────────────────────────
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: rustbrain
+      POSTGRES_PASSWORD: rustbrain
+      POSTGRES_DB: rustbrain
+    networks: [rb-e2e-net]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rustbrain"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/rustbrain123
+      # Tiny heap so the runner doesn't OOM.  Adequate for a 5-file fixture.
+      NEO4J_server_memory_heap_max__size: 512m
+      NEO4J_server_memory_pagecache_size: 128m
+      NEO4J_server_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
+    networks: [rb-e2e-net]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  qdrant:
+    image: qdrant/qdrant:v1.13.0
+    networks: [rb-e2e-net]
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo >/dev/tcp/localhost/6333' 2>/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  kafka:
+    image: apache/kafka:3.9
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      CLUSTER_ID: VGVzdENsdXN0ZXJJZEtleQ
+    networks: [rb-e2e-net]
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 30s
+
+  kafka-init:
+    image: apache/kafka:3.9
+    depends_on:
+      kafka:
+        condition: service_healthy
+    restart: "no"
+    networks: [rb-e2e-net]
+    # 1 partition per topic is sufficient for a single-run smoke test.
+    command: >
+      bash -c "
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.clone.commands     --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.expand.commands    --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.parse.commands     --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.parsed-items.v1           --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.typecheck.commands --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.typechecked-items.v1      --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.graph.commands     --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.ingest.embed.commands     --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.source-files.v1           --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 1 --replication-factor 1 &&
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.tombstones.v1             --partitions 1 --replication-factor 1 &&
+        echo 'kafka-init: all topics created'
+      "
+
+  # Fake Ollama: serves /api/embeddings with a zero-vector.
+  # Lets embed-worker complete without a GPU.
+  ollama-stub:
+    image: python:3.12-slim
+    command: python3 /app/ollama-stub.py
+    volumes:
+      - ./scripts/ollama-stub.py:/app/ollama-stub.py:ro
+    networks: [rb-e2e-net]
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:11434/api/tags')\" 2>/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ── Database migrations ─────────────────────────────────────────────────────
+
+  rb-migrations:
+    image: pgvector/pgvector:pg16
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+    volumes:
+      - ../migrations:/migrations:ro
+      - ./scripts/migrate-control.sh:/usr/local/bin/migrate-control.sh:ro
+      - ./scripts/migrate-tenant.sh:/usr/local/bin/migrate-tenant.sh:ro
+    command: ["sh", "-c", "sh /usr/local/bin/migrate-control.sh && sh /usr/local/bin/migrate-tenant.sh"]
+    restart: "no"
+    networks: [rb-e2e-net]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ── Pipeline services ───────────────────────────────────────────────────────
+
+  control-api:
+    build:
+      context: ..
+      dockerfile: docker/control-api/Dockerfile
+    image: ghcr.io/jarnura/rustacean/control-api:e2e
+    environment:
+      RB_DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      RB_LISTEN_ADDR: "0.0.0.0:8080"
+      RB_CORS_ORIGINS: "http://localhost:8080"
+      RB_BASE_URL: "http://control-api:8080"
+      RB_EMAIL_TRANSPORT: console
+      RB_SECURE_COOKIES: "false"
+      RB_MIGRATIONS_ROOT: /migrations
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_NEO4J_URI: "bolt://neo4j:7687"
+      RB_NEO4J_PASSWORD: rustbrain123
+      RUST_LOG: "info,control_api=debug"
+    volumes:
+      - ../migrations:/migrations:ro
+    ports:
+      - "18080:8080"
+    networks: [rb-e2e-net]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
+
+  ingest-clone:
+    build:
+      context: ..
+      dockerfile: docker/ingest-clone/Dockerfile
+    image: ghcr.io/jarnura/rustacean/ingest-clone:e2e
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      GITHUB_APP_ID: "${SMOKE_GH_APP_ID}"
+      GITHUB_APP_PRIVATE_KEY_PEM: "${GITHUB_APP_PRIVATE_KEY_PEM}"
+      GITHUB_WEBHOOK_SECRET: "e2e-smoke-test-secret"
+      RUST_LOG: "info,ingest_clone=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  expand-worker:
+    build:
+      context: ..
+      dockerfile: docker/expand-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/expand-worker:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      RUST_LOG: "info,expand_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  parse-worker:
+    build:
+      context: ..
+      dockerfile: docker/parse-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/parse-worker:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      RUST_LOG: "info,parse_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  typecheck-worker:
+    build:
+      context: ..
+      dockerfile: docker/typecheck-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/typecheck-worker:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      RUST_LOG: "info,typecheck_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  ingest-graph:
+    build:
+      context: ..
+      dockerfile: docker/ingest-graph/Dockerfile
+    image: ghcr.io/jarnura/rustacean/ingest-graph:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      RUST_LOG: "info,ingest_graph=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  embed-worker:
+    build:
+      context: ..
+      dockerfile: docker/embed-worker/Dockerfile
+    image: ghcr.io/jarnura/rustacean/embed-worker:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_BLOB_BASE_PATH: /data/blobs
+      RB_OLLAMA_URL: "http://ollama-stub:11434"
+      RB_EMBEDDING_MODEL: "nomic-embed-text"
+      RB_EMBEDDING_DIMENSIONS: "768"
+      QDRANT_URL: "http://qdrant:6333"
+      RUST_LOG: "info,embed_worker=debug"
+    volumes:
+      - blob-data:/data/blobs
+    networks: [rb-e2e-net]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      qdrant:
+        condition: service_healthy
+      ollama-stub:
+        condition: service_healthy
+
+  projector-pg:
+    build:
+      context: ..
+      dockerfile: docker/projector-pg/Dockerfile
+    image: ghcr.io/jarnura/rustacean/projector-pg:e2e
+    environment:
+      DATABASE_URL: postgres://rustbrain:rustbrain@postgres:5432/rustbrain
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RUST_LOG: "info,projector_pg=debug"
+    networks: [rb-e2e-net]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rb-migrations:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  projector-neo4j:
+    build:
+      context: ..
+      dockerfile: docker/projector-neo4j/Dockerfile
+    image: ghcr.io/jarnura/rustacean/projector-neo4j:e2e
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: rustbrain123
+      RUST_LOG: "info,projector_neo4j=debug"
+    networks: [rb-e2e-net]
+    depends_on:
+      neo4j:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+networks:
+  rb-e2e-net:
+    driver: bridge
+
+volumes:
+  blob-data:

--- a/compose/scripts/ollama-stub.py
+++ b/compose/scripts/ollama-stub.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Minimal Ollama stub for E2E testing.
+
+Serves two endpoints that embed-worker needs:
+  GET  /api/tags        — health check (returns empty model list)
+  POST /api/embeddings  — returns zero-vector of the requested dimensions
+
+Runs on port 11434 (Ollama default).
+"""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+DIMENSIONS = 768
+
+
+class OllamaStubHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass  # silence access logs in compose output
+
+    def _send_json(self, status: int, body: dict) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        if self.path == "/api/tags":
+            self._send_json(200, {"models": []})
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if self.path == "/api/embeddings":
+            length = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(length)  # consume body; we don't need it
+            self._send_json(200, {"embedding": [0.0] * DIMENSIONS})
+        else:
+            self._send_json(404, {"error": "not found"})
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("0.0.0.0", 11434), OllamaStubHandler)
+    print("ollama-stub: listening on :11434", flush=True)
+    server.serve_forever()

--- a/compose/scripts/ollama-stub.py
+++ b/compose/scripts/ollama-stub.py
@@ -10,14 +10,16 @@ Runs on port 11434 (Ollama default).
 """
 
 import json
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 DIMENSIONS = 768
 
 
 class OllamaStubHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
-        pass  # silence access logs in compose output
+        # Log to stderr so embed-worker request activity is visible in compose logs.
+        print(f"ollama-stub: {self.address_string()} {fmt % args}", file=sys.stderr, flush=True)
 
     def _send_json(self, status: int, body: dict) -> None:
         payload = json.dumps(body).encode()
@@ -43,6 +45,6 @@ class OllamaStubHandler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    server = HTTPServer(("0.0.0.0", 11434), OllamaStubHandler)
+    server = ThreadingHTTPServer(("0.0.0.0", 11434), OllamaStubHandler)
     print("ollama-stub: listening on :11434", flush=True)
     server.serve_forever()

--- a/scripts/e2e-smoke-test.sh
+++ b/scripts/e2e-smoke-test.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Pipeline E2E smoke test (RUSAA-645).
+#
+# Starts the rb-e2e compose stack, runs a full 9-stage ingest cycle against a
+# real GitHub repository (fixture: jarnura/rb-smoke-fixture), and asserts:
+#   1. ingestion_runs.status reaches 'succeeded' within SMOKE_TIMEOUT_SECS
+#   2. code_symbols count > 0 in the tenant Postgres schema
+#   3. Neo4j contains at least one node with the ingested repo_id property
+#
+# Required env vars (set via GitHub Actions secrets in the smoke workflow):
+#   SMOKE_GH_APP_ID              — GitHub App numeric ID
+#   GITHUB_APP_PRIVATE_KEY_PEM   — raw RSA PEM private key for ingest-clone
+#   SMOKE_INSTALLATION_ID        — numeric GitHub installation ID for the test repo
+#   SMOKE_GITHUB_REPO_ID         — numeric GitHub repo ID
+#   SMOKE_GITHUB_REPO_FULL_NAME  — e.g. "jarnura/rb-smoke-fixture"
+#
+# Optional:
+#   SMOKE_TIMEOUT_SECS    — max seconds to wait for pipeline (default: 600)
+#   SMOKE_POLL_INTERVAL   — polling interval in seconds (default: 10)
+#
+# Run from the project root:
+#   bash scripts/e2e-smoke-test.sh
+
+set -euo pipefail
+
+COMPOSE_FILE="compose/e2e.yml"
+DC="docker compose -f ${COMPOSE_FILE}"
+API="http://localhost:18080"
+TIMEOUT_SECS="${SMOKE_TIMEOUT_SECS:-600}"
+POLL_INTERVAL="${SMOKE_POLL_INTERVAL:-10}"
+COOKIE_JAR="/tmp/smoke-cookies-$$.txt"
+SMOKE_FAILED=0
+
+SMOKE_EMAIL="smoke@e2e.test"
+SMOKE_PASS="smoke-password-e2e-123"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+log()  { echo "[$(date -u +%H:%M:%S)] [smoke] $*"; }
+fail() { SMOKE_FAILED=1; log "FAIL: $*" >&2; exit 1; }
+
+gen_uuid() { python3 -c "import uuid; print(uuid.uuid4())"; }
+
+LOG_DIR="/tmp/smoke-compose-logs"
+
+dump_logs() {
+  log "--- container logs (last 100 lines per service) ---"
+  mkdir -p "${LOG_DIR}"
+  for svc in control-api ingest-clone expand-worker parse-worker typecheck-worker \
+              ingest-graph embed-worker projector-pg projector-neo4j; do
+    echo "=== ${svc} ==="
+    ${DC} logs --no-color --tail 100 "${svc}" 2>/dev/null \
+      | tee "${LOG_DIR}/${svc}.log" || true
+  done
+}
+
+cleanup() {
+  [ "$SMOKE_FAILED" = "1" ] && dump_logs
+  rm -f "$COOKIE_JAR"
+  log "Tearing down compose stack..."
+  ${DC} down -v --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Run a SQL statement against the shared postgres container (-t -A → plain rows).
+psql_q() {
+  ${DC} exec -T postgres psql -U rustbrain -d rustbrain -t -A -c "$1"
+}
+
+# Run a Cypher statement and return the scalar result on the last output line.
+neo4j_q() {
+  ${DC} exec -T neo4j cypher-shell \
+    -u neo4j -p rustbrain123 --format plain "$1" \
+    | tail -1 | tr -d '[:space:]'
+}
+
+# ── Validate required env vars ────────────────────────────────────────────────
+
+log "Checking required env vars..."
+for var in SMOKE_GH_APP_ID GITHUB_APP_PRIVATE_KEY_PEM \
+           SMOKE_INSTALLATION_ID SMOKE_GITHUB_REPO_ID SMOKE_GITHUB_REPO_FULL_NAME; do
+  [ -n "${!var}" ] || fail "required env var ${var} is not set"
+done
+log "All required env vars present."
+
+# ── Build and start compose stack ────────────────────────────────────────────
+
+log "Building compose images..."
+${DC} build
+
+log "Starting compose stack (detached)..."
+${DC} up -d
+
+# ── Wait for control-api /health ──────────────────────────────────────────────
+
+log "Waiting for control-api /health (up to 120 s)..."
+deadline=$(( $(date +%s) + 120 ))
+until curl -sf "${API}/health" >/dev/null 2>&1; do
+  (( $(date +%s) < deadline )) || fail "control-api /health did not succeed within 120 s"
+  sleep 3
+done
+log "control-api is healthy."
+
+# ── Sign up a test user ───────────────────────────────────────────────────────
+
+log "Signing up test user (${SMOKE_EMAIL})..."
+curl -sf -X POST "${API}/v1/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${SMOKE_EMAIL}\",\"password\":\"${SMOKE_PASS}\",\"tenant_name\":\"Smoke Tenant\"}" \
+  -c "${COOKIE_JAR}" \
+  >/dev/null
+log "Signup complete."
+
+# ── Verify email directly in Postgres (bypasses email transport) ──────────────
+
+log "Marking email as verified in DB..."
+psql_q "UPDATE control.users SET email_verified_at = now() WHERE email = '${SMOKE_EMAIL}';"
+
+user_id=$(psql_q "SELECT id FROM control.users WHERE email = '${SMOKE_EMAIL}';")
+[ -n "${user_id}" ] || fail "could not fetch user_id for ${SMOKE_EMAIL}"
+log "user_id=${user_id}"
+
+tenant_id=$(psql_q \
+  "SELECT tenant_id FROM control.tenant_members WHERE user_id = '${user_id}' LIMIT 1;")
+[ -n "${tenant_id}" ] || fail "could not fetch tenant_id for user ${user_id}"
+log "tenant_id=${tenant_id}"
+
+# ── Re-login to get a fresh session that reflects verified email ──────────────
+
+log "Logging in with verified session..."
+rm -f "${COOKIE_JAR}"
+curl -sf -X POST "${API}/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${SMOKE_EMAIL}\",\"password\":\"${SMOKE_PASS}\"}" \
+  -c "${COOKIE_JAR}" \
+  >/dev/null
+log "Logged in successfully."
+
+# ── Seed GitHub installation + repo (bypass OAuth callback flow) ──────────────
+
+INSTALL_UUID=$(gen_uuid)
+REPO_UUID=$(gen_uuid)
+
+log "Inserting github_installation (id=${INSTALL_UUID}, gh_id=${SMOKE_INSTALLATION_ID})..."
+psql_q "INSERT INTO control.github_installations
+  (id, tenant_id, github_installation_id, account_login, account_type, account_id)
+  VALUES (
+    '${INSTALL_UUID}',
+    '${tenant_id}',
+    ${SMOKE_INSTALLATION_ID},
+    'smoke-org',
+    'Organization',
+    1
+  );"
+
+log "Inserting repo (id=${REPO_UUID}, full_name=${SMOKE_GITHUB_REPO_FULL_NAME})..."
+psql_q "INSERT INTO control.repos
+  (id, tenant_id, installation_id, github_repo_id, full_name, default_branch, connected_by)
+  VALUES (
+    '${REPO_UUID}',
+    '${tenant_id}',
+    '${INSTALL_UUID}',
+    ${SMOKE_GITHUB_REPO_ID},
+    '${SMOKE_GITHUB_REPO_FULL_NAME}',
+    'main',
+    '${user_id}'
+  );"
+log "Test fixture seeded."
+
+# ── Trigger ingestion via API ─────────────────────────────────────────────────
+
+log "Triggering ingestion for repo_id=${REPO_UUID}..."
+trigger_resp=$(curl -sf -X POST "${API}/v1/repos/${REPO_UUID}/ingestions" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  -b "${COOKIE_JAR}")
+
+ingest_run_id=$(echo "${trigger_resp}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['ingest_run_id'])" 2>/dev/null \
+  || true)
+[ -n "${ingest_run_id}" ] \
+  || fail "trigger_ingestion did not return ingest_run_id. response=${trigger_resp}"
+log "Ingestion queued: ingest_run_id=${ingest_run_id}"
+
+# ── Poll ingestion_runs until 'succeeded' (or timeout / terminal failure) ─────
+
+log "Polling for pipeline completion (timeout=${TIMEOUT_SECS} s, interval=${POLL_INTERVAL} s)..."
+deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+run_status=""
+while true; do
+  run_status=$(psql_q \
+    "SELECT status FROM control.ingestion_runs WHERE id = '${ingest_run_id}';")
+  remaining=$(( deadline - $(date +%s) ))
+  log "  status=${run_status} (${remaining} s remaining)"
+
+  case "${run_status}" in
+    succeeded)
+      break
+      ;;
+    failed|cancelled)
+      log "Stage breakdown:"
+      psql_q "SELECT stage, status, error
+              FROM control.pipeline_stage_runs
+              WHERE ingestion_run_id = '${ingest_run_id}'
+              ORDER BY stage;" || true
+      fail "ingestion run ended with status=${run_status}"
+      ;;
+  esac
+
+  if (( $(date +%s) >= deadline )); then
+    log "Stage breakdown at timeout:"
+    psql_q "SELECT stage, status
+            FROM control.pipeline_stage_runs
+            WHERE ingestion_run_id = '${ingest_run_id}'
+            ORDER BY stage;" || true
+    fail "pipeline did not complete within ${TIMEOUT_SECS} s (last status=${run_status})"
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done
+log "Pipeline status=succeeded."
+
+# ── Assert: code_symbols present in tenant Postgres schema ───────────────────
+
+log "Asserting code_symbols in Postgres..."
+tenant_schema=$(psql_q \
+  "SELECT schema_name FROM control.tenants WHERE id = '${tenant_id}';")
+[ -n "${tenant_schema}" ] \
+  || fail "could not resolve schema_name for tenant ${tenant_id}"
+log "  tenant_schema=${tenant_schema}"
+
+symbol_count=$(psql_q \
+  "SELECT COUNT(*) FROM \"${tenant_schema}\".code_symbols WHERE repo_id = '${REPO_UUID}';")
+symbol_count="${symbol_count//[[:space:]]/}"
+log "  code_symbols count=${symbol_count}"
+(( symbol_count > 0 )) \
+  || fail "expected code_symbols > 0 in ${tenant_schema}, got ${symbol_count}"
+log "Postgres assertion PASSED (${symbol_count} symbols)."
+
+# ── Assert: nodes present in Neo4j ───────────────────────────────────────────
+
+log "Asserting nodes in Neo4j..."
+neo4j_count=$(neo4j_q \
+  "MATCH (n {repo_id: '${REPO_UUID}'}) RETURN count(n) AS cnt;")
+log "  neo4j node count=${neo4j_count}"
+(( neo4j_count > 0 )) \
+  || fail "expected Neo4j nodes > 0 for repo_id=${REPO_UUID}, got ${neo4j_count}"
+log "Neo4j assertion PASSED (${neo4j_count} nodes)."
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+log "E2E pipeline smoke test PASSED."

--- a/scripts/e2e-smoke-test.sh
+++ b/scripts/e2e-smoke-test.sh
@@ -55,7 +55,10 @@ dump_logs() {
 }
 
 cleanup() {
-  [ "$SMOKE_FAILED" = "1" ] && dump_logs
+  # Dump logs on any non-zero exit, not just explicit fail() calls.
+  # set -e can abort without setting SMOKE_FAILED (unbound variable, broken pipe, etc.).
+  local exit_code=$?
+  [ "$exit_code" -eq 0 ] && [ "$SMOKE_FAILED" = "0" ] || dump_logs
   rm -f "$COOKIE_JAR"
   log "Tearing down compose stack..."
   ${DC} down -v --remove-orphans 2>/dev/null || true
@@ -68,9 +71,10 @@ psql_q() {
 }
 
 # Run a Cypher statement and return the scalar result on the last output line.
+# Redirect stderr to suppress advisory startup lines that would corrupt tail -1.
 neo4j_q() {
   ${DC} exec -T neo4j cypher-shell \
-    -u neo4j -p rustbrain123 --format plain "$1" \
+    -u neo4j -p rustbrain123 --format plain "$1" 2>/dev/null \
     | tail -1 | tr -d '[:space:]'
 }
 
@@ -116,12 +120,13 @@ log "Signup complete."
 log "Marking email as verified in DB..."
 psql_q "UPDATE control.users SET email_verified_at = now() WHERE email = '${SMOKE_EMAIL}';"
 
-user_id=$(psql_q "SELECT id FROM control.users WHERE email = '${SMOKE_EMAIL}';")
+user_id=$(psql_q "SELECT id FROM control.users WHERE email = '${SMOKE_EMAIL}';" | tr -d '[:space:]')
 [ -n "${user_id}" ] || fail "could not fetch user_id for ${SMOKE_EMAIL}"
 log "user_id=${user_id}"
 
 tenant_id=$(psql_q \
-  "SELECT tenant_id FROM control.tenant_members WHERE user_id = '${user_id}' LIMIT 1;")
+  "SELECT tenant_id FROM control.tenant_members WHERE user_id = '${user_id}' LIMIT 1;" \
+  | tr -d '[:space:]')
 [ -n "${tenant_id}" ] || fail "could not fetch tenant_id for user ${user_id}"
 log "tenant_id=${tenant_id}"
 
@@ -224,15 +229,17 @@ log "Pipeline status=succeeded."
 
 log "Asserting code_symbols in Postgres..."
 tenant_schema=$(psql_q \
-  "SELECT schema_name FROM control.tenants WHERE id = '${tenant_id}';")
+  "SELECT schema_name FROM control.tenants WHERE id = '${tenant_id}';" | tr -d '[:space:]')
 [ -n "${tenant_schema}" ] \
   || fail "could not resolve schema_name for tenant ${tenant_id}"
 log "  tenant_schema=${tenant_schema}"
 
 symbol_count=$(psql_q \
-  "SELECT COUNT(*) FROM \"${tenant_schema}\".code_symbols WHERE repo_id = '${REPO_UUID}';")
-symbol_count="${symbol_count//[[:space:]]/}"
+  "SELECT COUNT(*) FROM \"${tenant_schema}\".code_symbols WHERE repo_id = '${REPO_UUID}';" \
+  | tr -d '[:space:]')
 log "  code_symbols count=${symbol_count}"
+[[ "${symbol_count}" =~ ^[0-9]+$ ]] \
+  || fail "non-numeric symbol_count from Postgres: '${symbol_count}' — query may have failed"
 (( symbol_count > 0 )) \
   || fail "expected code_symbols > 0 in ${tenant_schema}, got ${symbol_count}"
 log "Postgres assertion PASSED (${symbol_count} symbols)."
@@ -243,6 +250,8 @@ log "Asserting nodes in Neo4j..."
 neo4j_count=$(neo4j_q \
   "MATCH (n {repo_id: '${REPO_UUID}'}) RETURN count(n) AS cnt;")
 log "  neo4j node count=${neo4j_count}"
+[[ "${neo4j_count}" =~ ^[0-9]+$ ]] \
+  || fail "non-numeric neo4j_count from cypher-shell: '${neo4j_count}' — query may have failed"
 (( neo4j_count > 0 )) \
   || fail "expected Neo4j nodes > 0 for repo_id=${REPO_UUID}, got ${neo4j_count}"
 log "Neo4j assertion PASSED (${neo4j_count} nodes)."


### PR DESCRIPTION
## Summary

- Adds a full 9-stage pipeline smoke test that closes a gap identified in a prior post-incident RCA: no test exercised the complete ingestion pipeline end-to-end
- Introduces a lightweight E2E compose stack (neo4j 512m heap, ollama-stub, 1 Kafka partition) to run within CI runner memory limits (~7 GB)
- CI job skips on fork PRs (secrets unavailable) and runs on every push to main + `workflow_dispatch`

**This test would have caught RC-1** (GITHUB_APP_ID missing → ingest-clone crash at startup).

## Files changed

| File | Description |
|------|-------------|
| `compose/e2e.yml` | Lightweight stack: postgres, neo4j (512m/128m), qdrant, kafka (1 partition), ollama-stub, all pipeline workers |
| `compose/scripts/ollama-stub.py` | Minimal Python HTTP server mimicking Ollama's `/api/embeddings` endpoint with 768-dim zero-vectors |
| `scripts/e2e-smoke-test.sh` | Smoke runner: signup → email-verify → seed GH installation + repo → trigger ingestion → poll → assert Postgres + Neo4j |
| `.github/workflows/pipeline-e2e.yml` | CI workflow; decodes base64 PEM secret; uploads compose logs on failure |

## Test plan

- [ ] Confirm five secrets are set in repo settings: `SMOKE_GH_APP_ID`, `SMOKE_GH_PRIVATE_KEY_PEM_B64`, `SMOKE_INSTALLATION_ID`, `SMOKE_GITHUB_REPO_ID`, `SMOKE_GITHUB_REPO_FULL_NAME`
- [ ] Trigger `workflow_dispatch` on this branch and verify all three assertions pass
- [ ] Verify the job is skipped on a fork PR (no secrets)
- [ ] Verify compose logs artifact is uploaded on a forced failure

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)