### PR TITLE
[REQ-OP-04] fix(infra): auto-rebuild all 10 Rust services on source changes

### DIFF
--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -1,6 +1,6 @@
 # Dev-stack Auto-rebuild
 
-When a commit lands on `main` that touches a built service (control-api, frontend), the dev-stack on mars automatically rebuilds the affected images and restarts the containers. UAT always runs against `main` HEAD.
+When a commit lands on `main` that touches any built service, the dev-stack on mars automatically rebuilds the affected images and restarts the containers. UAT always runs against `main` HEAD.
 
 ## How it works
 
@@ -15,14 +15,18 @@ Two scripts live in `scripts/`:
 
 The rebuild script maps changed file paths to services:
 
-| Changed path | Service rebuilt |
+| Changed path | Services rebuilt |
 |---|---|
-| `services/control-api/**`, `crates/**`, `Cargo.toml`, `Cargo.lock`, `docker/control-api/**`, `migrations/**`, `proto/**` | `control-api` (+ re-runs `rb-migrations`) |
+| `crates/**`, `Cargo.toml`, `Cargo.lock`, `proto/**` | **All 10 Rust services** (shared dependency change) |
+| `services/<name>/**`, `docker/<name>/**` | That specific service only |
+| `migrations/**` | `control-api` (+ re-runs `rb-migrations`) |
 | `frontend/**`, `docker/frontend/**` | `frontend` |
-| `compose/dev.yml`, `compose/full.yml`, `compose/tailscale.yml`, `compose/tailscale.env`, `compose/scripts/**` | both services |
+| `compose/dev.yml`, `compose/full.yml`, `compose/tailscale.yml`, `compose/tailscale.env`, `compose/scripts/**` | All services |
 | Anything else (docs, `.github/`, governance, …) | **no rebuild** |
 
-Rebuilds are idempotent — re-running is safe. Migrations are always re-run before control-api restarts; they skip already-applied versions.
+The 10 Rust services are: `control-api`, `parse-worker`, `typecheck-worker`, `ingest-graph`, `ingest-clone`, `expand-worker`, `embed-worker`, `projector-pg`, `projector-neo4j`, `tombstoner`.
+
+Rebuilds are idempotent — re-running is safe. Migrations are re-run before control-api restarts; they skip already-applied versions.
 
 ### Health checks
 
@@ -30,6 +34,7 @@ After restart the script waits 15 s then probes:
 
 - **control-api** — `GET http://localhost:${CONTROL_API_HOST_PORT:-8080}/health` → expects HTTP 200
 - **frontend** — `GET http://localhost:${FRONTEND_HOST_PORT:-15173}/` → expects HTTP 200
+- **All other Rust services** — `docker inspect` → expects container running
 
 Results are written to the rebuild log and optionally posted as a GitHub commit status.
 
@@ -69,7 +74,7 @@ $COMPOSE_CMD build
 ```
 
 This tags all 11 custom images locally. Subsequent rebuilds are handled automatically by
-`dev-stack-watch.sh` (control-api and frontend only) or manually for other services.
+`dev-stack-watch.sh` for all services whose source paths change on `main`.
 
 ### 4. Create the systemd service
 
@@ -203,7 +208,7 @@ scripts/dev-stack-auto-rebuild.sh --cold-start                        # builds b
 scripts/dev-stack-auto-rebuild.sh --cold-start <prev_sha> <new_sha>  # with explicit SHA range
 ```
 
-`--cold-start` forces both `control-api` and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so databases, queues, and all other infrastructure services start alongside the application containers.
+`--cold-start` forces all 10 Rust services and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so databases, queues, and all other infrastructure services start alongside the application containers.
 
 The watcher (`dev-stack-watch.sh`) automatically detects a stopped stack at startup and on each new-commit cycle, and passes `--cold-start` to the rebuild script when needed. The `COMPOSE_CMD` environment variable must be set (or accept the default) for cold-start detection to work correctly.
 

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -140,12 +140,19 @@ fi
 
 # -- Detect changed paths (skipped in cold-start mode) -----------------------
 
-REBUILD_CONTROL_API=false
+ALL_RUST_SERVICES=(
+  control-api parse-worker typecheck-worker ingest-graph ingest-clone
+  expand-worker embed-worker projector-pg projector-neo4j tombstoner
+)
+declare -A REBUILD_SERVICE
 REBUILD_FRONTEND=false
+
+mark_rust_service() { REBUILD_SERVICE["$1"]=true; }
+mark_all_rust()    { for svc in "${ALL_RUST_SERVICES[@]}"; do mark_rust_service "$svc"; done; }
 
 if [[ "$COLD_START" == "true" ]]; then
   echo "[dev-stack-auto-rebuild] cold start — forcing rebuild of all services"
-  REBUILD_CONTROL_API=true
+  mark_all_rust
   REBUILD_FRONTEND=true
 else
   CHANGED_FILES="$(git diff --name-only "$PREV_SHA" "$NEW_SHA" 2>/dev/null || true)"
@@ -158,20 +165,39 @@ else
 
   while IFS= read -r f; do
     case "$f" in
-      # control-api source: Rust crates, Dockerfiles, migrations, proto
-      services/control-api/*|crates/*|Cargo.toml|Cargo.lock|docker/control-api/*|migrations/*|proto/*)
-        REBUILD_CONTROL_API=true ;;
-      # frontend source
+      crates/*|Cargo.toml|Cargo.lock|proto/*)
+        mark_all_rust ;;
+      migrations/*)
+        mark_rust_service control-api ;;
+      services/control-api/*|docker/control-api/*)
+        mark_rust_service control-api ;;
+      services/parse-worker/*|docker/parse-worker/*)
+        mark_rust_service parse-worker ;;
+      services/typecheck-worker/*|docker/typecheck-worker/*)
+        mark_rust_service typecheck-worker ;;
+      services/ingest-graph/*|docker/ingest-graph/*)
+        mark_rust_service ingest-graph ;;
+      services/ingest-clone/*|docker/ingest-clone/*)
+        mark_rust_service ingest-clone ;;
+      services/expand-worker/*|docker/expand-worker/*)
+        mark_rust_service expand-worker ;;
+      services/embed-worker/*|docker/embed-worker/*)
+        mark_rust_service embed-worker ;;
+      services/projector-pg/*|docker/projector-pg/*)
+        mark_rust_service projector-pg ;;
+      services/projector-neo4j/*|docker/projector-neo4j/*)
+        mark_rust_service projector-neo4j ;;
+      services/tombstoner/*|docker/tombstoner/*)
+        mark_rust_service tombstoner ;;
       frontend/*|docker/frontend/*)
         REBUILD_FRONTEND=true ;;
-      # compose config changes affect all built services
       compose/dev.yml|compose/full.yml|compose/tailscale.yml|compose/tailscale.env|compose/scripts/*)
-        REBUILD_CONTROL_API=true
+        mark_all_rust
         REBUILD_FRONTEND=true ;;
     esac
   done <<< "$CHANGED_FILES"
 
-  if [[ "$REBUILD_CONTROL_API" == "false" && "$REBUILD_FRONTEND" == "false" ]]; then
+  if [[ "${#REBUILD_SERVICE[@]}" -eq 0 && "$REBUILD_FRONTEND" == "false" ]]; then
     echo "[dev-stack-auto-rebuild] no service paths changed — skipping"
     log_record "skipped" "" "[]" "no service paths changed"
     exit 0
@@ -186,16 +212,17 @@ COMPOSE_CMD="${COMPOSE_CMD:-docker compose -f $REPO_ROOT/compose/dev.yml}"
 
 post_gh_status "pending" "Dev-stack rebuild in progress"
 
-if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
-  echo "[dev-stack-auto-rebuild] building control-api..."
-  if ! $COMPOSE_CMD build control-api 2>&1; then
-    echo "[dev-stack-auto-rebuild] control-api build FAILED"
-    log_record "build_failed" "" '["control-api"]' "control-api build error"
-    post_gh_status "failure" "control-api build failed"
+for svc in "${ALL_RUST_SERVICES[@]}"; do
+  [[ "${REBUILD_SERVICE[$svc]:-}" == "true" ]] || continue
+  echo "[dev-stack-auto-rebuild] building $svc..."
+  if ! $COMPOSE_CMD build "$svc" 2>&1; then
+    echo "[dev-stack-auto-rebuild] $svc build FAILED"
+    log_record "build_failed" "" "[\"$svc\"]" "$svc build error"
+    post_gh_status "failure" "$svc build failed"
     exit 1
   fi
-  SERVICES_REBUILT+=(control-api)
-fi
+  SERVICES_REBUILT+=("$svc")
+done
 
 if [[ "$REBUILD_FRONTEND" == "true" ]]; then
   echo "[dev-stack-auto-rebuild] building frontend..."
@@ -210,49 +237,40 @@ fi
 
 # -- Restart -----------------------------------------------------------------
 
+REBUILT_JSON="$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")"
+
 if [[ "$COLD_START" == "true" ]]; then
-  # Cold start: run migrations then bring up the entire stack (infra + app services).
-  # --no-deps is intentionally omitted so dependencies (postgres, neo4j, qdrant, etc.) start too.
   echo "[dev-stack-auto-rebuild] cold start: running migrations..."
   if ! $COMPOSE_CMD up --force-recreate rb-migrations 2>&1; then
     echo "[dev-stack-auto-rebuild] rb-migrations FAILED"
-    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "cold start migrations failed"
+    log_record "restart_failed" "" "$REBUILT_JSON" "cold start migrations failed"
     post_gh_status "failure" "Cold start rb-migrations failed"
     exit 1
   fi
   echo "[dev-stack-auto-rebuild] cold start: bringing up full stack..."
   if ! $COMPOSE_CMD up -d 2>&1; then
     echo "[dev-stack-auto-rebuild] full stack up FAILED"
-    log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "cold start compose up -d error"
+    log_record "restart_failed" "" "$REBUILT_JSON" "cold start compose up -d error"
     post_gh_status "failure" "Cold start compose up -d failed"
     exit 1
   fi
 else
-  if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+  if [[ "${REBUILD_SERVICE[control-api]:-}" == "true" ]]; then
     echo "[dev-stack-auto-rebuild] re-running migrations..."
-    # Blocks until rb-migrations exits (restart: "no"). Idempotent — skips applied versions.
     if ! $COMPOSE_CMD up --force-recreate rb-migrations 2>&1; then
       echo "[dev-stack-auto-rebuild] rb-migrations FAILED"
-      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "migrations failed"
+      log_record "restart_failed" "" "$REBUILT_JSON" "migrations failed"
       post_gh_status "failure" "rb-migrations failed"
-      exit 1
-    fi
-
-    echo "[dev-stack-auto-rebuild] restarting control-api..."
-    if ! $COMPOSE_CMD up -d --no-deps --force-recreate control-api 2>&1; then
-      echo "[dev-stack-auto-rebuild] control-api restart FAILED"
-      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "control-api compose up error"
-      post_gh_status "failure" "control-api restart failed"
       exit 1
     fi
   fi
 
-  if [[ "$REBUILD_FRONTEND" == "true" ]]; then
-    echo "[dev-stack-auto-rebuild] restarting frontend..."
-    if ! $COMPOSE_CMD up -d --no-deps --force-recreate frontend 2>&1; then
-      echo "[dev-stack-auto-rebuild] frontend restart FAILED"
-      log_record "restart_failed" "" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")" "frontend compose up error"
-      post_gh_status "failure" "frontend restart failed"
+  if [[ "${#SERVICES_REBUILT[@]}" -gt 0 ]]; then
+    echo "[dev-stack-auto-rebuild] restarting: ${SERVICES_REBUILT[*]}"
+    if ! $COMPOSE_CMD up -d --no-deps --force-recreate "${SERVICES_REBUILT[@]}" 2>&1; then
+      echo "[dev-stack-auto-rebuild] restart FAILED for: ${SERVICES_REBUILT[*]}"
+      log_record "restart_failed" "" "$REBUILT_JSON" "compose up error"
+      post_gh_status "failure" "Restart failed: ${SERVICES_REBUILT[*]}"
       exit 1
     fi
   fi
@@ -266,7 +284,7 @@ sleep 15
 HEALTH_OK=true
 HEALTH_DETAIL=""
 
-if [[ "$REBUILD_CONTROL_API" == "true" ]]; then
+if [[ "${REBUILD_SERVICE[control-api]:-}" == "true" ]]; then
   PORT="${CONTROL_API_HOST_PORT:-8080}"
   HTTP_CODE="$(curl -s -o /tmp/rb-health-check.json -w "%{http_code}" \
     --max-time 10 "http://localhost:${PORT}/health" 2>/dev/null || echo "000")"
@@ -292,7 +310,18 @@ if [[ "$REBUILD_FRONTEND" == "true" ]]; then
   fi
 fi
 
-REBUILT_JSON="$(python3 -c "import json,sys; print(json.dumps(sys.argv[1].split()))" "${SERVICES_REBUILT[*]}")"
+for svc in "${SERVICES_REBUILT[@]}"; do
+  [[ "$svc" == "control-api" || "$svc" == "frontend" ]] && continue
+  RUNNING="$(docker inspect --format '{{.State.Running}}' "rustbrain-dev-${svc}-1" 2>/dev/null || echo "false")"
+  if [[ "$RUNNING" == "true" ]]; then
+    HEALTH_DETAIL="${HEALTH_DETAIL}${svc}=ok "
+  else
+    HEALTH_OK=false
+    HEALTH_DETAIL="${HEALTH_DETAIL}${svc}=FAIL(not-running) "
+    echo "[dev-stack-auto-rebuild] $svc health check failed: container not running"
+  fi
+done
+
 HEALTH_DETAIL="${HEALTH_DETAIL% }"  # trim trailing space
 
 if [[ "$HEALTH_OK" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Expanded `dev-stack-auto-rebuild.sh` path detection to cover all 10 Rust services (was only control-api + frontend)
- Changes to shared crates (`crates/**`, `Cargo.toml`, `Cargo.lock`, `proto/**`) now trigger rebuild of **all** Rust services, not just control-api
- Each service directory (`services/<name>/**`, `docker/<name>/**`) maps to its specific service rebuild
- Build loop, restart, and health checks now operate on the full set of affected services
- Updated `docs/dev-stack-auto-rebuild.md` to document the expanded rules

## Root Cause

The stale Docker image incident was caused by the auto-rebuild script ignoring 9 of 11 services. When shared crate fixes (rb-parse-syn span fix, rb-tracing trace_id fix) landed on main, only control-api was rebuilt — parse-worker, typecheck-worker, ingest-graph, projector-pg, and others kept running images from before the fix.

## Test plan

- [x] `bash -n` syntax check passes
- [x] Dry-run path matching: `crates/` change marks all 10 services
- [x] Dry-run path matching: `services/parse-worker/` change marks only parse-worker
- [ ] Deploy to mars and verify next main merge triggers correct selective rebuilds

Closes #290