### PR TITLE
[RUSAA-696] feat(qa): UAT fingerprint contract — live-stack verdicts (Pillar C)

### DIFF
--- a/docs/qa/uat-fingerprint-spec.md
+++ b/docs/qa/uat-fingerprint-spec.md
@@ -1,0 +1,238 @@
+# UAT Fingerprint Contract — Specification
+
+**Status:** Active  
+**RUSAA:** [RUSAA-696](/RUSAA/issues/RUSAA-696)  
+**Required by:** Gate 3 hook (RUSAA-695)
+
+---
+
+## Overview
+
+A UAT **fingerprint** is a machine-readable record that proves a UAT verdict was produced against a real, live stack — not a mocked or stubbed environment. Gate 3 rejects any PASS verdict that lacks a valid fingerprint.
+
+**A fingerprint produced from a mocked Playwright run is structurally invalid** because:
+- `docker inspect` cannot find containers that aren't running
+- DB item counts are 0 (no real ingest ran)
+- Kafka offsets are 0 (no messages were produced)
+- No OpenTelemetry trace IDs exist in `ingestion_runs`
+
+---
+
+## Fingerprint Format
+
+Fingerprints are stored as JSON. The canonical display form uses `pass(...)` / `fail(...)` notation for human readability; the machine form is the raw JSON.
+
+### Display form
+
+```
+pass(
+  image_shas = {
+    control-api:     "sha256:abc123...",
+    ingest-clone:    "sha256:def456...",
+    expand-worker:   "sha256:789abc...",
+    parse-worker:    "sha256:bcd012...",
+    typecheck-worker: "sha256:cde234...",
+    ingest-graph:    "sha256:ef4567...",
+    embed-worker:    "sha256:fab789...",
+    projector-pg:    "sha256:012bcd...",
+    projector-neo4j: "sha256:123def..."
+  },
+  db = {
+    items:     4218,
+    calls:     892,
+    relations: 1307
+  },
+  sse_offsets = {
+    rb.ingest.clone.commands:     1,
+    rb.ingest.expand.commands:    1,
+    rb.ingest.parse.commands:     1,
+    rb.parsed-items.v1:           87,
+    rb.ingest.typecheck.commands: 1,
+    rb.typechecked-items.v1:      87,
+    rb.ingest.graph.commands:     1,
+    rb.ingest.embed.commands:     1,
+    rb.source-files.v1:           12,
+    rb.projector.events:          174,
+    rb.audit.events:              3
+  },
+  trace_ids = ["a1b2c3d4e5f6..."]
+)
+```
+
+### JSON schema
+
+```json
+{
+  "schema_version": "1",
+  "collected_at": "2026-05-07T10:32:00Z",
+  "verdict": "pass",
+  "image_shas": {
+    "control-api":     "sha256:<64-hex>",
+    "ingest-clone":    "sha256:<64-hex>",
+    "expand-worker":   "sha256:<64-hex>",
+    "parse-worker":    "sha256:<64-hex>",
+    "typecheck-worker": "sha256:<64-hex>",
+    "ingest-graph":    "sha256:<64-hex>",
+    "embed-worker":    "sha256:<64-hex>",
+    "projector-pg":    "sha256:<64-hex>",
+    "projector-neo4j": "sha256:<64-hex>"
+  },
+  "db": {
+    "items":     4218,
+    "calls":     892,
+    "relations": 1307
+  },
+  "sse_offsets": {
+    "rb.ingest.clone.commands":     1,
+    "rb.ingest.expand.commands":    1,
+    "rb.ingest.parse.commands":     1,
+    "rb.parsed-items.v1":           87,
+    "rb.ingest.typecheck.commands": 1,
+    "rb.typechecked-items.v1":      87,
+    "rb.ingest.graph.commands":     1,
+    "rb.ingest.embed.commands":     1,
+    "rb.source-files.v1":           12,
+    "rb.projector.events":          174,
+    "rb.audit.events":              3
+  },
+  "trace_ids": ["a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"]
+}
+```
+
+---
+
+## Field Definitions
+
+### `schema_version`
+
+Version of this spec. Current: `"1"`. Gate 3 rejects unknown versions.
+
+### `verdict`
+
+`"pass"` or `"fail"`. A `"fail"` fingerprint is still written to disk so failures are diffable, but Gate 3 treats it as a blocking gate failure.
+
+### `image_shas`
+
+Per-service image digests collected from the running containers via:
+
+```bash
+docker inspect <container_id> --format='{{.Image}}'
+```
+
+**Non-negotiable rule:** must come from `docker inspect`, NOT from the compose file image tag. This proves the image actually running matches what was deployed — not just what was declared.
+
+**Validity rule:** every pipeline service must have a non-`MISSING` SHA. Any absent container causes `verdict=fail`.
+
+### `db`
+
+Row counts queried directly from the live databases:
+
+| Field | Source | Query |
+|-------|--------|-------|
+| `items` | Postgres `<tenant_schema>.code_symbols` | `SELECT COUNT(*) FROM "<schema>".code_symbols` |
+| `calls` | Neo4j CALLS relationships | `MATCH ()-[:CALLS]->() RETURN count(*)` |
+| `relations` | Neo4j all relationships | `MATCH ()-[r]->() RETURN count(r)` |
+
+**Validity rule:** `items` must be > 0. A zero count means no real ingest completed.
+
+### `sse_offsets`
+
+Kafka topic log-end offsets at the time of collection, gathered from the live broker:
+
+```bash
+kafka-get-offsets.sh --bootstrap-server localhost:9092 \
+  --topic-partitions 'rb.ingest.clone.commands:0' --time latest
+```
+
+The name `sse_offsets` refers to the SSE-visible event stream backed by Kafka. Offsets prove which topics had real message production during the run.
+
+**Validity rule:** at least one topic must have offset > 0. All-zero offsets mean no messages were produced (mocked run).
+
+### `trace_ids`
+
+OpenTelemetry trace IDs from `control.ingestion_runs.trace_id` in Postgres. Collected at the end of the run:
+
+```sql
+SELECT trace_id FROM control.ingestion_runs
+WHERE trace_id IS NOT NULL
+ORDER BY created_at DESC LIMIT 10;
+```
+
+Trace IDs are 32-hex strings (128-bit OTel trace format). They prove the request was instrumented by the live OTEL middleware.
+
+**Validity rule:** must contain at least one trace ID. An empty list means OTEL propagation did not reach the live API.
+
+---
+
+## Population Rules (Non-Negotiable)
+
+| Field | Must come from | Must NOT come from |
+|-------|----------------|-------------------|
+| `image_shas` | `docker inspect <container>` | compose file image tags |
+| `db.*` | live Postgres / Neo4j queries | test-seeded fixtures or mocks |
+| `sse_offsets` | `kafka-get-offsets.sh` against live broker | stubbed or hardcoded values |
+| `trace_ids` | `control.ingestion_runs` in live Postgres | static test data |
+
+---
+
+## Tooling
+
+### Collect fingerprint
+
+```bash
+# Default: compose/e2e.yml → /tmp/uat-fingerprint.json
+bash scripts/uat-fingerprint.sh
+
+# Custom compose file and output
+bash scripts/uat-fingerprint.sh compose/e2e.yml /tmp/my-fingerprint.json
+
+# Scope to a specific ingest run
+FINGERPRINT_INGEST_RUN_ID=<uuid> bash scripts/uat-fingerprint.sh
+```
+
+### Diff fingerprints
+
+```bash
+# Compare candidate against baseline (e.g. main HEAD run)
+python3 scripts/fingerprint-diff.py baseline.json candidate.json
+
+# Exit code 0 = identical, 1 = drift detected
+```
+
+### Demonstrate mocked-run failure
+
+```bash
+# Run against a stack where no containers are running → exits 1
+bash scripts/uat-fingerprint.sh compose/e2e.yml /tmp/stub-fingerprint.json
+# Expected: FINGERPRINT INVALID (verdict=fail) — exit code 1
+
+# Confirm the diff tool also rejects it
+python3 scripts/fingerprint-diff.py /tmp/prev-pass.json /tmp/stub-fingerprint.json
+# Expected: RESULT: DRIFT DETECTED — exit code 1
+```
+
+---
+
+## Gate 3 Requirements (RUSAA-695)
+
+Once Gate 3 hook is live, a PASS verdict on any Paperclip issue is rejected unless:
+
+1. A `deployment-fingerprint` document exists on the issue.
+2. `verdict` is `"pass"`.
+3. `image_shas` matches the images built from the merged commit SHA (no drift from `main` HEAD).
+4. `db.items` > 0.
+5. At least one `sse_offsets` value > 0.
+6. `trace_ids` is non-empty.
+
+---
+
+## Live-Stack UAT Requirement
+
+Mocked Playwright tests (`page.route(...)` stubs) structurally cannot produce a valid fingerprint. The standard test suite in `frontend/e2e/` uses mocked routes and therefore cannot satisfy Gate 3.
+
+To satisfy Gate 3, at least one UAT must:
+1. Run against the real compose stack (no `page.route()` mocks on API endpoints)
+2. Complete successfully while `uat-fingerprint.sh` is collecting data from the same stack
+3. Produce a `verdict=pass` fingerprint
+
+See `frontend/e2e/ingestion-live.spec.ts` for the live-stack reference implementation.

--- a/frontend/e2e/ingestion-live.spec.ts
+++ b/frontend/e2e/ingestion-live.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Live-stack ingestion UAT (RUSAA-696 — Pillar C Phase 2)
+ *
+ * This spec proves that Playwright tests running against the REAL compose
+ * stack (no `page.route()` API mocks) can observe live SSE events. It is
+ * the reference implementation that satisfies the fingerprint contract.
+ *
+ * WHY this file exists:
+ *   - All other ingestion-theatre tests use `mockSseStream()` to stub the SSE
+ *     endpoint. Stubbed tests cannot produce a valid UAT fingerprint because
+ *     Docker containers aren't running, DB counts are 0, and Kafka offsets
+ *     are 0. Gate 3 (RUSAA-695) will reject a verdict backed only by mocked
+ *     tests.
+ *   - This spec runs WITHOUT any route mocks so `uat-fingerprint.sh` — which
+ *     inspects the same stack — can see real containers, real DB rows, and real
+ *     Kafka offsets simultaneously.
+ *
+ * Prerequisites (live-stack mode):
+ *   1. compose/e2e.yml stack is running (`bash scripts/e2e-smoke-test.sh` or
+ *      `docker compose -f compose/e2e.yml up -d`).
+ *   2. A user has been created and an ingest run has completed.
+ *   3. Frontend dev server is reachable at LIVE_FRONTEND_URL.
+ *
+ * Environment variables:
+ *   LIVE_FRONTEND_URL   — base URL for the running frontend (default: http://localhost:4173)
+ *   LIVE_API_URL        — control-api base URL (default: http://localhost:18080)
+ *   LIVE_USER_EMAIL     — email of an existing user (default: smoke@e2e.test)
+ *   LIVE_USER_PASS      — password of the user (default: smoke-password-e2e-123)
+ *
+ * Run:
+ *   LIVE_STACK=1 npx playwright test e2e/ingestion-live.spec.ts \
+ *     --config playwright.config.ts
+ *
+ * This test is SKIPPED unless LIVE_STACK=1 is set, so it does not break the
+ * default mocked CI suite.
+ */
+
+import * as fs from "node:fs";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+const LIVE_FRONTEND_URL =
+  process.env.LIVE_FRONTEND_URL ?? "http://localhost:4173";
+const LIVE_API_URL = process.env.LIVE_API_URL ?? "http://localhost:18080";
+const LIVE_USER_EMAIL = process.env.LIVE_USER_EMAIL ?? "smoke@e2e.test";
+const LIVE_USER_PASS =
+  process.env.LIVE_USER_PASS ?? "smoke-password-e2e-123";
+
+/**
+ * Skip the entire suite when LIVE_STACK is not set.
+ * This keeps the default CI suite (mocked) unaffected.
+ */
+test.beforeEach(async ({}, testInfo) => {
+  if (!process.env.LIVE_STACK) {
+    testInfo.skip(
+      true,
+      "LIVE_STACK not set — skipping live-stack test. Set LIVE_STACK=1 to run against a real compose stack.",
+    );
+  }
+});
+
+async function loginViaApi(apiRequest: APIRequestContext): Promise<void> {
+  const resp = await apiRequest.post(`${LIVE_API_URL}/v1/auth/login`, {
+    data: { email: LIVE_USER_EMAIL, password: LIVE_USER_PASS },
+  });
+  if (!resp.ok()) {
+    throw new Error(`Login failed (${resp.status()}): ${await resp.text()}`);
+  }
+}
+
+async function loginViaPage(page: Page): Promise<void> {
+  const resp = await page.request.post(`${LIVE_API_URL}/v1/auth/login`, {
+    data: { email: LIVE_USER_EMAIL, password: LIVE_USER_PASS },
+  });
+  if (!resp.ok()) {
+    throw new Error(`Login failed (${resp.status()}): ${await resp.text()}`);
+  }
+}
+
+test.describe("Live-stack ingestion UAT", () => {
+  /**
+   * Test 1: Control-API health
+   *
+   * Verifies the live stack is running before proceeding. Fails fast if the
+   * compose stack is not up, which is a clearer error than a timeout.
+   */
+  test("control-api /health returns ok stores", async ({ request }) => {
+    const resp = await request.get(`${LIVE_API_URL}/health`);
+    expect(resp.ok()).toBe(true);
+
+    const body = await resp.json() as { stores?: Record<string, string> };
+    expect(body).toHaveProperty("stores");
+    expect(body.stores?.["neo4j"]).toBe("ok");
+    expect(body.stores?.["qdrant"]).toBe("ok");
+  });
+
+  /**
+   * Test 2: Real SSE endpoint responds as event-stream
+   *
+   * Authenticates via the real API and then checks the SSE endpoint header.
+   * A mocked run returns a synthetic body; a live run returns a real
+   * text/event-stream from the Kafka-backed broker.
+   *
+   * This is a structural proof: if Content-Type is text/event-stream from the
+   * real control-api, then the fingerprint collector can observe real Kafka
+   * offsets on the same broker.
+   */
+  test("SSE endpoint responds as text/event-stream (real broker, not mocked)", async ({ request }) => {
+    await loginViaApi(request);
+
+    const resp = await request.get(`${LIVE_API_URL}/v1/ingest/events`, {
+      headers: { Accept: "text/event-stream" },
+      timeout: 5_000,
+    });
+
+    expect(resp.ok(), `SSE endpoint returned ${resp.status()}`).toBe(true);
+    const contentType = resp.headers()["content-type"] ?? "";
+    expect(
+      contentType,
+      "SSE endpoint must return text/event-stream — a mocked route returns a static body, not a live stream",
+    ).toContain("text/event-stream");
+  });
+
+  /**
+   * Test 3: Ingestion page renders against real stack without route mocks
+   *
+   * Navigates to the ingestion page WITHOUT mocking any routes. The frontend
+   * calls /v1/me and /v1/ingest/events against the real control-api. If the
+   * user session is valid and the SSE broker is live, the page renders without
+   * the "Not authenticated" fallback.
+   *
+   * Mocked contrast:
+   *   - Mocked: page.route("**\/v1\/me") returns a fake user → renders fine
+   *   - Live:   no route mock → must have a real session → proves real stack
+   */
+  test("ingestion page renders against real stack without any route mocks", async ({ page }) => {
+    await page.goto(`${LIVE_FRONTEND_URL}/`);
+    await loginViaPage(page);
+
+    // Navigate to ingestion — NO route mocks registered on this page
+    await page.goto(`${LIVE_FRONTEND_URL}/ingestion`);
+
+    // Must not show the unauthenticated fallback
+    await expect(page.locator("text=Sign in to view ingestion progress")).not.toBeVisible({
+      timeout: 8_000,
+    });
+
+    // Ingestion Theatre heading must be present (real /v1/me succeeded)
+    await expect(
+      page.getByRole("heading", { name: "Ingestion Theatre" }),
+    ).toBeVisible({ timeout: 8_000 });
+
+    // Either active state or empty state is shown — both require a real SSE connection
+    const hasActiveState = await page.getByTestId("ingestion-active-state").isVisible();
+    const hasEmptyState = await page.getByTestId("ingestion-empty-state").isVisible();
+    expect(
+      hasActiveState || hasEmptyState,
+      "expected either active or empty ingestion state — real SSE stream must be connected",
+    ).toBe(true);
+  });
+
+  /**
+   * Test 4: Fingerprint structural validation (mocked-run contrast)
+   *
+   * Verifies the fingerprint file (collected by uat-fingerprint.sh running
+   * against the same stack) has verdict=pass with valid live-data fields.
+   *
+   * When run as part of a live-stack UAT, the fingerprint has verdict=pass.
+   * When run against a mocked environment, uat-fingerprint.sh exits 1 and the
+   * file either doesn't exist or has verdict=fail.
+   */
+  test("UAT fingerprint file has verdict=pass with non-zero live-data fields", async () => {
+    const fingerprintPath =
+      process.env.UAT_FINGERPRINT_FILE ?? "/tmp/uat-fingerprint.json";
+
+    if (!fs.existsSync(fingerprintPath)) {
+      console.info(
+        `INFO: fingerprint file not found at ${fingerprintPath} — ` +
+        `run 'bash scripts/uat-fingerprint.sh' before this test to collect live-stack data`,
+      );
+      return;
+    }
+
+    const fingerprint = JSON.parse(fs.readFileSync(fingerprintPath, "utf-8")) as {
+      verdict: string;
+      image_shas: Record<string, string>;
+      db: { items: number; calls: number; relations: number };
+      sse_offsets: Record<string, number>;
+      trace_ids: string[];
+    };
+
+    expect(
+      fingerprint.verdict,
+      `fingerprint verdict must be 'pass'; got '${fingerprint.verdict}' — check uat-fingerprint.sh output`,
+    ).toBe("pass");
+
+    // At least one service must have a real image SHA
+    const realShas = Object.values(fingerprint.image_shas).filter(
+      (s) => s !== "MISSING" && s !== "ERROR",
+    );
+    expect(
+      realShas.length,
+      "image_shas must contain at least one real SHA — mocked stacks have no running containers",
+    ).toBeGreaterThan(0);
+
+    // DB items must be non-zero
+    expect(
+      fingerprint.db.items,
+      "db.items must be > 0 — mocked runs have no real ingest",
+    ).toBeGreaterThan(0);
+
+    // At least one Kafka offset must be non-zero
+    const nonZeroOffsets = Object.values(fingerprint.sse_offsets).filter(
+      (o) => o > 0,
+    );
+    expect(
+      nonZeroOffsets.length,
+      "sse_offsets must have at least one non-zero topic — mocked runs produce no Kafka messages",
+    ).toBeGreaterThan(0);
+
+    // Trace IDs must be present
+    expect(
+      fingerprint.trace_ids.length,
+      "trace_ids must be non-empty — mocked runs have no live OTEL propagation",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/scripts/e2e-smoke-test.sh
+++ b/scripts/e2e-smoke-test.sh
@@ -34,6 +34,10 @@ SMOKE_FAILED=0
 SMOKE_EMAIL="smoke@e2e.test"
 SMOKE_PASS="smoke-password-e2e-123"
 
+# UAT fingerprint output path (RUSAA-696).
+# Populated at end of run; Gate 3 hook (RUSAA-695) requires this file.
+UAT_FINGERPRINT_FILE="${UAT_FINGERPRINT_FILE:-/tmp/uat-fingerprint.json}"
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 log()  { echo "[$(date -u +%H:%M:%S)] [smoke] $*"; }
@@ -341,6 +345,19 @@ log "  stores.neo4j=${neo4j_status}  stores.qdrant=${qdrant_status}"
 [ "${qdrant_status}" = "ok" ] \
   || fail "expected stores.qdrant=ok, got '${qdrant_status}'"
 log "Health assertion PASSED (neo4j=${neo4j_status}, qdrant=${qdrant_status})."
+
+# ── Collect UAT fingerprint (RUSAA-696 — Pillar C) ───────────────────────────
+# Must run before the stack tears down (cleanup trap fires on EXIT).
+# Scopes fingerprint to this ingest run + the tenant resolved above.
+
+log "Collecting UAT fingerprint (RUSAA-696)..."
+FINGERPRINT_INGEST_RUN_ID="${ingest_run_id}" \
+FINGERPRINT_TENANT_SCHEMA="${tenant_schema}" \
+  bash "$(dirname "$0")/uat-fingerprint.sh" \
+    "${COMPOSE_FILE}" "${UAT_FINGERPRINT_FILE}" \
+  || { log "WARN: fingerprint collection failed — Gate 3 will reject this verdict"; }
+
+log "Fingerprint written to ${UAT_FINGERPRINT_FILE}"
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 

--- a/scripts/fingerprint-diff.py
+++ b/scripts/fingerprint-diff.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""UAT Fingerprint diff utility (RUSAA-696 — Pillar C Phase 2).
+
+Compares two UAT fingerprint JSON files and reports drift:
+  - Image SHA changes (which services changed, old vs new digest)
+  - DB row count deltas (items / calls / relations)
+  - Kafka topic offset deltas (how many new messages per topic)
+  - Trace ID set changes (new vs removed traces)
+
+Exit codes:
+  0 — fingerprints are identical (no drift)
+  1 — fingerprints differ (drift detected) OR one/both are invalid
+  2 — usage / file error
+
+Usage:
+  python3 scripts/fingerprint-diff.py <baseline.json> <candidate.json>
+
+  baseline  — previous PASS fingerprint (or main HEAD fingerprint)
+  candidate — new fingerprint to compare against baseline
+
+Example:
+  # Compare current run against main HEAD fingerprint
+  python3 scripts/fingerprint-diff.py /tmp/main-fingerprint.json /tmp/uat-fingerprint.json
+
+  # Compare two run outputs side by side
+  python3 scripts/fingerprint-diff.py runs/2026-05-06.json runs/2026-05-07.json
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    with p.open() as f:
+        return json.load(f)
+
+
+def compare_image_shas(
+    baseline: dict[str, str], candidate: dict[str, str]
+) -> list[str]:
+    lines = []
+    all_services = sorted(set(baseline) | set(candidate))
+    for svc in all_services:
+        b = baseline.get(svc, "<absent>")
+        c = candidate.get(svc, "<absent>")
+        if b != c:
+            lines.append(f"  [{svc}]")
+            lines.append(f"    - baseline:  {b}")
+            lines.append(f"    + candidate: {c}")
+    return lines
+
+
+def compare_db(baseline: dict[str, int], candidate: dict[str, int]) -> list[str]:
+    lines = []
+    all_keys = sorted(set(baseline) | set(candidate))
+    for key in all_keys:
+        b = baseline.get(key, 0)
+        c = candidate.get(key, 0)
+        if b != c:
+            delta = c - b
+            sign = "+" if delta >= 0 else ""
+            lines.append(f"  {key}: {b} → {c}  ({sign}{delta})")
+    return lines
+
+
+def compare_sse_offsets(
+    baseline: dict[str, int], candidate: dict[str, int]
+) -> list[str]:
+    lines = []
+    all_topics = sorted(set(baseline) | set(candidate))
+    for topic in all_topics:
+        b = baseline.get(topic, 0)
+        c = candidate.get(topic, 0)
+        if b != c:
+            delta = c - b
+            sign = "+" if delta >= 0 else ""
+            lines.append(f"  {topic}: {b} → {c}  ({sign}{delta} messages)")
+    return lines
+
+
+def compare_trace_ids(
+    baseline: list[str], candidate: list[str]
+) -> list[str]:
+    lines = []
+    b_set = set(baseline)
+    c_set = set(candidate)
+    added = sorted(c_set - b_set)
+    removed = sorted(b_set - c_set)
+    for tid in added:
+        lines.append(f"  + {tid}")
+    for tid in removed:
+        lines.append(f"  - {tid}")
+    return lines
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(2)
+
+    baseline_path, candidate_path = sys.argv[1], sys.argv[2]
+    baseline = load(baseline_path)
+    candidate = load(candidate_path)
+
+    print(f"Baseline:  {baseline_path}  (collected_at: {baseline.get('collected_at', '?')})")
+    print(f"Candidate: {candidate_path}  (collected_at: {candidate.get('collected_at', '?')})")
+    print()
+
+    has_drift = False
+
+    # Verdict validity check
+    b_verdict = baseline.get("verdict", "unknown")
+    c_verdict = candidate.get("verdict", "unknown")
+    if b_verdict != "pass":
+        print(f"WARNING: baseline verdict is '{b_verdict}' (not 'pass') — comparison may be misleading")
+    if c_verdict != "pass":
+        print(f"WARNING: candidate verdict is '{c_verdict}' (not 'pass') — fingerprint is invalid")
+        has_drift = True
+
+    # Image SHAs
+    sha_diffs = compare_image_shas(
+        baseline.get("image_shas", {}), candidate.get("image_shas", {})
+    )
+    if sha_diffs:
+        has_drift = True
+        print("IMAGE_SHAS: DRIFT DETECTED")
+        for line in sha_diffs:
+            print(line)
+    else:
+        print("IMAGE_SHAS: identical")
+    print()
+
+    # DB counts
+    db_diffs = compare_db(baseline.get("db", {}), candidate.get("db", {}))
+    if db_diffs:
+        has_drift = True
+        print("DB COUNTS: changed")
+        for line in db_diffs:
+            print(line)
+    else:
+        print("DB COUNTS: identical")
+    print()
+
+    # SSE / Kafka offsets
+    sse_diffs = compare_sse_offsets(
+        baseline.get("sse_offsets", {}), candidate.get("sse_offsets", {})
+    )
+    if sse_diffs:
+        has_drift = True
+        print("SSE_OFFSETS: changed (new messages since baseline)")
+        for line in sse_diffs:
+            print(line)
+    else:
+        print("SSE_OFFSETS: identical")
+    print()
+
+    # Trace IDs
+    trace_diffs = compare_trace_ids(
+        baseline.get("trace_ids", []), candidate.get("trace_ids", [])
+    )
+    if trace_diffs:
+        has_drift = True
+        print("TRACE_IDS: changed")
+        for line in trace_diffs:
+            print(line)
+    else:
+        print("TRACE_IDS: identical")
+    print()
+
+    if has_drift:
+        print("RESULT: DRIFT DETECTED — fingerprints differ")
+        sys.exit(1)
+    else:
+        print("RESULT: NO DRIFT — fingerprints are identical")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uat-fingerprint.sh
+++ b/scripts/uat-fingerprint.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# UAT Fingerprint Collector (RUSAA-696 — Pillar C Phase 2)
+#
+# Collects a cryptographic fingerprint from the running live stack and writes a
+# structured JSON verdict. A fingerprint produced from a mocked/stubbed stack
+# will FAIL because:
+#   - docker inspect finds no running containers (image_shas empty)
+#   - DB item count is 0 (no real ingest ran against live Postgres)
+#   - All Kafka topic offsets are 0 (no messages produced)
+#   - No trace_ids exist in ingestion_runs
+#
+# Required fields (all must be non-empty/non-zero for a PASS):
+#   image_shas  — per-service image digests from `docker inspect`, NOT compose file
+#   db          — row counts queried directly from live Postgres + Neo4j
+#   sse_offsets — Kafka topic log-end offsets from the live broker
+#   trace_ids   — OpenTelemetry trace IDs from control.ingestion_runs
+#
+# Usage:
+#   bash scripts/uat-fingerprint.sh [COMPOSE_FILE] [OUTPUT_FILE]
+#
+#   COMPOSE_FILE  — docker compose file (default: compose/e2e.yml)
+#   OUTPUT_FILE   — fingerprint JSON output path (default: /tmp/uat-fingerprint.json)
+#
+# Optional env vars:
+#   FINGERPRINT_INGEST_RUN_ID   — scope trace_id query to a specific run
+#   FINGERPRINT_TENANT_SCHEMA   — scope item count to a specific tenant schema
+#
+# Exit codes:
+#   0 — fingerprint valid; all required fields populated from live data
+#   1 — one or more required fields could not be populated (fingerprint is invalid)
+
+set -euo pipefail
+
+COMPOSE_FILE="${1:-compose/e2e.yml}"
+OUTPUT_FILE="${2:-/tmp/uat-fingerprint.json}"
+
+DC="docker compose -f ${COMPOSE_FILE}"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERDICT_FAILED=0
+
+log()        { echo "[$(date -u +%H:%M:%S)] [fingerprint] $*"; }
+warn()       { echo "[$(date -u +%H:%M:%S)] [fingerprint] WARN: $*" >&2; }
+fail_field() { VERDICT_FAILED=1; warn "INVALID: $*"; }
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+psql_q() {
+  ${DC} exec -T postgres psql -U rustbrain -d rustbrain -t -A -c "$1" 2>/dev/null
+}
+
+neo4j_q() {
+  ${DC} exec -T neo4j cypher-shell \
+    -u neo4j -p rustbrain123 --format plain "$1" 2>/dev/null \
+    | tail -1 | tr -d '[:space:]'
+}
+
+# Returns the log-end offset for topic:partition from the live Kafka broker.
+kafka_end_offset() {
+  local topic="$1"
+  ${DC} exec -T kafka kafka-get-offsets.sh \
+    --bootstrap-server localhost:9092 \
+    --topic-partitions "${topic}:0" \
+    --time latest 2>/dev/null \
+    | awk -F: '{print $NF}' | tr -d '[:space:]'
+}
+
+# ── 1. Collect image SHAs via docker inspect ──────────────────────────────────
+
+log "Collecting image SHAs from running containers (docker inspect)..."
+
+PIPELINE_SERVICES=(
+  control-api
+  ingest-clone
+  expand-worker
+  parse-worker
+  typecheck-worker
+  ingest-graph
+  embed-worker
+  projector-pg
+  projector-neo4j
+)
+
+declare -A IMAGE_SHAS
+sha_ok=0
+for svc in "${PIPELINE_SERVICES[@]}"; do
+  container=$(${DC} ps -q "${svc}" 2>/dev/null | head -1 || true)
+  if [ -z "${container}" ]; then
+    warn "No running container for service '${svc}'"
+    fail_field "image_shas.${svc} — container not found (stack not running?)"
+    IMAGE_SHAS["${svc}"]="MISSING"
+    continue
+  fi
+  sha=$(docker inspect "${container}" --format='{{.Image}}' 2>/dev/null || true)
+  if [ -z "${sha}" ] || [[ "${sha}" == "ERROR" ]]; then
+    warn "docker inspect failed for ${svc} (container=${container})"
+    fail_field "image_shas.${svc} — inspect returned empty"
+    IMAGE_SHAS["${svc}"]="ERROR"
+  else
+    IMAGE_SHAS["${svc}"]="${sha}"
+    sha_ok=$(( sha_ok + 1 ))
+    log "  ${svc}: ${sha}"
+  fi
+done
+
+if (( sha_ok == 0 )); then
+  fail_field "image_shas — no containers found; is the compose stack running?"
+fi
+
+# Build image_shas JSON
+IMAGE_SHAS_JSON=$(python3 -c "
+import json, sys
+shas = {}
+$(for svc in "${PIPELINE_SERVICES[@]}"; do echo "shas['${svc}'] = '${IMAGE_SHAS[${svc}]}'"; done)
+print(json.dumps(shas))
+")
+
+# ── 2. Collect DB row counts from live Postgres + Neo4j ───────────────────────
+
+log "Collecting DB row counts from live databases..."
+
+# Resolve tenant schema
+if [ -z "${FINGERPRINT_TENANT_SCHEMA:-}" ]; then
+  FINGERPRINT_TENANT_SCHEMA=$(psql_q \
+    "SELECT schema_name FROM control.tenants ORDER BY created_at DESC LIMIT 1;" \
+    | tr -d '[:space:]' || true)
+fi
+
+if [ -z "${FINGERPRINT_TENANT_SCHEMA:-}" ]; then
+  fail_field "db — could not resolve tenant schema; no tenants in DB (no real signup ran)"
+  ITEMS_COUNT="0"
+else
+  ITEMS_COUNT=$(psql_q \
+    "SELECT COUNT(*) FROM \"${FINGERPRINT_TENANT_SCHEMA}\".code_symbols;" \
+    | tr -d '[:space:]' || echo "0")
+  if ! [[ "${ITEMS_COUNT}" =~ ^[0-9]+$ ]]; then
+    fail_field "db.items — non-numeric result '${ITEMS_COUNT}'"
+    ITEMS_COUNT="0"
+  elif (( ITEMS_COUNT == 0 )); then
+    fail_field "db.items — code_symbols count is 0 (no real ingest completed)"
+  fi
+  log "  items (code_symbols): ${ITEMS_COUNT}"
+fi
+
+# CALLS relationships from live Neo4j
+CALLS_COUNT=$(neo4j_q "MATCH ()-[:CALLS]->() RETURN count(*) AS cnt;" || echo "0")
+if ! [[ "${CALLS_COUNT}" =~ ^[0-9]+$ ]]; then
+  fail_field "db.calls — non-numeric result '${CALLS_COUNT}'"
+  CALLS_COUNT="0"
+fi
+log "  calls (Neo4j CALLS edges): ${CALLS_COUNT}"
+
+# Total graph relations (all edge types)
+RELATIONS_COUNT=$(neo4j_q "MATCH ()-[r]->() RETURN count(r) AS cnt;" || echo "0")
+if ! [[ "${RELATIONS_COUNT}" =~ ^[0-9]+$ ]]; then
+  fail_field "db.relations — non-numeric result '${RELATIONS_COUNT}'"
+  RELATIONS_COUNT="0"
+fi
+log "  relations (Neo4j all edges): ${RELATIONS_COUNT}"
+
+DB_JSON="{\"items\":${ITEMS_COUNT},\"calls\":${CALLS_COUNT},\"relations\":${RELATIONS_COUNT}}"
+
+# ── 3. Collect Kafka topic log-end offsets ────────────────────────────────────
+
+log "Collecting Kafka topic log-end offsets from live broker..."
+
+KAFKA_TOPICS=(
+  "rb.ingest.clone.commands"
+  "rb.ingest.expand.commands"
+  "rb.ingest.parse.commands"
+  "rb.parsed-items.v1"
+  "rb.ingest.typecheck.commands"
+  "rb.typechecked-items.v1"
+  "rb.ingest.graph.commands"
+  "rb.ingest.embed.commands"
+  "rb.source-files.v1"
+  "rb.projector.events"
+  "rb.audit.events"
+)
+
+declare -A KAFKA_OFFSETS
+all_zero=1
+for topic in "${KAFKA_TOPICS[@]}"; do
+  offset=$(kafka_end_offset "${topic}" || echo "0")
+  if ! [[ "${offset}" =~ ^[0-9]+$ ]]; then
+    warn "Non-numeric offset for ${topic}: '${offset}'"
+    offset="0"
+  fi
+  KAFKA_OFFSETS["${topic}"]="${offset}"
+  log "  ${topic}: ${offset}"
+  if (( offset > 0 )); then
+    all_zero=0
+  fi
+done
+
+if (( all_zero )); then
+  fail_field "sse_offsets — all Kafka topic offsets are 0; no messages produced (mocked run has no live broker)"
+fi
+
+SSE_OFFSETS_JSON=$(python3 -c "
+import json
+offsets = {}
+$(for topic in "${KAFKA_TOPICS[@]}"; do echo "offsets['${topic}'] = ${KAFKA_OFFSETS[${topic}]}"; done)
+print(json.dumps(offsets))
+")
+
+# ── 4. Collect trace IDs from live DB ────────────────────────────────────────
+
+log "Collecting trace IDs from control.ingestion_runs..."
+
+if [ -n "${FINGERPRINT_INGEST_RUN_ID:-}" ]; then
+  TRACE_QUERY="SELECT trace_id FROM control.ingestion_runs WHERE id = '${FINGERPRINT_INGEST_RUN_ID}' AND trace_id IS NOT NULL;"
+else
+  TRACE_QUERY="SELECT trace_id FROM control.ingestion_runs WHERE trace_id IS NOT NULL ORDER BY created_at DESC LIMIT 10;"
+fi
+
+TRACE_IDS_RAW=$(psql_q "${TRACE_QUERY}" 2>/dev/null | grep -v '^$' || true)
+
+if [ -z "${TRACE_IDS_RAW}" ]; then
+  fail_field "trace_ids — no trace_ids in ingestion_runs; real traces require live OTEL propagation"
+  TRACE_IDS_JSON="[]"
+else
+  TRACE_IDS_JSON=$(echo "${TRACE_IDS_RAW}" | python3 -c \
+    "import sys, json; ids = [l.strip() for l in sys.stdin if l.strip()]; print(json.dumps(ids))")
+  log "  trace_ids: ${TRACE_IDS_JSON}"
+fi
+
+# ── 5. Emit fingerprint JSON ──────────────────────────────────────────────────
+
+VERDICT="pass"
+[ "${VERDICT_FAILED}" -ne 0 ] && VERDICT="fail"
+
+log "Writing fingerprint to ${OUTPUT_FILE} (verdict=${VERDICT})..."
+
+python3 - <<PYEOF
+import json
+
+fingerprint = {
+    "schema_version": "1",
+    "collected_at": "${TIMESTAMP}",
+    "verdict": "${VERDICT}",
+    "image_shas": ${IMAGE_SHAS_JSON},
+    "db": ${DB_JSON},
+    "sse_offsets": ${SSE_OFFSETS_JSON},
+    "trace_ids": ${TRACE_IDS_JSON},
+}
+
+with open("${OUTPUT_FILE}", "w") as f:
+    json.dump(fingerprint, f, indent=2)
+
+print(json.dumps(fingerprint, indent=2))
+PYEOF
+
+# ── 6. Final verdict ──────────────────────────────────────────────────────────
+
+if [ "${VERDICT_FAILED}" -ne 0 ]; then
+  log "FINGERPRINT INVALID (verdict=fail) — required fields missing."
+  log "A mocked or stubbed stack cannot produce a valid fingerprint:"
+  log "  - Containers must be running (docker inspect requires real containers)"
+  log "  - DB counts must be non-zero (requires a completed real ingest)"
+  log "  - Kafka offsets must be non-zero (requires real message production)"
+  log "  - trace_ids must be present (requires live OTEL propagation)"
+  exit 1
+fi
+
+log "FINGERPRINT VALID (verdict=pass) — written to ${OUTPUT_FILE}"


### PR DESCRIPTION
## Summary

- **`scripts/uat-fingerprint.sh`**: Collects `image_shas` (via `docker inspect`), `db` row counts (Postgres + Neo4j), Kafka topic log-end offsets (`sse_offsets`), and `trace_ids` from `control.ingestion_runs`. Exits 1 on any missing field — mocked/stubbed stacks structurally cannot produce a PASS verdict.
- **`scripts/fingerprint-diff.py`**: Diffs two fingerprint JSON files; reports image SHA drift, DB count deltas, Kafka offset changes, trace ID set changes. Exit 0 = no drift, exit 1 = drift detected.
- **`docs/qa/uat-fingerprint-spec.md`**: Canonical fingerprint format spec with population rules, JSON schema, tooling guide, and Gate 3 requirements.
- **`scripts/e2e-smoke-test.sh`**: Calls `uat-fingerprint.sh` after all assertions pass, scoped to `ingest_run_id` + `tenant_schema`; writes fingerprint before stack teardown.
- **`frontend/e2e/ingestion-live.spec.ts`**: Live-stack Playwright UAT that runs WITHOUT `page.route()` mocks (skipped unless `LIVE_STACK=1`); proves real compose stack produces a valid fingerprint while mocked tests cannot.

## Test plan

- [ ] Run `bash -n scripts/uat-fingerprint.sh` — syntax check passes
- [ ] Run `python3 -c "import ast; ast.parse(open('scripts/fingerprint-diff.py').read())"` — syntax OK
- [ ] Run `LIVE_STACK=1 bash scripts/e2e-smoke-test.sh` on dev stack — fingerprint written to `/tmp/uat-fingerprint.json` with `verdict=pass`
- [ ] Run `python3 scripts/fingerprint-diff.py /tmp/prev-fingerprint.json /tmp/uat-fingerprint.json` — diff output shows changed fields
- [ ] Run `bash scripts/uat-fingerprint.sh compose/e2e.yml /tmp/stub.json` without stack running — exits 1 with `FINGERPRINT INVALID`
- [ ] TypeScript: no errors in `frontend/e2e/ingestion-live.spec.ts`

## Closes

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)