### PR TITLE
[RUSAA-264] fix(test): seed tenant rows in upsert_guard_rejects_cross_tenant_owner

### DIFF
--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -271,6 +271,21 @@ mod tests {
         let tenant_b = Uuid::new_v4();
         let github_installation_id: i64 = rand::random::<i32>().abs() as i64 + 1_000_000;
 
+        // Seed the two test tenants (required by FK on github_installations.tenant_id).
+        sqlx::query(
+            "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES \
+             ($1, $2, 'QA Tenant A', $3), ($4, $5, 'QA Tenant B', $6)",
+        )
+        .bind(tenant_a)
+        .bind(format!("qa-tenant-a-{tenant_a}"))
+        .bind(format!("qa_tenant_a_{}", tenant_a.simple()))
+        .bind(tenant_b)
+        .bind(format!("qa-tenant-b-{tenant_b}"))
+        .bind(format!("qa_tenant_b_{}", tenant_b.simple()))
+        .execute(&pool)
+        .await
+        .expect("seed tenants");
+
         // Seed tenant_a owning this installation.
         sqlx::query(
             "INSERT INTO control.github_installations \
@@ -332,7 +347,7 @@ mod tests {
 
         assert!(same_tenant_result.is_some(), "same-tenant re-install must succeed");
 
-        // Cleanup.
+        // Cleanup installations then tenants (FK order).
         sqlx::query(
             "DELETE FROM control.github_installations WHERE github_installation_id = $1",
         )
@@ -340,5 +355,11 @@ mod tests {
         .execute(&pool)
         .await
         .ok();
+        sqlx::query("DELETE FROM control.tenants WHERE id IN ($1, $2)")
+            .bind(tenant_a)
+            .bind(tenant_b)
+            .execute(&pool)
+            .await
+            .ok();
     }
 }


### PR DESCRIPTION
## Thinking Path

> 1. During QA, I ran `cargo test -p control-api --lib -- routes::github::install` with `RB_DATABASE_URL` set.
> 2. `upsert_guard_rejects_cross_tenant_owner` panicked with FK violation 23503 on `github_installations.tenant_id`.
> 3. The test generates `Uuid::new_v4()` for `tenant_a`/`tenant_b` but never inserts them into `control.tenants`.
> 4. The FK constraint `github_installations_tenant_id_fkey → control.tenants(id)` blocks the install insert before the ON CONFLICT guard runs.
> 5. Fix: seed two test tenants before the installation insert; delete them after installation cleanup.

## What Changed

- `services/control-api/src/routes/github/install.rs`: Added `INSERT INTO control.tenants` for QA Tenant A and QA Tenant B before the installation seed; added corresponding `DELETE FROM control.tenants` in the cleanup block.

## Verification

```
RB_DATABASE_URL="postgres://..." cargo test -p control-api --lib -- routes::github::install
```

All 5 tests pass: `state_token_invalid_hex_is_rejected`, `install_url_response_serializes`, `github_installation_conflict_is_409`, `state_token_round_trip`, `upsert_guard_rejects_cross_tenant_owner`.

## Risks

- Minimal: only the test setup is changed; the production handler and SQL guard are untouched.
- Test leaves data in the DB if it panics mid-cleanup. The cleanup block uses `.ok()` to absorb errors; this is acceptable for a test helper.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6) — strong reasoning, code review

## Checklist

- [x] No production logic changed — test setup only
- [x] All 5 install handler tests pass with live DB
- [x] Conventional commit format
- [x] Closes #294

Closes #294
Related: found during QA validation of the cross-tenant install fix (PR #291)
