### PR TITLE
verify: cargo-chef cache behavior — same-branch rebuild measurement

### DIFF
--- a/services/control-api/src/main.rs
+++ b/services/control-api/src/main.rs
@@ -1,3 +1,4 @@
+// docker cargo-chef cache hit verification — run 1
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use control_api::Config;

--- a/services/control-api/src/main.rs
+++ b/services/control-api/src/main.rs
@@ -1,4 +1,4 @@
-// docker cargo-chef cache hit verification — run 1
+// docker cargo-chef cache hit verification — run 2
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use control_api::Config;


### PR DESCRIPTION
## Summary

Throwaway draft PR to measure docker-build cache behavior on the same branch with the cargo-chef pipeline (Phase B, [Paperclip task in comments]). Two pushes will land here:

- Run 1 (this commit): cold against scope=control-api cache; establishes recipe.json + cooks dep layer + builds source.
- Run 2 (follow-up commit): one-line source-only change; expectation is `apt-get install` and `cargo chef cook` show as `CACHED` and only `cargo build --release` reruns.

Timings will be posted on the linked Paperclip task. This PR will be closed without merge.

## Migration type

Not applicable — no schema migration.

## Test plan

- [ ] First docker-build run completes; capture step-by-step durations.
- [ ] Push run-2 commit with single-line source touch.
- [ ] Second docker-build run shows `[builder 1/5]` apt + `[builder 3/5]` chef cook as `CACHED`.
- [ ] Close PR without merging.