### PR TITLE
[RUSAA-1057] fix(docker): add agent-runner COPY to 9 Dockerfiles + wire into compose

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -113,7 +113,8 @@ services:
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.source-files.v1           --partitions 6  --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 12 --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000 &&
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.tombstones.v1             --partitions 3  --replication-factor 1 --config retention.ms=604800000
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.tombstones.v1             --partitions 3  --replication-factor 1 --config retention.ms=604800000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.agent.commands             --partitions 6  --replication-factor 1 --config retention.ms=604800000
       "
 
   loki:
@@ -506,6 +507,32 @@ services:
       otel-collector:
         condition: service_started
 
+  agent-runner:
+    build:
+      context: ..
+      dockerfile: docker/agent-runner/Dockerfile
+    image: ghcr.io/jarnura/rustacean/agent-runner:dev
+    pull_policy: never
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      RB_AGENT_WORKSPACE_BASE: /data/agent-workspaces
+      RB_CONTROL_API_BASE_URL: "http://control-api:8080"
+      RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_SERVICE_NAME: agent-runner
+      RUST_LOG: "info,agent_runner=debug"
+    volumes:
+      - agent-workspace-data:/data/agent-workspaces
+    networks:
+      - rb-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      otel-collector:
+        condition: service_started
+
   caddy:
     image: caddy:2-alpine
     volumes:
@@ -575,3 +602,4 @@ volumes:
   ollama_data:
   caddy_data:
   blob-data:
+  agent-workspace-data:

--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency downloads before copying source.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/rb-tracing/Cargo.toml      crates/rb-tracing/Cargo.toml
+COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
+COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
+COPY services/migrate/Cargo.toml       services/migrate/Cargo.toml
+COPY services/control-api/Cargo.toml   services/control-api/Cargo.toml
+COPY services/audit-worker/Cargo.toml  services/audit-worker/Cargo.toml
+COPY services/ingest-clone/Cargo.toml    services/ingest-clone/Cargo.toml
+COPY services/expand-worker/Cargo.toml   services/expand-worker/Cargo.toml
+COPY services/parse-worker/Cargo.toml    services/parse-worker/Cargo.toml
+COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
+COPY services/ingest-graph/Cargo.toml    services/ingest-graph/Cargo.toml
+COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
+COPY services/projector-neo4j/Cargo.toml services/projector-neo4j/Cargo.toml
+COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
+COPY services/embed-worker/Cargo.toml    services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml    services/agent-runner/Cargo.toml
+
+# Stub sources so `cargo build` caches deps without the full source tree.
+RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
+    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
+    mkdir -p services/agent-runner/src && \
+    printf 'fn main() {}' > services/agent-runner/src/main.rs && \
+    cargo build --release -p agent-runner 2>/dev/null || true && \
+    rm -rf crates/*/src services/*/src
+
+# Install build dependencies (rdkafka requires cmake + C toolchain).
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
+        gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy real source and build.
+COPY crates/                 crates/
+COPY services/agent-runner/  services/agent-runner/
+COPY proto/                  proto/
+
+RUN cargo build --release -p agent-runner
+
+# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Install git and ssh for cloning during agent execution
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 git openssh-client && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+USER nonroot
+
+COPY --from=builder /app/target/release/rb-agent-runner /usr/local/bin/rb-agent-runner
+
+ENTRYPOINT ["/usr/local/bin/rb-agent-runner"]

--- a/docker/embed-worker/Dockerfile
+++ b/docker/embed-worker/Dockerfile
@@ -23,6 +23,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/expand-worker/Dockerfile
+++ b/docker/expand-worker/Dockerfile
@@ -24,6 +24,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -25,6 +25,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/ingest-graph/Dockerfile
+++ b/docker/ingest-graph/Dockerfile
@@ -23,6 +23,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/parse-worker/Dockerfile
+++ b/docker/parse-worker/Dockerfile
@@ -25,6 +25,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-neo4j/Dockerfile
+++ b/docker/projector-neo4j/Dockerfile
@@ -23,6 +23,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -24,6 +24,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -25,6 +25,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \

--- a/docker/typecheck-worker/Dockerfile
+++ b/docker/typecheck-worker/Dockerfile
@@ -23,6 +23,7 @@ COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
 COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
 COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
 COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
 
 # Stub sources so `cargo build` caches deps without the full source tree.
 RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \


### PR DESCRIPTION
## Summary
Fixes the broken Docker build introduced by the agent-runner workspace member addition. Adds missing agent-runner/Cargo.toml COPY to 9 service Dockerfiles, creates docker/agent-runner/Dockerfile, adds agent-runner service and rb.agent.commands Kafka topic to compose/dev.yml so the live dev stack can rebuild and run Wave 7 code.

## GitHub Issue
Closes #322

## Changes
- Added `COPY services/agent-runner/Cargo.toml services/agent-runner/Cargo.toml` to 9 Dockerfiles: embed-worker, expand-worker, ingest-clone, ingest-graph, parse-worker, projector-neo4j, projector-pg, tombstoner, typecheck-worker
- Created `docker/agent-runner/Dockerfile` with rb-kafka/rb-schemas/rb-tracing dependencies
- Added `agent-runner` service to `compose/dev.yml` with `agent-workspace-data` volume
- Added `rb.agent.commands` topic to `kafka-init`

## Migration type
N/A — No schema changes. Docker infrastructure fix only.
