### PR TITLE
[RUSAA-1105] infra(compose): wire RB_INTERNAL_SECRET into control-api

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -258,6 +258,7 @@ services:
       RB_QDRANT_URL: "http://qdrant:6333"
       RB_OLLAMA_URL: "http://ollama:11434"
       RB_MIGRATIONS_ROOT: /migrations
+      RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
     volumes:
       - ../migrations:/migrations:ro
     ports:


### PR DESCRIPTION
## Summary

`control-api` fails boot validation when `RB_INTERNAL_SECRET` is unset (added by PR #319 / agent-runner work). `compose/dev.yml` had the env var on `agent-runner` but not on `control-api`, so the first stack rebuild from main HEAD that included the new validation logic crash-looped with:

```
Error: control-api boot validation failed (1 error(s)):
  - RB_INTERNAL_SECRET is required and must be non-empty. Set a strong shared secret for agent-runner callbacks.
```

This adds the same `${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}` default to the `control-api` service block so both services share a secret in dev and the stack boots cleanly. Production / non-dev envs must still override via `dev.env`.

## GitHub Issue
Closes #338

## Context
Surfaced while rebuilding the dev stack to deploy PR #331 (MCP routes). After this one-line fix, the rebuilt control-api came up healthy and the MCP route is live:

```
$ curl -s http://localhost:18080/openapi.json | jq '.paths | keys | map(select(contains("mcp")))'
["/mcp"]
$ curl -s -X POST http://localhost:18080/mcp -H 'Content-Type: application/json' -d '{}'
{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"parse error"}}
```

## Migration type
N/A — no schema changes.

## Test plan
- [x] Rebuilt control-api image from main HEAD
- [x] Recreated container; `/health` returns 200
- [x] `/openapi.json` lists `/mcp`
- [x] `POST /mcp` serves JSON-RPC protocol errors (parse error / auth required), not 404
- [x] `POST /v1/agents/sessions` returns 422 on empty body
- [x] `GET /v1/agents/sessions` returns 401 (route exists, requires auth)