### PR TITLE
[RUSAA-1153] fix(control-api): prevent AtomicUsize underflow in TenantSessionCount::decrement

### DIFF
--- a/services/control-api/src/routes/agents/sessions.rs
+++ b/services/control-api/src/routes/agents/sessions.rs
@@ -470,10 +470,14 @@ pub async fn patch_session_status(
         return Err(AppError::Unauthorized);
     }
 
-    sqlx::query(
+    // Guard against double-terminal transitions: if the session is already in a
+    // terminal state, the UPDATE will match 0 rows, preventing a spurious
+    // `decrement()` that would underflow `TenantSessionCount`.
+    let result = sqlx::query(
         "UPDATE agents.agent_sessions
          SET status = $1, pid = $2, exit_code = $3
-         WHERE id = $4 AND tenant_id = $5",
+         WHERE id = $4 AND tenant_id = $5
+           AND status NOT IN ('terminated', 'cancelled')",
     )
     .bind(&req.status)
     .bind(req.pid)
@@ -484,8 +488,10 @@ pub async fn patch_session_status(
     .await
     .map_err(|e| AppError::Internal(anyhow::anyhow!("DB update failed: {e}")))?;
 
-    // Release the session slot in the registry when the process terminates.
-    if TERMINAL_STATUSES.contains(&req.status.as_str()) {
+    // Release the session slot in the registry only when the UPDATE actually
+    // applied (rows_affected > 0).  A zero result means the session was already
+    // terminal, so no slot was held.
+    if TERMINAL_STATUSES.contains(&req.status.as_str()) && result.rows_affected() > 0 {
         let _ = state.agent_registry.remove(&session_id);
         state.tenant_session_count.decrement(&req.tenant_id);
     }

--- a/services/control-api/src/routes/agents/sessions.rs
+++ b/services/control-api/src/routes/agents/sessions.rs
@@ -470,9 +470,6 @@ pub async fn patch_session_status(
         return Err(AppError::Unauthorized);
     }
 
-    // Guard against double-terminal transitions: if the session is already in a
-    // terminal state, the UPDATE will match 0 rows, preventing a spurious
-    // `decrement()` that would underflow `TenantSessionCount`.
     let result = sqlx::query(
         "UPDATE agents.agent_sessions
          SET status = $1, pid = $2, exit_code = $3
@@ -488,9 +485,6 @@ pub async fn patch_session_status(
     .await
     .map_err(|e| AppError::Internal(anyhow::anyhow!("DB update failed: {e}")))?;
 
-    // Release the session slot in the registry only when the UPDATE actually
-    // applied (rows_affected > 0).  A zero result means the session was already
-    // terminal, so no slot was held.
     if TERMINAL_STATUSES.contains(&req.status.as_str()) && result.rows_affected() > 0 {
         let _ = state.agent_registry.remove(&session_id);
         state.tenant_session_count.decrement(&req.tenant_id);

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -175,15 +175,35 @@ impl TenantSessionCount {
         }
     }
 
-    /// Decrement the session count for a tenant.
+    /// Decrement the session count for a tenant, flooring at 0.
+    ///
+    /// Uses a CAS loop instead of `fetch_sub` so that a spurious extra decrement
+    /// (e.g. double-terminal callback from agent-runner) never wraps to `usize::MAX`.
     pub fn decrement(&self, tenant_id: &Uuid) {
         if let Some(count) = self.counts.get(tenant_id) {
-            let prev = count.fetch_sub(1, Ordering::Relaxed);
-            // Clean up zero-count entries to avoid unbounded map growth.
-            if prev <= 1 {
-                drop(count);
-                self.counts
-                    .remove_if(tenant_id, |_, v| v.load(Ordering::Relaxed) == 0);
+            loop {
+                let current = count.load(Ordering::Relaxed);
+                if current == 0 {
+                    return;
+                }
+                if count
+                    .compare_exchange_weak(
+                        current,
+                        current - 1,
+                        Ordering::SeqCst,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    let should_cleanup = current == 1;
+                    drop(count);
+                    if should_cleanup {
+                        // Clean up zero-count entries to avoid unbounded map growth.
+                        self.counts
+                            .remove_if(tenant_id, |_, v| v.load(Ordering::Relaxed) == 0);
+                    }
+                    return;
+                }
             }
         }
     }
@@ -463,6 +483,18 @@ mod tests {
         counter.decrement(&tenant);
         assert_eq!(counter.count(&tenant), 0);
         assert!(counter.counts.is_empty() || counter.counts.get(&tenant).is_none());
+    }
+
+    #[test]
+    fn tenant_session_count_decrement_floors_at_zero() {
+        let counter = TenantSessionCount::new();
+        let tenant = Uuid::new_v4();
+        assert!(counter.try_increment(&tenant, 5));
+        counter.decrement(&tenant);
+        assert_eq!(counter.count(&tenant), 0);
+        // Second decrement must not underflow to usize::MAX.
+        counter.decrement(&tenant);
+        assert_eq!(counter.count(&tenant), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace `fetch_sub` in `TenantSessionCount::decrement()` with a CAS loop that floors at 0, preventing wrap-around to `usize::MAX` on spurious extra decrements.
- Add `AND status NOT IN ('terminated', 'cancelled')` guard to the UPDATE in `patch_session_status()`; only release the session slot when `rows_affected > 0` to cut off the double-terminal path at the source.
- Add `tenant_session_count_decrement_floors_at_zero` unit test.

## GitHub Issue
Closes #355

## Checklist
- [x] `cargo test -p control-api` passes
- [x] `cargo clippy -p control-api --lib -- -D warnings` passes (pre-existing deprecated test warnings are unrelated)
- [x] `cargo fmt -p control-api` applied
- [x] No `RUSAA-XX` outside the title bracket prefix