### PR TITLE
[RUSAA-1177] perf(docker): add BuildKit cache mounts to speed up Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+target/
+.git/
+secrets/
+frontend/node_modules/
+frontend/axe-results/
+frontend/playwright-report/
+frontend/test-results/
+test-results/
+compose/*.env
+*.md

--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p agent-runner
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p agent-runner
 
 COPY . .
-RUN cargo build --release -p agent-runner
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p agent-runner && \
+    cp target/release/rb-agent-runner /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -49,6 +56,6 @@ RUN mkdir -p /data/agent-workspaces && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/rb-agent-runner /usr/local/bin/rb-agent-runner
+COPY --from=builder /usr/local/bin/rb-agent-runner /usr/local/bin/rb-agent-runner
 
 ENTRYPOINT ["/usr/local/bin/rb-agent-runner"]

--- a/docker/control-api/Dockerfile
+++ b/docker/control-api/Dockerfile
@@ -22,10 +22,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p control-api
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p control-api
 
 COPY . .
-RUN cargo build --release -p control-api
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p control-api && \
+    cp target/release/control-api target/release/rb-test-producer /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 # debian:bookworm-slim matches the builder's glibc 2.36 and supplies libz + sasl2
@@ -41,8 +48,8 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/control-api      /usr/local/bin/control-api
-COPY --from=builder /app/target/release/rb-test-producer /usr/local/bin/rb-test-producer
+COPY --from=builder /usr/local/bin/control-api      /usr/local/bin/control-api
+COPY --from=builder /usr/local/bin/rb-test-producer /usr/local/bin/rb-test-producer
 COPY --from=builder /app/migrations                       /app/migrations
 
 ENV RB_MIGRATIONS_ROOT=/app/migrations

--- a/docker/embed-worker/Dockerfile
+++ b/docker/embed-worker/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p embed-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p embed-worker
 
 COPY . .
-RUN cargo build --release -p embed-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p embed-worker && \
+    cp target/release/embed-worker /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -40,6 +47,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/embed-worker /usr/local/bin/embed-worker
+COPY --from=builder /usr/local/bin/embed-worker /usr/local/bin/embed-worker
 
 ENTRYPOINT ["/usr/local/bin/embed-worker"]

--- a/docker/expand-worker/Dockerfile
+++ b/docker/expand-worker/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p expand-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p expand-worker
 
 COPY . .
-RUN cargo build --release -p expand-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p expand-worker && \
+    cp target/release/expand-worker /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -40,6 +47,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/expand-worker /usr/local/bin/expand-worker
+COPY --from=builder /usr/local/bin/expand-worker /usr/local/bin/expand-worker
 
 ENTRYPOINT ["/usr/local/bin/expand-worker"]

--- a/docker/ingest-clone/Dockerfile
+++ b/docker/ingest-clone/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p ingest-clone
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p ingest-clone
 
 COPY . .
-RUN cargo build --release -p ingest-clone
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p ingest-clone && \
+    cp target/release/ingest-clone /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -41,6 +48,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/ingest-clone /usr/local/bin/ingest-clone
+COPY --from=builder /usr/local/bin/ingest-clone /usr/local/bin/ingest-clone
 
 ENTRYPOINT ["/usr/local/bin/ingest-clone"]

--- a/docker/ingest-graph/Dockerfile
+++ b/docker/ingest-graph/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p ingest-graph
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p ingest-graph
 
 COPY . .
-RUN cargo build --release -p ingest-graph
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p ingest-graph && \
+    cp target/release/ingest-graph /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -40,6 +47,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/ingest-graph /usr/local/bin/ingest-graph
+COPY --from=builder /usr/local/bin/ingest-graph /usr/local/bin/ingest-graph
 
 ENTRYPOINT ["/usr/local/bin/ingest-graph"]

--- a/docker/parse-worker/Dockerfile
+++ b/docker/parse-worker/Dockerfile
@@ -24,10 +24,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p parse-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p parse-worker
 
 COPY . .
-RUN cargo build --release -p parse-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p parse-worker && \
+    cp target/release/parse-worker /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -41,6 +48,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/parse-worker /usr/local/bin/parse-worker
+COPY --from=builder /usr/local/bin/parse-worker /usr/local/bin/parse-worker
 
 ENTRYPOINT ["/usr/local/bin/parse-worker"]

--- a/docker/projector-neo4j/Dockerfile
+++ b/docker/projector-neo4j/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p projector-neo4j
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p projector-neo4j
 
 COPY . .
-RUN cargo build --release -p projector-neo4j
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p projector-neo4j && \
+    cp target/release/projector-neo4j /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -40,6 +47,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/projector-neo4j /usr/local/bin/projector-neo4j
+COPY --from=builder /usr/local/bin/projector-neo4j /usr/local/bin/projector-neo4j
 
 ENTRYPOINT ["/usr/local/bin/projector-neo4j"]

--- a/docker/projector-pg/Dockerfile
+++ b/docker/projector-pg/Dockerfile
@@ -22,10 +22,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p projector-pg
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p projector-pg
 
 COPY . .
-RUN cargo build --release -p projector-pg
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p projector-pg && \
+    cp target/release/projector-pg /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -39,6 +46,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/projector-pg /usr/local/bin/projector-pg
+COPY --from=builder /usr/local/bin/projector-pg /usr/local/bin/projector-pg
 
 ENTRYPOINT ["/usr/local/bin/projector-pg"]

--- a/docker/tombstoner/Dockerfile
+++ b/docker/tombstoner/Dockerfile
@@ -22,10 +22,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p tombstoner
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p tombstoner
 
 COPY . .
-RUN cargo build --release -p tombstoner
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p tombstoner && \
+    cp target/release/tombstoner /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -39,6 +46,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/tombstoner /usr/local/bin/tombstoner
+COPY --from=builder /usr/local/bin/tombstoner /usr/local/bin/tombstoner
 
 ENTRYPOINT ["/usr/local/bin/tombstoner"]

--- a/docker/typecheck-worker/Dockerfile
+++ b/docker/typecheck-worker/Dockerfile
@@ -23,10 +23,17 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p typecheck-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p typecheck-worker
 
 COPY . .
-RUN cargo build --release -p typecheck-worker
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p typecheck-worker && \
+    cp target/release/typecheck-worker /usr/local/bin/
 
 # ── Stage 4: minimal runtime image ────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -40,6 +47,6 @@ RUN apt-get update -qq && \
 
 USER nonroot
 
-COPY --from=builder /app/target/release/typecheck-worker /usr/local/bin/typecheck-worker
+COPY --from=builder /usr/local/bin/typecheck-worker /usr/local/bin/typecheck-worker
 
 ENTRYPOINT ["/usr/local/bin/typecheck-worker"]


### PR DESCRIPTION
## Summary

- Add BuildKit `--mount=type=cache` for Cargo registry, git, and target directory to all 11 Rust Dockerfiles
- Stage compiled binaries to `/usr/local/bin/` inside the build step so they survive cache mount unmounting
- Add `.dockerignore` to reduce build context size (`target/`, `.git/`, `node_modules/`, test artifacts)

## GitHub Issue
Closes #367

## Checklist
- [x] All 11 Rust Dockerfiles updated with cache mounts on `cargo chef cook` and `cargo build`
- [x] Runtime `COPY --from=builder` paths updated to `/usr/local/bin/`
- [x] `.dockerignore` added
- [x] CI already uses `docker/setup-buildx-action@v3` — cache mounts work out of the box
- [x] `# syntax=docker/dockerfile:1` already present — BuildKit syntax enabled