### PR TITLE
[RUSAA-712] fix(control-api): make GitHub callback state param optional

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1785,8 +1785,8 @@ export interface operations {
             readonly query: {
                 /** @description GitHub numeric installation ID */
                 readonly installation_id: number;
-                /** @description Opaque state token from install-url */
-                readonly state: string;
+                /** @description Opaque state token from install-url (absent for GitHub-initiated redirects) */
+                readonly state?: string;
                 /** @description install or update */
                 readonly setup_action?: string;
             };

--- a/openapi.json
+++ b/openapi.json
@@ -445,8 +445,8 @@
           {
             "name": "state",
             "in": "query",
-            "description": "Opaque state token from install-url",
-            "required": true,
+            "description": "Opaque state token from install-url (absent for GitHub-initiated redirects)",
+            "required": false,
             "schema": {
               "type": "string"
             }

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -82,7 +82,8 @@ pub async fn github_install_url(
 #[derive(Debug, Deserialize)]
 pub struct CallbackParams {
     pub installation_id: i64,
-    pub state: String,
+    #[serde(default)]
+    pub state: Option<String>,
     #[serde(default)]
     pub setup_action: Option<String>,
 }
@@ -92,7 +93,7 @@ pub struct CallbackParams {
     path = "/v1/github/callback",
     params(
         ("installation_id" = i64, Query, description = "GitHub numeric installation ID"),
-        ("state" = String, Query, description = "Opaque state token from install-url"),
+        ("state" = Option<String>, Query, description = "Opaque state token from install-url (absent for GitHub-initiated redirects)"),
         ("setup_action" = Option<String>, Query, description = "install or update"),
     ),
     responses(
@@ -108,7 +109,19 @@ pub async fn github_callback(
 ) -> Result<impl IntoResponse, AppError> {
     let gh = state.gh.as_ref().ok_or(AppError::GithubAppNotConfigured)?;
 
-    let raw = hex::decode(&params.state).map_err(|_| AppError::InvalidToken)?;
+    let state_hex = match params.state {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            tracing::info!(
+                installation_id = params.installation_id,
+                setup_action = ?params.setup_action,
+                "github callback: no state token (GitHub-initiated redirect), sending to repos"
+            );
+            return Ok(Redirect::to(&format!("{}/repos", state.config.base_url)));
+        }
+    };
+
+    let raw = hex::decode(&state_hex).map_err(|_| AppError::InvalidToken)?;
     let token_hash = rb_github::hash_token(&raw);
     let row: Option<(Uuid, Uuid)> = sqlx::query_as(
         "UPDATE control.github_install_states \


### PR DESCRIPTION
## Summary
- GitHub-initiated redirects (`setup_action=update`) omit the `state` query parameter, causing a 400 "missing field `state`" deserialization error on `GET /v1/github/callback`
- Made `CallbackParams.state` an `Option<String>` with `#[serde(default)]`, so stateless callbacks gracefully redirect to `/repos` instead of failing
- Updated utoipa OpenAPI annotation to reflect the optional parameter

## Context
Discovered during Wave 6 board verification. When a GitHub App is reconfigured or updated, GitHub redirects to the callback URL without a `state` token. The previous mandatory `state: String` field caused axum's query deserializer to reject the request.

## Test plan
- [x] Existing unit tests pass (`state_token_round_trip`, `install_url_response_serializes`, `state_token_invalid_hex_is_rejected`)
- [x] Deployed and verified on dev stack — GitHub callback with and without state both work correctly
- [x] Full ingestion pipeline (9/9 stages) succeeded after fix

Closes #288