### PR TITLE
[RUSAA-1129] fix(compose): remove duplicate RB_INTERNAL_SECRET in control-api env

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -251,7 +251,6 @@ services:
       RB_GH_APP_ID: "${RB_GH_APP_ID:-}"
       RB_GH_APP_PRIVATE_KEY: "${RB_GH_APP_PRIVATE_KEY:-}"
       RB_GH_APP_WEBHOOK_SECRET: "${RB_GH_APP_WEBHOOK_SECRET:-dev-secret-do-not-use-in-prod}"
-      RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
       RB_INTERNAL_LISTEN_ADDR: "0.0.0.0:8081"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: control-api


### PR DESCRIPTION
## Summary

PR #325 and PR #339 both added `RB_INTERNAL_SECRET` to `compose/dev.yml`'s `control-api` environment block. The squash merges landed sequentially without rebase, leaving two identical YAML keys in the same map on `main`:

- Line 254 — added by #325, sits after `RB_GH_APP_WEBHOOK_SECRET` (with `RB_INTERNAL_LISTEN_ADDR`)
- Line 264 — added by #339, sits after `RB_MIGRATIONS_ROOT`

YAML parsers silently keep the last definition, so the stack still boots with the right value, but the duplicate is a correctness bug — a future edit could change one and not the other and the wrong value would win with no warning.

## Fix

Remove the line-254 copy. Keep the line-264 copy (next to the other boot-validated secrets/config that PR #339 added). Net diff: -1 line in `compose/dev.yml`.

## GitHub Issue

Closes #346

## Migration type

No migration in this PR.

## Verification

- `docker compose -f compose/dev.yml config` parses cleanly.
- Rendered config has exactly two `RB_INTERNAL_SECRET` entries — one per service (`control-api`, `agent-runner`).

## Checklist

- [x] Working tree of `compose/dev.yml` shows only one `RB_INTERNAL_SECRET` per service block
- [x] `docker compose -f compose/dev.yml config` succeeds
- [x] No internal references in PR body
- [x] No code changes outside `compose/dev.yml`
