### PR TITLE
[RUSAA-1097] feat(migrations): 015 drop orphan tenant_*.agent_sessions

### DIFF
--- a/migrations/control/015_drop_legacy_tenant_agent_sessions.sql
+++ b/migrations/control/015_drop_legacy_tenant_agent_sessions.sql
@@ -1,0 +1,48 @@
+-- DROP orphan tenant_*.agent_sessions tables (destructive).
+--
+-- Board approval: Gate-2 approval 704c9bb8-7816-43d0-82da-8e79548bc39c.
+-- Source of truth for agent sessions: agents.agent_sessions in the control
+-- schema (ADR-009 §4.1). Prior investigation confirmed the tenant-scoped
+-- copies of this table are dead state (0 rows across all schemas) with no
+-- code readers or writers — they were left behind by a reverted ad-hoc
+-- provisioning script and were never integrated into the tenant template.
+--
+-- For each tenant_* schema that still has an orphan agent_sessions table, drop:
+--   1. trigger     update_agent_sessions_updated_at_trigger
+--   2. table       agent_sessions
+--   3. function    update_agent_sessions_updated_at()
+--
+-- Idempotent: uses DROP ... IF EXISTS and conditional schema-table lookup,
+-- so re-running is a no-op. Scope adjusts dynamically to current tenant count.
+
+DO $$
+DECLARE
+    s_name TEXT;
+BEGIN
+    FOR s_name IN
+        SELECT n.nspname
+        FROM pg_namespace n
+        WHERE n.nspname LIKE 'tenant\_%' ESCAPE '\'
+        ORDER BY n.nspname
+    LOOP
+        IF EXISTS (
+            SELECT 1
+            FROM pg_class c
+            JOIN pg_namespace ns ON ns.oid = c.relnamespace
+            WHERE ns.nspname = s_name
+              AND c.relname  = 'agent_sessions'
+              AND c.relkind  = 'r'
+        ) THEN
+            EXECUTE format(
+                'DROP TRIGGER IF EXISTS update_agent_sessions_updated_at_trigger ON %I.agent_sessions',
+                s_name
+            );
+            EXECUTE format('DROP TABLE IF EXISTS %I.agent_sessions', s_name);
+            EXECUTE format(
+                'DROP FUNCTION IF EXISTS %I.update_agent_sessions_updated_at()',
+                s_name
+            );
+            RAISE NOTICE 'dropped orphan agent_sessions in schema %', s_name;
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

Destructive migration that drops dead-state `tenant_<id>.agent_sessions` tables created by a reverted ad-hoc provisioning script. Source of truth is `agents.agent_sessions` in the control schema (ADR-009 §4.1).

## Migration type

**Destructive — requires board approval (obtained).**

- Tables touched: `tenant_<id>.agent_sessions` (orphans only) — 27 of 30 tenant schemas at execution time.
- Operations:
  - `DROP TRIGGER IF EXISTS update_agent_sessions_updated_at_trigger`
  - `DROP TABLE IF EXISTS agent_sessions`
  - `DROP FUNCTION IF EXISTS update_agent_sessions_updated_at()`

Idempotent: re-running is a no-op. Scope adjusts dynamically to current tenant count.

**Untouched**: `agents.agent_sessions` (control schema, live).

## Board Approval

Gate-2 approval `704c9bb8-7816-43d0-82da-8e79548bc39c` (approved by board).

Prior investigation confirmed orphans are dead state (0 rows across all 22/25 schemas at investigation time, 27/30 at execution), with zero code readers/writers.

## GitHub Issue

Closes #334

## Verification (dev DB)

- 27 orphan tables dropped + 27 trigger functions removed.
- `agents.agent_sessions` row count and schema unchanged.
- Second migration run is a clean no-op (idempotent).
- `rb-migrations` init container picks up v015 and records it in `control.schema_migrations`.
- Code audit: no source path references `tenant_<id>.agent_sessions`; all sqlx queries hit `agents.agent_sessions`.

## Checklist

- [x] Migration runs cleanly on dev DB
- [x] `SELECT count(*) FROM information_schema.tables WHERE table_name='agent_sessions' AND table_schema LIKE 'tenant_%'` returns 0
- [x] Idempotent (second run no-op)
- [x] `rb-migrations` end-to-end run records v015
- [x] No application errors after migration (no code references dropped tables)
- [x] No `RUSAA-XX` references outside the title bracket prefix