### PR TITLE
[RUSAA-1142] perf(docker): cargo-chef + per-service cache scope + :sha tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,11 @@ jobs:
           context: .
           file: docker/control-api/Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: ghcr.io/${{ github.repository }}/control-api:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}/control-api:dev
+            ghcr.io/${{ github.repository }}/control-api:sha-${{ github.sha }}
+          cache-from: type=gha,scope=control-api
+          cache-to: type=gha,scope=control-api,mode=max
 
   frontend-e2e:
     name: frontend e2e

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -1,64 +1,33 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml      crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
-COPY crates/rb-secrets/Cargo.toml      crates/rb-secrets/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml         crates/rb-blob/Cargo.toml
-COPY crates/rb-storage-neo4j/Cargo.toml crates/rb-storage-neo4j/Cargo.toml
-COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
-COPY crates/rb-storage-pg/Cargo.toml  crates/rb-storage-pg/Cargo.toml
-COPY crates/rb-audit-cli/Cargo.toml   crates/rb-audit-cli/Cargo.toml
-COPY services/migrate/Cargo.toml       services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml   services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml  services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml    services/ingest-clone/Cargo.toml
-COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
-COPY services/expand-worker/Cargo.toml   services/expand-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml    services/agent-runner/Cargo.toml
-COPY crates/rb-parse-syn/Cargo.toml           crates/rb-parse-syn/Cargo.toml
-COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/control-api/src && \
-    printf 'fn main() {}' > services/control-api/src/main.rs && \
-    cargo build --release -p control-api 2>/dev/null || true && \
-    # Remove stub artifacts so real source replaces them.
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Copy real source and build.
-COPY crates/              crates/
-COPY services/control-api/  services/control-api/
-COPY services/migrate/      services/migrate/
-COPY services/audit-worker/ services/audit-worker/
-COPY services/parse-worker/ services/parse-worker/
-COPY proto/                 proto/
-COPY migrations/            migrations/
-
-# Install rdkafka build deps (needed because migrate crate uses rdkafka).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p control-api
+
+COPY . .
 RUN cargo build --release -p control-api
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 # debian:bookworm-slim matches the builder's glibc 2.36 and supplies libz + sasl2
 # required by rdkafka at runtime (distroless/cc-debian12 lacks libz.so.1).
 FROM debian:bookworm-slim AS runtime
@@ -72,9 +41,9 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/control-api     /usr/local/bin/control-api
+COPY --from=builder /app/target/release/control-api      /usr/local/bin/control-api
 COPY --from=builder /app/target/release/rb-test-producer /usr/local/bin/rb-test-producer
-COPY --from=builder /app/migrations                      /app/migrations
+COPY --from=builder /app/migrations                       /app/migrations
 
 ENV RB_MIGRATIONS_ROOT=/app/migrations
 


### PR DESCRIPTION
## Summary

Replaces the hand-rolled stub-pin pattern in `docker/control-api/Dockerfile` with a three-stage `cargo-chef` pipeline so dependency builds are cached independently of source changes; reorders apt-get install in the builder stage; scopes the GHA cache to `control-api`; and tags every build with `:sha-${{ github.sha }}` alongside `:dev`.

Control-api only — Phase C generalizes to the other 11 Dockerfiles.

## GitHub Issue

Closes #357

## Changes

### `docker/control-api/Dockerfile`

- Replaces the 25× `COPY crates/.../Cargo.toml` block and the `find | xargs touch` stub hack with `cargo-chef`'s recipe-driven flow:
  - `chef` base from `lukemathwalker/cargo-chef:latest-rust-1-bookworm`
  - `planner` stage runs `cargo chef prepare` to produce `recipe.json` from the full source
  - `builder` stage installs apt deps **first**, then `cargo chef cook --release --recipe-path recipe.json -p control-api`, then `COPY . .` + `cargo build --release -p control-api`
- Runtime stage unchanged in spirit: `debian:bookworm-slim` + ca-certificates, libssl3, libsasl2-2, zlib1g, libcurl4; nonroot user; same `ENTRYPOINT`/`CMD`/`EXPOSE`.
- `rb-test-producer` is still produced (it's a bin target in the `control-api` package, so `cargo build -p control-api` builds it alongside the main binary).

### `.github/workflows/ci.yml` `docker-build` job

- `cache-to: type=gha,scope=control-api,mode=max`
- `cache-from: type=gha,scope=control-api`
- `tags:` adds `ghcr.io/${{ github.repository }}/control-api:sha-${{ github.sha }}` alongside `:dev`
- Push-on-main behavior unchanged.

## Migration type

Not applicable — Docker / CI changes only, no schema migration.

## Test plan

- [x] `docker-build` CI job green on this PR head (run 25696039329 — 403s cold build)
- [x] All other required CI checks green (clippy, security lint, cargo test, runtime-smoke, etc.)
- [ ] First post-merge push to `main` records cold-run timings + image size as a follow-up data point

## Out of scope

- Multi-image Dockerfile matrix (Phase C of the parent epic)
- Digest pinning of `lukemathwalker/cargo-chef` / `debian:bookworm-slim` (Tier 3)
- sccache / self-hosted runners (Tier 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
