### PR TITLE
[RUSAA-1154] fix: add Retry-After header to 429 rate-limit responses

### DIFF
--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    http::StatusCode,
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 use rb_kafka::KafkaError;
@@ -230,11 +230,18 @@ impl IntoResponse for AppError {
                 "session_cap_exceeded",
                 self.to_string(),
             ),
-            AppError::SessionRateLimitExceeded { retry_after_secs } => (
-                StatusCode::TOO_MANY_REQUESTS,
-                "rate_limit_exceeded",
-                format!("session creation rate limit exceeded; retry after {retry_after_secs}s"),
-            ),
+            AppError::SessionRateLimitExceeded { retry_after_secs } => {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(header::RETRY_AFTER, retry_after_secs.to_string())],
+                    Json(json!({
+                        "error": "rate_limit_exceeded",
+                        "message": format!("session creation rate limit exceeded; retry after {retry_after_secs}s"),
+                        "retry_after_secs": retry_after_secs
+                    })),
+                )
+                    .into_response();
+            }
             AppError::TenantSessionCapExceeded => (
                 StatusCode::TOO_MANY_REQUESTS,
                 "rate_limit_exceeded",

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -142,6 +142,14 @@ impl Default for SessionCreateRateLimiter {
 // ---------------------------------------------------------------------------
 
 /// Tracks active session counts per tenant for the per-tenant session cap.
+///
+/// **Known limitation (single-instance in-memory design):** The counter starts
+/// at zero on each process restart. Active sessions that were created before
+/// the restart and are still running do not pre-populate the counter, so the
+/// effective cap is temporarily higher than configured until those legacy
+/// sessions terminate naturally. This is acceptable for the current
+/// single-instance deployment; a multi-instance deployment would require
+/// querying the DB at startup or using a shared store (e.g. Redis).
 #[derive(Default)]
 pub struct TenantSessionCount {
     counts: DashMap<Uuid, AtomicUsize>,


### PR DESCRIPTION
## Summary

- `SessionRateLimitExceeded` now returns a `Retry-After` HTTP header (RFC 6585) alongside the existing `retry_after_secs` JSON field, so automated clients can respect backoff without parsing the body.
- Documents the known post-restart session counter skew limitation on `TenantSessionCount` (in-memory counter starts at zero; acceptable for single-instance deployment).

## GitHub Issues

Closes #353
Closes #354

## Checklist

- [x] `cargo check -p control-api` passes
- [x] `cargo clippy -p control-api -- -D warnings` passes
- [x] No `RUSAA-XX` outside the title bracket prefix