### PR TITLE
[RUSAA-1115] fix(compose): create rb.agent.events topic in kafka-init

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -114,7 +114,8 @@ services:
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.projector.events          --partitions 12 --replication-factor 1 --config retention.ms=2592000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.audit.events              --partitions 3  --replication-factor 1 --config retention.ms=7776000000 &&
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.tombstones.v1             --partitions 3  --replication-factor 1 --config retention.ms=604800000 &&
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.agent.commands             --partitions 6  --replication-factor 1 --config retention.ms=604800000
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.agent.commands             --partitions 6  --replication-factor 1 --config retention.ms=604800000 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic rb.agent.events               --partitions 6  --replication-factor 1 --config retention.ms=604800000
       "
 
   loki:


### PR DESCRIPTION
## Summary

- Adds `rb.agent.events` to the `kafka-init` topic creation block in `compose/dev.yml` so the agent-runner can publish session lifecycle / error events back to the control plane.
- Topic config (6 partitions, 604800000ms retention) mirrors `infra/kafka/topics.yaml:172-176` — the canonical spec asserted by `services/migrate/tests/kafka_integration.rs:89`.
- `compose/full.yml` inherits via `include: - dev.yml`, so no second edit needed.

## GitHub Issue

Closes #340

## Migration type

N/A — compose-only change. No DB migration.

## Why P0

Without this topic, `auto.create.topics.enable=false` causes every runner publish to fail with `UnknownTopicOrPartition`. Sessions stay `pending` forever, even on success. Wave 7 UAT is blocked on this.

## Verification

- `docker exec rustbrain-dev-kafka-1 kafka-topics.sh ... --list | grep agent` previously showed only `rb.agent.commands`; out-of-band patch on the live broker added `rb.agent.events` (6 partitions, 7-day retention) so UAT can resume immediately.
- After this change, a fresh `docker compose -f compose/dev.yml up kafka-init` recreates both topics on any clean stack.

## Checklist

- [x] Compose change matches canonical topic spec
- [x] No internal references in PR
- [x] No docs/architecture changes needed