### PR TITLE
[RUSAA-1192] feat: storage + auth foundation for GitHub App Manifest flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "agent-runner"
 version = "0.1.0"
 dependencies = [
@@ -991,6 +1026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1289,6 +1335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1804,6 +1859,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2344,6 +2409,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2961,6 +3035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3401,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3787,6 +3879,7 @@ dependencies = [
 name = "rb-github"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "base64",
  "chrono",
  "dashmap",
@@ -3801,10 +3894,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlx",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5498,6 +5593,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/compose/dev.env.tpl
+++ b/compose/dev.env.tpl
@@ -27,6 +27,7 @@ RB_BASE_URL=http://localhost:15173
 # RB_GH_APP_ID=         # numeric GitHub App ID, e.g. 123456
 # RB_GH_APP_PRIVATE_KEY=  # base64-encoded RSA PEM: base64 -w0 < app.pem
 # RB_GH_APP_WEBHOOK_SECRET=dev-secret-do-not-use-in-prod
+# RB_GH_APP_ENC_KEY=    # base64 of 32-byte AES-256 key for the Manifest flow; openssl rand 32 | base64 -w0
 
 # For ingest-clone (raw PEM, not base64):
 # GITHUB_APP_ID=

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -251,6 +251,7 @@ services:
       RB_GH_APP_ID: "${RB_GH_APP_ID:-}"
       RB_GH_APP_PRIVATE_KEY: "${RB_GH_APP_PRIVATE_KEY:-}"
       RB_GH_APP_WEBHOOK_SECRET: "${RB_GH_APP_WEBHOOK_SECRET:-dev-secret-do-not-use-in-prod}"
+      RB_GH_APP_ENC_KEY: "${RB_GH_APP_ENC_KEY:-}"
       RB_INTERNAL_LISTEN_ADDR: "0.0.0.0:8081"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: control-api

--- a/compose/env.schema.toml
+++ b/compose/env.schema.toml
@@ -235,6 +235,13 @@ default = "dev-secret-do-not-use-in-prod"
 description = "HMAC-SHA256 shared secret for GitHub webhook verification."
 services = ["control-api"]
 
+[var.RB_GH_APP_ENC_KEY]
+required = false
+description = "Base64-encoded 32-byte AES-256-GCM key used to encrypt GitHub App credentials stored in control.github_app_config (Manifest flow). Generate: openssl rand 32 | base64 -w0"
+services = ["control-api"]
+regex = "^[A-Za-z0-9+/]+=*$"
+danger = "Must decode to exactly 32 bytes. Required to register an App via the UI; the legacy env-based App config does not need this."
+
 [var.GITHUB_APP_ID]
 required = false
 description = "GitHub App numeric ID for ingest-clone."

--- a/crates/rb-github/Cargo.toml
+++ b/crates/rb-github/Cargo.toml
@@ -25,6 +25,9 @@ hmac.workspace = true
 subtle.workspace = true
 moka.workspace = true
 hex.workspace = true
+aes-gcm.workspace = true
+sqlx.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/rb-github/src/app_config_store.rs
+++ b/crates/rb-github/src/app_config_store.rs
@@ -1,0 +1,427 @@
+//! Storage layer for the platform-admin–registered GitHub App credentials
+//! (Phase 1 of the Manifest flow).
+//!
+//! Persists encrypted GitHub App credentials in `control.github_app_config`.
+//! Phase 1 only ships the store; the per-request `GhApp` loader that consumes
+//! these rows lands in Phase 2.
+//!
+//! ## Encryption
+//!
+//! AES-256-GCM with a per-row random 12-byte nonce. The key is read from
+//! `RB_GH_APP_ENC_KEY` (base64 of exactly 32 bytes) and is dedicated to GitHub
+//! App secrets — independent from `RB_TOKEN_ENC_KEY` so the two rotation
+//! lifetimes do not couple. The active `encryption_key_id` is recorded on the
+//! row (`'gh-app-v1'` today) so a future rotation job can target stale rows
+//! without a table scan.
+//!
+//! ## Singleton-active invariant
+//!
+//! Migration `017_github_app_config.sql` enforces a partial unique index
+//! `((1)) WHERE is_active`, so at most one row may be active. [`AppConfigStore::insert_replacing`]
+//! runs a transactional `UPDATE ... SET is_active=false` ahead of the `INSERT`
+//! to preserve the invariant when a new App replaces the current one.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use base64::Engine as _;
+use chrono::{DateTime, Utc};
+use rand::RngCore as _;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::secret::Secret;
+
+/// Active key identifier recorded on every newly written row. Future rotation
+/// flips the constant and re-encrypts rows in the background.
+pub const CURRENT_ENCRYPTION_KEY_ID: &str = "gh-app-v1";
+
+/// Nonce length for AES-256-GCM (96 bits, the AEAD-recommended size).
+const NONCE_LEN: usize = 12;
+
+/// Errors raised by the store. Storage and crypto failures are returned
+/// distinctly so callers can surface 503 vs. 500 appropriately.
+#[derive(Debug, thiserror::Error)]
+pub enum AppConfigError {
+    /// `RB_GH_APP_ENC_KEY` env var is unset or empty.
+    #[error(
+        "RB_GH_APP_ENC_KEY is required to read or write github_app_config. \
+         Set it to a base64-encoded 32-byte AES-256 key before enabling the \
+         Manifest flow."
+    )]
+    KeyMissing,
+
+    /// `RB_GH_APP_ENC_KEY` is not valid base64.
+    #[error("RB_GH_APP_ENC_KEY is not valid base64: {0}")]
+    KeyNotBase64(#[from] base64::DecodeError),
+
+    /// Decoded key bytes are not exactly 32 bytes.
+    #[error("RB_GH_APP_ENC_KEY must decode to exactly 32 bytes, got {0}")]
+    KeyWrongLength(usize),
+
+    /// AES-GCM encrypt/decrypt failure (tag mismatch, malformed input, etc.).
+    /// The inner aead error is intentionally not surfaced — it varies across
+    /// failure modes and is not actionable to the caller.
+    #[error("github_app_config crypto failure")]
+    Crypto,
+
+    /// Postgres / sqlx failure.
+    #[error("github_app_config storage error: {0}")]
+    Db(#[from] sqlx::Error),
+
+    /// Stored row records an `encryption_key_id` we do not have a key for.
+    /// Surfaces during rollouts where the key id was bumped without rotation.
+    #[error("github_app_config row encrypted with unknown key id {0}")]
+    UnknownKeyId(String),
+
+    /// Stored nonce bytes are not the expected length.
+    #[error("github_app_config row has malformed {0} nonce ({1} bytes)")]
+    MalformedNonce(&'static str, usize),
+}
+
+/// AES-256-GCM key material derived from `RB_GH_APP_ENC_KEY`.
+///
+/// The key is stored inside the cipher and never re-exposed. Cloning the
+/// struct clones the underlying cipher — cheap (`Aes256Gcm` is `Clone`-able
+/// via its key schedule reference) and safe to share across tasks.
+#[derive(Clone)]
+pub struct EncryptionKey {
+    cipher: Aes256Gcm,
+    key_id: &'static str,
+}
+
+impl std::fmt::Debug for EncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKey")
+            .field("key_id", &self.key_id)
+            .field("cipher", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl EncryptionKey {
+    /// Load the active key from `RB_GH_APP_ENC_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppConfigError::KeyMissing`] when the env var is unset,
+    /// [`AppConfigError::KeyNotBase64`] when the value is malformed, or
+    /// [`AppConfigError::KeyWrongLength`] when the decoded byte length is
+    /// not exactly 32 bytes.
+    pub fn from_env() -> Result<Self, AppConfigError> {
+        let raw = std::env::var("RB_GH_APP_ENC_KEY")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .ok_or(AppConfigError::KeyMissing)?;
+        Self::from_base64(&raw)
+    }
+
+    /// Decode a base64-encoded 32-byte key. Exposed for tests; production
+    /// callers use [`EncryptionKey::from_env`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppConfigError::KeyNotBase64`] when the value is malformed,
+    /// or [`AppConfigError::KeyWrongLength`] when the decoded byte length is
+    /// not exactly 32 bytes.
+    pub fn from_base64(b64: &str) -> Result<Self, AppConfigError> {
+        let bytes = base64::engine::general_purpose::STANDARD.decode(b64.trim())?;
+        if bytes.len() != 32 {
+            return Err(AppConfigError::KeyWrongLength(bytes.len()));
+        }
+        let key = Key::<Aes256Gcm>::from_slice(&bytes);
+        Ok(Self {
+            cipher: Aes256Gcm::new(key),
+            key_id: CURRENT_ENCRYPTION_KEY_ID,
+        })
+    }
+
+    /// Identifier persisted in `encryption_key_id` for rows this key produces.
+    #[must_use]
+    pub fn key_id(&self) -> &'static str {
+        self.key_id
+    }
+
+    /// Encrypt `plaintext`. Returns `(nonce, ciphertext)` for storage. A fresh
+    /// 12-byte nonce is generated on every call.
+    fn seal(&self, plaintext: &[u8]) -> Result<(Vec<u8>, Vec<u8>), AppConfigError> {
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        rand::rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ct = self
+            .cipher
+            .encrypt(nonce, plaintext)
+            .map_err(|_| AppConfigError::Crypto)?;
+        Ok((nonce_bytes.to_vec(), ct))
+    }
+
+    fn open(&self, nonce_bytes: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, AppConfigError> {
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(AppConfigError::MalformedNonce("aes-gcm", nonce_bytes.len()));
+        }
+        let nonce = Nonce::from_slice(nonce_bytes);
+        self.cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| AppConfigError::Crypto)
+    }
+}
+
+/// New-row inserts: caller passes plaintext credentials. The store handles
+/// encryption and the `is_active` swap.
+#[derive(Debug, Clone)]
+pub struct NewAppConfig {
+    pub app_id: i64,
+    pub slug: String,
+    pub client_id: String,
+    pub client_secret: Secret<String>,
+    pub private_key_pem: Secret<String>,
+    pub webhook_secret: Secret<String>,
+}
+
+/// Decrypted view of an `github_app_config` row.
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    pub id: i64,
+    pub app_id: i64,
+    pub slug: String,
+    pub client_id: String,
+    pub client_secret: Secret<String>,
+    pub private_key_pem: Secret<String>,
+    pub webhook_secret: Secret<String>,
+    pub encryption_key_id: String,
+    pub installed_by_user_id: Uuid,
+    pub is_active: bool,
+    pub created_at: DateTime<Utc>,
+    pub deactivated_at: Option<DateTime<Utc>>,
+}
+
+/// Postgres-backed store for the App-config table.
+///
+/// The store is cheap to clone — it holds a `PgPool` (already `Arc`-wrapped
+/// internally) and a key-material handle.
+#[derive(Clone)]
+pub struct AppConfigStore {
+    pool: PgPool,
+    key: EncryptionKey,
+}
+
+impl AppConfigStore {
+    #[must_use]
+    pub fn new(pool: PgPool, key: EncryptionKey) -> Self {
+        Self { pool, key }
+    }
+
+    /// Return the currently-active row, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppConfigError::Db`] on transport failures and
+    /// [`AppConfigError::Crypto`] / [`AppConfigError::UnknownKeyId`] when a
+    /// row cannot be decrypted with the current key material.
+    pub async fn load_active(&self) -> Result<Option<AppConfig>, AppConfigError> {
+        let row: Option<EncryptedRow> = sqlx::query_as::<_, EncryptedRow>(
+            "SELECT id, app_id, slug, client_id, \
+                    client_secret_ciphertext, client_secret_nonce, \
+                    private_key_ciphertext, private_key_nonce, \
+                    webhook_secret_ciphertext, webhook_secret_nonce, \
+                    encryption_key_id, installed_by_user_id, is_active, \
+                    created_at, deactivated_at \
+               FROM github_app_config \
+              WHERE is_active = true \
+              LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|r| self.decrypt_row(r)).transpose()
+    }
+
+    /// Insert a new active row, deactivating any existing active row in the
+    /// same transaction. Returns the freshly inserted row's id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppConfigError::Crypto`] when sealing the secrets fails, or
+    /// [`AppConfigError::Db`] on transport / constraint failures (the
+    /// singleton partial unique index should never fire because the
+    /// deactivation runs in the same transaction).
+    pub async fn insert_replacing(
+        &self,
+        new: NewAppConfig,
+        installed_by_user_id: Uuid,
+    ) -> Result<i64, AppConfigError> {
+        let (cs_nonce, cs_ct) = self.key.seal(new.client_secret.expose().as_bytes())?;
+        let (pk_nonce, pk_ct) = self.key.seal(new.private_key_pem.expose().as_bytes())?;
+        let (ws_nonce, ws_ct) = self.key.seal(new.webhook_secret.expose().as_bytes())?;
+
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query(
+            "UPDATE github_app_config \
+                SET is_active = false, deactivated_at = now() \
+              WHERE is_active = true",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let id: (i64,) = sqlx::query_as(
+            "INSERT INTO github_app_config \
+                 (app_id, slug, client_id, \
+                  client_secret_ciphertext, client_secret_nonce, \
+                  private_key_ciphertext, private_key_nonce, \
+                  webhook_secret_ciphertext, webhook_secret_nonce, \
+                  encryption_key_id, installed_by_user_id, is_active) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, true) \
+             RETURNING id",
+        )
+        .bind(new.app_id)
+        .bind(&new.slug)
+        .bind(&new.client_id)
+        .bind(&cs_ct)
+        .bind(&cs_nonce)
+        .bind(&pk_ct)
+        .bind(&pk_nonce)
+        .bind(&ws_ct)
+        .bind(&ws_nonce)
+        .bind(self.key.key_id())
+        .bind(installed_by_user_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(id.0)
+    }
+
+    fn decrypt_row(&self, row: EncryptedRow) -> Result<AppConfig, AppConfigError> {
+        if row.encryption_key_id != self.key.key_id() {
+            return Err(AppConfigError::UnknownKeyId(row.encryption_key_id));
+        }
+        let cs = self
+            .key
+            .open(&row.client_secret_nonce, &row.client_secret_ciphertext)?;
+        let pk = self
+            .key
+            .open(&row.private_key_nonce, &row.private_key_ciphertext)?;
+        let ws = self
+            .key
+            .open(&row.webhook_secret_nonce, &row.webhook_secret_ciphertext)?;
+        Ok(AppConfig {
+            id: row.id,
+            app_id: row.app_id,
+            slug: row.slug,
+            client_id: row.client_id,
+            client_secret: Secret::new(String::from_utf8(cs).map_err(|_| AppConfigError::Crypto)?),
+            private_key_pem: Secret::new(
+                String::from_utf8(pk).map_err(|_| AppConfigError::Crypto)?,
+            ),
+            webhook_secret: Secret::new(String::from_utf8(ws).map_err(|_| AppConfigError::Crypto)?),
+            encryption_key_id: row.encryption_key_id,
+            installed_by_user_id: row.installed_by_user_id,
+            is_active: row.is_active,
+            created_at: row.created_at,
+            deactivated_at: row.deactivated_at,
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct EncryptedRow {
+    id: i64,
+    app_id: i64,
+    slug: String,
+    client_id: String,
+    client_secret_ciphertext: Vec<u8>,
+    client_secret_nonce: Vec<u8>,
+    private_key_ciphertext: Vec<u8>,
+    private_key_nonce: Vec<u8>,
+    webhook_secret_ciphertext: Vec<u8>,
+    webhook_secret_nonce: Vec<u8>,
+    encryption_key_id: String,
+    installed_by_user_id: Uuid,
+    is_active: bool,
+    created_at: DateTime<Utc>,
+    deactivated_at: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_key() -> EncryptionKey {
+        let bytes = [7u8; 32];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+        EncryptionKey::from_base64(&b64).expect("from_base64")
+    }
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let key = fresh_key();
+        let plaintext = b"super-secret-pem-bytes";
+        let (nonce, ct) = key.seal(plaintext).expect("seal");
+        assert_eq!(nonce.len(), NONCE_LEN);
+        assert_ne!(ct.as_slice(), plaintext, "ciphertext must differ");
+        let recovered = key.open(&nonce, &ct).expect("open");
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn seal_uses_unique_nonce_per_call() {
+        let key = fresh_key();
+        let (n1, _) = key.seal(b"x").expect("seal 1");
+        let (n2, _) = key.seal(b"x").expect("seal 2");
+        assert_ne!(n1, n2, "two seals must produce distinct nonces");
+    }
+
+    #[test]
+    fn open_rejects_tampered_ciphertext() {
+        let key = fresh_key();
+        let (nonce, mut ct) = key.seal(b"data").expect("seal");
+        ct[0] ^= 0x01;
+        let err = key.open(&nonce, &ct).expect_err("must fail");
+        assert!(matches!(err, AppConfigError::Crypto));
+    }
+
+    #[test]
+    fn open_rejects_wrong_nonce_length() {
+        let key = fresh_key();
+        let (_, ct) = key.seal(b"data").expect("seal");
+        let err = key.open(&[0u8; 8], &ct).expect_err("must fail");
+        assert!(matches!(err, AppConfigError::MalformedNonce("aes-gcm", 8)));
+    }
+
+    #[test]
+    fn from_base64_rejects_wrong_length() {
+        let short = base64::engine::general_purpose::STANDARD.encode([0u8; 16]);
+        let err = EncryptionKey::from_base64(&short).expect_err("must fail");
+        assert!(matches!(err, AppConfigError::KeyWrongLength(16)));
+    }
+
+    #[test]
+    fn from_base64_rejects_garbage() {
+        let err = EncryptionKey::from_base64("not base64!!!").expect_err("must fail");
+        assert!(matches!(err, AppConfigError::KeyNotBase64(_)));
+    }
+
+    #[test]
+    fn from_env_reads_var_and_missing_returns_key_missing() {
+        // Combined so the env-var read and clear cannot race with another test
+        // touching the same variable in parallel.
+        let bytes = [3u8; 32];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+        // SAFETY: scoped to this test; cleaned up before exit.
+        unsafe { std::env::set_var("RB_GH_APP_ENC_KEY", &b64) };
+        let key = EncryptionKey::from_env().expect("from_env when set");
+        assert_eq!(key.key_id(), CURRENT_ENCRYPTION_KEY_ID);
+        // SAFETY: same scope.
+        unsafe { std::env::remove_var("RB_GH_APP_ENC_KEY") };
+        let err = EncryptionKey::from_env().expect_err("must fail when unset");
+        assert!(matches!(err, AppConfigError::KeyMissing));
+    }
+
+    #[test]
+    fn debug_does_not_leak_key_bytes() {
+        let key = fresh_key();
+        let dbg = format!("{key:?}");
+        assert!(dbg.contains("REDACTED"));
+        assert!(!dbg.contains('7'));
+    }
+}

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_config_store;
 mod app_jwt;
 mod client;
 mod error;
@@ -8,6 +9,10 @@ mod state_token;
 mod token_cache;
 mod webhook;
 
+pub use app_config_store::{
+    AppConfig, AppConfigError, AppConfigStore, CURRENT_ENCRYPTION_KEY_ID, EncryptionKey,
+    NewAppConfig,
+};
 pub use client::{AppIdentity, AppOwner, InstallationInfo, RepoInfo};
 pub use error::GhError;
 pub use repos::{RepoItem, RepoPage};

--- a/migrations/control/017_github_app_config.sql
+++ b/migrations/control/017_github_app_config.sql
@@ -1,0 +1,74 @@
+-- Control schema: GH-XX Phase 1 — Self-service GitHub App registration via Manifest flow.
+--
+-- Adds the storage half of the Manifest flow: a singleton-active
+-- `github_app_config` row that holds the App credentials (encrypted), a
+-- short-lived `github_manifest_states` table for replay-safe state tokens,
+-- and a `users.is_platform_admin` flag gating the admin-only register flow.
+--
+-- The actual register endpoints, per-request GhApp loader, and FE screen
+-- land in subsequent phases. After this migration applies, the env-var path
+-- in `services/control-api/src/server.rs::build_gh_app` continues to work
+-- unchanged.
+--
+-- Encryption: AES-256-GCM with per-row 12-byte random nonce.  Key comes
+-- from `RB_GH_APP_ENC_KEY` (base64 32 bytes), dedicated and independent
+-- from `RB_TOKEN_ENC_KEY` so GH App secret rotation does not require
+-- re-encrypting OAuth tokens (and vice versa).  `encryption_key_id`
+-- defaults to `'gh-app-v1'` and is the rotation pivot.
+--
+-- Migration type: Additive (CREATE TABLE, ADD COLUMN with default).
+-- Joint approval: Platform + Architect per AGENTS.md § Schema Migrations.
+
+ALTER TABLE users
+    ADD COLUMN is_platform_admin BOOLEAN NOT NULL DEFAULT false;
+
+-- App credentials.  Singleton-active is enforced by the partial unique
+-- index below: at most one row may have is_active=true at any time.
+-- Replacing the active App is a two-statement transaction:
+--   UPDATE github_app_config SET is_active=false, deactivated_at=now() WHERE is_active;
+--   INSERT INTO github_app_config (...) VALUES (..., true);
+CREATE TABLE github_app_config (
+    id                          BIGSERIAL   PRIMARY KEY,
+    app_id                      BIGINT      NOT NULL,
+    slug                        TEXT        NOT NULL,
+    client_id                   TEXT        NOT NULL,
+    client_secret_ciphertext    BYTEA       NOT NULL,
+    client_secret_nonce         BYTEA       NOT NULL,
+    private_key_ciphertext      BYTEA       NOT NULL,
+    private_key_nonce           BYTEA       NOT NULL,
+    webhook_secret_ciphertext   BYTEA       NOT NULL,
+    webhook_secret_nonce        BYTEA       NOT NULL,
+    encryption_key_id           TEXT        NOT NULL DEFAULT 'gh-app-v1',
+    installed_by_user_id        UUID        NOT NULL REFERENCES users(id),
+    is_active                   BOOLEAN     NOT NULL DEFAULT true,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deactivated_at              TIMESTAMPTZ
+);
+
+-- At most one row may be active at any time.  Postgres ((1)) expression
+-- index is a documented pattern for whole-table singletons since PG14.
+CREATE UNIQUE INDEX github_app_config_singleton_active_idx
+    ON github_app_config ((1)) WHERE is_active;
+
+-- Replacement / audit queries scan recent rows first.
+CREATE INDEX github_app_config_created_at_idx
+    ON github_app_config (created_at DESC);
+
+-- One-shot state tokens for the manifest exchange.  Mirrors
+-- github_install_states: hashed token, 10-minute TTL, consumed_at for
+-- replay protection.
+CREATE TABLE github_manifest_states (
+    id                   BIGSERIAL   PRIMARY KEY,
+    state_token_hash     BYTEA       NOT NULL,
+    initiated_by_user_id UUID        NOT NULL REFERENCES users(id),
+    expires_at           TIMESTAMPTZ NOT NULL,
+    consumed_at          TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX github_manifest_states_hash_idx
+    ON github_manifest_states (state_token_hash);
+
+-- Sweeper-friendly index: open (un-consumed) tokens ordered by expiry.
+CREATE INDEX github_manifest_states_active_idx
+    ON github_manifest_states (expires_at) WHERE consumed_at IS NULL;

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result, bail};
+use base64::Engine as _;
 
 /// Service configuration loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -29,6 +30,11 @@ pub struct Config {
     /// `RB_GH_APP_WEBHOOK_SECRET` — shared secret for HMAC-SHA256 webhook
     /// signature verification.
     pub gh_app_webhook_secret: Option<String>,
+    /// `RB_GH_APP_ENC_KEY` — base64 of a 32-byte AES-256-GCM key used to
+    /// encrypt App credentials in `control.github_app_config`. Optional in
+    /// Phase 1 (no rows yet); becomes required in Phase 2 once the per-request
+    /// loader queries the table.
+    pub gh_app_enc_key_b64: Option<String>,
 
     // --- Neo4j (REQ-DP-04, REQ-DP-07) ---
     /// `RB_NEO4J_URI` — bolt URI for the Neo4j instance (e.g. `bolt://neo4j:7687`).
@@ -132,6 +138,9 @@ impl Config {
             gh_app_webhook_secret: env::var("RB_GH_APP_WEBHOOK_SECRET")
                 .ok()
                 .filter(|s| !s.is_empty()),
+            gh_app_enc_key_b64: env::var("RB_GH_APP_ENC_KEY")
+                .ok()
+                .filter(|s| !s.is_empty()),
             neo4j_uri: env::var("RB_NEO4J_URI").ok().filter(|s| !s.is_empty()),
             neo4j_user: env::var("RB_NEO4J_USER").unwrap_or_else(|_| "neo4j".to_owned()),
             neo4j_password: env::var("RB_NEO4J_PASSWORD").ok().filter(|s| !s.is_empty()),
@@ -222,6 +231,25 @@ impl Config {
             }
         }
 
+        // RB_GH_APP_ENC_KEY must decode to exactly 32 bytes when present. We
+        // validate the shape here so a misconfigured deployment fails fast at
+        // boot rather than at first manifest exchange.
+        if let Some(key) = self
+            .gh_app_enc_key_b64
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            match base64::engine::general_purpose::STANDARD.decode(key) {
+                Ok(bytes) if bytes.len() == 32 => {}
+                Ok(bytes) => errors.push(format!(
+                    "RB_GH_APP_ENC_KEY must decode to exactly 32 bytes, got {}",
+                    bytes.len()
+                )),
+                Err(e) => errors.push(format!("RB_GH_APP_ENC_KEY is not valid base64: {e}")),
+            }
+        }
+
         // RB_INTERNAL_SECRET must be non-empty when internal routes are used.
         // The internal routes are always compiled in, so require the secret.
         if self.internal_secret.as_ref().is_none_or(String::is_empty) {
@@ -267,6 +295,7 @@ impl Config {
             gh_app_id: None,
             gh_app_private_key_b64: None,
             gh_app_webhook_secret: None,
+            gh_app_enc_key_b64: None,
             neo4j_uri: None,
             neo4j_user: "neo4j".to_owned(),
             neo4j_password: None,
@@ -329,5 +358,41 @@ mod tests {
         let mut c = base();
         c.base_url = "ftp://localhost:15173".to_owned();
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_gh_app_enc_key_absent_passes() {
+        // RB_GH_APP_ENC_KEY is optional in Phase 1 — env-only deployments must
+        // continue to validate.
+        let mut c = base();
+        c.gh_app_enc_key_b64 = None;
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_gh_app_enc_key_correct_length_passes() {
+        let mut c = base();
+        c.gh_app_enc_key_b64 = Some(
+            base64::engine::general_purpose::STANDARD.encode([0u8; 32]),
+        );
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_gh_app_enc_key_wrong_length_fails() {
+        let mut c = base();
+        c.gh_app_enc_key_b64 = Some(
+            base64::engine::general_purpose::STANDARD.encode([0u8; 16]),
+        );
+        let err = c.validate().expect_err("must reject 16-byte key");
+        assert!(err.to_string().contains("32 bytes"));
+    }
+
+    #[test]
+    fn validate_gh_app_enc_key_garbage_fails() {
+        let mut c = base();
+        c.gh_app_enc_key_b64 = Some("not base64 !!!".to_owned());
+        let err = c.validate().expect_err("must reject malformed base64");
+        assert!(err.to_string().contains("base64"));
     }
 }

--- a/services/control-api/src/middleware/mod.rs
+++ b/services/control-api/src/middleware/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
 pub mod internal_auth;
 pub mod otel_trace;
+pub mod platform_admin;

--- a/services/control-api/src/middleware/platform_admin.rs
+++ b/services/control-api/src/middleware/platform_admin.rs
@@ -1,0 +1,59 @@
+//! Platform-admin authorization guard.
+//!
+//! `is_platform_admin` is a deployment-wide flag on `control.users`, distinct
+//! from the per-tenant `tenant_members.role`. Use [`require_platform_admin`]
+//! to gate routes that register or replace deployment-level resources
+//! (e.g. the GitHub App).
+//!
+//! Behaviour mirrors [`super::auth::require_verified_session`]: returns
+//! `AppError::Unauthorized` for anonymous / API-key / expired-session
+//! callers, `AppError::EmailNotVerified` for unverified sessions, and
+//! `AppError::InsufficientRole` for verified sessions whose user row has
+//! `is_platform_admin = false`.
+
+use sqlx::PgPool;
+
+use crate::{
+    error::AppError,
+    middleware::auth::{AuthContext, SessionInfo, require_verified_session},
+};
+
+/// Resolve the verified session and require `users.is_platform_admin = true`.
+///
+/// # Errors
+///
+/// Propagates the auth errors documented on
+/// [`super::auth::require_verified_session`] and adds:
+/// - [`AppError::InsufficientRole`] when the verified user is not a platform
+///   admin.
+/// - [`AppError::Database`] when the lookup fails.
+// First consumer ships in Phase 3 (admin endpoints); keep it `pub` so the
+// follow-up PR only adds a call-site rather than re-exporting.
+#[allow(dead_code)]
+pub async fn require_platform_admin(
+    pool: &PgPool,
+    auth: AuthContext,
+) -> Result<SessionInfo, AppError> {
+    let session = require_verified_session(auth)?;
+
+    let row: Option<(bool,)> = sqlx::query_as(
+        "SELECT is_platform_admin FROM control.users WHERE id = $1 AND status = 'active'",
+    )
+    .bind(session.user_id)
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some((true,)) => Ok(session),
+        _ => Err(AppError::InsufficientRole),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // The DB-touching path is covered by the integration tests that land with
+    // the Phase 3 admin endpoints (they exercise the 401/403 branches end to
+    // end). Pure unit coverage here would require mocking the pool, which the
+    // codebase intentionally avoids — see existing patterns in
+    // services/control-api/src/middleware/auth_tests.rs.
+}

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -58,6 +58,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_api_key_revocation_tests.rs
+++ b/services/control-api/tests/integration_api_key_revocation_tests.rs
@@ -68,6 +68,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -62,6 +62,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -45,6 +45,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -58,6 +58,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -337,6 +337,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_id: None,
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,


### PR DESCRIPTION
## Summary

Phase 1 of the self-service GitHub App registration via Manifest flow (board-approved plan).
Lays the storage and authz foundation so a platform admin can later register a GitHub App
from the UI without shell access. This PR ships only the foundation — the per-request
`GhApp` loader, admin endpoints, and FE admin screen land in follow-up phases.

- **Additive migration `017_github_app_config.sql`**: `is_platform_admin` flag on
  `control.users`, new `github_app_config` table with AES-256-GCM-encrypted secrets and a
  singleton-active partial unique index, and a `github_manifest_states` table mirroring the
  existing install-states pattern (10-minute TTL + `consumed_at` replay protection).
- **`rb-github::AppConfigStore`**: load/insert helpers with per-row 12-byte nonces and
  `encryption_key_id = 'gh-app-v1'`. Keyed by a **dedicated `RB_GH_APP_ENC_KEY`** (base64
  32 bytes), isolated from `RB_TOKEN_ENC_KEY` so the two rotation lifetimes do not couple.
- **`require_platform_admin` guard**: mirrors `require_verified_session` and additionally
  requires `users.is_platform_admin = true`. Returns 401 for anonymous/API-key/expired
  sessions, 403 for non-admin verified sessions.
- **Config plumbing**: `Config.gh_app_enc_key_b64` read from `RB_GH_APP_ENC_KEY`;
  `Config::validate` fails fast on malformed or wrong-length keys (base64 + 32-byte check).
- **Compose**: env schema + dev.env template + dev.yml declare the new optional var.

## GitHub Issue

Closes #376

## Migration type

**Additive** (CREATE TABLE, ADD COLUMN with default). Joint Platform + Architect approval
per `docs/AGENTS.md` § Schema Migrations.

## Bootstrap (operator note)

Until the FE admin screen lands, the first platform admin is flipped via SQL:

```sql
UPDATE control.users SET is_platform_admin = true WHERE email = 'operator@example.com';
```

This is acceptable for a platform-admin-only surface and is removed once the FE admin
screen lands in a later phase.

## Checklist

- [x] Migration smoke against live dev DB in a `BEGIN; ... ROLLBACK;` block — all DDL
  applies cleanly; second-active-row insert is rejected with `unique_violation`
  (singleton invariant verified).
- [x] `cargo test -p rb-github --lib app_config_store` — 8 tests pass (encrypt/decrypt
  round-trip, tamper detection, nonce-length checks, key shape validation, `Debug` redaction).
- [x] `cargo test -p control-api --lib config` — 11 tests pass, including 4 new for
  `RB_GH_APP_ENC_KEY` validation.
- [x] `cargo check --workspace` clean.
- [x] `cargo clippy -p rb-github -p control-api --lib --tests -- -D warnings` clean on
  changed code. (Legacy `control_api::build` deprecation warnings in unrelated integration
  tests are pre-existing.)
- [x] No tracker ids in the diff outside the title bracket prefix.