### PR TITLE
fix(rb-tracing): read trace_id via OpenTelemetrySpanExt, not Context::current()

### DIFF
--- a/crates/rb-tracing/src/json_layer.rs
+++ b/crates/rb-tracing/src/json_layer.rs
@@ -2,6 +2,7 @@ use opentelemetry::trace::TraceContextExt as _;
 use serde_json::{Map, Value};
 use std::{fmt, io::Write, sync::Mutex};
 use tracing::{Event, Subscriber};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 // ── Timestamp ────────────────────────────────────────────────────────────────
@@ -143,8 +144,11 @@ where
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         let meta = event.metadata();
 
-        // OpenTelemetry span context — valid only when a tracer provider is installed.
-        let otel_ctx = opentelemetry::Context::current();
+        // OpenTelemetry span context — read from the current tracing span's extensions
+        // via OpenTelemetrySpanExt, NOT from opentelemetry::Context::current().
+        // tracing-opentelemetry 0.29 does not call Context::attach() in on_enter,
+        // so the thread-local OTel context is never populated during request handling.
+        let otel_ctx = tracing::Span::current().context();
         let otel_span = otel_ctx.span();
         let sc = otel_span.span_context();
         let (trace_id, span_id) = if sc.is_valid() {

--- a/crates/rb-tracing/src/lib.rs
+++ b/crates/rb-tracing/src/lib.rs
@@ -8,6 +8,7 @@ pub use json_layer::StructuredJsonLayer;
 /// Reads from the current tracing span's extensions via `OpenTelemetrySpanExt`
 /// rather than `opentelemetry::Context::current()`, which is never populated
 /// by `tracing-opentelemetry` 0.29.
+#[must_use]
 pub fn current_trace_id() -> Option<String> {
     use opentelemetry::trace::TraceContextExt as _;
     use tracing_opentelemetry::OpenTelemetrySpanExt as _;

--- a/crates/rb-tracing/src/lib.rs
+++ b/crates/rb-tracing/src/lib.rs
@@ -2,6 +2,21 @@ mod json_layer;
 
 pub use json_layer::StructuredJsonLayer;
 
+/// Returns the W3C 32-hex trace ID of the currently entered tracing span,
+/// or `None` when no active OpenTelemetry span context is available.
+///
+/// Reads from the current tracing span's extensions via `OpenTelemetrySpanExt`
+/// rather than `opentelemetry::Context::current()`, which is never populated
+/// by `tracing-opentelemetry` 0.29.
+pub fn current_trace_id() -> Option<String> {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+    let otel_ctx = tracing::Span::current().context();
+    let otel_span = otel_ctx.span();
+    let sc = otel_span.span_context();
+    sc.is_valid().then(|| sc.trace_id().to_string())
+}
+
 use opentelemetry::{global, trace::TracerProvider as _};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, SpanExporter, WithExportConfig as _};

--- a/services/control-api/src/routes/ingest/trigger.rs
+++ b/services/control-api/src/routes/ingest/trigger.rs
@@ -10,7 +10,6 @@
 use std::time::Duration;
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
-use opentelemetry::trace::TraceContextExt as _;
 use rb_kafka::EventEnvelope;
 use rb_schemas::{IngestRequest, TenantId};
 use serde::{Deserialize, Serialize};
@@ -131,10 +130,7 @@ pub async fn trigger_ingestion(
 
     // Capture the active OTel trace ID so Grafana/Tempo links work.
     // Returns None when no HTTP middleware has established a trace context.
-    let trace_id: Option<String> = {
-        let span_ctx = opentelemetry::Context::current().span().span_context().clone();
-        span_ctx.is_valid().then(|| span_ctx.trace_id().to_string())
-    };
+    let trace_id = rb_tracing::current_trace_id();
 
     // 3. Build the Kafka envelope before opening the transaction (pure in-memory,
     //    no I/O). This lets us publish to Kafka while still inside the transaction


### PR DESCRIPTION
## Summary

- `tracing-opentelemetry` 0.29 removed the `Context::attach()` call from `on_enter`, so `opentelemetry::Context::current()` is never populated during request handling — both `StructuredJsonLayer::on_event` and `trigger.rs` were reading from this empty thread-local, producing empty `trace_id` in every log line and ingestion response.
- Fixed by switching both call sites to `OpenTelemetrySpanExt::context()`, which reads the OTel context from the current tracing span's extensions (populated in `on_new_span`, where the span ID is eagerly assigned).
- Extracted `rb_tracing::current_trace_id()` as a shared helper so the pattern is not duplicated.

## Changes

| File | Change |
|------|--------|
| `crates/rb-tracing/src/json_layer.rs` | Replace `opentelemetry::Context::current()` with `tracing::Span::current().context()` via `OpenTelemetrySpanExt` |
| `crates/rb-tracing/src/lib.rs` | Add `pub fn current_trace_id() -> Option<String>` helper |
| `services/control-api/src/routes/ingest/trigger.rs` | Use `rb_tracing::current_trace_id()`, remove stale `TraceContextExt` import |

Closes #269

## Test plan

- [x] `cargo test -p rb-tracing` — 7/7 pass
- [x] `cargo test -p control-api` — 296 pass, 0 fail
- [x] No new dependencies (tracing-opentelemetry already in workspace)