### PR TITLE
[REQ-RUN-01] fix(agent-runner): pre-chown /data/agent-workspaces in Dockerfile

### DIFF
--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -57,6 +57,14 @@ RUN apt-get update -qq && \
     groupadd --gid 65532 nonroot && \
     useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
 
+# Pre-create the agent workspace mount point with nonroot ownership.
+# Docker named volumes inherit ownership/permissions from the image's directory
+# on first mount, so this ensures the runner (UID 65532) can write to
+# /data/agent-workspaces without an init container or compose-level chown.
+RUN mkdir -p /data/agent-workspaces && \
+    chown 65532:65532 /data/agent-workspaces && \
+    chmod 0700 /data/agent-workspaces
+
 USER nonroot
 
 COPY --from=builder /app/target/release/rb-agent-runner /usr/local/bin/rb-agent-runner


### PR DESCRIPTION
## Summary

Pre-create `/data/agent-workspaces` with ownership `65532:65532` and mode `0700` in `docker/agent-runner/Dockerfile` so that the Docker named volume `agent-workspace-data` inherits the right ownership when it is first populated. The runner container runs as UID 65532, so without this the volume comes up `root:root` mode `0755` and every `POST /v1/agents/sessions` stalls in `pending` (workspace creation `Permission denied`).

## Root cause

`docker/agent-runner/Dockerfile` switches to `USER nonroot` (UID 65532) without ever creating the `/data/agent-workspaces` path in the image. Docker named volumes inherit ownership from the underlying directory in the image only if that directory exists at the time the volume is first mounted; otherwise the volume is created `root:root`. The compose mount `agent-workspace-data:/data/agent-workspaces` (compose/dev.yml:526) therefore landed as root-owned, even though the runner runs as nonroot.

## Change

Add a `RUN` layer between the user creation and `USER nonroot` that creates `/data/agent-workspaces`, `chown`s it to `65532:65532`, and sets mode `0700` (ADR-009 §4 requirement for per-tenant workspace privacy).

## GitHub Issue

Closes #342

## Migration type

N/A — Dockerfile only.

## Verification

Reproduced and verified locally:

```
$ docker compose ... build agent-runner   # picks up new RUN
$ docker compose ... stop agent-runner && docker compose ... rm -f agent-runner
$ docker volume rm rustbrain-dev_agent-workspace-data
$ docker compose ... up -d --no-deps agent-runner

$ docker exec rustbrain-dev-agent-runner-1 ls -la /data/agent-workspaces
drwx------ 2 nonroot nonroot 4096 May 11 17:21 .

$ docker exec rustbrain-dev-agent-runner-1 id
uid=65532(nonroot) gid=65532(nonroot)

$ docker exec rustbrain-dev-agent-runner-1 sh -c 'mkdir -p /data/agent-workspaces/_test && echo OK && rmdir /data/agent-workspaces/_test'
OK
```

## Checklist

- [x] Reproduced the failure mode before the fix (`mkdir: Permission denied`)
- [x] Built `agent-runner` image and exercised on a clean volume
- [x] Verified ownership = `nonroot:nonroot` and mode `0700`
- [x] Verified runner user can create subdirectories
- [x] No internal references; only the Dockerfile changed
- [x] Discovered during Wave 7 UAT round 2; unblocks agent session execution