### PR TITLE
[REQ-FE-06] feat: add GET list and detail endpoints for agent sessions

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -50,7 +50,12 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        readonly get?: never;
+        /**
+         * List all agent sessions for the current session's tenant.
+         * @description Returns sessions ordered by `created_at DESC`.
+         *     Requires an active session.
+         */
+        readonly get: operations["list_sessions"];
         readonly put?: never;
         readonly post: operations["create_session"];
         readonly delete?: never;
@@ -66,7 +71,13 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        readonly get?: never;
+        /**
+         * Get a single agent session by ID.
+         * @description Performs a two-step lookup (matching `delete_session`'s pattern) so that
+         *     a cross-tenant access attempt yields 403 instead of 404. The query selects
+         *     by `id` only; tenant ownership is then verified in application code.
+         */
+        readonly get: operations["get_session"];
         readonly put?: never;
         readonly post?: never;
         readonly delete: operations["delete_session"];
@@ -1134,6 +1145,9 @@ export interface components {
             /** Format: int64 */
             readonly total_count: number;
         };
+        readonly ListSessionsResponse: {
+            readonly sessions: readonly components["schemas"]["SessionItem"][];
+        };
         readonly LoginRequest: {
             /** @description RFC 5322 email address. */
             readonly email: string;
@@ -1284,6 +1298,49 @@ export interface components {
              * @description Cosine similarity score in `[0, 1]`.
              */
             readonly score: number;
+        };
+        readonly SessionDetail: {
+            /** Format: date-time */
+            readonly completed_at?: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            /** Format: int32 */
+            readonly exit_code?: number | null;
+            /** Format: date-time */
+            readonly failed_at?: string | null;
+            readonly failure_reason?: string | null;
+            /** Format: uuid */
+            readonly id: string;
+            readonly input_prompt_preview: string;
+            /** Format: int32 */
+            readonly pid?: number | null;
+            readonly runtime_kind: string;
+            /** Format: date-time */
+            readonly started_at?: string | null;
+            readonly status: string;
+            /** Format: int64 */
+            readonly token_budget: number;
+            /** Format: int64 */
+            readonly tokens_used: number;
+            readonly workspace_path: string;
+        };
+        readonly SessionItem: {
+            /** Format: date-time */
+            readonly completed_at?: string | null;
+            /** Format: date-time */
+            readonly created_at: string;
+            /** Format: uuid */
+            readonly id: string;
+            readonly input_prompt_preview: string;
+            readonly runtime_kind: string;
+            /** Format: date-time */
+            readonly started_at?: string | null;
+            readonly status: string;
+            /** Format: int64 */
+            readonly token_budget: number;
+            /** Format: int64 */
+            readonly tokens_used: number;
+            readonly workspace_path: string;
         };
         readonly SignupRequest: {
             /** @description RFC 5322 email address. */
@@ -1504,6 +1561,33 @@ export interface operations {
             };
         };
     };
+    readonly list_sessions: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description List of agent sessions */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ListSessionsResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     readonly create_session: {
         readonly parameters: {
             readonly query?: never;
@@ -1547,6 +1631,50 @@ export interface operations {
             };
             /** @description Kafka unavailable */
             readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_session: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Session ID */
+                readonly id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Session details */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["SessionDetail"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session belongs to another tenant */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session not found */
+            readonly 404: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -61,6 +61,29 @@
       }
     },
     "/v1/agents/sessions": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "List all agent sessions for the current session's tenant.",
+        "description": "Returns sessions ordered by `created_at DESC`.\nRequires an active session.",
+        "operationId": "list_sessions",
+        "responses": {
+          "200": {
+            "description": "List of agent sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSessionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        }
+      },
       "post": {
         "tags": [
           "agents"
@@ -96,6 +119,47 @@
       }
     },
     "/v1/agents/sessions/{id}": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Get a single agent session by ID.",
+        "description": "Performs a two-step lookup (matching `delete_session`'s pattern) so that\na cross-tenant access attempt yields 403 instead of 404. The query selects\nby `id` only; tenant ownership is then verified in application code.",
+        "operationId": "get_session",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "Session belongs to another tenant"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      },
       "delete": {
         "tags": [
           "agents"
@@ -2565,6 +2629,20 @@
           }
         }
       },
+      "ListSessionsResponse": {
+        "type": "object",
+        "required": [
+          "sessions"
+        ],
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SessionItem"
+            }
+          }
+        }
+      },
       "LoginRequest": {
         "type": "object",
         "required": [
@@ -3003,6 +3081,147 @@
             "type": "number",
             "format": "float",
             "description": "Cosine similarity score in `[0, 1]`."
+          }
+        }
+      },
+      "SessionDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "runtime_kind",
+          "status",
+          "input_prompt_preview",
+          "workspace_path",
+          "tokens_used",
+          "token_budget",
+          "created_at"
+        ],
+        "properties": {
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "exit_code": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "failed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "failure_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "input_prompt_preview": {
+            "type": "string"
+          },
+          "pid": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "runtime_kind": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "token_budget": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "tokens_used": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "workspace_path": {
+            "type": "string"
+          }
+        }
+      },
+      "SessionItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "runtime_kind",
+          "status",
+          "input_prompt_preview",
+          "workspace_path",
+          "tokens_used",
+          "token_budget",
+          "created_at"
+        ],
+        "properties": {
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "input_prompt_preview": {
+            "type": "string"
+          },
+          "runtime_kind": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "token_budget": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "tokens_used": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "workspace_path": {
+            "type": "string"
           }
         }
       },

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -60,8 +60,8 @@ use crate::routes::{
         query::traversal::get_callees,
         agents::sessions::create_session,
         agents::sessions::delete_session,
-        agents::sessions::get_session,
-        agents::sessions::list_sessions,
+        agents::session_queries::get_session,
+        agents::session_queries::list_sessions,
         agents::events::session_events,
     ),
     components(
@@ -124,9 +124,9 @@ use crate::routes::{
             query::usages::UsagesResponse,
             agents::sessions::CreateSessionRequest,
             agents::sessions::CreateSessionResponse,
-            agents::sessions::SessionItem,
-            agents::sessions::ListSessionsResponse,
-            agents::sessions::SessionDetail,
+            agents::session_queries::SessionItem,
+            agents::session_queries::ListSessionsResponse,
+            agents::session_queries::SessionDetail,
         )
     ),
     tags(

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -60,6 +60,8 @@ use crate::routes::{
         query::traversal::get_callees,
         agents::sessions::create_session,
         agents::sessions::delete_session,
+        agents::sessions::get_session,
+        agents::sessions::list_sessions,
         agents::events::session_events,
     ),
     components(
@@ -122,6 +124,9 @@ use crate::routes::{
             query::usages::UsagesResponse,
             agents::sessions::CreateSessionRequest,
             agents::sessions::CreateSessionResponse,
+            agents::sessions::SessionItem,
+            agents::sessions::ListSessionsResponse,
+            agents::sessions::SessionDetail,
         )
     ),
     tags(

--- a/services/control-api/src/routes/agents/mod.rs
+++ b/services/control-api/src/routes/agents/mod.rs
@@ -1,10 +1,9 @@
 //! Agent execution routes (ADR-009 Option B — process-spawning via rb-agent-runner).
 
 pub mod events;
+pub mod session_queries;
 pub mod sessions;
 
 pub use events::session_events;
-pub use sessions::{
-    create_session, delete_session, delete_session_api_key, get_session, list_sessions,
-    patch_session_status,
-};
+pub use session_queries::{get_session, list_sessions};
+pub use sessions::{create_session, delete_session, delete_session_api_key, patch_session_status};

--- a/services/control-api/src/routes/agents/mod.rs
+++ b/services/control-api/src/routes/agents/mod.rs
@@ -4,4 +4,7 @@ pub mod events;
 pub mod sessions;
 
 pub use events::session_events;
-pub use sessions::{create_session, delete_session, delete_session_api_key, patch_session_status};
+pub use sessions::{
+    create_session, delete_session, delete_session_api_key, get_session, list_sessions,
+    patch_session_status,
+};

--- a/services/control-api/src/routes/agents/session_queries.rs
+++ b/services/control-api/src/routes/agents/session_queries.rs
@@ -1,0 +1,322 @@
+//! Read-side endpoints for agent sessions (ADR-009 Option B).
+//!
+//! - `GET /v1/agents/sessions`       — list sessions for the caller's tenant
+//! - `GET /v1/agents/sessions/{id}`  — get session detail
+//!
+//! Extracted from `sessions.rs` to keep both files under the 600-line cap.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    response::IntoResponse,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, require_verified_session},
+    state::AppState,
+};
+
+/// Maximum number of sessions returned by `GET /v1/agents/sessions`.
+const MAX_SESSIONS: i64 = 100;
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SessionItem {
+    pub id: Uuid,
+    pub runtime_kind: String,
+    pub status: String,
+    pub input_prompt_preview: String,
+    pub workspace_path: String,
+    pub tokens_used: i64,
+    pub token_budget: i64,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<SessionItem>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SessionDetail {
+    pub id: Uuid,
+    pub runtime_kind: String,
+    pub status: String,
+    pub input_prompt_preview: String,
+    pub workspace_path: String,
+    pub tokens_used: i64,
+    pub token_budget: i64,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub pid: Option<i32>,
+    pub exit_code: Option<i32>,
+    pub failed_at: Option<DateTime<Utc>>,
+    pub failure_reason: Option<String>,
+}
+
+type SessionRow = (
+    Uuid,
+    String,
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+);
+
+type SessionDetailRow = (
+    Uuid,
+    Uuid,
+    String,
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+    Option<i32>,
+    Option<i32>,
+    Option<DateTime<Utc>>,
+    Option<String>,
+);
+
+// ---------------------------------------------------------------------------
+// GET /v1/agents/sessions
+// ---------------------------------------------------------------------------
+
+/// List all agent sessions for the current session's tenant.
+///
+/// Returns sessions ordered by `created_at DESC`.
+/// Requires an active session.
+#[utoipa::path(
+    get,
+    path = "/v1/agents/sessions",
+    responses(
+        (status = 200, description = "List of agent sessions", body = ListSessionsResponse),
+        (status = 401, description = "Not authenticated"),
+    ),
+    tag = "agents"
+)]
+pub async fn list_sessions(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let rows: Vec<SessionRow> = sqlx::query_as(
+        "SELECT id, runtime_kind, status, input_prompt_preview, workspace_path,
+                tokens_used, token_budget, created_at, started_at, completed_at
+         FROM agents.agent_sessions
+         WHERE tenant_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2",
+    )
+    .bind(session.tenant_id)
+    .bind(MAX_SESSIONS)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
+
+    let sessions = rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                runtime_kind,
+                status,
+                input_prompt_preview,
+                workspace_path,
+                tokens_used,
+                token_budget,
+                created_at,
+                started_at,
+                completed_at,
+            )| SessionItem {
+                id,
+                runtime_kind,
+                status,
+                input_prompt_preview,
+                workspace_path,
+                tokens_used,
+                token_budget,
+                created_at,
+                started_at,
+                completed_at,
+            },
+        )
+        .collect();
+
+    Ok(Json(ListSessionsResponse { sessions }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/agents/sessions/{id}
+// ---------------------------------------------------------------------------
+
+/// Get a single agent session by ID.
+///
+/// Performs a two-step lookup (matching `delete_session`'s pattern) so that
+/// a cross-tenant access attempt yields 403 instead of 404. The query selects
+/// by `id` only; tenant ownership is then verified in application code.
+#[utoipa::path(
+    get,
+    path = "/v1/agents/sessions/{id}",
+    params(("id" = Uuid, Path, description = "Session ID")),
+    responses(
+        (status = 200, description = "Session details", body = SessionDetail),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Session belongs to another tenant"),
+        (status = 404, description = "Session not found"),
+    ),
+    tag = "agents"
+)]
+pub async fn get_session(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Path(session_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let row: Option<SessionDetailRow> = sqlx::query_as(
+        "SELECT id, tenant_id, runtime_kind, status, input_prompt_preview, workspace_path,
+                tokens_used, token_budget, created_at, started_at, completed_at,
+                pid, exit_code, failed_at, failure_reason
+         FROM agents.agent_sessions
+         WHERE id = $1",
+    )
+    .bind(session_id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
+
+    let (
+        id,
+        row_tenant_id,
+        runtime_kind,
+        status,
+        input_prompt_preview,
+        workspace_path,
+        tokens_used,
+        token_budget,
+        created_at,
+        started_at,
+        completed_at,
+        pid,
+        exit_code,
+        failed_at,
+        failure_reason,
+    ) = row.ok_or(AppError::NotFound)?;
+
+    if row_tenant_id != session.tenant_id {
+        return Err(AppError::InsufficientRole);
+    }
+
+    Ok(Json(SessionDetail {
+        id,
+        runtime_kind,
+        status,
+        input_prompt_preview,
+        workspace_path,
+        tokens_used,
+        token_budget,
+        created_at,
+        started_at,
+        completed_at,
+        pid,
+        exit_code,
+        failed_at,
+        failure_reason,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_sessions_is_100() {
+        assert_eq!(MAX_SESSIONS, 100);
+    }
+
+    #[test]
+    fn session_item_serializes_all_fields() {
+        let item = SessionItem {
+            id: Uuid::new_v4(),
+            runtime_kind: "claude_code".to_owned(),
+            status: "running".to_owned(),
+            input_prompt_preview: "hello".to_owned(),
+            workspace_path: "tenant/session".to_owned(),
+            tokens_used: 42,
+            token_budget: 100_000,
+            created_at: Utc::now(),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+        };
+        let val = serde_json::to_value(&item).unwrap();
+        assert!(val.get("id").is_some());
+        assert_eq!(val["runtime_kind"], "claude_code");
+        assert_eq!(val["status"], "running");
+        assert!(val.get("tokens_used").is_some());
+        assert!(val.get("token_budget").is_some());
+        assert!(val.get("created_at").is_some());
+        assert!(val["started_at"].is_string());
+        assert!(val["completed_at"].is_null());
+        // Security: no api_key_id or system_prompt
+        assert!(val.get("api_key_id").is_none());
+        assert!(val.get("system_prompt").is_none());
+    }
+
+    #[test]
+    fn session_detail_serializes_extra_fields() {
+        let detail = SessionDetail {
+            id: Uuid::new_v4(),
+            runtime_kind: "opencode".to_owned(),
+            status: "failed".to_owned(),
+            input_prompt_preview: String::new(),
+            workspace_path: String::new(),
+            tokens_used: 0,
+            token_budget: 100_000,
+            created_at: Utc::now(),
+            started_at: None,
+            completed_at: None,
+            pid: Some(1234),
+            exit_code: Some(1),
+            failed_at: Some(Utc::now()),
+            failure_reason: Some("OOM".to_owned()),
+        };
+        let val = serde_json::to_value(&detail).unwrap();
+        assert_eq!(val["pid"], 1234);
+        assert_eq!(val["exit_code"], 1);
+        assert!(val["failed_at"].is_string());
+        assert_eq!(val["failure_reason"], "OOM");
+        // Security: no api_key_id or system_prompt
+        assert!(val.get("api_key_id").is_none());
+        assert!(val.get("system_prompt").is_none());
+    }
+
+    #[test]
+    fn list_sessions_response_wraps_sessions_array() {
+        let resp = ListSessionsResponse { sessions: vec![] };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["sessions"].is_array());
+    }
+}

--- a/services/control-api/src/routes/agents/sessions.rs
+++ b/services/control-api/src/routes/agents/sessions.rs
@@ -1,6 +1,8 @@
 //! Agent session management routes (ADR-009 Option B).
 //!
+//! - `GET  /v1/agents/sessions`             — list sessions for the caller's tenant
 //! - `POST /v1/agents/sessions`             — INSERT row + publish `SessionStart` to Kafka
+//! - `GET  /v1/agents/sessions/{id}`        — get session detail
 //! - `DELETE /v1/agents/sessions/{id}`      — publish `SessionTerminate` to Kafka
 //! - `PATCH /internal/agent/sessions/{id}/status`   — agent-runner callback to update DB
 //! - `DELETE /internal/agent/sessions/{id}/api-key` — agent-runner callback to revoke key
@@ -24,7 +26,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rb_auth::ApiKey;
 use rb_kafka::EventEnvelope;
 use rb_schemas::{
@@ -493,6 +495,219 @@ pub async fn delete_session_api_key(
 }
 
 // ---------------------------------------------------------------------------
+// GET /v1/agents/sessions
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SessionItem {
+    pub id: Uuid,
+    pub runtime_kind: String,
+    pub status: String,
+    pub input_prompt_preview: String,
+    pub workspace_path: String,
+    pub tokens_used: i64,
+    pub token_budget: i64,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<SessionItem>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SessionDetail {
+    pub id: Uuid,
+    pub runtime_kind: String,
+    pub status: String,
+    pub input_prompt_preview: String,
+    pub workspace_path: String,
+    pub tokens_used: i64,
+    pub token_budget: i64,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub pid: Option<i32>,
+    pub exit_code: Option<i32>,
+    pub failed_at: Option<DateTime<Utc>>,
+    pub failure_reason: Option<String>,
+}
+
+type SessionRow = (
+    Uuid,
+    String,
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+);
+
+type SessionDetailRow = (
+    Uuid,
+    String,
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+    Option<i32>,
+    Option<i32>,
+    Option<DateTime<Utc>>,
+    Option<String>,
+);
+
+/// List all agent sessions for the current session's tenant.
+///
+/// Returns sessions ordered by `created_at DESC`.
+/// Requires an active session.
+#[utoipa::path(
+    get,
+    path = "/v1/agents/sessions",
+    responses(
+        (status = 200, description = "List of agent sessions", body = ListSessionsResponse),
+        (status = 401, description = "Not authenticated"),
+    ),
+    tag = "agents"
+)]
+pub async fn list_sessions(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    const MAX_SESSIONS: i64 = 100;
+
+    let rows: Vec<SessionRow> = sqlx::query_as(
+        "SELECT id, runtime_kind, status, input_prompt_preview, workspace_path,
+                tokens_used, token_budget, created_at, started_at, completed_at
+         FROM agents.agent_sessions
+         WHERE tenant_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2",
+    )
+    .bind(session.tenant_id)
+    .bind(MAX_SESSIONS)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
+
+    let sessions = rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                runtime_kind,
+                status,
+                input_prompt_preview,
+                workspace_path,
+                tokens_used,
+                token_budget,
+                created_at,
+                started_at,
+                completed_at,
+            )| SessionItem {
+                id,
+                runtime_kind,
+                status,
+                input_prompt_preview,
+                workspace_path,
+                tokens_used,
+                token_budget,
+                created_at,
+                started_at,
+                completed_at,
+            },
+        )
+        .collect();
+
+    Ok(Json(ListSessionsResponse { sessions }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/agents/sessions/{id}
+// ---------------------------------------------------------------------------
+
+/// Get a single agent session by ID.
+///
+/// Returns 404 if the session does not exist or does not belong to the caller's tenant.
+/// Requires an active session.
+#[utoipa::path(
+    get,
+    path = "/v1/agents/sessions/{id}",
+    params(("id" = Uuid, Path, description = "Session ID")),
+    responses(
+        (status = 200, description = "Session details", body = SessionDetail),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Session belongs to another tenant"),
+        (status = 404, description = "Session not found"),
+    ),
+    tag = "agents"
+)]
+pub async fn get_session(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Path(session_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let row: Option<SessionDetailRow> = sqlx::query_as(
+        "SELECT id, runtime_kind, status, input_prompt_preview, workspace_path,
+                tokens_used, token_budget, created_at, started_at, completed_at,
+                pid, exit_code, failed_at, failure_reason
+         FROM agents.agent_sessions
+         WHERE id = $1 AND tenant_id = $2",
+    )
+    .bind(session_id)
+    .bind(session.tenant_id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
+
+    let (
+        id,
+        runtime_kind,
+        status,
+        input_prompt_preview,
+        workspace_path,
+        tokens_used,
+        token_budget,
+        created_at,
+        started_at,
+        completed_at,
+        pid,
+        exit_code,
+        failed_at,
+        failure_reason,
+    ) = row.ok_or(AppError::NotFound)?;
+
+    Ok(Json(SessionDetail {
+        id,
+        runtime_kind,
+        status,
+        input_prompt_preview,
+        workspace_path,
+        tokens_used,
+        token_budget,
+        created_at,
+        started_at,
+        completed_at,
+        pid,
+        exit_code,
+        failed_at,
+        failure_reason,
+    }))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -559,5 +774,68 @@ mod tests {
         assert!(VALID_AGENT_STATUSES.contains(&"terminated"));
         assert!(!VALID_AGENT_STATUSES.contains(&"unknown"));
         assert!(!VALID_AGENT_STATUSES.contains(&"'DROP TABLE'"));
+    }
+
+    #[test]
+    fn session_item_serializes_all_fields() {
+        let item = SessionItem {
+            id: Uuid::new_v4(),
+            runtime_kind: "claude_code".to_owned(),
+            status: "running".to_owned(),
+            input_prompt_preview: "hello".to_owned(),
+            workspace_path: "tenant/session".to_owned(),
+            tokens_used: 42,
+            token_budget: 100_000,
+            created_at: Utc::now(),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+        };
+        let val = serde_json::to_value(&item).unwrap();
+        assert!(val.get("id").is_some());
+        assert_eq!(val["runtime_kind"], "claude_code");
+        assert_eq!(val["status"], "running");
+        assert!(val.get("tokens_used").is_some());
+        assert!(val.get("token_budget").is_some());
+        assert!(val.get("created_at").is_some());
+        assert!(val["started_at"].is_string());
+        assert!(val["completed_at"].is_null());
+        // Security: no api_key_id or system_prompt
+        assert!(val.get("api_key_id").is_none());
+        assert!(val.get("system_prompt").is_none());
+    }
+
+    #[test]
+    fn session_detail_serializes_extra_fields() {
+        let detail = SessionDetail {
+            id: Uuid::new_v4(),
+            runtime_kind: "opencode".to_owned(),
+            status: "failed".to_owned(),
+            input_prompt_preview: String::new(),
+            workspace_path: String::new(),
+            tokens_used: 0,
+            token_budget: 100_000,
+            created_at: Utc::now(),
+            started_at: None,
+            completed_at: None,
+            pid: Some(1234),
+            exit_code: Some(1),
+            failed_at: Some(Utc::now()),
+            failure_reason: Some("OOM".to_owned()),
+        };
+        let val = serde_json::to_value(&detail).unwrap();
+        assert_eq!(val["pid"], 1234);
+        assert_eq!(val["exit_code"], 1);
+        assert!(val["failed_at"].is_string());
+        assert_eq!(val["failure_reason"], "OOM");
+        // Security: no api_key_id or system_prompt
+        assert!(val.get("api_key_id").is_none());
+        assert!(val.get("system_prompt").is_none());
+    }
+
+    #[test]
+    fn list_sessions_response_wraps_sessions_array() {
+        let resp = ListSessionsResponse { sessions: vec![] };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["sessions"].is_array());
     }
 }

--- a/services/control-api/src/routes/agents/sessions.rs
+++ b/services/control-api/src/routes/agents/sessions.rs
@@ -1,11 +1,12 @@
-//! Agent session management routes (ADR-009 Option B).
+//! Agent session lifecycle routes (ADR-009 Option B).
 //!
-//! - `GET  /v1/agents/sessions`             — list sessions for the caller's tenant
 //! - `POST /v1/agents/sessions`             — INSERT row + publish `SessionStart` to Kafka
-//! - `GET  /v1/agents/sessions/{id}`        — get session detail
 //! - `DELETE /v1/agents/sessions/{id}`      — publish `SessionTerminate` to Kafka
 //! - `PATCH /internal/agent/sessions/{id}/status`   — agent-runner callback to update DB
 //! - `DELETE /internal/agent/sessions/{id}/api-key` — agent-runner callback to revoke key
+//!
+//! Read-side endpoints (`GET /v1/agents/sessions`, `GET /v1/agents/sessions/{id}`)
+//! live in [`super::session_queries`].
 //!
 //! # Prompt security
 //!
@@ -26,7 +27,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use rb_auth::ApiKey;
 use rb_kafka::EventEnvelope;
 use rb_schemas::{
@@ -495,219 +496,6 @@ pub async fn delete_session_api_key(
 }
 
 // ---------------------------------------------------------------------------
-// GET /v1/agents/sessions
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct SessionItem {
-    pub id: Uuid,
-    pub runtime_kind: String,
-    pub status: String,
-    pub input_prompt_preview: String,
-    pub workspace_path: String,
-    pub tokens_used: i64,
-    pub token_budget: i64,
-    pub created_at: DateTime<Utc>,
-    pub started_at: Option<DateTime<Utc>>,
-    pub completed_at: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListSessionsResponse {
-    pub sessions: Vec<SessionItem>,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct SessionDetail {
-    pub id: Uuid,
-    pub runtime_kind: String,
-    pub status: String,
-    pub input_prompt_preview: String,
-    pub workspace_path: String,
-    pub tokens_used: i64,
-    pub token_budget: i64,
-    pub created_at: DateTime<Utc>,
-    pub started_at: Option<DateTime<Utc>>,
-    pub completed_at: Option<DateTime<Utc>>,
-    pub pid: Option<i32>,
-    pub exit_code: Option<i32>,
-    pub failed_at: Option<DateTime<Utc>>,
-    pub failure_reason: Option<String>,
-}
-
-type SessionRow = (
-    Uuid,
-    String,
-    String,
-    String,
-    String,
-    i64,
-    i64,
-    DateTime<Utc>,
-    Option<DateTime<Utc>>,
-    Option<DateTime<Utc>>,
-);
-
-type SessionDetailRow = (
-    Uuid,
-    String,
-    String,
-    String,
-    String,
-    i64,
-    i64,
-    DateTime<Utc>,
-    Option<DateTime<Utc>>,
-    Option<DateTime<Utc>>,
-    Option<i32>,
-    Option<i32>,
-    Option<DateTime<Utc>>,
-    Option<String>,
-);
-
-/// List all agent sessions for the current session's tenant.
-///
-/// Returns sessions ordered by `created_at DESC`.
-/// Requires an active session.
-#[utoipa::path(
-    get,
-    path = "/v1/agents/sessions",
-    responses(
-        (status = 200, description = "List of agent sessions", body = ListSessionsResponse),
-        (status = 401, description = "Not authenticated"),
-    ),
-    tag = "agents"
-)]
-pub async fn list_sessions(
-    State(state): State<AppState>,
-    auth: AuthContext,
-) -> Result<impl IntoResponse, AppError> {
-    let session = require_verified_session(auth)?;
-
-    const MAX_SESSIONS: i64 = 100;
-
-    let rows: Vec<SessionRow> = sqlx::query_as(
-        "SELECT id, runtime_kind, status, input_prompt_preview, workspace_path,
-                tokens_used, token_budget, created_at, started_at, completed_at
-         FROM agents.agent_sessions
-         WHERE tenant_id = $1
-         ORDER BY created_at DESC
-         LIMIT $2",
-    )
-    .bind(session.tenant_id)
-    .bind(MAX_SESSIONS)
-    .fetch_all(&state.pool)
-    .await
-    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
-
-    let sessions = rows
-        .into_iter()
-        .map(
-            |(
-                id,
-                runtime_kind,
-                status,
-                input_prompt_preview,
-                workspace_path,
-                tokens_used,
-                token_budget,
-                created_at,
-                started_at,
-                completed_at,
-            )| SessionItem {
-                id,
-                runtime_kind,
-                status,
-                input_prompt_preview,
-                workspace_path,
-                tokens_used,
-                token_budget,
-                created_at,
-                started_at,
-                completed_at,
-            },
-        )
-        .collect();
-
-    Ok(Json(ListSessionsResponse { sessions }))
-}
-
-// ---------------------------------------------------------------------------
-// GET /v1/agents/sessions/{id}
-// ---------------------------------------------------------------------------
-
-/// Get a single agent session by ID.
-///
-/// Returns 404 if the session does not exist or does not belong to the caller's tenant.
-/// Requires an active session.
-#[utoipa::path(
-    get,
-    path = "/v1/agents/sessions/{id}",
-    params(("id" = Uuid, Path, description = "Session ID")),
-    responses(
-        (status = 200, description = "Session details", body = SessionDetail),
-        (status = 401, description = "Not authenticated"),
-        (status = 403, description = "Session belongs to another tenant"),
-        (status = 404, description = "Session not found"),
-    ),
-    tag = "agents"
-)]
-pub async fn get_session(
-    State(state): State<AppState>,
-    auth: AuthContext,
-    Path(session_id): Path<Uuid>,
-) -> Result<impl IntoResponse, AppError> {
-    let session = require_verified_session(auth)?;
-
-    let row: Option<SessionDetailRow> = sqlx::query_as(
-        "SELECT id, runtime_kind, status, input_prompt_preview, workspace_path,
-                tokens_used, token_budget, created_at, started_at, completed_at,
-                pid, exit_code, failed_at, failure_reason
-         FROM agents.agent_sessions
-         WHERE id = $1 AND tenant_id = $2",
-    )
-    .bind(session_id)
-    .bind(session.tenant_id)
-    .fetch_optional(&state.pool)
-    .await
-    .map_err(|e| AppError::Internal(anyhow::anyhow!("DB error: {e}")))?;
-
-    let (
-        id,
-        runtime_kind,
-        status,
-        input_prompt_preview,
-        workspace_path,
-        tokens_used,
-        token_budget,
-        created_at,
-        started_at,
-        completed_at,
-        pid,
-        exit_code,
-        failed_at,
-        failure_reason,
-    ) = row.ok_or(AppError::NotFound)?;
-
-    Ok(Json(SessionDetail {
-        id,
-        runtime_kind,
-        status,
-        input_prompt_preview,
-        workspace_path,
-        tokens_used,
-        token_budget,
-        created_at,
-        started_at,
-        completed_at,
-        pid,
-        exit_code,
-        failed_at,
-        failure_reason,
-    }))
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -774,68 +562,5 @@ mod tests {
         assert!(VALID_AGENT_STATUSES.contains(&"terminated"));
         assert!(!VALID_AGENT_STATUSES.contains(&"unknown"));
         assert!(!VALID_AGENT_STATUSES.contains(&"'DROP TABLE'"));
-    }
-
-    #[test]
-    fn session_item_serializes_all_fields() {
-        let item = SessionItem {
-            id: Uuid::new_v4(),
-            runtime_kind: "claude_code".to_owned(),
-            status: "running".to_owned(),
-            input_prompt_preview: "hello".to_owned(),
-            workspace_path: "tenant/session".to_owned(),
-            tokens_used: 42,
-            token_budget: 100_000,
-            created_at: Utc::now(),
-            started_at: Some(Utc::now()),
-            completed_at: None,
-        };
-        let val = serde_json::to_value(&item).unwrap();
-        assert!(val.get("id").is_some());
-        assert_eq!(val["runtime_kind"], "claude_code");
-        assert_eq!(val["status"], "running");
-        assert!(val.get("tokens_used").is_some());
-        assert!(val.get("token_budget").is_some());
-        assert!(val.get("created_at").is_some());
-        assert!(val["started_at"].is_string());
-        assert!(val["completed_at"].is_null());
-        // Security: no api_key_id or system_prompt
-        assert!(val.get("api_key_id").is_none());
-        assert!(val.get("system_prompt").is_none());
-    }
-
-    #[test]
-    fn session_detail_serializes_extra_fields() {
-        let detail = SessionDetail {
-            id: Uuid::new_v4(),
-            runtime_kind: "opencode".to_owned(),
-            status: "failed".to_owned(),
-            input_prompt_preview: String::new(),
-            workspace_path: String::new(),
-            tokens_used: 0,
-            token_budget: 100_000,
-            created_at: Utc::now(),
-            started_at: None,
-            completed_at: None,
-            pid: Some(1234),
-            exit_code: Some(1),
-            failed_at: Some(Utc::now()),
-            failure_reason: Some("OOM".to_owned()),
-        };
-        let val = serde_json::to_value(&detail).unwrap();
-        assert_eq!(val["pid"], 1234);
-        assert_eq!(val["exit_code"], 1);
-        assert!(val["failed_at"].is_string());
-        assert_eq!(val["failure_reason"], "OOM");
-        // Security: no api_key_id or system_prompt
-        assert!(val.get("api_key_id").is_none());
-        assert!(val.get("system_prompt").is_none());
-    }
-
-    #[test]
-    fn list_sessions_response_wraps_sessions_array() {
-        let resp = ListSessionsResponse { sessions: vec![] };
-        let val = serde_json::to_value(&resp).unwrap();
-        assert!(val["sessions"].is_array());
     }
 }

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -128,8 +128,14 @@ pub fn build_public(state: AppState) -> Router {
         .route("/v1/ingest/test-publish", post(test_publish))
         .route("/v1/audit", get(list_audit_events))
         // Agent session routes (ADR-009 Option B)
-        .route("/v1/agents/sessions", post(create_session).get(list_sessions))
-        .route("/v1/agents/sessions/{id}", get(get_session).delete(delete_session))
+        .route(
+            "/v1/agents/sessions",
+            post(create_session).get(list_sessions),
+        )
+        .route(
+            "/v1/agents/sessions/{id}",
+            get(get_session).delete(delete_session),
+        )
         .route("/v1/agents/sessions/{id}/events", get(session_events))
         .with_state(state)
 }

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -22,8 +22,8 @@ use axum::{
 use crate::middleware::internal_auth::require_internal_secret;
 use crate::routes::{
     agents::{
-        create_session, delete_session, delete_session_api_key, patch_session_status,
-        session_events,
+        create_session, delete_session, delete_session_api_key, get_session, list_sessions,
+        patch_session_status, session_events,
     },
     api_keys::{create_api_key, list_api_keys, revoke_api_key},
     audit::list_audit_events,
@@ -128,8 +128,8 @@ pub fn build_public(state: AppState) -> Router {
         .route("/v1/ingest/test-publish", post(test_publish))
         .route("/v1/audit", get(list_audit_events))
         // Agent session routes (ADR-009 Option B)
-        .route("/v1/agents/sessions", post(create_session))
-        .route("/v1/agents/sessions/{id}", delete(delete_session))
+        .route("/v1/agents/sessions", post(create_session).get(list_sessions))
+        .route("/v1/agents/sessions/{id}", get(get_session).delete(delete_session))
         .route("/v1/agents/sessions/{id}/events", get(session_events))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Add two GET endpoints to the control-api that the execution viewer (REQ-FE-06) needs as a data source:

- `GET /v1/agents/sessions` — list sessions for the authenticated user's tenant, ordered by `created_at DESC`, capped at 100
- `GET /v1/agents/sessions/{id}` — return session detail including `pid`, `exit_code`, `failed_at`, `failure_reason`

Previously, `GET /v1/agents/sessions` returned 405 because only POST and DELETE were registered on that route.

### Security
- `api_key_id`, `system_prompt`, and `model` are excluded from all responses
- All endpoints require `require_verified_session` and are tenant-scoped

### Design decisions
- Follows `list_api_keys` pattern (fetch all, ordered DESC, limit cap) per constraint — no pagination
- No schema changes, no new dependencies, no modifications to existing handlers

## GitHub Issue
Closes #329

## Checklist
- [x] `cargo test -p control-api -- sessions` passes (12/12)
- [x] `cargo check -p control-api` passes (zero errors in changed files)
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Docs updated if architecture changed (OpenAPI schemas registered)