### PR TITLE
[REQ-MC-01] feat(mcp): wire POST /mcp endpoint with rb-mcp protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "rb-email",
  "rb-github",
  "rb-kafka",
+ "rb-mcp",
  "rb-query",
  "rb-schemas",
  "rb-secrets",
@@ -3824,6 +3825,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
+ "uuid",
+]
+
+[[package]]
+name = "rb-mcp"
+version = "0.1.0"
+dependencies = [
+ "dashmap",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "services/tombstoner",
     "services/embed-worker",
     "services/agent-runner",
+    "crates/rb-mcp",
 ]
 
 [workspace.package]

--- a/crates/rb-mcp/Cargo.toml
+++ b/crates/rb-mcp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rb-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+dashmap.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rb-mcp/src/lib.rs
+++ b/crates/rb-mcp/src/lib.rs
@@ -1,0 +1,24 @@
+//! MCP (Model Context Protocol) protocol types for Rustbrain's agent integration.
+//!
+//! This crate provides JSON-RPC 2.0 envelope types and MCP-specific protocol
+//! structures used to implement the `POST /mcp` endpoint in control-api.
+//!
+//! **Architecture constraint (ADR-009 §1):** this crate has NO dependency on
+//! `rb-query`.  Tool dispatch is wired inside `control-api` so the protocol
+//! library stays thin and reusable.
+
+mod protocol;
+mod session;
+mod types;
+
+pub use session::McpSessionStore;
+pub use protocol::{
+    ClientInfo, InitializeParams, InitializeResult, ServerCapabilities, ServerInfo,
+    ToolCallParams, ToolCallResult, ToolContent, ToolDefinition, ToolsCapability,
+    ToolsListResult, MCP_PROTOCOL_VERSION, phase1_tools,
+};
+pub use types::{
+    JsonRpcError, JsonRpcErrorResponse, JsonRpcRequest, JsonRpcResponse,
+    INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
+    TENANT_DRIFT, SESSION_NOT_FOUND, TOOL_NOT_FOUND, UNAUTHORIZED_MCP,
+};

--- a/crates/rb-mcp/src/protocol.rs
+++ b/crates/rb-mcp/src/protocol.rs
@@ -1,0 +1,230 @@
+//! MCP 1.0 protocol types: initialize, tools/list, tools/call, ping.
+//!
+//! Reference: <https://spec.modelcontextprotocol.io/specification/>
+//!
+//! Rustbrain Phase 1 supports two read-only tools: `search_items` and
+//! `get_item`.  Phase 2 adds `get_callers`, `get_callees`, `get_trait_impls`,
+//! and `run_query` (admin-only).
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// MCP protocol version spoken by this server.
+pub const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+// ---------------------------------------------------------------------------
+// initialize
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct InitializeParams {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    #[serde(rename = "clientInfo")]
+    pub client_info: Option<ClientInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClientInfo {
+    pub name: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: &'static str,
+    #[serde(rename = "serverInfo")]
+    pub server_info: ServerInfo,
+    pub capabilities: ServerCapabilities,
+}
+
+impl InitializeResult {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            protocol_version: MCP_PROTOCOL_VERSION,
+            server_info: ServerInfo {
+                name: "rustbrain".to_owned(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+            capabilities: ServerCapabilities {
+                tools: ToolsCapability { list_changed: false },
+            },
+        }
+    }
+}
+
+impl Default for InitializeResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerCapabilities {
+    pub tools: ToolsCapability,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolsCapability {
+    /// Whether the tool list may change during a session.
+    /// False for Phase 1 — the tool set is static.
+    #[serde(rename = "listChanged")]
+    pub list_changed: bool,
+}
+
+// ---------------------------------------------------------------------------
+// tools/list
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct ToolsListResult {
+    pub tools: Vec<ToolDefinition>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: serde_json::Value,
+}
+
+/// Returns the Phase 1 tool catalogue (`search_items` + `get_item`).
+#[must_use]
+pub fn phase1_tools() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: "search_items".to_owned(),
+            description: "Semantic search over code symbols in the Rustbrain repository graph. \
+                          Returns ranked fully-qualified names matching the natural-language query."
+                .to_owned(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language or code search query"
+                    },
+                    "repo_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Optional: restrict search to this repository UUID"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "description": "Max results to return (default 10, max 50)"
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: "get_item".to_owned(),
+            description: "Fetch a code symbol by its fully-qualified name (FQN) within a \
+                          repository. Returns metadata, source location, and inline source text \
+                          for items ≤ 512 KiB."
+                .to_owned(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "repo_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Repository UUID"
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "description": "Fully-qualified name of the code symbol (e.g. my_crate::module::MyStruct)"
+                    }
+                },
+                "required": ["repo_id", "fqn"],
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// tools/call
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ToolCallParams {
+    pub name: String,
+    /// Tool-specific arguments matching the tool's `inputSchema`.
+    pub arguments: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolCallResult {
+    pub content: Vec<ToolContent>,
+    /// Present and `true` only when the tool execution produced an error.
+    #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+impl ToolCallResult {
+    pub fn success(text: impl Into<String>) -> Self {
+        Self { content: vec![ToolContent::text(text)], is_error: None }
+    }
+
+    pub fn error(text: impl Into<String>) -> Self {
+        Self { content: vec![ToolContent::text(text)], is_error: Some(true) }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+impl ToolContent {
+    pub fn text(s: impl Into<String>) -> Self {
+        Self { content_type: "text".to_owned(), text: s.into() }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase1_tools_returns_two_entries() {
+        let tools = phase1_tools();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name, "search_items");
+        assert_eq!(tools[1].name, "get_item");
+    }
+
+    #[test]
+    fn initialize_result_uses_protocol_version() {
+        let result = InitializeResult::new();
+        assert_eq!(result.protocol_version, MCP_PROTOCOL_VERSION);
+        assert_eq!(result.server_info.name, "rustbrain");
+    }
+
+    #[test]
+    fn tool_call_result_error_flag() {
+        let r = ToolCallResult::error("oops");
+        assert_eq!(r.is_error, Some(true));
+        let s = ToolCallResult::success("ok");
+        assert!(s.is_error.is_none());
+    }
+}

--- a/crates/rb-mcp/src/session.rs
+++ b/crates/rb-mcp/src/session.rs
@@ -1,0 +1,78 @@
+//! In-process MCP session store (ADR-009 Phase 1).
+//!
+//! Keyed by the opaque session UUID returned in `Mcp-Session-Id`. The value
+//! is the `tenant_id` bound at `initialize` time and is IMMUTABLE: every
+//! `tools/call` rejects a mismatched auth tenant (`TENANT_DRIFT -32000`).
+//!
+//! Session eviction is not implemented in Phase 1; Phase 2 adds an idle-timeout reaper.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// Thread-safe in-memory MCP session table.
+///
+/// Each session maps a random UUID session ID → bound `tenant_id`. The store
+/// is cheap to clone (Arc-wrapped internally) and can be placed in a shared `AppState`.
+#[derive(Clone, Default)]
+pub struct McpSessionStore(Arc<DashMap<Uuid, Uuid>>);
+
+impl McpSessionStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Arc::new(DashMap::new()))
+    }
+
+    /// Register a new session bound to `tenant_id` and return its UUID.
+    #[must_use]
+    pub fn create(&self, tenant_id: Uuid) -> Uuid {
+        let session_id = Uuid::new_v4();
+        self.0.insert(session_id, tenant_id);
+        session_id
+    }
+
+    /// Return the `tenant_id` for the given `session_id`, or `None` if unknown/evicted.
+    #[must_use]
+    pub fn tenant_id(&self, session_id: &Uuid) -> Option<Uuid> {
+        self.0.get(session_id).map(|r| *r)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_returns_distinct_ids() {
+        let store = McpSessionStore::new();
+        let tid = Uuid::new_v4();
+        assert_ne!(store.create(tid), store.create(tid));
+    }
+
+    #[test]
+    fn tenant_id_round_trips() {
+        let store = McpSessionStore::new();
+        let tid = Uuid::new_v4();
+        let sid = store.create(tid);
+        assert_eq!(store.tenant_id(&sid), Some(tid));
+    }
+
+    #[test]
+    fn unknown_session_returns_none() {
+        let store = McpSessionStore::new();
+        assert_eq!(store.tenant_id(&Uuid::new_v4()), None);
+    }
+
+    #[test]
+    fn clone_shares_same_backing_store() {
+        let store = McpSessionStore::new();
+        let tid = Uuid::new_v4();
+        let sid = store.create(tid);
+        assert_eq!(store.clone().tenant_id(&sid), Some(tid));
+    }
+}

--- a/crates/rb-mcp/src/types.rs
+++ b/crates/rb-mcp/src/types.rs
@@ -1,0 +1,128 @@
+//! JSON-RPC 2.0 envelope types.
+//!
+//! Spec: <https://www.jsonrpc.org/specification>
+
+use serde::{Deserialize, Serialize};
+
+/// Expected value of the `jsonrpc` field in every message.
+pub const JSONRPC_VERSION: &str = "2.0";
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+/// Standard JSON-RPC 2.0 parse error (invalid JSON received).
+pub const PARSE_ERROR: i32 = -32_700;
+/// Invalid JSON-RPC request object.
+pub const INVALID_REQUEST: i32 = -32_600;
+/// Method does not exist or is not available.
+pub const METHOD_NOT_FOUND: i32 = -32_601;
+/// Invalid method parameters.
+pub const INVALID_PARAMS: i32 = -32_602;
+/// Internal JSON-RPC error.
+pub const INTERNAL_ERROR: i32 = -32_603;
+
+/// Auth context at MCP session does not match the current request tenant.
+pub const TENANT_DRIFT: i32 = -32_000;
+/// `Mcp-Session-Id` header references an unknown or expired session.
+pub const SESSION_NOT_FOUND: i32 = -32_001;
+/// The requested tool name is not registered on this server.
+pub const TOOL_NOT_FOUND: i32 = -32_002;
+/// Request lacks valid authentication credentials.
+pub const UNAUTHORIZED_MCP: i32 = -32_003;
+
+// ---------------------------------------------------------------------------
+// Request / response envelopes
+// ---------------------------------------------------------------------------
+
+/// JSON-RPC 2.0 inbound request (or notification when `id` is absent).
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    /// Must equal `"2.0"`.
+    pub jsonrpc: String,
+    /// Absent for notifications (e.g. `notifications/initialized`).
+    #[serde(default)]
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    pub params: Option<serde_json::Value>,
+}
+
+/// JSON-RPC 2.0 success response.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    pub id: Option<serde_json::Value>,
+    pub result: serde_json::Value,
+}
+
+impl JsonRpcResponse {
+    #[must_use]
+    pub fn ok(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self { jsonrpc: JSONRPC_VERSION, id, result }
+    }
+}
+
+/// JSON-RPC 2.0 error response.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcErrorResponse {
+    pub jsonrpc: &'static str,
+    pub id: Option<serde_json::Value>,
+    pub error: JsonRpcError,
+}
+
+impl JsonRpcErrorResponse {
+    pub fn new(id: Option<serde_json::Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION,
+            id,
+            error: JsonRpcError { code, message: message.into(), data: None },
+        }
+    }
+}
+
+/// Error detail nested inside a [`JsonRpcErrorResponse`].
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ok_response_serialises_correctly() {
+        let resp = JsonRpcResponse::ok(Some(json!(1)), json!({"answer": 42}));
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["result"]["answer"], 42);
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn error_response_omits_data_when_none() {
+        let resp = JsonRpcErrorResponse::new(Some(json!(2)), METHOD_NOT_FOUND, "not found");
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["error"]["code"], METHOD_NOT_FOUND);
+        assert!(v["error"].get("data").is_none());
+    }
+
+    #[test]
+    fn notification_has_null_id() {
+        let rpc: JsonRpcRequest = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }))
+        .unwrap();
+        assert!(rpc.id.is_none());
+    }
+}

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -26,6 +26,22 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/mcp": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post: operations["mcp_handler"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/ready": {
         readonly parameters: {
             readonly query?: never;
@@ -1531,6 +1547,35 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["HealthResponse"];
                 };
+            };
+        };
+    };
+    readonly mcp_handler: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": unknown;
+            };
+        };
+        readonly responses: {
+            /** @description JSON-RPC 2.0 response with Mcp-Session-Id header */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/openapi.json
+++ b/openapi.json
@@ -36,6 +36,30 @@
         }
       }
     },
+    "/mcp": {
+      "post": {
+        "tags": [
+          "mcp"
+        ],
+        "operationId": "mcp_handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "JSON-RPC 2.0 response with Mcp-Session-Id header"
+          },
+          "401": {
+            "description": "Authentication required"
+          }
+        }
+      }
+    },
     "/ready": {
       "get": {
         "tags": [
@@ -3757,6 +3781,10 @@
     {
       "name": "agents",
       "description": "Agent session management (ADR-009 Option B)"
+    },
+    {
+      "name": "mcp",
+      "description": "Model Context Protocol endpoint (ADR-009)"
     }
   ]
 }

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -34,6 +34,7 @@ rb-storage-pg = { path = "../../crates/rb-storage-pg", version = "0.1.0" }
 rb-storage-neo4j = { path = "../../crates/rb-storage-neo4j", version = "0.1.0" }
 rb-storage-qdrant = { path = "../../crates/rb-storage-qdrant", version = "0.1.0" }
 rb-query = { path = "../../crates/rb-query", version = "0.1.0" }
+rb-mcp = { path = "../../crates/rb-mcp", version = "0.1.0" }
 async-trait.workspace = true
 rb-tracing = { path = "../../crates/rb-tracing", version = "0.1.0" }
 reqwest.workspace = true

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -7,7 +7,7 @@ use utoipa::OpenApi;
 
 use crate::routes::{
     agents, api_keys, audit, auth, auth_logout, auth_password_reset, auth_verify, github, health,
-    ingest, me, query, repos, tenants, tenants::delete as tenant_delete,
+    ingest, me, mcp, query, repos, tenants, tenants::delete as tenant_delete,
     tenants::members as tenant_members,
 };
 
@@ -63,6 +63,7 @@ use crate::routes::{
         agents::session_queries::get_session,
         agents::session_queries::list_sessions,
         agents::events::session_events,
+        mcp::mcp_handler,
     ),
     components(
         schemas(
@@ -141,7 +142,8 @@ use crate::routes::{
         (name = "github", description = "GitHub App integration"),
         (name = "query", description = "Code graph queries"),
         (name = "search", description = "Semantic code search"),
-        (name = "agents", description = "Agent session management (ADR-009 Option B)")
+        (name = "agents", description = "Agent session management (ADR-009 Option B)"),
+        (name = "mcp", description = "Model Context Protocol endpoint (ADR-009)")
     )
 )]
 pub struct ApiDoc;

--- a/services/control-api/src/routes/mcp/audit.rs
+++ b/services/control-api/src/routes/mcp/audit.rs
@@ -1,0 +1,70 @@
+//! Audit-event helper for MCP tool calls.
+//!
+//! Every `tools/call` invocation writes one row to `audit.audit_events` with
+//! the tool name and a SHA-256 hash of the raw arguments (never the arguments
+//! themselves — ADR-009 §security model).
+
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub(super) async fn write_tool_call_audit(
+    pool: &PgPool,
+    tenant_id: Uuid,
+    actor_user_id: Option<Uuid>,
+    tool_name: &str,
+    args: &serde_json::Value,
+    outcome: &str,
+) {
+    let args_sha256 = {
+        let mut h = Sha256::new();
+        h.update(args.to_string().as_bytes());
+        format!("{:x}", h.finalize())
+    };
+
+    let result = sqlx::query(
+        "INSERT INTO audit.audit_events \
+         (event_id, tenant_id, actor_kind, actor_user_id, action, outcome, occurred_at, payload) \
+         VALUES ($1, $2, 'mcp_client', $3, $4, $5, now(), $6) \
+         ON CONFLICT (tenant_id, event_id) DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(tenant_id)
+    .bind(actor_user_id)
+    .bind(format!("mcp.tools.call.{tool_name}"))
+    .bind(outcome)
+    .bind(serde_json::json!({ "tool": tool_name, "args_sha256": args_sha256 }))
+    .execute(pool)
+    .await;
+
+    if let Err(e) = result {
+        tracing::warn!(
+            tenant_id = %tenant_id,
+            tool = tool_name,
+            outcome,
+            "failed to write MCP audit event: {e}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn args_sha256_is_deterministic() {
+        let args = serde_json::json!({"query": "my fn"});
+        let hash1 = {
+            let mut h = Sha256::new();
+            h.update(args.to_string().as_bytes());
+            format!("{:x}", h.finalize())
+        };
+        let hash2 = {
+            let mut h = Sha256::new();
+            h.update(args.to_string().as_bytes());
+            format!("{:x}", h.finalize())
+        };
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 64);
+    }
+}

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -1,0 +1,214 @@
+//! Tool dispatch for Phase 1 MCP tools: `search_items` and `get_item`.
+//!
+//! **Architecture (ADR-009 §1):** tool implementations live here in
+//! `control-api`, not in `rb-mcp`.  The `rb-mcp` crate owns protocol types
+//! only; it has no dependency on `rb-query`.
+
+use rb_mcp::ToolCallResult;
+use rb_query::{DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, items, semantic_search};
+use rb_schemas::TenantId;
+use rb_tenant::TenantCtx;
+use uuid::Uuid;
+
+use crate::{error::AppError, state::AppState};
+
+pub(super) async fn dispatch_search_items(
+    state: &AppState,
+    tenant_id: Uuid,
+    args: &serde_json::Value,
+) -> Result<ToolCallResult, AppError> {
+    let query = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or(AppError::InvalidInput)?;
+
+    if query.trim().is_empty() {
+        return Err(AppError::InvalidInput);
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    let limit = args
+        .get("limit")
+        .and_then(serde_json::Value::as_u64)
+        .map_or(DEFAULT_SEARCH_LIMIT, |n| n as u32)
+        .clamp(1, MAX_SEARCH_LIMIT);
+
+    let repo_id_filter: Option<Uuid> = args
+        .get("repo_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok());
+
+    let qdrant = state.qdrant.as_deref().ok_or(AppError::ServiceUnavailable)?;
+    let ollama_url =
+        state.config.ollama_url.as_deref().ok_or(AppError::ServiceUnavailable)?;
+
+    if let Some(rid) = repo_id_filter {
+        let owned: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM control.repos \
+             WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+        )
+        .bind(rid)
+        .bind(tenant_id)
+        .fetch_optional(&state.pool)
+        .await?;
+        owned.ok_or(AppError::NotFound)?;
+    }
+
+    let vector = embed_query(&state.http_client, ollama_url, &state.config.embedding_model, query)
+        .await?;
+
+    let tenant = TenantId::from(tenant_id);
+    let opts = SearchOptions { limit, repo_id: repo_id_filter };
+    let hits = semantic_search(qdrant, &tenant, &vector, opts).await?;
+
+    let results: Vec<serde_json::Value> = hits
+        .into_iter()
+        .map(|h| {
+            let crate_name =
+                h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
+            serde_json::json!({
+                "fqn": h.fqn,
+                "crate_name": crate_name,
+                "repo_id": h.repo_id,
+                "score": h.score
+            })
+        })
+        .collect();
+
+    let text = serde_json::to_string_pretty(&results).unwrap_or_default();
+    Ok(ToolCallResult::success(text))
+}
+
+pub(super) async fn dispatch_get_item(
+    state: &AppState,
+    tenant_id: Uuid,
+    args: &serde_json::Value,
+) -> Result<ToolCallResult, AppError> {
+    let repo_id: Uuid = args
+        .get("repo_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .ok_or(AppError::InvalidInput)?;
+
+    let fqn = args
+        .get("fqn")
+        .and_then(|v| v.as_str())
+        .ok_or(AppError::InvalidInput)?;
+
+    let owned: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM control.repos \
+         WHERE id = $1 AND tenant_id = $2 AND archived_at IS NULL",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await?;
+    owned.ok_or(AppError::NotFound)?;
+
+    let ctx = TenantCtx::new(TenantId::from(tenant_id));
+    let symbol = items::get_by_fqn(&state.pool, &ctx, repo_id, fqn).await?;
+
+    match symbol {
+        None => Ok(ToolCallResult::success("No symbol found for the given repo_id and fqn.")),
+        Some(s) => {
+            let payload = serde_json::json!({
+                "id": s.id,
+                "fqn": s.fqn,
+                "kind": s.kind,
+                "repo_id": repo_id,
+                "source_path": s.source_path,
+                "line_start": s.line_start,
+                "line_end": s.line_end,
+                "source_text": s.source_text,
+                "blob_ref": s.blob_ref
+            });
+            let text = serde_json::to_string_pretty(&payload).unwrap_or_default();
+            Ok(ToolCallResult::success(text))
+        }
+    }
+}
+
+async fn embed_query(
+    http: &reqwest::Client,
+    ollama_url: &str,
+    model: &str,
+    query: &str,
+) -> Result<Vec<f32>, AppError> {
+    let url = format!("{}/api/embeddings", ollama_url.trim_end_matches('/'));
+    let body = serde_json::json!({ "model": model, "prompt": query });
+
+    let resp = http
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!("Ollama request failed: {e}");
+            AppError::ServiceUnavailable
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        tracing::warn!("Ollama returned HTTP {status}: {text}");
+        return Err(AppError::ServiceUnavailable);
+    }
+
+    let json: serde_json::Value = resp.json().await.map_err(|e| {
+        tracing::warn!("Ollama response parse error: {e}");
+        AppError::ServiceUnavailable
+    })?;
+
+    let embedding = json
+        .get("embedding")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            tracing::warn!("Ollama response missing 'embedding' array");
+            AppError::ServiceUnavailable
+        })?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    embedding
+        .iter()
+        .map(|v| v.as_f64().map(|f| f as f32).ok_or(AppError::ServiceUnavailable))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_items_requires_query_field() {
+        let args = serde_json::json!({ "limit": 5 });
+        assert!(args.get("query").and_then(|v| v.as_str()).is_none());
+    }
+
+    #[test]
+    fn get_item_requires_repo_id_and_fqn() {
+        let args = serde_json::json!({ "repo_id": "not-a-uuid", "fqn": "foo::bar" });
+        let repo: Option<Uuid> = args
+            .get("repo_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok());
+        assert!(repo.is_none());
+
+        let valid = serde_json::json!({
+            "repo_id": "550e8400-e29b-41d4-a716-446655440000",
+            "fqn": "my_crate::MyStruct"
+        });
+        let repo2: Option<Uuid> = valid
+            .get("repo_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok());
+        assert!(repo2.is_some());
+    }
+
+    #[test]
+    fn limit_clamping() {
+        let over = 200_u32.clamp(1, MAX_SEARCH_LIMIT);
+        assert_eq!(over, MAX_SEARCH_LIMIT);
+        let zero = 0_u32.clamp(1, MAX_SEARCH_LIMIT);
+        assert_eq!(zero, 1);
+    }
+}

--- a/services/control-api/src/routes/mcp/mod.rs
+++ b/services/control-api/src/routes/mcp/mod.rs
@@ -1,0 +1,311 @@
+mod audit;
+mod dispatch;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use rb_mcp::{
+    InitializeParams, JsonRpcErrorResponse, JsonRpcRequest, JsonRpcResponse,
+    MCP_PROTOCOL_VERSION, METHOD_NOT_FOUND, SESSION_NOT_FOUND, TENANT_DRIFT,
+    TOOL_NOT_FOUND, UNAUTHORIZED_MCP,
+    InitializeResult, ToolCallParams, ToolsListResult, phase1_tools,
+};
+use uuid::Uuid;
+
+use crate::{
+    middleware::auth::{AuthContext, Scope},
+    state::AppState,
+};
+
+pub use handler::mcp_handler;
+#[allow(unused_imports)]
+pub use handler::__path_mcp_handler;
+
+mod handler {
+    use super::{AppState, AuthContext, HeaderMap, Response, State, dispatch};
+
+    #[utoipa::path(
+        post,
+        path = "/mcp",
+        tag = "mcp",
+        request_body = serde_json::Value,
+        responses(
+            (status = 200, description = "JSON-RPC 2.0 response with Mcp-Session-Id header"),
+            (status = 401, description = "Authentication required"),
+        )
+    )]
+    pub async fn mcp_handler(
+        State(state): State<AppState>,
+        auth: AuthContext,
+        headers: HeaderMap,
+        body: axum::body::Bytes,
+    ) -> Response {
+        dispatch(&state, auth, headers, body).await.unwrap_or_else(|e| e)
+    }
+}
+
+type McpResult = Result<Response, Response>;
+
+async fn dispatch(
+    state: &AppState,
+    auth: AuthContext,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> McpResult {
+    let rpc: JsonRpcRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("MCP parse error: {e}");
+            return Err(rpc_err(None, rb_mcp::PARSE_ERROR, "parse error"));
+        }
+    };
+
+    if rpc.jsonrpc != "2.0" {
+        return Err(rpc_err(rpc.id, rb_mcp::INVALID_REQUEST, "jsonrpc must be '2.0'"));
+    }
+
+    match rpc.method.as_str() {
+        "initialize" => handle_initialize(state, auth, rpc),
+        "notifications/initialized" => {
+            Ok((StatusCode::ACCEPTED, "").into_response())
+        }
+        "ping" => Ok(rpc_ok(rpc.id, serde_json::json!({}))),
+        "tools/list" => handle_tools_list(state, auth, &headers, rpc),
+        "tools/call" => handle_tools_call(state, auth, headers, rpc).await,
+        _ => Err(rpc_err(rpc.id, METHOD_NOT_FOUND, "method not found")),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn handle_initialize(
+    state: &AppState,
+    auth: AuthContext,
+    rpc: JsonRpcRequest,
+) -> McpResult {
+    let tenant_id = require_auth_tenant(auth)
+        .map_err(|()| rpc_err(rpc.id.clone(), UNAUTHORIZED_MCP, "authentication required"))?;
+
+    if let Some(params) = &rpc.params {
+        if let Ok(p) = serde_json::from_value::<InitializeParams>(params.clone()) {
+            tracing::debug!(
+                protocol_version = %p.protocol_version,
+                client = ?p.client_info.as_ref().map(|c| &c.name),
+                "MCP initialize"
+            );
+            if p.protocol_version != MCP_PROTOCOL_VERSION {
+                tracing::warn!(
+                    requested = %p.protocol_version,
+                    supported = %MCP_PROTOCOL_VERSION,
+                    "MCP client requested newer protocol; proceeding with {MCP_PROTOCOL_VERSION}"
+                );
+            }
+        }
+    }
+
+    let session_id = state.mcp_sessions.create(tenant_id);
+    tracing::info!(tenant_id = %tenant_id, session_id = %session_id, "MCP session created");
+
+    let result = serde_json::to_value(InitializeResult::new()).unwrap_or(serde_json::json!({}));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Mcp-Session-Id",
+        HeaderValue::from_str(&session_id.to_string()).expect("uuid is valid header value"),
+    );
+
+    Ok((headers, rpc_json_ok(rpc.id, result)).into_response())
+}
+
+#[allow(clippy::result_large_err)]
+fn handle_tools_list(
+    state: &AppState,
+    auth: AuthContext,
+    headers: &HeaderMap,
+    rpc: JsonRpcRequest,
+) -> McpResult {
+    validate_session(state, auth, headers, rpc.id.clone())?;
+    let result = serde_json::to_value(ToolsListResult { tools: phase1_tools() })
+        .unwrap_or(serde_json::json!({}));
+    Ok(rpc_ok(rpc.id, result))
+}
+
+async fn handle_tools_call(
+    state: &AppState,
+    auth: AuthContext,
+    headers: HeaderMap,
+    rpc: JsonRpcRequest,
+) -> McpResult {
+    let (session_tenant_id, actor_user_id) =
+        validate_session(state, auth, &headers, rpc.id.clone())?;
+
+    let params: ToolCallParams = match rpc.params.as_ref().and_then(|p| {
+        serde_json::from_value(p.clone()).ok()
+    }) {
+        Some(p) => p,
+        None => {
+            return Err(rpc_err(
+                rpc.id,
+                rb_mcp::INVALID_PARAMS,
+                "tools/call requires {name, arguments}",
+            ));
+        }
+    };
+
+    let args = params.arguments.unwrap_or(serde_json::json!({}));
+
+    let tool_result = match params.name.as_str() {
+        "search_items" => {
+            dispatch::dispatch_search_items(state, session_tenant_id, &args).await
+        }
+        "get_item" => {
+            dispatch::dispatch_get_item(state, session_tenant_id, &args).await
+        }
+        _ => {
+            return Err(rpc_err(rpc.id, TOOL_NOT_FOUND, "unknown tool"));
+        }
+    };
+
+    let (call_result, outcome) = match tool_result {
+        Ok(r) => (r, "success"),
+        Err(e) => {
+            tracing::warn!(
+                tool = %params.name,
+                tenant_id = %session_tenant_id,
+                "MCP tool call failed: {e:?}"
+            );
+            (rb_mcp::ToolCallResult::error(format!("{e:?}")), "error")
+        }
+    };
+
+    audit::write_tool_call_audit(
+        &state.pool,
+        session_tenant_id,
+        actor_user_id,
+        &params.name,
+        &args,
+        outcome,
+    )
+    .await;
+
+    let result = serde_json::to_value(&call_result).unwrap_or(serde_json::json!({}));
+    Ok(rpc_ok(rpc.id, result))
+}
+
+fn require_auth_tenant(auth: AuthContext) -> Result<Uuid, ()> {
+    match auth {
+        AuthContext::Session(info) if info.email_verified => Ok(info.tenant_id),
+        AuthContext::ApiKey(info) if info.scopes.contains(&Scope::Read) => Ok(info.tenant_id),
+        _ => Err(()),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_session(
+    state: &AppState,
+    auth: AuthContext,
+    headers: &HeaderMap,
+    req_id: Option<serde_json::Value>,
+) -> Result<(Uuid, Option<Uuid>), Response> {
+    let (auth_tenant_id, actor_user_id) = match auth {
+        AuthContext::Session(info) if info.email_verified => (info.tenant_id, Some(info.user_id)),
+        AuthContext::ApiKey(info) if info.scopes.contains(&Scope::Read) => {
+            (info.tenant_id, Some(info.user_id))
+        }
+        _ => {
+            return Err(rpc_err(req_id, UNAUTHORIZED_MCP, "unauthorized"));
+        }
+    };
+
+    let session_id: Uuid = headers
+        .get("Mcp-Session-Id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(Uuid::nil());
+
+    match state.mcp_sessions.tenant_id(&session_id) {
+        None => Err(rpc_err(req_id, SESSION_NOT_FOUND, "session not found or expired")),
+        Some(session_tenant) if session_tenant != auth_tenant_id => {
+            tracing::warn!(
+                auth_tenant = %auth_tenant_id,
+                session_tenant = %session_tenant,
+                "MCP tenant drift detected"
+            );
+            Err(rpc_err(req_id, TENANT_DRIFT, "tenant mismatch"))
+        }
+        Some(session_tenant) => Ok((session_tenant, actor_user_id)),
+    }
+}
+
+fn rpc_ok(id: Option<serde_json::Value>, result: serde_json::Value) -> Response {
+    axum::Json(JsonRpcResponse::ok(id, result)).into_response()
+}
+
+fn rpc_json_ok(id: Option<serde_json::Value>, result: serde_json::Value) -> axum::Json<JsonRpcResponse> {
+    axum::Json(JsonRpcResponse::ok(id, result))
+}
+
+fn rpc_err(id: Option<serde_json::Value>, code: i32, message: &str) -> Response {
+    axum::Json(JsonRpcErrorResponse::new(id, code, message)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{ApiKeyInfo, SessionInfo};
+
+    fn verified_session(tenant_id: Uuid) -> SessionInfo {
+        SessionInfo {
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            tenant_id,
+            email_verified: true,
+        }
+    }
+
+    #[test]
+    fn anonymous_auth_rejected() {
+        assert!(require_auth_tenant(AuthContext::Anonymous).is_err());
+    }
+
+    #[test]
+    fn expired_session_rejected() {
+        assert!(require_auth_tenant(AuthContext::ExpiredSession).is_err());
+    }
+
+    #[test]
+    fn unverified_session_rejected() {
+        let mut info = verified_session(Uuid::new_v4());
+        info.email_verified = false;
+        assert!(require_auth_tenant(AuthContext::Session(info)).is_err());
+    }
+
+    #[test]
+    fn verified_session_returns_tenant() {
+        let tid = Uuid::new_v4();
+        assert_eq!(require_auth_tenant(AuthContext::Session(verified_session(tid))), Ok(tid));
+    }
+
+    #[test]
+    fn read_scoped_api_key_accepted() {
+        let tid = Uuid::new_v4();
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: tid,
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Read],
+        };
+        assert_eq!(require_auth_tenant(AuthContext::ApiKey(key)), Ok(tid));
+    }
+
+    #[test]
+    fn write_only_api_key_rejected() {
+        let key = ApiKeyInfo {
+            key_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            scopes: vec![Scope::Write],
+        };
+        assert!(require_auth_tenant(AuthContext::ApiKey(key)).is_err());
+    }
+}

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod auth_verify;
 pub mod github;
 pub mod health;
 pub mod ingest;
+pub mod mcp;
 pub mod me;
 pub mod query;
 pub mod repos;
@@ -42,6 +43,7 @@ use crate::routes::{
     ingest::test_publish::test_publish,
     ingest::trigger::trigger_ingestion,
     me::{get_me, switch_tenant},
+    mcp::mcp_handler,
     query::graph::post_graph_query,
     query::impls::get_trait_impls,
     query::items::get_item,
@@ -127,6 +129,8 @@ pub fn build_public(state: AppState) -> Router {
         .route("/v1/ingest/events", get(events_stream))
         .route("/v1/ingest/test-publish", post(test_publish))
         .route("/v1/audit", get(list_audit_events))
+        // MCP endpoint (ADR-009)
+        .route("/mcp", post(mcp_handler))
         // Agent session routes (ADR-009 Option B)
         .route(
             "/v1/agents/sessions",

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -136,7 +136,7 @@ pub async fn run(config: Config) -> Result<()> {
         http_client: reqwest::Client::new(),
         neo4j_uri: config.neo4j_uri.clone(),
         kafka_consistency: Arc::clone(&kafka_consistency),
-        mcp_sessions: McpSessionStore,
+        mcp_sessions: McpSessionStore::new(),
         agent_registry: AgentRegistry::new(),
         agent_commands_producer,
         internal_secret: config.internal_secret.clone().unwrap_or_default(),

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -17,17 +17,7 @@ use rb_storage_qdrant::TenantVectorStore;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-/// Placeholder for the MCP session store — kept for binary compatibility
-/// during migration.  Will be removed when MCP routes are fully retired.
-#[derive(Clone, Default)]
-pub struct McpSessionStore;
-
-impl McpSessionStore {
-    #[must_use]
-    pub fn new() -> Self {
-        Self
-    }
-}
+pub use rb_mcp::McpSessionStore;
 
 use crate::config::Config;
 


### PR DESCRIPTION
## Summary

Adds the JSON-RPC 2.0 MCP server endpoint that REQ-MC-01 requires but was returning 404 in the live API. Live binary lacked any `/mcp*` route — this PR wires it end-to-end.

## What's Included

- **`crates/rb-mcp`** (new) — JSON-RPC 2.0 envelopes + MCP 1.0 protocol types (`initialize`, `tools/list`, `tools/call`, `ping`). No `rb-query` dep per ADR-009 §1; protocol crate stays thin and reusable. Includes `McpSessionStore` (`Arc<DashMap<Uuid, Uuid>>`) binding session-id → tenant-id.
- **`POST /mcp`** in `control-api`:
  - `initialize` — creates session, returns `Mcp-Session-Id` header (immutable tenant binding).
  - `notifications/initialized` — 202 ACK.
  - `ping` — liveness probe.
  - `tools/list` — Phase-1 catalogue: `search_items`, `get_item`.
  - `tools/call` — dispatched in `services/control-api/src/routes/mcp/dispatch.rs` (tool implementations live in control-api, not rb-mcp).
- **Tenant isolation** — every `tools/call` re-checks auth tenant against session tenant; mismatch → `TENANT_DRIFT (-32000)`. Repo ownership verified against `control.repos` before dispatch.
- **Audit** — every `tools/call` writes `audit.audit_events` row with SHA-256 of args (never raw args; ADR-009 security model).
- **OpenAPI** — `mcp::mcp_handler` registered in `ApiDoc` paths and `mcp` tag added.

## GitHub issue

Closes #310

## Acceptance (REQ-MC-01)

- [x] `POST /mcp` `initialize` returns 200 with `protocolVersion`, `serverInfo`, `capabilities`, and `Mcp-Session-Id` header.
- [x] `tools/list` returns Phase-1 catalogue (`search_items`, `get_item`).
- [x] Cross-tenant `tools/call` rejected with `TENANT_DRIFT (-32000)` (covered by `validate_session`).
- [x] `openapi.json` includes `/mcp` POST under `mcp` tag.

## Test results

- 10/10 `rb-mcp` unit tests pass (`cargo test -p rb-mcp`).
- 10/10 `control-api` MCP unit tests pass (`cargo test -p control-api --lib mcp::`).
- `cargo build -p rb-mcp -p control-api` clean.
- `cargo clippy -p rb-mcp -p control-api --lib --bins -- -D warnings` clean.

## Notes for reviewer

- Pre-existing `uninlined_format_args` clippy warnings in `services/control-api/tests/integration_*.rs` are unrelated to this PR (untouched test files); should be addressed in a separate hygiene pass.
- `COMPANY.md` typechange in working tree is a local symlink and was deliberately excluded from this commit.