### PR TITLE
[RUSAA-1096] feat(migrations): tenant agent_sessions provisioning template

### DIFF
--- a/migrations/tenant/007_agent_sessions.sql
+++ b/migrations/tenant/007_agent_sessions.sql
@@ -1,0 +1,60 @@
+-- Per-tenant schema: RUSAA-1096 — agent_sessions provisioning
+--
+-- Tenant-scoped table tracking process-spawning agent sessions per ADR-009
+-- Option B.  Distinct from public/shared agents.agent_sessions; this table
+-- records per-tenant lifecycle metadata for the agent-runner.
+--
+-- 22 existing tenant schemas already carry this table from a one-shot manual
+-- backfill (recorded with version 7, checksum 091d969b…).  This file is the
+-- canonical source going forward so that:
+--   - migrate-tenant.sh (rb-migrations init container) applies it to the
+--     three older tenants that missed the backfill (startup self-heal),
+--   - the Rust signup flow applies it to every new tenant immediately,
+--   - all CREATE statements are idempotent (IF NOT EXISTS / OR REPLACE /
+--     DROP TRIGGER IF EXISTS) so re-application is safe.
+--
+-- Coordinates with Wave 7 control-schema migrations 010/013/014.  This file
+-- does NOT alter agents.agent_sessions (the global table); the fix is
+-- tenant-schema-scoped per the parent RUSAA-1071 acceptance note.
+
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           UUID        NOT NULL,
+    session_id          TEXT        NOT NULL UNIQUE,
+    runtime             TEXT        NOT NULL,
+    status              TEXT        NOT NULL,
+    workspace_path      TEXT        NOT NULL,
+    api_key_id          UUID,
+    pid                 INTEGER,
+    exit_code           INTEGER,
+    duration_ms         BIGINT,
+    termination_reason  TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    terminated_at       TIMESTAMPTZ,
+    CONSTRAINT agent_sessions_runtime_check
+        CHECK (runtime IN ('claude_code', 'opencode', 'pi')),
+    CONSTRAINT agent_sessions_status_check
+        CHECK (status IN ('pending', 'running', 'terminated', 'error'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_tenant_id  ON agent_sessions (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_session_id ON agent_sessions (session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_status     ON agent_sessions (status);
+
+-- updated_at maintenance trigger — function lives in the tenant schema so
+-- each tenant owns its own copy (matches existing 22-tenant backfill layout).
+CREATE OR REPLACE FUNCTION update_agent_sessions_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS update_agent_sessions_updated_at_trigger ON agent_sessions;
+CREATE TRIGGER update_agent_sessions_updated_at_trigger
+    BEFORE UPDATE ON agent_sessions
+    FOR EACH ROW EXECUTE FUNCTION update_agent_sessions_updated_at();

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -371,6 +371,18 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
     Some((state, pool))
 }
 
+/// Same as [`real_db_state`] but with `migrations_root` set so signup runs the
+/// per-tenant migrations against the newly created tenant schema.  Skipped
+/// gracefully when `RB_DATABASE_URL` or `RB_MIGRATIONS_ROOT` is absent.
+async fn real_db_state_with_migrations() -> Option<(AppState, PgPool)> {
+    let migrations_root = std::env::var("RB_MIGRATIONS_ROOT").ok()?;
+    let (mut state, pool) = real_db_state().await?;
+    let mut config = (*state.config).clone();
+    config.migrations_root = Some(std::path::PathBuf::from(migrations_root));
+    state.config = Arc::new(config);
+    Some((state, pool))
+}
+
 fn json_body(v: &serde_json::Value) -> Body {
     Body::from(serde_json::to_vec(v).expect("serialise JSON"))
 }
@@ -529,6 +541,91 @@ async fn integration_login_rate_limit() {
         StatusCode::TOO_MANY_REQUESTS,
         "6th attempt must be rate-limited"
     );
+}
+
+/// RUSAA-1096: signup must run all per-tenant migrations, including the
+/// agent_sessions table that ADR-009 Option B requires for per-tenant
+/// process-spawning agent session metadata.
+///
+/// Skipped when `RB_DATABASE_URL` or `RB_MIGRATIONS_ROOT` is unset.
+#[tokio::test]
+async fn integration_signup_provisions_tenant_agent_sessions_table() {
+    let Some((state, pool)) = real_db_state_with_migrations().await else {
+        return;
+    };
+    let app = build(state);
+    let email = format!(
+        "integ-tenant-agentsess-{}@test.example",
+        Uuid::new_v4().simple()
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/signup")
+                .header("content-type", "application/json")
+                .body(json_body(&serde_json::json!({
+                    "email": email,
+                    "password": "correct-horse-battery-staple",
+                    "tenant_name": "RUSAA-1096 Agent Sessions Provision",
+                })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "signup must return 201");
+
+    let (schema_name,): (String,) = sqlx::query_as(
+        "SELECT t.schema_name FROM control.tenants t \
+         JOIN control.tenant_members tm ON tm.tenant_id = t.id \
+         JOIN control.users u ON u.id = tm.user_id \
+         WHERE u.email = $1",
+    )
+    .bind(&email)
+    .fetch_one(&pool)
+    .await
+    .expect("must look up tenant schema for new user");
+
+    let (table_count,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM information_schema.tables \
+         WHERE table_schema = $1 AND table_name = 'agent_sessions'",
+    )
+    .bind(&schema_name)
+    .fetch_one(&pool)
+    .await
+    .expect("must query information_schema");
+    assert_eq!(
+        table_count, 1,
+        "agent_sessions must exist in new tenant schema {schema_name}"
+    );
+
+    // Sanity-check core columns so a future migration drift is caught fast.
+    let columns: Vec<(String,)> = sqlx::query_as(
+        "SELECT column_name FROM information_schema.columns \
+         WHERE table_schema = $1 AND table_name = 'agent_sessions' \
+         ORDER BY ordinal_position",
+    )
+    .bind(&schema_name)
+    .fetch_all(&pool)
+    .await
+    .expect("must query information_schema.columns");
+    let names: Vec<&str> = columns.iter().map(|c| c.0.as_str()).collect();
+    for required in [
+        "id",
+        "tenant_id",
+        "session_id",
+        "runtime",
+        "status",
+        "workspace_path",
+        "created_at",
+        "updated_at",
+    ] {
+        assert!(
+            names.contains(&required),
+            "agent_sessions must have `{required}` column (got {names:?})"
+        );
+    }
 }
 
 /// Signup response must set `rb_session` cookie with Secure + `HttpOnly` flags.


### PR DESCRIPTION
## Summary

New tenants created after 2026-05-07 are missing the per-tenant `agent_sessions` table.  Three dev tenants reproduce this; 22 older tenants carry it from a manual one-shot backfill that never landed in the provisioning template.

This PR makes the per-tenant `agent_sessions` table part of the canonical tenant migration sequence so:

1. **New signups** — `POST /v1/auth/signup` runs the migration immediately against the freshly created tenant schema via the existing `migrate::migrate_tenant_schema` call in `services/control-api/src/routes/auth.rs:73`.
2. **Startup self-heal for existing tenants** — the rb-migrations init container script `compose/scripts/migrate-tenant.sh` already iterates every `tenant_[0-9a-f]{24}` schema and applies missing migrations.  Adding the file plugs into that loop without code changes.
3. **Idempotent for the 22 manually-backfilled tenants** — bash init script skips by version, so they are untouched.

## GitHub Issue
Closes #332.  Parent Paperclip task:  / .

## Migration type
**Additive**
- Tables touched (in tenant schemas only): `agent_sessions` (new)
- Operations: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS` (3×), `CREATE OR REPLACE FUNCTION`, `DROP TRIGGER IF EXISTS`, `CREATE TRIGGER`
- Does **not** alter the public/shared `agents.agent_sessions` table per the parent's acceptance note.

## Verification

Manually applied against the dev DB (`rustbrain-dev-postgres-1`):

| Step | Result |
|---|---|
| Pre-state | 25 tenant schemas, 22 with `agent_sessions`, 3 missing |
| Run `migrate-tenant.sh` with new migration mounted | v007 applied to the 3 missing tenants; skipped (by version) for the 22 backfilled ones |
| Post-state | 26 tenant schemas (incl. new integration-test signup), 26 with `agent_sessions` |
| Re-apply migration to a fresh schema | All `CREATE … IF NOT EXISTS` paths idempotent (NOTICEs only, no errors) |

Integration test `integration_signup_provisions_tenant_agent_sessions_table` (new) drives a full `POST /v1/auth/signup` against a real DB and asserts the table + core columns (`id`, `tenant_id`, `session_id`, `runtime`, `status`, `workspace_path`, `created_at`, `updated_at`) exist in the new tenant schema.

## Test plan

- [x] `cargo build -p control-api --tests`
- [x] `cargo test -p control-api --test integration_tests` (16/16 pass)
- [x] New test passes with real DB + `RB_MIGRATIONS_ROOT`
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean (matches CI invocation)
- [x] `migrate-tenant.sh` idempotent end-to-end against live dev DB (25 → 26 tenants with table)

## Notes

- The 22 backfilled tenants will have a checksum drift between their existing `schema_migrations` row (checksum `091d969b…` from the manual one-shot) and this file's SHA-256.  This is inert: bash init container skips by version; the Rust runner is only invoked against fresh schemas at signup.  Documented here in case a future tenant-side runner ever iterates existing schemas.

Co-Authored-By: Rust-brain-by-GOV Bot <bot@example.com>