### PR TITLE
[REQ-FE-06] feat(frontend): agent execution viewer

### DIFF
--- a/frontend/e2e/agent-execution.spec.ts
+++ b/frontend/e2e/agent-execution.spec.ts
@@ -26,7 +26,7 @@ async function mockRecentIngestions(
   page: import("@playwright/test").Page,
   runs: unknown[] = [],
 ): Promise<void> {
-  await page.route("**/v1/ingestions/recent", (route) =>
+  await page.route("**/v1/ingestions/recent*", (route) =>
     route.fulfill({ json: { runs } }),
   );
 }

--- a/frontend/e2e/agent-execution.spec.ts
+++ b/frontend/e2e/agent-execution.spec.ts
@@ -26,7 +26,7 @@ async function mockRecentIngestions(
   page: import("@playwright/test").Page,
   runs: unknown[] = [],
 ): Promise<void> {
-  await page.route("**/v1/tenants/*/ingestions/recent", (route) =>
+  await page.route("**/v1/ingestions/recent", (route) =>
     route.fulfill({ json: { runs } }),
   );
 }
@@ -106,7 +106,9 @@ test.describe("Agent Execution — live events", () => {
     await mockRecentIngestions(page, [
       {
         id: "run-001",
+        repo_id: "repo-1",
         status: "succeeded",
+        created_at: "2024-01-01T00:00:00Z",
         started_at: "2024-01-01T00:00:00Z",
         finished_at: "2024-01-01T00:01:00Z",
         trace_id: "trace-abc123",

--- a/frontend/e2e/agent-execution.spec.ts
+++ b/frontend/e2e/agent-execution.spec.ts
@@ -1,0 +1,149 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { mockAuthenticatedSession } from "./fixtures/mock-api";
+
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function mockSseStream(
+  page: import("@playwright/test").Page,
+  events: string[] = [],
+): Promise<void> {
+  await page.route("**/v1/ingest/events", async (route) => {
+    const body = events.join("") || "";
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+      body,
+    });
+  });
+}
+
+async function mockRecentIngestions(
+  page: import("@playwright/test").Page,
+  runs: unknown[] = [],
+): Promise<void> {
+  await page.route("**/v1/tenants/*/ingestions/recent", (route) =>
+    route.fulfill({ json: { runs } }),
+  );
+}
+
+async function setupPage(page: import("@playwright/test").Page): Promise<void> {
+  await mockAuthenticatedSession(page);
+  await mockSseStream(page);
+  await mockRecentIngestions(page);
+}
+
+test.describe("Agent Execution — empty state", () => {
+  test("renders heading and empty session history", async ({ page }) => {
+    await setupPage(page);
+    await page.goto("/agents/executions");
+
+    await expect(
+      page.getByRole("heading", { name: "Agent Execution" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText("No execution sessions found."),
+    ).toBeVisible();
+  });
+
+  test("empty stream shows placeholder", async ({ page }) => {
+    await setupPage(page);
+    await page.goto("/agents/executions");
+
+    await expect(
+      page.getByText("No events yet. Events will appear here when an execution is running."),
+    ).toBeVisible();
+  });
+
+  test("empty state a11y: no serious/critical axe violations", async ({
+    page,
+  }) => {
+    await setupPage(page);
+    await page.goto("/agents/executions");
+
+    await expect(
+      page.getByRole("heading", { name: "Agent Execution" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .analyze();
+    const violations = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+    expect(
+      violations,
+      violations.map((v) => `${v.id}: ${v.description}`).join("\n"),
+    ).toHaveLength(0);
+  });
+});
+
+test.describe("Agent Execution — live events", () => {
+  test("SSE event appears in the stream", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockRecentIngestions(page);
+    await mockSseStream(page, [
+      "id: evt-1\n",
+      "event: ingest.status\n",
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","error_message":"","occurred_at_ms":1700000001000}\n',
+      "\n",
+    ]);
+
+    await page.goto("/agents/executions");
+
+    await expect(page.getByText("ingest.status")).toBeVisible();
+    await expect(page.getByText(/processing/)).toBeVisible();
+  });
+
+  test("session history table renders with data", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockSseStream(page);
+    await mockRecentIngestions(page, [
+      {
+        id: "run-001",
+        status: "succeeded",
+        started_at: "2024-01-01T00:00:00Z",
+        finished_at: "2024-01-01T00:01:00Z",
+        trace_id: "trace-abc123",
+      },
+    ]);
+
+    await page.goto("/agents/executions");
+
+    const table = page.getByRole("table", { name: "Execution session history" });
+    await expect(table).toBeVisible();
+    await expect(page.getByText("run-001".slice(0, 8))).toBeVisible();
+    await expect(page.getByText("succeeded")).toBeVisible();
+  });
+});
+
+test.describe("Agent Execution — SSE error state", () => {
+  test("shows disconnected indicator when SSE fails", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockRecentIngestions(page);
+    await page.route("**/v1/ingest/events", (route) =>
+      route.fulfill({ status: 500, body: "Internal Server Error" }),
+    );
+
+    await page.goto("/agents/executions");
+
+    await expect(page.getByText("Disconnected")).toBeVisible();
+  });
+});
+
+test.describe("Agent Execution — auth gate", () => {
+  test("shows sign-in prompt when not authenticated", async ({ page }) => {
+    await page.route("**/v1/me", (route) => route.fulfill({ status: 401 }));
+    await mockSseStream(page);
+
+    await page.goto("/agents/executions");
+    await expect(
+      page.getByText("Sign in to view agent execution sessions."),
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -47,6 +47,12 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
               Ingestion
             </Link>
             <Link
+              to={routes.agentExecution}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
+            >
+              Agents
+            </Link>
+            <Link
               to={routes.activity}
               className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
             >

--- a/frontend/src/components/agent-execution/ExecutionStream.tsx
+++ b/frontend/src/components/agent-execution/ExecutionStream.tsx
@@ -1,0 +1,106 @@
+import { useEventStream, type StreamedEvent } from "@/hooks/useEventStream";
+
+interface ExecutionStreamProps {
+  readonly streamUrl: string;
+}
+
+export function ExecutionStream({ streamUrl }: ExecutionStreamProps): JSX.Element {
+  const { events, lastEventId, readyState } = useEventStream(streamUrl);
+
+  const agentEvents = events.filter(
+    (e) => e.type !== "stream-reset",
+  );
+
+  return (
+    <section
+      aria-label="Live execution stream"
+      className="rounded-lg border border-border bg-card"
+    >
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-sm font-medium">Live Stream</h2>
+        <div className="flex items-center gap-2">
+          <ConnectionIndicator readyState={readyState} />
+          {lastEventId && (
+            <span className="font-mono text-xs text-muted-foreground">
+              last: {lastEventId.slice(0, 8)}…
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="max-h-80 overflow-y-auto p-4">
+        {agentEvents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No events yet. Events will appear here when an execution is running.
+          </p>
+        ) : (
+          <ul aria-label="Stream events" className="space-y-2">
+            {agentEvents.map((event, i) => (
+              <EventRow key={event.id ?? i} event={event} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ConnectionIndicator({
+  readyState,
+}: {
+  readonly readyState: "connecting" | "open" | "closed";
+}): JSX.Element {
+  const label =
+    readyState === "open"
+      ? "Connected"
+      : readyState === "connecting"
+        ? "Connecting…"
+        : "Disconnected";
+
+  const color =
+    readyState === "open"
+      ? "bg-green-500"
+      : readyState === "connecting"
+        ? "bg-yellow-500 animate-pulse"
+        : "bg-muted-foreground";
+
+  return (
+    <div className="flex items-center gap-1.5" aria-live="polite">
+      <span aria-hidden="true" className={`h-2 w-2 rounded-full ${color}`} />
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function EventRow({ event }: { readonly event: StreamedEvent }): JSX.Element {
+  let parsedData: unknown;
+  try {
+    parsedData = JSON.parse(event.data);
+  } catch {
+    parsedData = event.data;
+  }
+
+  const isObject = typeof parsedData === "object" && parsedData !== null;
+
+  return (
+    <li className="rounded border border-border/50 bg-muted/20 px-3 py-2">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
+          {event.type}
+        </span>
+        {event.id && (
+          <span className="font-mono text-xs text-muted-foreground">
+            #{event.id.slice(0, 6)}
+          </span>
+        )}
+      </div>
+      {isObject ? (
+        <pre className="whitespace-pre-wrap text-xs text-muted-foreground">
+          {JSON.stringify(parsedData, null, 2)}
+        </pre>
+      ) : (
+        <p className="text-xs text-muted-foreground">{String(parsedData)}</p>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/agent-execution/ExecutionStream.tsx
+++ b/frontend/src/components/agent-execution/ExecutionStream.tsx
@@ -1,11 +1,12 @@
-import { useEventStream, type StreamedEvent } from "@/hooks/useEventStream";
+import type { EventStreamReadyState, StreamedEvent } from "@/hooks/useEventStream";
 
 interface ExecutionStreamProps {
-  readonly streamUrl: string;
+  readonly events: ReadonlyArray<StreamedEvent>;
+  readonly lastEventId: string | null;
+  readonly readyState: EventStreamReadyState;
 }
 
-export function ExecutionStream({ streamUrl }: ExecutionStreamProps): JSX.Element {
-  const { events, lastEventId, readyState } = useEventStream(streamUrl);
+export function ExecutionStream({ events, lastEventId, readyState }: ExecutionStreamProps): JSX.Element {
 
   const agentEvents = events.filter(
     (e) => e.type !== "stream-reset",

--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -1,0 +1,126 @@
+import type { RecentIngestionRun } from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { formatTimestamp } from "@/components/activity/utils";
+
+const STATUS_CELL_CLASS: Record<string, string> = {
+  succeeded: "text-green-600 dark:text-green-400",
+  done: "text-green-600 dark:text-green-400",
+  failed: "text-destructive",
+  running: "text-blue-600 dark:text-blue-400",
+  processing: "text-blue-600 dark:text-blue-400",
+  queued: "text-muted-foreground",
+  pending: "text-muted-foreground",
+};
+
+function RunStatusCell({ status }: { readonly status: string }): JSX.Element {
+  const cls = STATUS_CELL_CLASS[status] ?? "text-muted-foreground";
+  return <span className={`text-xs font-medium capitalize ${cls}`}>{status}</span>;
+}
+
+interface SessionHistoryProps {
+  readonly sessions: readonly RecentIngestionRun[];
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly error: { status: number; body: unknown } | null;
+}
+
+export function SessionHistory({
+  sessions,
+  isLoading,
+  isError,
+  error,
+}: SessionHistoryProps): JSX.Element {
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">Loading sessions…</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">
+          {error?.status === 404
+            ? "Agent execution endpoint not yet available. Waiting on backend."
+            : formatApiError(error, "Could not load session history.")}
+        </p>
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">No execution sessions found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm" aria-label="Execution session history">
+        <thead className="border-b border-border bg-muted/40">
+          <tr>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Session
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Status
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Started
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Finished
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Trace
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sessions.map((session) => (
+            <SessionRow key={session.id} session={session} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface SessionRowProps {
+  readonly session: RecentIngestionRun;
+}
+
+function SessionRow({ session }: SessionRowProps): JSX.Element {
+  return (
+    <tr className="border-b border-border last:border-0 hover:bg-muted/20">
+      <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+        {session.id.slice(0, 8)}…
+      </td>
+      <td className="px-4 py-2">
+        <RunStatusCell status={session.status} />
+      </td>
+      <td className="px-4 py-2 text-xs text-muted-foreground">
+        {session.started_at ? formatTimestamp(session.started_at) : "—"}
+      </td>
+      <td className="px-4 py-2 text-xs text-muted-foreground">
+        {session.finished_at ? formatTimestamp(session.finished_at) : "—"}
+      </td>
+      <td className="px-4 py-2">
+        {session.trace_id ? (
+          <span
+            className="font-mono text-xs text-muted-foreground"
+            title={session.trace_id}
+          >
+            {session.trace_id.slice(0, 8)}…
+          </span>
+        ) : (
+          <span className="font-mono text-xs text-muted-foreground/50">—</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/agent-execution/index.ts
+++ b/frontend/src/components/agent-execution/index.ts
@@ -1,0 +1,2 @@
+export { ExecutionStream } from "./ExecutionStream";
+export { SessionHistory } from "./SessionHistory";

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -13,7 +13,6 @@ export const routes = {
   codeWorkspace: "/repos/$repoId/code",
   activity: "/activity",
   agentExecution: "/agents/executions",
-  agentRun: "/agents/$agentUrlKey/runs/$sessionId",
   trace: "/trace/$traceId",
 } as const;
 

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -12,6 +12,8 @@ export const routes = {
   ingestion: "/ingestion",
   codeWorkspace: "/repos/$repoId/code",
   activity: "/activity",
+  agentExecution: "/agents/executions",
+  agentRun: "/agents/$agentUrlKey/runs/$sessionId",
   trace: "/trace/$traceId",
 } as const;
 

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -1,0 +1,101 @@
+import { useMe, useRecentIngestions, useInvalidateRecentIngestions } from "@/api";
+import { useEffect } from "react";
+import { PageContainer } from "@/components/repos/PageContainer";
+import { useEventStream } from "@/hooks/useEventStream";
+import { SessionHistory } from "@/components/agent-execution/SessionHistory";
+import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
+
+export function AgentExecutionPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading session…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">Agent Execution</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Sign in to view agent execution sessions.
+        </p>
+      </PageContainer>
+    );
+  }
+
+  return <AgentExecutionInner tenantId={me.data.current_tenant.id} />;
+}
+
+interface AgentExecutionInnerProps {
+  readonly tenantId: string;
+}
+
+function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Element {
+  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+
+  const recentSessions = useRecentIngestions(tenantId);
+  const invalidateSessions = useInvalidateRecentIngestions();
+
+  const { events } = useEventStream(`${apiBase}/v1/ingest/events`);
+
+  useEffect(() => {
+    const latestIngest = events
+      .filter((e) => e.type === "ingest.status")
+      .at(-1);
+    if (!latestIngest) return;
+    try {
+      const parsed = JSON.parse(latestIngest.data) as { status?: string };
+      if (parsed.status === "succeeded" || parsed.status === "done") {
+        void invalidateSessions(tenantId);
+      }
+    } catch {
+      // malformed event — ignore
+    }
+  }, [events, tenantId, invalidateSessions]);
+
+  const sessions = recentSessions.data?.runs ?? [];
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Agent Execution
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          View execution sessions, live event streams, and trace details.
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        <section aria-labelledby="sessions-heading">
+          <h2
+            id="sessions-heading"
+            className="mb-3 text-base font-semibold tracking-tight"
+          >
+            Session History
+          </h2>
+          <SessionHistory
+            sessions={sessions}
+            isLoading={recentSessions.isLoading}
+            isError={recentSessions.isError}
+            error={recentSessions.error}
+          />
+        </section>
+
+        <section aria-labelledby="stream-heading">
+          <h2
+            id="stream-heading"
+            className="mb-3 text-base font-semibold tracking-tight"
+          >
+            Execution Stream
+          </h2>
+          <ExecutionStream streamUrl={`${apiBase}/v1/ingest/events`} />
+        </section>
+      </div>
+    </PageContainer>
+  );
+}

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -37,10 +37,13 @@ interface AgentExecutionInnerProps {
 function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Element {
   const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
 
+  // useRecentIngestions fetches from the backend's ingestion-runs table,
+  // which backs the "Agent Execution" view — each ingestion run corresponds
+  // to an agent execution session.
   const recentSessions = useRecentIngestions(tenantId);
   const invalidateSessions = useInvalidateRecentIngestions();
 
-  const { events } = useEventStream(`${apiBase}/v1/ingest/events`);
+  const { events, lastEventId, readyState } = useEventStream(`${apiBase}/v1/ingest/events`);
 
   useEffect(() => {
     const latestIngest = events
@@ -93,7 +96,7 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
           >
             Execution Stream
           </h2>
-          <ExecutionStream streamUrl={`${apiBase}/v1/ingest/events`} />
+          <ExecutionStream events={events} lastEventId={lastEventId} readyState={readyState} />
         </section>
       </div>
     </PageContainer>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,6 +9,7 @@ import {
 import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
+import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
 import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { CodeWorkspacePage } from "@/pages/CodeWorkspacePage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
@@ -135,6 +136,12 @@ const activityRoute = createRoute({
   component: ActivityPage,
 });
 
+const agentExecutionRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.agentExecution,
+  component: AgentExecutionPage,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -158,6 +165,7 @@ const routeTree = rootRoute.addChildren([
   ingestionRoute,
   codeWorkspaceRoute,
   activityRoute,
+  agentExecutionRoute,
   catchAllRoute,
 ]);
 


### PR DESCRIPTION
## Summary

Adds the Agent Execution Viewer page for running and viewing agent execution sessions with live SSE event stream.

Closes #320

## Changes

- **AgentExecutionPage** — main page composing SessionHistory and ExecutionStream, gated behind auth
- **SessionHistory** — table component displaying recent ingestion runs with status color coding and trace ID
- **ExecutionStream** — SSE-powered live event stream with connection status indicator (Connected/Connecting/Disconnected)
- **Router** — registered `/agents/executions` route with `AgentExecutionPage`
- **Navigation** — added "Agents" link to AppShell nav bar
- **Barrel export** — `components/agent-execution/index.ts`

## Design Decisions

- Trace IDs displayed as text (not links) since the trace detail page does not yet exist in the route tree. When a TracePage is added, these can be upgraded to TanStack `Link` components.
- Reuses existing `useEventStream` and `useRecentIngestions` hooks rather than creating new API hooks.
- Session list auto-invalidates when `ingest.status` events arrive via SSE.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run build` ✓