### PR TITLE
[RUSAA-1142] perf(docker): build all 12 images via matrix + per-service path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,99 @@ jobs:
     name: detect changed paths
     runs-on: ubuntu-latest
     outputs:
-      docker: ${{ steps.filter.outputs.docker }}
+      # JSON array of image names whose filter matched changed files. The
+      # docker-build matrix expands this with fromJson(); an empty array
+      # skips the matrix job entirely.
+      images: ${{ steps.compute.outputs.images }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # YAML anchor `workspace` is the conservative bucket: anything that
+          # could change the dep graph for every Rust image. Each per-image
+          # filter starts with *workspace, then adds its own service + docker
+          # paths. A pure source-only change under `services/<x>/**` matches
+          # only that image, not the others.
           filters: |
-            docker:
-              - 'docker/**'
-              - 'Dockerfile*'
+            workspace: &workspace
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - 'services/**'
+              - 'rust-toolchain.toml'
               - 'crates/**'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+            agent-runner:
+              - *workspace
+              - 'services/agent-runner/**'
+              - 'docker/agent-runner/**'
+            control-api:
+              - *workspace
+              - 'services/control-api/**'
+              - 'services/migrate/**'
+              - 'docker/control-api/**'
+              - 'migrations/**'
+            embed-worker:
+              - *workspace
+              - 'services/embed-worker/**'
+              - 'docker/embed-worker/**'
+            expand-worker:
+              - *workspace
+              - 'services/expand-worker/**'
+              - 'docker/expand-worker/**'
+            frontend:
+              - 'frontend/**'
+              - 'docker/frontend/**'
+              - '.github/workflows/ci.yml'
+            ingest-clone:
+              - *workspace
+              - 'services/ingest-clone/**'
+              - 'docker/ingest-clone/**'
+            ingest-graph:
+              - *workspace
+              - 'services/ingest-graph/**'
+              - 'docker/ingest-graph/**'
+            parse-worker:
+              - *workspace
+              - 'services/parse-worker/**'
+              - 'docker/parse-worker/**'
+            projector-neo4j:
+              - *workspace
+              - 'services/projector-neo4j/**'
+              - 'docker/projector-neo4j/**'
+            projector-pg:
+              - *workspace
+              - 'services/projector-pg/**'
+              - 'docker/projector-pg/**'
+            tombstoner:
+              - *workspace
+              - 'services/tombstoner/**'
+              - 'docker/tombstoner/**'
+            typecheck-worker:
+              - *workspace
+              - 'services/typecheck-worker/**'
+              - 'docker/typecheck-worker/**'
+      - id: compute
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          CHANGED: ${{ steps.filter.outputs.changes }}
+        run: |
+          set -euo pipefail
+          ALL='["agent-runner","control-api","embed-worker","expand-worker","frontend","ingest-clone","ingest-graph","parse-worker","projector-neo4j","projector-pg","tombstoner","typecheck-worker"]'
+          # On push-to-main, always build every image so :sha-<sha> tags exist
+          # for every service. The path filter is only an optimisation for PRs.
+          if [ "$EVENT" = "push" ] && [ "$REF" = "refs/heads/main" ]; then
+            echo "images=$ALL" >> "$GITHUB_OUTPUT"
+            echo "Selected images: ALL (push to main)"
+          else
+            # Strip the `workspace` meta-filter — it has no docker/workspace/
+            # image, only exists as the shared anchor included by every Rust
+            # image's filter. jq drops it cleanly.
+            SELECTED="$(printf '%s' "${CHANGED:-[]}" | jq -c '. - ["workspace"]')"
+            echo "images=$SELECTED" >> "$GITHUB_OUTPUT"
+            echo "Selected images: $SELECTED"
+          fi
 
   # ── Real Rust jobs ─────────────────────────────────────────────────────────
 
@@ -210,13 +289,20 @@ jobs:
   # ── Stub jobs (wired in later waves) ──────────────────────────────────────
 
   docker-build:
-    name: docker build + push
+    name: docker build + push (${{ matrix.image }})
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.docker == 'true' || github.event_name == 'push'
+    # Skip the matrix entirely when no image filter matched. fromJson('[]')
+    # produces an empty matrix and GHA would still spawn a no-op job, so we
+    # guard with an explicit if.
+    if: needs.changes.outputs.images != '[]' && needs.changes.outputs.images != ''
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.changes.outputs.images) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -228,17 +314,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push control-api image
+      - name: Build and push ${{ matrix.image }} image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/control-api/Dockerfile
+          file: docker/${{ matrix.image }}/Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Tag every image on main with both :dev (rolling) and :sha-<sha>
+          # (deterministic). PRs only build locally — no push, no tag drift.
           tags: |
-            ghcr.io/${{ github.repository }}/control-api:dev
-            ghcr.io/${{ github.repository }}/control-api:sha-${{ github.sha }}
-          cache-from: type=gha,scope=control-api
-          cache-to: type=gha,scope=control-api,mode=max
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:dev
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:sha-${{ github.sha }}
+          # Per-image GHA cache scope so concurrent matrix entries do not
+          # stomp each other's dependency layers.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
 
   frontend-e2e:
     name: frontend e2e

--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -1,55 +1,37 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml      crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
-COPY services/migrate/Cargo.toml       services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml   services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml  services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml    services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml   services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml    services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml    services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml    services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml      services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml    services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml    services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/agent-runner/src && \
-    printf 'fn main() {}' > services/agent-runner/src/main.rs && \
-    cargo build --release -p agent-runner 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                 crates/
-COPY services/agent-runner/  services/agent-runner/
-COPY proto/                  proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p agent-runner
 
+COPY . .
 RUN cargo build --release -p agent-runner
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
-# Install git and ssh for cloning during agent execution
+# Install git and ssh for cloning during agent execution.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 git openssh-client && \

--- a/docker/embed-worker/Dockerfile
+++ b/docker/embed-worker/Dockerfile
@@ -1,53 +1,34 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/embed-worker/src && \
-    printf 'fn main() {}' > services/embed-worker/src/main.rs && \
-    cargo build --release -p embed-worker 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                   crates/
-COPY services/embed-worker/    services/embed-worker/
-COPY proto/                    proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p embed-worker
 
+COPY . .
 RUN cargo build --release -p embed-worker
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/expand-worker/Dockerfile
+++ b/docker/expand-worker/Dockerfile
@@ -1,54 +1,34 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml                 crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml                 crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml                   crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                    crates/rb-blob/Cargo.toml
-COPY crates/rb-feature-resolver/Cargo.toml        crates/rb-feature-resolver/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/expand-worker/src && \
-    printf 'fn main() {}' > services/expand-worker/src/main.rs && \
-    cargo build --release -p expand-worker 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                    crates/
-COPY services/expand-worker/    services/expand-worker/
-COPY proto/                     proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p expand-worker
 
+COPY . .
 RUN cargo build --release -p expand-worker
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -1,57 +1,37 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────��───────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
-COPY crates/rb-github/Cargo.toml              crates/rb-github/Cargo.toml
-COPY crates/rb-secrets/Cargo.toml             crates/rb-secrets/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/ingest-clone/src && \
-    printf 'fn main() {}' > services/ingest-clone/src/main.rs && \
-    cargo build --release -p ingest-clone 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                    crates/
-COPY services/ingest-clone/     services/ingest-clone/
-COPY proto/                     proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p ingest-clone
 
+COPY . .
 RUN cargo build --release -p ingest-clone
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
+# git is required because ingest-clone shells out to git for repo cloning.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 git && \

--- a/docker/ingest-graph/Dockerfile
+++ b/docker/ingest-graph/Dockerfile
@@ -1,53 +1,34 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/ingest-graph/src && \
-    printf 'fn main() {}' > services/ingest-graph/src/main.rs && \
-    cargo build --release -p ingest-graph 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                    crates/
-COPY services/ingest-graph/     services/ingest-graph/
-COPY proto/                     proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p ingest-graph
 
+COPY . .
 RUN cargo build --release -p ingest-graph
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/parse-worker/Dockerfile
+++ b/docker/parse-worker/Dockerfile
@@ -1,55 +1,35 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
-COPY crates/rb-parse-syn/Cargo.toml           crates/rb-parse-syn/Cargo.toml
-COPY crates/rb-parse-tree-sitter/Cargo.toml   crates/rb-parse-tree-sitter/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/parse-worker/src && \
-    printf 'fn main() {}' > services/parse-worker/src/main.rs && \
-    cargo build --release -p parse-worker 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+# parse-worker pulls in tree-sitter-rust grammar which needs cmake + C/C++.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka, tree-sitter-rust grammar require cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                  crates/
-COPY services/parse-worker/   services/parse-worker/
-COPY proto/                   proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p parse-worker
 
+COPY . .
 RUN cargo build --release -p parse-worker
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/projector-neo4j/Dockerfile
+++ b/docker/projector-neo4j/Dockerfile
@@ -1,53 +1,34 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-storage-neo4j/Cargo.toml       crates/rb-storage-neo4j/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/projector-neo4j/src && \
-    printf 'fn main() {}' > services/projector-neo4j/src/main.rs && \
-    cargo build --release -p projector-neo4j 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                      crates/
-COPY services/projector-neo4j/    services/projector-neo4j/
-COPY proto/                       proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p projector-neo4j
 
+COPY . .
 RUN cargo build --release -p projector-neo4j
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -1,54 +1,33 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml      crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml      crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml        crates/rb-kafka/Cargo.toml
-COPY crates/rb-tenant/Cargo.toml       crates/rb-tenant/Cargo.toml
-COPY crates/rb-storage-pg/Cargo.toml   crates/rb-storage-pg/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/projector-pg/src && \
-    printf 'fn main() {}' > services/projector-pg/src/main.rs && \
-    cargo build --release -p projector-pg 2>/dev/null || true && \
-    # Remove stub artifacts so real source replaces them.
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Copy real source and build.
-COPY crates/                 crates/
-COPY services/projector-pg/  services/projector-pg/
-COPY proto/                  proto/
-
-# Install rdkafka build deps.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p projector-pg
+
+COPY . .
 RUN cargo build --release -p projector-pg
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -1,54 +1,33 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml        crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml        crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml          crates/rb-kafka/Cargo.toml
-COPY crates/rb-tenant/Cargo.toml         crates/rb-tenant/Cargo.toml
-COPY crates/rb-storage-pg/Cargo.toml     crates/rb-storage-pg/Cargo.toml
-COPY crates/rb-storage-neo4j/Cargo.toml  crates/rb-storage-neo4j/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/tombstoner/src && \
-    printf 'fn main() {}' > services/tombstoner/src/main.rs && \
-    cargo build --release -p tombstoner 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Copy real source and build.
-COPY crates/                  crates/
-COPY services/tombstoner/     services/tombstoner/
-COPY proto/                   proto/
-
-# Install rdkafka build deps.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p tombstoner
+
+COPY . .
 RUN cargo build --release -p tombstoner
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \

--- a/docker/typecheck-worker/Dockerfile
+++ b/docker/typecheck-worker/Dockerfile
@@ -1,53 +1,34 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS builder
-
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
 WORKDIR /app
 
-# Cache dependency downloads before copying source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/rb-tracing/Cargo.toml             crates/rb-tracing/Cargo.toml
-COPY crates/rb-schemas/Cargo.toml             crates/rb-schemas/Cargo.toml
-COPY crates/rb-kafka/Cargo.toml               crates/rb-kafka/Cargo.toml
-COPY crates/rb-blob/Cargo.toml                crates/rb-blob/Cargo.toml
-COPY services/migrate/Cargo.toml              services/migrate/Cargo.toml
-COPY services/control-api/Cargo.toml          services/control-api/Cargo.toml
-COPY services/audit-worker/Cargo.toml         services/audit-worker/Cargo.toml
-COPY services/ingest-clone/Cargo.toml         services/ingest-clone/Cargo.toml
-COPY services/expand-worker/Cargo.toml        services/expand-worker/Cargo.toml
-COPY services/parse-worker/Cargo.toml         services/parse-worker/Cargo.toml
-COPY services/typecheck-worker/Cargo.toml     services/typecheck-worker/Cargo.toml
-COPY services/ingest-graph/Cargo.toml         services/ingest-graph/Cargo.toml
-COPY services/projector-pg/Cargo.toml         services/projector-pg/Cargo.toml
-COPY services/projector-neo4j/Cargo.toml      services/projector-neo4j/Cargo.toml
-COPY services/tombstoner/Cargo.toml           services/tombstoner/Cargo.toml
-COPY services/embed-worker/Cargo.toml         services/embed-worker/Cargo.toml
-COPY services/agent-runner/Cargo.toml         services/agent-runner/Cargo.toml
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+# Builds a recipe.json that captures the dependency graph from the full source
+# tree. Only changes when Cargo.toml / Cargo.lock files change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Stub sources so `cargo build` caches deps without the full source tree.
-RUN find crates services -name "Cargo.toml" | sed 's|Cargo.toml|src/lib.rs|' | \
-    xargs -I{} sh -c 'mkdir -p "$(dirname {})" && touch "{}"' && \
-    mkdir -p services/typecheck-worker/src && \
-    printf 'fn main() {}' > services/typecheck-worker/src/main.rs && \
-    cargo build --release -p typecheck-worker 2>/dev/null || true && \
-    rm -rf crates/*/src services/*/src
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Install apt build deps FIRST so they are cached independently of recipe.json.
+# Then cook deps (cached unless the recipe changes), then copy source + build.
+FROM chef AS builder
 
-# Install build dependencies (rdkafka requires cmake + C toolchain).
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config \
         gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy real source and build.
-COPY crates/                     crates/
-COPY services/typecheck-worker/  services/typecheck-worker/
-COPY proto/                      proto/
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p typecheck-worker
 
+COPY . .
 RUN cargo build --release -p typecheck-worker
 
-# ── Stage 2: minimal runtime image ────────────────────────────────────────────
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update -qq && \


### PR DESCRIPTION
## Summary

Phase C of [](https://github.com/f-crop/rustacean/issues/337) — extends the Phase B cargo-chef template (#358) to the remaining 11 Dockerfiles and converts `docker-build` from a single `control-api` build into a matrix that builds **all 12 images** with per-image GHA cache scopes and per-service path filters.

## Dockerfiles (11)

Applied the Phase B chef → planner → builder pattern to:
- `agent-runner`, `embed-worker`, `expand-worker`, `ingest-clone`, `ingest-graph`, `parse-worker`, `projector-neo4j`, `projector-pg`, `tombstoner`, `typecheck-worker`

Per Dockerfile:
- Replaced the 17-line `COPY crates/.../Cargo.toml` + stub-pin block with `lukemathwalker/cargo-chef:latest-rust-1-bookworm` recipe stages.
- Builder-stage apt deps install **before** recipe copy, so apt is cached independently of `Cargo.lock` churn.
- Preserved each Dockerfile's prior runtime extras (`git` in `ingest-clone`; `git` + `openssh-client` + `/data/agent-workspaces` chown in `agent-runner`).
- Preserved each Dockerfile's prior apt build deps (`gcc/g++` retained where the legacy Dockerfile had them).
- `frontend` (Node) stays on its existing `npm ci`/nginx pattern; it is part of the matrix but not converted to cargo-chef.

## CI (`.github/workflows/ci.yml`)

- `changes` job emits a **JSON array of image names** whose `dorny/paths-filter` matched. A shared YAML anchor `workspace` (Cargo files, `crates/**`, `proto/**`, `rust-toolchain.toml`, the CI workflow itself) is included by every Rust-image filter; pure source-only changes under `services/<x>/**` therefore rebuild **only** image `<x>`.
- `docker-build` is now a **matrix** job (`fail-fast: false`, one entry per image) gated by `needs.changes.outputs.images`. An empty array skips the matrix entirely.
- Per-image GHA cache scope: `cache-from`/`cache-to: type=gha,scope=\${{ matrix.image }},mode=max` — concurrent matrix entries never stomp each other's dependency layers.
- Every image on `main` is tagged with both `:dev` (rolling) and `:sha-\${{ github.sha }}` (deterministic). PRs build locally without pushing.
- Pushes to `main` always build all 12 images so `:sha-<sha>` tags exist for every service.

## Done gate (Gate 3 path)

- Draft PR opened with `docker-build` matrix wired up for all 12 images on a cold cache run.
- Path-filter behaviour will be verified by the PR itself: this PR touches `crates/**`-equivalent paths (only `docker/**` and CI workflow), so all 12 images should rebuild — exactly the conservative case.
- Follow-up no-op commit under a single `services/<x>/**` will validate that ONLY that image rebuilds.

## GitHub Issue

Closes #362

## Out of scope

- Digest pinning (Tier 3, deferred)
- sccache, self-hosted runners (Tier 4, deferred)

## Migration type
Additive — no schema changes; this is CI + Dockerfile only.

## Checklist
- [x] Crate name verified per service (`-p <crate>` matches `services/<x>/Cargo.toml` package name).
- [x] Runtime extras preserved per service (git, openssh, /data/agent-workspaces chown).
- [x] Apt deps preserved per service.
- [x] Dockerfile syntax linted via `docker build` legacy frontend parse.
- [x] YAML structure verified via `python3 -c "import yaml; yaml.safe_load(...)"` plus dorny anchor expansion check.
- [ ] CI matrix green for all 12 images (validated by this PR's run).