### PR TITLE
fix(migrate): support multi-statement SQL migration files

### DIFF
--- a/services/migrate/src/pg/runner.rs
+++ b/services/migrate/src/pg/runner.rs
@@ -201,7 +201,11 @@ fn apply_migration<'c>(
         sqlx::query(&begin_tx).execute(&mut *conn).await?;
         // SET LOCAL is transaction-scoped; lets migration SQL omit schema prefix.
         sqlx::query(&set_search_path).execute(&mut *conn).await?;
-        sqlx::query(&file_sql).execute(&mut *conn).await?;
+        // sqlx::query does not support multi-statement strings, so split on ';'
+        // while respecting string literals, identifiers, and comments.
+        for stmt in split_statements(&file_sql) {
+            sqlx::query(stmt).execute(&mut *conn).await?;
+        }
         sqlx::query(&insert_sql)
             .bind(version)
             .bind(&description)
@@ -211,6 +215,167 @@ fn apply_migration<'c>(
         sqlx::query("COMMIT").execute(&mut *conn).await?;
         Ok(())
     })
+}
+
+/// Split a SQL string into individual statements on unquoted `;` delimiters.
+///
+/// Handles single-quoted strings (`'...'`), double-quoted identifiers (`"..."`),
+/// line comments (`-- ...`), block comments (`/* ... */`), and dollar-quoted
+/// strings (`$tag$...$tag$`). Empty statements are omitted.
+fn split_statements(sql: &str) -> Vec<&str> {
+    let mut stmts = Vec::new();
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut start = 0usize;
+    let mut pos = 0usize;
+
+    while pos < len {
+        match bytes[pos] {
+            // Line comment: skip to end of line
+            b'-' if pos + 1 < len && bytes[pos + 1] == b'-' => {
+                pos += 2;
+                while pos < len && bytes[pos] != b'\n' {
+                    pos += 1;
+                }
+            }
+            // Block comment: skip to */
+            b'/' if pos + 1 < len && bytes[pos + 1] == b'*' => {
+                pos += 2;
+                while pos + 1 < len && !(bytes[pos] == b'*' && bytes[pos + 1] == b'/') {
+                    pos += 1;
+                }
+                if pos + 1 < len {
+                    pos += 2;
+                }
+            }
+            // Single-quoted string: handle '' escape
+            b'\'' => {
+                pos += 1;
+                while pos < len {
+                    if bytes[pos] == b'\'' {
+                        pos += 1;
+                        if pos < len && bytes[pos] == b'\'' {
+                            pos += 1; // '' escape — continue
+                        } else {
+                            break;
+                        }
+                    } else {
+                        pos += 1;
+                    }
+                }
+            }
+            // Double-quoted identifier: handle "" escape
+            b'"' => {
+                pos += 1;
+                while pos < len {
+                    if bytes[pos] == b'"' {
+                        pos += 1;
+                        if pos < len && bytes[pos] == b'"' {
+                            pos += 1; // "" escape — continue
+                        } else {
+                            break;
+                        }
+                    } else {
+                        pos += 1;
+                    }
+                }
+            }
+            // Dollar-quoted string: $tag$...$tag$
+            b'$' => {
+                let tag_start = pos;
+                pos += 1;
+                while pos < len && bytes[pos] != b'$' {
+                    if bytes[pos].is_ascii_alphanumeric() || bytes[pos] == b'_' {
+                        pos += 1;
+                    } else {
+                        break; // not a valid dollar-quote tag
+                    }
+                }
+                if pos < len && bytes[pos] == b'$' {
+                    pos += 1;
+                    let tag = &bytes[tag_start..pos];
+                    let tag_len = tag.len();
+                    while pos + tag_len <= len {
+                        if &bytes[pos..pos + tag_len] == tag {
+                            pos += tag_len;
+                            break;
+                        }
+                        pos += 1;
+                    }
+                }
+            }
+            // Statement terminator
+            b';' => {
+                let stmt = sql[start..pos].trim();
+                if !stmt.is_empty() {
+                    stmts.push(stmt);
+                }
+                pos += 1;
+                start = pos;
+            }
+            _ => {
+                pos += 1;
+            }
+        }
+    }
+
+    // Trailing content with no terminating semicolon
+    let trailing = sql[start..].trim();
+    if !trailing.is_empty() {
+        stmts.push(trailing);
+    }
+
+    stmts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_statements;
+
+    #[test]
+    fn single_statement() {
+        assert_eq!(split_statements("SELECT 1"), vec!["SELECT 1"]);
+        assert_eq!(split_statements("SELECT 1;"), vec!["SELECT 1"]);
+    }
+
+    #[test]
+    fn multiple_statements() {
+        let sql = "CREATE TABLE foo (id INT);\nCREATE TABLE bar (id INT);";
+        assert_eq!(split_statements(sql), vec!["CREATE TABLE foo (id INT)", "CREATE TABLE bar (id INT)"]);
+    }
+
+    #[test]
+    fn ignores_semicolons_in_string_literals() {
+        let sql = "INSERT INTO t VALUES ('hello; world');\nSELECT 1;";
+        assert_eq!(split_statements(sql), vec!["INSERT INTO t VALUES ('hello; world')", "SELECT 1"]);
+    }
+
+    #[test]
+    fn ignores_semicolons_in_line_comments() {
+        let sql = "-- this; is a comment\nSELECT 1;";
+        assert_eq!(split_statements(sql), vec!["-- this; is a comment\nSELECT 1"]);
+    }
+
+    #[test]
+    fn ignores_semicolons_in_block_comments() {
+        let sql = "/* semi; in comment */ SELECT 1;";
+        assert_eq!(split_statements(sql), vec!["/* semi; in comment */ SELECT 1"]);
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_statements_skipped() {
+        let sql = "  ;  SELECT 1;  ;  ";
+        assert_eq!(split_statements(sql), vec!["SELECT 1"]);
+    }
+
+    #[test]
+    fn dollar_quoted_string_with_semicolon() {
+        let sql = "DO $$BEGIN RAISE NOTICE 'hi;'; END$$;\nSELECT 2;";
+        let stmts = split_statements(sql);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].starts_with("DO $$"));
+        assert_eq!(stmts[1], "SELECT 2");
+    }
 }
 
 /// Returns the path to the migrations directory for a given sub-dir name.

--- a/services/migrate/tests/pg_integration.rs
+++ b/services/migrate/tests/pg_integration.rs
@@ -131,6 +131,41 @@ async fn test_tenant_creates_schema_and_applies() {
 }
 
 #[tokio::test]
+async fn test_multi_statement_migration_applied() {
+    let Some(url) = test_pool_url() else {
+        eprintln!("SKIP test_multi_statement_migration_applied: TEST_DATABASE_URL not set");
+        return;
+    };
+
+    let pool = connect(&url).await;
+    drop_schema(&pool, "control").await;
+
+    // Two CREATE TABLE statements in a single migration file — the bug case.
+    let multi_sql =
+        "CREATE TABLE foo_ms (id INT PRIMARY KEY);\nCREATE TABLE bar_ms (id INT PRIMARY KEY);";
+    let repo = make_repo("control", &[("001_multi.sql", multi_sql)]);
+
+    let n = migrate_control(&pool, repo.path())
+        .await
+        .expect("multi-statement migration failed");
+    assert_eq!(n, 1, "one migration file applied");
+
+    for table in &["foo_ms", "bar_ms"] {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = 'control' AND table_name = $1)",
+        )
+        .bind(*table)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(exists, "table '{table}' must exist after multi-statement migration");
+    }
+
+    drop_schema(&pool, "control").await;
+}
+
+#[tokio::test]
 async fn test_failed_migration_rolled_back() {
     let Some(url) = test_pool_url() else {
         eprintln!("SKIP test_failed_migration_rolled_back: TEST_DATABASE_URL not set");


### PR DESCRIPTION
## Summary

`sqlx::query().execute()` only supports a single SQL statement per call. Migration files with multiple statements (e.g. `migrations/tenant/002_code_tables.sql` with 5 CREATE TABLE/EXTENSION + 7 CREATE INDEX) were failing silently or erroring, requiring a manual psql workaround.

Introduce `split_statements()` in `services/migrate/src/pg/runner.rs`: a state-machine parser that splits on unquoted `;` delimiters while correctly handling:
- Single-quoted strings (`'...'` with `''` escape)
- Double-quoted identifiers (`"..."` with `""` escape)
- Line comments (`-- ...`)
- Block comments (`/* ... */`)
- Dollar-quoted strings (`$$...$$` and `$tag$...$tag$`)

`apply_migration()` now iterates the split results and executes each statement individually inside the existing `BEGIN`/`COMMIT` transaction. No schema or checksum logic changed.

## GitHub Issue
Closes #271

## Migration type
N/A — no schema changes. Runner logic fix only.

## Checklist
- [x] `cargo build -p migrate` passes
- [x] 7 unit tests for `split_statements` all pass (`cargo test -p migrate --lib`)
- [x] Integration test `test_multi_statement_migration_applied` added (requires `TEST_DATABASE_URL`)
- [x] No internal Paperclip/issue references in PR