### PR TITLE
[RUSAA-1065] fix(infra): wire RB_INTERNAL_SECRET + reachable internal listener for agent-runner callbacks

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -250,6 +250,8 @@ services:
       RB_GH_APP_ID: "${RB_GH_APP_ID:-}"
       RB_GH_APP_PRIVATE_KEY: "${RB_GH_APP_PRIVATE_KEY:-}"
       RB_GH_APP_WEBHOOK_SECRET: "${RB_GH_APP_WEBHOOK_SECRET:-dev-secret-do-not-use-in-prod}"
+      RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
+      RB_INTERNAL_LISTEN_ADDR: "0.0.0.0:8081"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: control-api
       RUST_LOG: "info,control_api=debug"
@@ -516,7 +518,7 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_AGENT_WORKSPACE_BASE: /data/agent-workspaces
-      RB_CONTROL_API_BASE_URL: "http://control-api:8080"
+      RB_CONTROL_API_BASE_URL: "http://control-api:8081"
       RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: agent-runner


### PR DESCRIPTION
## Summary

Three-line `compose/dev.yml` change so the control-api ↔ agent-runner callback path actually works after PR #319/#321/#323. Without this:
- `control-api` crashes on boot (`RB_INTERNAL_SECRET is required and must be non-empty`).
- Even if it booted, every agent-runner callback would hit the public listener at port 8080 → 404 (no `/internal/*` routes there).
- The internal listener at 127.0.0.1:8081 is loopback-only inside the container — unreachable from agent-runner.

## Changes

- `control-api` env: add `RB_INTERNAL_SECRET` (mirrors agent-runner's value) and `RB_INTERNAL_LISTEN_ADDR=0.0.0.0:8081`.
- `agent-runner` env: point `RB_CONTROL_API_BASE_URL` at `:8081` (the internal listener); agent-runner only calls `/internal/*` (verified in `services/agent-runner/src/session.rs:347,367`).

## GitHub Issue

Closes #324

## Migration type

None (compose env wiring only — no schema, no migrations).

## Test plan

- [x] `docker compose --env-file compose/tailscale.env -f compose/dev.yml up -d --force-recreate control-api agent-runner` on `mars` succeeds (control-api boots).
- [x] `GET /openapi.json` on `:18080` includes `/v1/agents/sessions`, `/v1/agents/sessions/{id}`, `/v1/agents/sessions/{id}/events`.
- [x] `POST /v1/agents/sessions` returns `401 unauthorized` (route reached, auth required) — was 404 before.
- [x] `PATCH /internal/agent/sessions/{uuid}/status` from inside `rustbrain-dev_rb-net` returns `401 unauthorized` (route reached, secret middleware engaged) — was 404 before.

Surfaces in the Wave 7 stack redeploy (P0) which itself unblocks Wave 7 full UAT.