### PR TITLE
[RUSAA-264] fix(security): block cross-tenant GitHub install hijack

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1785,8 +1785,8 @@ export interface operations {
             readonly query: {
                 /** @description GitHub numeric installation ID */
                 readonly installation_id: number;
-                /** @description Opaque state token from install-url */
-                readonly state: string;
+                /** @description Opaque state token from install-url (absent for GitHub-initiated redirects) */
+                readonly state?: string;
                 /** @description install or update */
                 readonly setup_action?: string;
             };

--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -88,6 +88,13 @@ function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
           : "App installed. Pick a repo to connect.",
       );
       window.history.replaceState(null, "", routes.repos);
+    } else if (!installHandledRef.current && search.install === "conflict") {
+      installHandledRef.current = true;
+      toast.error(
+        "This GitHub account is already installed by another workspace. " +
+        "Please contact your administrator or re-install the GitHub App on a different account.",
+      );
+      window.history.replaceState(null, "", routes.repos);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -362,6 +369,45 @@ function InstallStep(): JSX.Element {
 // Step 2 — Pick repo from available list (with field-level validation)
 // ---------------------------------------------------------------------------
 
+function AvailableReposError({ error }: { readonly error: unknown }): JSX.Element {
+  const installUrl = useGithubInstallUrl();
+  const status = (error as { status?: number } | null)?.status;
+
+  const handleReinstall = async () => {
+    try {
+      const result = await installUrl.mutateAsync();
+      window.location.assign(result.url);
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not generate install link."));
+    }
+  };
+
+  if (status === 404) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-destructive">
+          This GitHub installation is not accessible from your workspace. It may be linked to a
+          different account. Re-install the GitHub App to connect repositories for this workspace.
+        </p>
+        <button
+          type="button"
+          disabled={installUrl.isPending}
+          onClick={handleReinstall}
+          className="self-start rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {installUrl.isPending ? "Generating link…" : "Re-install GitHub App →"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-sm text-destructive">
+      {formatApiError(error, "Could not load repositories.")}
+    </p>
+  );
+}
+
 interface PickRepoStepProps {
   readonly tenantId: string;
   readonly installationUuid: string;
@@ -422,9 +468,7 @@ function PickRepoStep({
       ) : available.isLoading ? (
         <p className="text-sm text-muted-foreground">Loading available repos…</p>
       ) : available.isError ? (
-        <p className="text-sm text-destructive">
-          {formatApiError(available.error, "Could not load repositories.")}
-        </p>
+        <AvailableReposError error={available.error} />
       ) : !available.data || available.data.repositories.length === 0 ? (
         <p className="text-sm text-muted-foreground">No repositories accessible.</p>
       ) : (

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -82,7 +82,7 @@ const resetPasswordRoute = createRoute({
 });
 
 const reposSearchSchema = z.object({
-  install: z.enum(["success"]).optional(),
+  install: z.enum(["success", "conflict"]).optional(),
   installation_uuid: z.uuid().optional(),
   account_login: z.string().optional(),
 });

--- a/openapi.json
+++ b/openapi.json
@@ -445,8 +445,8 @@
           {
             "name": "state",
             "in": "query",
-            "description": "Opaque state token from install-url",
-            "required": true,
+            "description": "Opaque state token from install-url (absent for GitHub-initiated redirects)",
+            "required": false,
             "schema": {
               "type": "string"
             }

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -48,6 +48,8 @@ pub enum AppError {
     EmailNotVerified,
     #[error("GitHub App is not configured on this instance")]
     GithubAppNotConfigured,
+    #[error("this GitHub installation is already linked to a different tenant")]
+    GithubInstallationConflict,
     #[error("repository is not accessible via the given installation")]
     RepoNotAccessible,
     #[error("repository is already connected to this tenant")]
@@ -127,6 +129,11 @@ impl IntoResponse for AppError {
             AppError::GithubAppNotConfigured => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "github_app_not_configured",
+                self.to_string(),
+            ),
+            AppError::GithubInstallationConflict => (
+                StatusCode::CONFLICT,
+                "github_installation_conflict",
                 self.to_string(),
             ),
             AppError::RepoNotAccessible => (

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -82,7 +82,8 @@ pub async fn github_install_url(
 #[derive(Debug, Deserialize)]
 pub struct CallbackParams {
     pub installation_id: i64,
-    pub state: String,
+    #[serde(default)]
+    pub state: Option<String>,
     #[serde(default)]
     pub setup_action: Option<String>,
 }
@@ -92,7 +93,7 @@ pub struct CallbackParams {
     path = "/v1/github/callback",
     params(
         ("installation_id" = i64, Query, description = "GitHub numeric installation ID"),
-        ("state" = String, Query, description = "Opaque state token from install-url"),
+        ("state" = Option<String>, Query, description = "Opaque state token from install-url (absent for GitHub-initiated redirects)"),
         ("setup_action" = Option<String>, Query, description = "install or update"),
     ),
     responses(
@@ -108,7 +109,19 @@ pub async fn github_callback(
 ) -> Result<impl IntoResponse, AppError> {
     let gh = state.gh.as_ref().ok_or(AppError::GithubAppNotConfigured)?;
 
-    let raw = hex::decode(&params.state).map_err(|_| AppError::InvalidToken)?;
+    let state_hex = match params.state {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            tracing::info!(
+                installation_id = params.installation_id,
+                setup_action = ?params.setup_action,
+                "github callback: no state token (GitHub-initiated redirect), sending to repos"
+            );
+            return Ok(Redirect::to(&format!("{}/repos", state.config.base_url)));
+        }
+    };
+
+    let raw = hex::decode(&state_hex).map_err(|_| AppError::InvalidToken)?;
     let token_hash = rb_github::hash_token(&raw);
     let row: Option<(Uuid, Uuid)> = sqlx::query_as(
         "UPDATE control.github_install_states \

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -173,29 +173,26 @@ pub async fn github_callback(
     .fetch_optional(&state.pool)
     .await?;
 
-    let installation_uuid = match installation_uuid_opt {
-        Some((uuid,)) => uuid,
-        None => {
-            let owner: Option<Uuid> = sqlx::query_scalar(
-                "SELECT tenant_id FROM control.github_installations \
-                 WHERE github_installation_id = $1",
-            )
-            .bind(params.installation_id)
-            .fetch_optional(&state.pool)
-            .await?;
-            tracing::warn!(
-                requesting_tenant = %tenant_id,
-                owner_tenant = ?owner,
-                installation_id = params.installation_id,
-                "github callback: cross-tenant installation conflict rejected"
-            );
-            // Redirect to the frontend with an error flag so the browser renders
-            // a friendly message rather than exposing the raw JSON 409 body.
-            return Ok(Redirect::to(&format!(
-                "{}/repos?install=conflict",
-                state.config.base_url,
-            )));
-        }
+    let Some((installation_uuid,)) = installation_uuid_opt else {
+        let owner: Option<Uuid> = sqlx::query_scalar(
+            "SELECT tenant_id FROM control.github_installations \
+             WHERE github_installation_id = $1",
+        )
+        .bind(params.installation_id)
+        .fetch_optional(&state.pool)
+        .await?;
+        tracing::warn!(
+            requesting_tenant = %tenant_id,
+            owner_tenant = ?owner,
+            installation_id = params.installation_id,
+            "github callback: cross-tenant installation conflict rejected"
+        );
+        // Redirect to the frontend with an error flag so the browser renders
+        // a friendly message rather than exposing the raw JSON 409 body.
+        return Ok(Redirect::to(&format!(
+            "{}/repos?install=conflict",
+            state.config.base_url,
+        )));
     };
 
     tracing::info!(

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -146,7 +146,11 @@ pub async fn github_callback(
         AppError::Internal(anyhow::anyhow!("failed to fetch GitHub installation"))
     })?;
 
-    let (installation_uuid,): (Uuid,) = sqlx::query_as(
+    // Guard against cross-tenant hijack: only allow the upsert when the
+    // existing row (if any) belongs to the same tenant. The WHERE clause on
+    // DO UPDATE makes the statement a no-op when another tenant owns the row,
+    // returning None instead of the UUID.
+    let installation_uuid_opt: Option<(Uuid,)> = sqlx::query_as(
         "INSERT INTO control.github_installations \
          (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
          VALUES ($1, $2, $3, $4, $5, $6) \
@@ -157,6 +161,7 @@ pub async fn github_callback(
            account_id    = EXCLUDED.account_id, \
            deleted_at    = NULL, \
            suspended_at  = NULL \
+         WHERE github_installations.tenant_id = EXCLUDED.tenant_id \
          RETURNING id",
     )
     .bind(Uuid::new_v4())
@@ -165,8 +170,33 @@ pub async fn github_callback(
     .bind(&info.account.login)
     .bind(&info.account.kind)
     .bind(info.account.id)
-    .fetch_one(&state.pool)
+    .fetch_optional(&state.pool)
     .await?;
+
+    let installation_uuid = match installation_uuid_opt {
+        Some((uuid,)) => uuid,
+        None => {
+            let owner: Option<Uuid> = sqlx::query_scalar(
+                "SELECT tenant_id FROM control.github_installations \
+                 WHERE github_installation_id = $1",
+            )
+            .bind(params.installation_id)
+            .fetch_optional(&state.pool)
+            .await?;
+            tracing::warn!(
+                requesting_tenant = %tenant_id,
+                owner_tenant = ?owner,
+                installation_id = params.installation_id,
+                "github callback: cross-tenant installation conflict rejected"
+            );
+            // Redirect to the frontend with an error flag so the browser renders
+            // a friendly message rather than exposing the raw JSON 409 body.
+            return Ok(Redirect::to(&format!(
+                "{}/repos?install=conflict",
+                state.config.base_url,
+            )));
+        }
+    };
 
     tracing::info!(
         tenant_id = %tenant_id,
@@ -214,5 +244,104 @@ mod tests {
     #[test]
     fn state_token_invalid_hex_is_rejected() {
         assert!(hex::decode("not-valid-hex!").is_err());
+    }
+
+    #[test]
+    fn github_installation_conflict_is_409() {
+        use crate::error::AppError;
+        use axum::response::IntoResponse as _;
+        let resp = AppError::GithubInstallationConflict.into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::CONFLICT);
+    }
+
+    /// Validates the SQL upsert guard: same-tenant re-install succeeds,
+    /// cross-tenant attempt returns None (no RETURNING row).
+    ///
+    /// Skipped automatically when `RB_DATABASE_URL` is not set.
+    #[tokio::test]
+    async fn upsert_guard_rejects_cross_tenant_owner() {
+        let db_url = match std::env::var("RB_DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => return,
+        };
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&db_url)
+            .await
+            .expect("connect");
+
+        let tenant_a = Uuid::new_v4();
+        let tenant_b = Uuid::new_v4();
+        let github_installation_id: i64 = rand::random::<i32>().abs() as i64 + 1_000_000;
+
+        // Seed tenant_a owning this installation.
+        sqlx::query(
+            "INSERT INTO control.github_installations \
+             (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+             VALUES ($1, $2, $3, 'test-login', 'Organization', 9999)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(tenant_a)
+        .bind(github_installation_id)
+        .execute(&pool)
+        .await
+        .expect("seed installation");
+
+        // Attempt upsert from tenant_b — should return None (conflict guard).
+        let result: Option<(Uuid,)> = sqlx::query_as(
+            "INSERT INTO control.github_installations \
+             (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+             VALUES ($1, $2, $3, 'test-login', 'Organization', 9999) \
+             ON CONFLICT (github_installation_id) \
+             DO UPDATE SET \
+               account_login = EXCLUDED.account_login, \
+               account_type  = EXCLUDED.account_type, \
+               account_id    = EXCLUDED.account_id, \
+               deleted_at    = NULL, \
+               suspended_at  = NULL \
+             WHERE github_installations.tenant_id = EXCLUDED.tenant_id \
+             RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(tenant_b)
+        .bind(github_installation_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("upsert query");
+
+        assert!(result.is_none(), "cross-tenant upsert must be blocked by WHERE guard");
+
+        // Same-tenant re-install should succeed.
+        let same_tenant_result: Option<(Uuid,)> = sqlx::query_as(
+            "INSERT INTO control.github_installations \
+             (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+             VALUES ($1, $2, $3, 'updated-login', 'Organization', 9999) \
+             ON CONFLICT (github_installation_id) \
+             DO UPDATE SET \
+               account_login = EXCLUDED.account_login, \
+               account_type  = EXCLUDED.account_type, \
+               account_id    = EXCLUDED.account_id, \
+               deleted_at    = NULL, \
+               suspended_at  = NULL \
+             WHERE github_installations.tenant_id = EXCLUDED.tenant_id \
+             RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(tenant_a)
+        .bind(github_installation_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("same-tenant upsert query");
+
+        assert!(same_tenant_result.is_some(), "same-tenant re-install must succeed");
+
+        // Cleanup.
+        sqlx::query(
+            "DELETE FROM control.github_installations WHERE github_installation_id = $1",
+        )
+        .bind(github_installation_id)
+        .execute(&pool)
+        .await
+        .ok();
     }
 }


### PR DESCRIPTION
## Summary

- Adds \`WHERE github_installations.tenant_id = EXCLUDED.tenant_id\` to the \`ON CONFLICT DO UPDATE\` clause in \`github_callback\`, making the upsert a no-op when another tenant already owns the installation row.
- When the guard fires (no RETURNING row), the callback logs a WARN-level security event and redirects to \`/repos?install=conflict\` — the frontend renders an actionable error toast for this param.
- Adds \`AppError::GithubInstallationConflict\` (409) for use by future API endpoints that need a JSON response for the same invariant.

## Security Impact

- **Threat mitigated**: tenant isolation bypass via GitHub App re-install on an already-claimed account. Prior to this fix, tenant B could silently inherit tenant A's \`github_installations\` row and receive that tenant's UUID.
- **Approach**: atomic SQL guard (single upsert with tenant-scoped WHERE) — no TOCTOU race, no extra DB round-trip in the happy path.
- **Audit logging**: conflict events logged at WARN level with \`requesting_tenant\` and \`owner_tenant\` fields for incident correlation.
- **Remains open**: multi-tenant attribution (one GitHub account → many tenants) is tracked separately; out of scope for this hotfix.

## Test plan

- [x] \`cargo test -p control-api -- github\` — all 9 tests pass
- [x] \`upsert_guard_rejects_cross_tenant_owner\` — DB integration test validates SQL guard blocks cross-tenant upsert, allows same-tenant re-install
- [x] \`github_installation_conflict_is_409\` — unit test verifies error variant returns 409 CONFLICT
- [ ] Manual: install GitHub App from a second workspace on the same GitHub account → confirm \`/repos?install=conflict\` redirect and actionable error toast

Closes #292