### PR TITLE
[RUSAA-1185] feat: wire dev-stack auto-rebuild via post-merge hook; add agent-runner

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,47 @@
+# Repo-tracked git hooks
+
+These hooks are checked into source control and shared by every contributor.
+Git does not enable them automatically — run the installer once after cloning:
+
+```bash
+scripts/install-git-hooks.sh
+```
+
+That points `core.hooksPath` at this directory. Verify with:
+
+```bash
+scripts/install-git-hooks.sh --check
+```
+
+## Active hooks
+
+| Hook | Fires on | What it does |
+|------|----------|--------------|
+| `post-merge` | `git pull`, `git merge` (and the merge step of `git pull --rebase`) on `main` | Backgrounds `scripts/dev-stack-auto-rebuild.sh` with `ORIG_HEAD → HEAD`. Skips when current branch is not `main`, or when `RB_SKIP_AUTO_REBUILD=1`. |
+
+## Bypass
+
+For batched ops (e.g. cherry-pick chains) where you don't want a rebuild after every pull:
+
+```bash
+export RB_SKIP_AUTO_REBUILD=1
+git pull origin main
+unset RB_SKIP_AUTO_REBUILD
+```
+
+To skip one rebuild from inside the script (after the hook has already fired):
+
+```bash
+touch compose/.no-auto-rebuild
+# The rebuild script consumes and deletes this file on the next run.
+```
+
+## Logs
+
+Background rebuilds append to `$HOME/.local/state/rustbrain/post-merge-rebuild.log`
+and the structured NDJSON log at `$HOME/.local/state/rustbrain/dev-stack-rebuilds.ndjson`.
+
+```bash
+tail -f $HOME/.local/state/rustbrain/post-merge-rebuild.log
+scripts/dev-stack-auto-rebuild.sh --logs 10
+```

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# git post-merge hook — triggers dev-stack-auto-rebuild after `git pull` on main.
+#
+# Fires when:
+#   - You run `git pull` (or `git merge`) that fast-forwards or merges new commits
+#     into your local main.
+#
+# Skips when:
+#   - Current branch != main (feature branch work doesn't touch the dev stack)
+#   - $RB_SKIP_AUTO_REBUILD is set (manual override for batched ops)
+#   - compose/.no-auto-rebuild bypass file exists (consumed by the rebuild script)
+#
+# The hook only kicks off the rebuild; the rebuild script itself decides which
+# services actually need to be rebuilt based on the diff.
+#
+# Install with: scripts/install-git-hooks.sh
+
+set -euo pipefail
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+if [[ "$BRANCH" != "main" ]]; then
+  exit 0
+fi
+
+if [[ -n "${RB_SKIP_AUTO_REBUILD:-}" ]]; then
+  echo "[post-merge] RB_SKIP_AUTO_REBUILD set — skipping dev-stack rebuild"
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REBUILD_SCRIPT="$REPO_ROOT/scripts/dev-stack-auto-rebuild.sh"
+
+if [[ ! -x "$REBUILD_SCRIPT" ]]; then
+  echo "[post-merge] $REBUILD_SCRIPT not found or not executable — skipping" >&2
+  exit 0
+fi
+
+# ORIG_HEAD is set by git pull/merge to the SHA before the merge. Use it as PREV_SHA;
+# fall back to HEAD^1 if missing (e.g. on the very first pull).
+PREV_SHA="$(git rev-parse ORIG_HEAD 2>/dev/null || git rev-parse HEAD^1 2>/dev/null || true)"
+NEW_SHA="$(git rev-parse HEAD)"
+
+if [[ -z "$PREV_SHA" || "$PREV_SHA" == "$NEW_SHA" ]]; then
+  exit 0
+fi
+
+echo "[post-merge] dev-stack auto-rebuild: $PREV_SHA → $NEW_SHA"
+
+# Run in background so `git pull` returns immediately. Logs are appended to the
+# rebuild log file (see dev-stack-auto-rebuild.sh) and the systemd-style state dir.
+LOG_DIR="${RB_LOG_DIR:-$HOME/.local/state/rustbrain}"
+mkdir -p "$LOG_DIR"
+nohup "$REBUILD_SCRIPT" "$PREV_SHA" "$NEW_SHA" \
+  >>"$LOG_DIR/post-merge-rebuild.log" 2>&1 &
+disown || true
+
+echo "[post-merge] rebuild backgrounded — tail $LOG_DIR/post-merge-rebuild.log to follow"

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -1,6 +1,18 @@
 # Dev-stack Auto-rebuild
 
-When a commit lands on `main` that touches any built service, the dev-stack on mars automatically rebuilds the affected images and restarts the containers. UAT always runs against `main` HEAD.
+When a commit lands on `main` that touches any built service, the dev-stack automatically rebuilds the affected images and restarts the containers. UAT always runs against `main` HEAD.
+
+## Wiring (local dev box)
+
+Locally, the trigger is a git `post-merge` hook checked in under `.githooks/`. Enable it once after cloning:
+
+```bash
+scripts/install-git-hooks.sh
+```
+
+This sets `core.hooksPath = .githooks` so the `post-merge` hook fires on every `git pull` (or `git merge`) that advances `main`. The hook backgrounds `scripts/dev-stack-auto-rebuild.sh` with `ORIG_HEAD → HEAD`; rebuild logs land in `~/.local/state/rustbrain/post-merge-rebuild.log` and the structured NDJSON log. See [`.githooks/README.md`](../.githooks/README.md) for bypass and troubleshooting.
+
+For unattended boxes (mars), the watcher in `scripts/dev-stack-watch.sh` runs as a systemd service — see *Setup on mars* below.
 
 ## How it works
 
@@ -17,14 +29,14 @@ The rebuild script maps changed file paths to services:
 
 | Changed path | Services rebuilt |
 |---|---|
-| `crates/**`, `Cargo.toml`, `Cargo.lock`, `proto/**` | **All 10 Rust services** (shared dependency change) |
+| `crates/**`, `Cargo.toml`, `Cargo.lock`, `proto/**` | **All 11 Rust services** (shared dependency change) |
 | `services/<name>/**`, `docker/<name>/**` | That specific service only |
 | `migrations/**` | `control-api` (+ re-runs `rb-migrations`) |
 | `frontend/**`, `docker/frontend/**` | `frontend` |
 | `compose/dev.yml`, `compose/full.yml`, `compose/tailscale.yml`, `compose/tailscale.env`, `compose/scripts/**` | All services |
 | Anything else (docs, `.github/`, governance, …) | **no rebuild** |
 
-The 10 Rust services are: `control-api`, `parse-worker`, `typecheck-worker`, `ingest-graph`, `ingest-clone`, `expand-worker`, `embed-worker`, `projector-pg`, `projector-neo4j`, `tombstoner`.
+The 11 Rust services are: `control-api`, `agent-runner`, `parse-worker`, `typecheck-worker`, `ingest-graph`, `ingest-clone`, `expand-worker`, `embed-worker`, `projector-pg`, `projector-neo4j`, `tombstoner`.
 
 Rebuilds are idempotent — re-running is safe. Migrations are re-run before control-api restarts; they skip already-applied versions.
 
@@ -166,6 +178,36 @@ Each log record:
 ```
 
 `result` values: `ok`, `skipped`, `build_failed`, `restart_failed`, `health_failed`.
+
+## Done-gate evidence for code touching `control-api` / `agent-runner`
+
+Per CTO directive (2026-05-12), any PR that touches `services/control-api/` or `services/agent-runner/` must include a `stack-rebuild` line in its Done-gate evidence block. This closes the merged-but-not-deployed gap that has stalled four consecutive Wave 7 UAT rounds.
+
+The evidence block looks like:
+
+```
+Done-gate evidence:
+- Type: code
+- Artifact: https://github.com/f-crop/rustacean/pull/<PR#>
+- Verified by: gh pr view <PR#> --json mergedAt,state
+- stack-rebuild: control-api restarted at 2026-05-12T09:12:28Z
+- stack-rebuild: agent-runner restarted at 2026-05-12T09:12:28Z
+```
+
+Rules:
+
+1. **One `stack-rebuild:` line per service touched.** If the PR only touches `control-api`, only `control-api` needs a line. If it touches a shared crate (e.g. `crates/rb-storage-pg`), every Rust service that gets rebuilt counts and must be listed.
+2. **Timestamp must be after the PR's `mergedAt`.** The rebuild must observe code that's actually on `main`. Verify with:
+   ```bash
+   docker inspect <container> --format '{{.State.StartedAt}}'
+   ```
+3. **Acceptable rebuild sources:**
+   - The git `post-merge` hook fired automatically (preferred — see *Wiring* above).
+   - A manual `scripts/dev-stack-auto-rebuild.sh <prev_sha> <new_sha>` run.
+   - A `--cold-start` after a full stack restart.
+4. **`scripts/dev-stack-auto-rebuild.sh --logs 1`** prints the most recent rebuild record; the JSON includes timestamp + service list. Use it to populate the evidence block.
+
+This requirement applies to any code-type issue closed on or after 2026-05-12 whose merged PR touches the named service trees. Issues older than that are grandfathered.
 
 ## Bypassing the auto-rebuild for one merge
 

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -250,7 +250,7 @@ scripts/dev-stack-auto-rebuild.sh --cold-start                        # builds b
 scripts/dev-stack-auto-rebuild.sh --cold-start <prev_sha> <new_sha>  # with explicit SHA range
 ```
 
-`--cold-start` forces all 10 Rust services and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so databases, queues, and all other infrastructure services start alongside the application containers.
+`--cold-start` forces all 11 Rust services and `frontend` to rebuild, runs migrations, then calls `docker compose up -d` (without `--no-deps`) so databases, queues, and all other infrastructure services start alongside the application containers.
 
 The watcher (`dev-stack-watch.sh`) automatically detects a stopped stack at startup and on each new-commit cycle, and passes `--cold-start` to the rebuild script when needed. The `COMPOSE_CMD` environment variable must be set (or accept the default) for cold-start detection to work correctly.
 

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -141,7 +141,7 @@ fi
 # -- Detect changed paths (skipped in cold-start mode) -----------------------
 
 ALL_RUST_SERVICES=(
-  control-api parse-worker typecheck-worker ingest-graph ingest-clone
+  control-api agent-runner parse-worker typecheck-worker ingest-graph ingest-clone
   expand-worker embed-worker projector-pg projector-neo4j tombstoner
 )
 declare -A REBUILD_SERVICE
@@ -171,6 +171,8 @@ else
         mark_rust_service control-api ;;
       services/control-api/*|docker/control-api/*)
         mark_rust_service control-api ;;
+      services/agent-runner/*|docker/agent-runner/*)
+        mark_rust_service agent-runner ;;
       services/parse-worker/*|docker/parse-worker/*)
         mark_rust_service parse-worker ;;
       services/typecheck-worker/*|docker/typecheck-worker/*)

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install repo-tracked git hooks by pointing core.hooksPath at .githooks/.
+#
+# Idempotent: re-running is a no-op once configured.
+#
+# Usage:
+#   scripts/install-git-hooks.sh [--check]
+#
+#   --check  Exit 0 if hooks are already installed, non-zero otherwise.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR_REL=".githooks"
+HOOKS_DIR="$REPO_ROOT/$HOOKS_DIR_REL"
+
+if [[ ! -d "$HOOKS_DIR" ]]; then
+  echo "error: $HOOKS_DIR not found" >&2
+  exit 1
+fi
+
+CURRENT="$(git -C "$REPO_ROOT" config --local --get core.hooksPath || true)"
+
+if [[ "${1:-}" == "--check" ]]; then
+  if [[ "$CURRENT" == "$HOOKS_DIR_REL" ]]; then
+    echo "ok: core.hooksPath = $HOOKS_DIR_REL"
+    exit 0
+  fi
+  echo "fail: core.hooksPath = '$CURRENT' (expected '$HOOKS_DIR_REL')" >&2
+  exit 1
+fi
+
+# Mark every hook executable. Git refuses to run non-executable hooks.
+find "$HOOKS_DIR" -maxdepth 1 -type f -not -name '*.md' -exec chmod +x {} +
+
+if [[ "$CURRENT" == "$HOOKS_DIR_REL" ]]; then
+  echo "git hooks already installed (core.hooksPath = $HOOKS_DIR_REL)"
+  exit 0
+fi
+
+git -C "$REPO_ROOT" config --local core.hooksPath "$HOOKS_DIR_REL"
+echo "installed: core.hooksPath -> $HOOKS_DIR_REL"
+echo
+echo "Active hooks:"
+ls -1 "$HOOKS_DIR" | grep -v '\.md$' | sed 's/^/  /'
+echo
+echo "Test the post-merge hook locally with:"
+echo "  RB_SKIP_AUTO_REBUILD=1 git pull origin main   # safe (no rebuild)"
+echo "  git pull origin main                          # real (triggers rebuild)"


### PR DESCRIPTION
## Summary

Fixes the four-time UAT-stall pattern where merged Wave 7 fixes weren't running on the dev box because no automation rebuilt the stack and `agent-runner` was missing from the rebuild script entirely.

- `scripts/dev-stack-auto-rebuild.sh`: add `agent-runner` to `ALL_RUST_SERVICES` and to the path-to-service dispatch case (`services/agent-runner/*|docker/agent-runner/*`).
- `.githooks/post-merge` + `.githooks/README.md`: git hook that backgrounds the rebuild script on `git pull` against `main`. Skips on non-main branches and when `RB_SKIP_AUTO_REBUILD=1`.
- `scripts/install-git-hooks.sh`: idempotent installer that points `core.hooksPath` at `.githooks/` and marks every hook executable.
- `docs/dev-stack-auto-rebuild.md`:
  - Wiring section for local dev boxes (the existing systemd setup remains for mars/unattended boxes).
  - Service count corrected (10 → 11 Rust services).
  - Done-gate evidence section: PRs touching `services/control-api/` or `services/agent-runner/` must include `stack-rebuild: <container> restarted at <timestamp>` lines in the Done-gate evidence block.

## GitHub Issue

Closes #372

## Out of scope

Amending `COMPANY.md` § Done-Gate Standard to centralise the `stack-rebuild` evidence rule across all platform agents is governance scope and stays with the CTO/Architect. This PR documents the rule in the repo so it is discoverable from the rebuild scripts themselves; the governance amendment can lift the same wording when ready.

## Checklist

- [x] `bash -n` clean on all touched scripts
- [x] `scripts/install-git-hooks.sh --check` returns ok after install
- [x] Local manual rebuild verified containers restarted at a fresh timestamp (`2026-05-12T09:12:28Z`)
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Docs updated