### PR TITLE
[RUSAA-787] feat(infra): state-reconcile routine script + tenant migration 006

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /secrets
 compose/.no-auto-rebuild
 compose/*.env
+scripts/.state-reconcile-baseline

--- a/frontend/e2e/ingestion-live.spec.ts
+++ b/frontend/e2e/ingestion-live.spec.ts
@@ -36,7 +36,7 @@
  */
 
 import * as fs from "node:fs";
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const LIVE_FRONTEND_URL =
   process.env.LIVE_FRONTEND_URL ?? "http://localhost:4173";
@@ -57,15 +57,6 @@ test.beforeEach(async ({}, testInfo) => {
     );
   }
 });
-
-async function loginViaApi(apiRequest: APIRequestContext): Promise<void> {
-  const resp = await apiRequest.post(`${LIVE_API_URL}/v1/auth/login`, {
-    data: { email: LIVE_USER_EMAIL, password: LIVE_USER_PASS },
-  });
-  if (!resp.ok()) {
-    throw new Error(`Login failed (${resp.status()}): ${await resp.text()}`);
-  }
-}
 
 async function loginViaPage(page: Page): Promise<void> {
   const resp = await page.request.post(`${LIVE_API_URL}/v1/auth/login`, {
@@ -96,26 +87,38 @@ test.describe("Live-stack ingestion UAT", () => {
   /**
    * Test 2: Real SSE endpoint responds as event-stream
    *
-   * Authenticates via the real API and then checks the SSE endpoint header.
-   * A mocked run returns a synthetic body; a live run returns a real
-   * text/event-stream from the Kafka-backed broker.
+   * Uses page.evaluate() + fetch() to read response headers before the
+   * stream body closes. Playwright's request.get() hangs on SSE because it
+   * waits for the full body; fetch() resolves the Response promise as soon
+   * as headers arrive, regardless of whether the body stream is still open.
    *
    * This is a structural proof: if Content-Type is text/event-stream from the
    * real control-api, then the fingerprint collector can observe real Kafka
    * offsets on the same broker.
    */
-  test("SSE endpoint responds as text/event-stream (real broker, not mocked)", async ({ request }) => {
-    await loginViaApi(request);
+  test("SSE endpoint responds as text/event-stream (real broker, not mocked)", async ({ page }) => {
+    await page.goto(`${LIVE_FRONTEND_URL}/`);
+    await loginViaPage(page);
 
-    const resp = await request.get(`${LIVE_API_URL}/v1/ingest/events`, {
-      headers: { Accept: "text/event-stream" },
-      timeout: 5_000,
-    });
+    // Use browser-context fetch so the session cookie is included.
+    // fetch() resolves when headers arrive — no need to wait for stream close.
+    const result = await page.evaluate(
+      async ({ apiUrl }: { apiUrl: string }) => {
+        const resp = await fetch(`${apiUrl}/v1/ingest/events`, {
+          headers: { Accept: "text/event-stream" },
+        });
+        return {
+          ok: resp.ok,
+          status: resp.status,
+          contentType: resp.headers.get("content-type") ?? "",
+        };
+      },
+      { apiUrl: LIVE_API_URL },
+    );
 
-    expect(resp.ok(), `SSE endpoint returned ${resp.status()}`).toBe(true);
-    const contentType = resp.headers()["content-type"] ?? "";
+    expect(result.ok, `SSE endpoint returned ${result.status}`).toBe(true);
     expect(
-      contentType,
+      result.contentType,
       "SSE endpoint must return text/event-stream — a mocked route returns a static body, not a live stream",
     ).toContain("text/event-stream");
   });

--- a/migrations/tenant/006_tenant_code_tables.sql
+++ b/migrations/tenant/006_tenant_code_tables.sql
@@ -1,0 +1,58 @@
+-- Per-tenant schema: Phase 4 — Code projection tables
+-- Per-ADR-007 §11.9: projector-pg writes to these tables.
+
+CREATE TABLE IF NOT EXISTS code_files (
+    id              UUID        PRIMARY KEY,
+    repo_id         UUID        NOT NULL,
+    relative_path   TEXT        NOT NULL,
+    sha256          TEXT        NOT NULL,
+    size_bytes      BIGINT      NOT NULL,
+    ingest_run_id   UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, relative_path)
+);
+
+CREATE TABLE IF NOT EXISTS code_symbols (
+    id              UUID        PRIMARY KEY,
+    repo_id         UUID        NOT NULL,
+    file_id         UUID        NOT NULL REFERENCES code_files(id) ON DELETE CASCADE,
+    fqn             TEXT        NOT NULL,
+    item_kind       TEXT        NOT NULL,
+    item_data       JSONB,
+    ingest_run_id   UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, fqn)
+);
+
+CREATE TABLE IF NOT EXISTS code_relations (
+    id              UUID        PRIMARY KEY,
+    repo_id         UUID        NOT NULL,
+    source_fqn      TEXT        NOT NULL,
+    target_fqn      TEXT        NOT NULL,
+    relation_kind   TEXT        NOT NULL,
+    relation_data   JSONB,
+    ingest_run_id   UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS code_embeddings (
+    id              UUID        PRIMARY KEY,
+    repo_id         UUID        NOT NULL,
+    item_fqn        TEXT        NOT NULL,
+    model_id        TEXT        NOT NULL,
+    embedding       BYTEA,
+    ingest_run_id   UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, item_fqn, model_id)
+);
+
+CREATE INDEX idx_code_files_repo ON code_files (repo_id);
+CREATE INDEX idx_code_symbols_file ON code_symbols (file_id);
+CREATE INDEX idx_code_symbols_kind ON code_symbols (repo_id, item_kind);
+CREATE INDEX idx_code_relations_source ON code_relations (repo_id, source_fqn);
+CREATE INDEX idx_code_relations_target ON code_relations (repo_id, target_fqn);
+CREATE INDEX idx_code_embeddings_fqn ON code_embeddings (repo_id, item_fqn);

--- a/scripts/state-reconcile.sh
+++ b/scripts/state-reconcile.sh
@@ -199,25 +199,40 @@ get_live_env_keys_for_service() {
   docker exec "$container" env 2>/dev/null | cut -d= -f1 | sort || echo ""
 }
 
-# (c) declared migration head — sorted filenames hash for each schema dir
-get_declared_migration_hash() {
+# (c) count of declared migration files for a schema dir
+get_declared_migration_count() {
   local schema_dir="$1"  # "control" or "tenant"
   local dir="$REPO_ROOT/migrations/$schema_dir"
-  if [ ! -d "$dir" ]; then
-    echo "MISSING"
-    return
-  fi
-  # Hash is over sorted filenames (not content — migrations are append-only)
-  ls "$dir" | sort | sha256sum | awk '{print $1}'
+  [ -d "$dir" ] || { echo "0"; return; }
+  ls "$dir" | grep -c '\.sql$' || echo "0"
 }
 
-# (c) applied migration names from running DB _sqlx_migrations table
-get_applied_migrations() {
+# (c) max version applied in control.schema_migrations
+get_control_applied_count() {
   local compose_file="$1"
   docker compose -f "$compose_file" exec -T postgres \
     psql -U "$DB_USER" -d "$DB_NAME" -t -A \
-    -c "SELECT description FROM _sqlx_migrations ORDER BY installed_on ASC;" \
-    2>/dev/null | grep -v '^$' || echo ""
+    -c "SELECT COUNT(*) FROM control.schema_migrations;" \
+    2>/dev/null | tr -d '[:space:]' || echo "0"
+}
+
+# (c) max version applied in a tenant schema (sample first tenant found)
+get_tenant_applied_count() {
+  local compose_file="$1"
+  # Get a sample tenant schema name
+  local tenant_schema
+  tenant_schema=$(docker compose -f "$compose_file" exec -T postgres \
+    psql -U "$DB_USER" -d "$DB_NAME" -t -A \
+    -c "SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'tenant_%' LIMIT 1;" \
+    2>/dev/null | tr -d '[:space:]' || echo "")
+  if [ -z "$tenant_schema" ]; then
+    echo "NO_TENANT"
+    return
+  fi
+  docker compose -f "$compose_file" exec -T postgres \
+    psql -U "$DB_USER" -d "$DB_NAME" -t -A \
+    -c "SELECT COUNT(*) FROM ${tenant_schema}.schema_migrations;" \
+    2>/dev/null | tr -d '[:space:]' || echo "0"
 }
 
 # (d) fetch issues with deployment-fingerprint docs on the given env
@@ -351,28 +366,35 @@ reconcile_env() {
   # ── (c) Migration head vs running DB applied migrations ──────────────────
   log "  Dimension (c): declared migration head vs applied migrations in DB..."
   local dim_c_drift=()
-  # Test DB connectivity and table existence before proceeding
+  # Test DB connectivity via control.schema_migrations (actual migration table)
   local db_check_output
   db_check_output=$(docker compose -f "$compose_file" exec -T postgres \
     psql -U "$DB_USER" -d "$DB_NAME" -t -A \
-    -c "SELECT 1 FROM _sqlx_migrations LIMIT 1;" 2>&1) || true
+    -c "SELECT 1 FROM control.schema_migrations LIMIT 1;" 2>&1) || true
   if echo "$db_check_output" | grep -qi "does not exist\|no such table\|ERROR"; then
-    warn "  Dimension (c): _sqlx_migrations not found in $DB_NAME — skipping migration check"
+    warn "  Dimension (c): control.schema_migrations not found — skipping migration check"
   else
-    for schema_dir in control tenant; do
-      local applied
-      applied=$(get_applied_migrations "$compose_file" 2>/dev/null | grep -i "$schema_dir" || true)
-      local declared_count
-      declared_count=$(ls "$REPO_ROOT/migrations/$schema_dir/" 2>/dev/null | wc -l | tr -d ' ')
-      local applied_count
-      applied_count=$(echo "$applied" | grep -c . || true)
-      applied_count="${applied_count:-0}"
-      if [ "$applied_count" -lt "$declared_count" ]; then
-        local unapplied=$(( declared_count - applied_count ))
-        dim_c_drift+=("  [c] $schema_dir: $unapplied unapplied migration(s) (declared=$declared_count, applied=$applied_count)")
-      fi
-      log "    $schema_dir: declared=$declared_count applied=$applied_count"
-    done
+    # Control schema
+    local control_declared control_applied
+    control_declared=$(get_declared_migration_count "control")
+    control_applied=$(get_control_applied_count "$compose_file")
+    if [ "$control_applied" -lt "$control_declared" ]; then
+      local unapplied=$(( control_declared - control_applied ))
+      dim_c_drift+=("  [c] control: $unapplied unapplied migration(s) (declared=$control_declared, applied=$control_applied)")
+    fi
+    log "    control: declared=$control_declared applied=$control_applied"
+
+    # Tenant schema (sample one tenant to check the shared tenant migration set)
+    local tenant_declared tenant_applied
+    tenant_declared=$(get_declared_migration_count "tenant")
+    tenant_applied=$(get_tenant_applied_count "$compose_file")
+    if [ "$tenant_applied" = "NO_TENANT" ]; then
+      log "    tenant: no tenant schemas found — skipping tenant migration check"
+    elif [ "$tenant_applied" -lt "$tenant_declared" ]; then
+      local unapplied=$(( tenant_declared - tenant_applied ))
+      dim_c_drift+=("  [c] tenant: $unapplied unapplied migration(s) in sample tenant schema (declared=$tenant_declared, applied=$tenant_applied)")
+    fi
+    [ "$tenant_applied" != "NO_TENANT" ] && log "    tenant: declared=$tenant_declared applied=$tenant_applied"
   fi
   if [ ${#dim_c_drift[@]} -gt 0 ]; then
     drift_lines+=("### (c) Migration Head vs Applied Migrations")


### PR DESCRIPTION
## Summary

- Add `scripts/state-reconcile.sh` — 5-dimension continuous state reconciliation routine (fires every 30 min via scheduled routine)
- Add `migrations/tenant/006_tenant_code_tables.sql` — Phase 4 code projection tables per ADR-007 §11.9
- Fix dim (c) migration check — query `control.schema_migrations` (actual migration table), not `_sqlx_migrations`
- Gitignore `scripts/.state-reconcile-baseline` (runtime first-fire state file)

### Reconciliation dimensions checked per env

| Dim | Check |
|-----|-------|
| (a) | `git rev-parse origin/main` vs running container `org.opencontainers.image.revision` label |
| (b) | `compose/env.schema.toml` required keys vs `docker exec env` per service |
| (c) | Declared migration file count vs `control.schema_migrations` applied count |
| (d) | Per-issue `deployment-fingerprint.SHA` vs current `origin/main` |
| (e) | Latest UAT fingerprint `image_shas` vs running container image SHAs (UAT env only) |

Drift fires → idempotent `state-drift:<env>` umbrella issue (opened or updated). Drift-on-closed-done issues → comment only, no re-open.

## Migration type

Additive — new tables only; no destructive operations.

- Tables touched: `code_files`, `code_symbols`, `code_relations`, `code_embeddings` (tenant schema)
- Operations: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX`

## GitHub Issue

Closes #763

## Checklist

- [x] Script is idempotent (first-fire baseline skips; subsequent fires reconcile)
- [x] Budget guard at 80% prevents runaway API calls
- [x] dim (c) queries correct table: `control.schema_migrations` (not `_sqlx_migrations`)
- [x] No destructive git commands
- [x] Migration is additive only