### PR TITLE
[RUSAA-1203] feat: admin manifest endpoints + wiremock integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,10 +1183,12 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "urlencoding",
  "utoipa",
  "utoipa-axum",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1388,6 +1400,18 @@ dependencies = [
  "deadpool-runtime",
  "num_cpus",
  "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
  "tokio",
 ]
 
@@ -2871,7 +2895,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "deadpool",
+ "deadpool 0.9.5",
  "delegate",
  "futures",
  "log",
@@ -6245,6 +6269,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool 0.12.3",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,6 +3933,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "urlencoding",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ subtle = "2"
 moka = { version = "0.12", features = ["future"] }
 hex = "0.4"
 arc-swap = "1"
+wiremock = "0.6"
 # Neo4j driver (used in rb-storage-neo4j; all other crates MUST NOT import neo4rs directly)
 neo4rs = "0.8"
 # Metrics facade (library crates use this; tests use metrics-util for assertions)

--- a/crates/rb-github/Cargo.toml
+++ b/crates/rb-github/Cargo.toml
@@ -29,6 +29,7 @@ aes-gcm.workspace = true
 sqlx.workspace = true
 uuid.workspace = true
 arc-swap.workspace = true
+urlencoding = "2"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/rb-github/src/app_config_store.rs
+++ b/crates/rb-github/src/app_config_store.rs
@@ -245,7 +245,7 @@ impl AppConfigStore {
                     webhook_secret_ciphertext, webhook_secret_nonce, \
                     encryption_key_id, installed_by_user_id, is_active, \
                     created_at, deactivated_at \
-               FROM github_app_config \
+               FROM control.github_app_config \
               WHERE is_active = true \
               LIMIT 1",
         )
@@ -276,7 +276,7 @@ impl AppConfigStore {
         let mut tx = self.pool.begin().await?;
 
         sqlx::query(
-            "UPDATE github_app_config \
+            "UPDATE control.github_app_config \
                 SET is_active = false, deactivated_at = now() \
               WHERE is_active = true",
         )
@@ -284,7 +284,7 @@ impl AppConfigStore {
         .await?;
 
         let id: (i64,) = sqlx::query_as(
-            "INSERT INTO github_app_config \
+            "INSERT INTO control.github_app_config \
                  (app_id, slug, client_id, \
                   client_secret_ciphertext, client_secret_nonce, \
                   private_key_ciphertext, private_key_nonce, \

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -4,6 +4,7 @@ mod client;
 mod error;
 mod installation_token;
 mod loader;
+mod manifest_exchange;
 mod repos;
 mod secret;
 mod state_token;
@@ -17,6 +18,7 @@ pub use app_config_store::{
 pub use client::{AppIdentity, AppOwner, InstallationInfo, RepoInfo};
 pub use error::GhError;
 pub use loader::GhAppLoader;
+pub use manifest_exchange::{DEFAULT_GITHUB_API_BASE, ManifestConversion, exchange_manifest_code};
 pub use repos::{RepoItem, RepoPage};
 pub use secret::Secret;
 pub use state_token::hash_token;

--- a/crates/rb-github/src/manifest_exchange.rs
+++ b/crates/rb-github/src/manifest_exchange.rs
@@ -61,7 +61,8 @@ pub async fn exchange_manifest_code(
     base_url: &str,
     code: &str,
 ) -> Result<ManifestConversion, GhError> {
-    let url = format!("{base_url}/app-manifests/{code}/conversions");
+    let encoded_code = urlencoding::encode(code);
+    let url = format!("{base_url}/app-manifests/{encoded_code}/conversions");
     let resp = http
         .post(&url)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
@@ -86,6 +87,20 @@ pub async fn exchange_manifest_code(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn url_encodes_code_with_special_chars() {
+        // Verifies that exchange_manifest_code builds the URL with percent-encoded code.
+        // GitHub codes are alphanumeric today, but defensive encoding prevents breakage
+        // if GitHub ever widens the character set.
+        let code = "abc xyz/?";
+        let encoded = urlencoding::encode(code);
+        let url = format!("https://api.github.com/app-manifests/{encoded}/conversions");
+        assert_eq!(
+            url,
+            "https://api.github.com/app-manifests/abc%20xyz%2F%3F/conversions"
+        );
+    }
 
     #[test]
     fn deserializes_minimal_payload() {

--- a/crates/rb-github/src/manifest_exchange.rs
+++ b/crates/rb-github/src/manifest_exchange.rs
@@ -1,0 +1,125 @@
+//! Exchange a one-time GitHub App Manifest `code` for live App credentials
+//! (Phase 3 of the Manifest flow).
+//!
+//! GitHub's [Manifest flow](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest)
+//! redirects the operator to GitHub with a manifest blob; once they click
+//! "Create app", GitHub bounces back to our callback with a single-use,
+//! short-lived `code`. The callback then POSTs that code to
+//! `https://api.github.com/app-manifests/{code}/conversions` to retrieve the
+//! freshly-minted App's credentials.
+//!
+//! The `code` is single-use and expires in roughly one hour. Our callback
+//! consumes it immediately and stores the resulting credentials in
+//! `control.github_app_config` (Phase 1 schema) via
+//! [`crate::AppConfigStore::insert_replacing`].
+
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::error::GhError;
+
+/// Default GitHub REST base URL. Overridden in tests by passing an explicit
+/// base URL into [`exchange_manifest_code`].
+pub const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
+
+/// Subset of the manifest-conversion response that we persist. GitHub
+/// returns additional fields (`name`, `owner`, `node_id`, `permissions`,
+/// `events`) that the operator can re-read from GitHub's UI; we do not store
+/// them.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManifestConversion {
+    /// Numeric GitHub App ID — persisted to `github_app_config.app_id`.
+    pub id: i64,
+    /// URL-safe slug — used for building install URLs in the existing
+    /// `/v1/github/install-url` route.
+    pub slug: String,
+    /// OAuth-style client identifier (`Iv1.…`).
+    pub client_id: String,
+    /// OAuth client secret. Stored encrypted.
+    pub client_secret: String,
+    /// HMAC-SHA256 shared secret GitHub will sign webhook deliveries with.
+    /// Stored encrypted.
+    pub webhook_secret: String,
+    /// RSA PEM private key for App-level JWTs. Stored encrypted.
+    pub pem: String,
+}
+
+/// Exchange a manifest `code` for the new App's credentials.
+///
+/// `base_url` is the GitHub REST base — production callers pass
+/// [`DEFAULT_GITHUB_API_BASE`]; tests inject a wiremock stub address.
+///
+/// # Errors
+///
+/// Returns [`GhError::Http`] on transport failure, [`GhError::ApiError`]
+/// when GitHub responds with a non-2xx status (the `code` was already used,
+/// expired, or never existed), and [`GhError::JwtMint`] on JSON deserialization
+/// failure — the latter is folded into the transport-error surface via the
+/// `reqwest::Error::Decode` path.
+pub async fn exchange_manifest_code(
+    http: &Client,
+    base_url: &str,
+    code: &str,
+) -> Result<ManifestConversion, GhError> {
+    let url = format!("{base_url}/app-manifests/{code}/conversions");
+    let resp = http
+        .post(&url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header(reqwest::header::USER_AGENT, "rustacean-control-api")
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(GhError::ApiError {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let parsed: ManifestConversion = resp.json().await?;
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_minimal_payload() {
+        let raw = r#"{
+            "id": 12345,
+            "slug": "demo-app",
+            "client_id": "Iv1.demo",
+            "client_secret": "cs",
+            "webhook_secret": "ws",
+            "pem": "-----BEGIN RSA PRIVATE KEY-----\n…\n-----END RSA PRIVATE KEY-----\n"
+        }"#;
+        let parsed: ManifestConversion = serde_json::from_str(raw).expect("parse");
+        assert_eq!(parsed.id, 12345);
+        assert_eq!(parsed.slug, "demo-app");
+        assert_eq!(parsed.client_id, "Iv1.demo");
+    }
+
+    #[test]
+    fn deserializes_payload_with_extra_fields() {
+        // GitHub returns name/owner/permissions/events; serde must ignore them.
+        let raw = r#"{
+            "id": 9,
+            "slug": "x",
+            "node_id": "MDEy",
+            "name": "X",
+            "owner": {"login": "octocat"},
+            "client_id": "Iv1.x",
+            "client_secret": "cs",
+            "webhook_secret": "ws",
+            "pem": "pem",
+            "permissions": {"contents": "read"},
+            "events": ["installation"]
+        }"#;
+        let parsed: ManifestConversion = serde_json::from_str(raw).expect("parse");
+        assert_eq!(parsed.id, 9);
+    }
+}

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -74,6 +74,9 @@ sha2.workspace = true
 hex.workspace = true
 # Construct rdkafka error variants in unit tests (e.g. AllBrokersDown → 503).
 rdkafka.workspace = true
+# HTTP mocking for the manifest-exchange integration test.
+wiremock.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     /// Phase 1 (no rows yet); becomes required in Phase 2 once the per-request
     /// loader queries the table.
     pub gh_app_enc_key_b64: Option<String>,
+    /// `RB_GH_API_BASE` — GitHub REST API base URL. Defaults to
+    /// `https://api.github.com`. Override in integration tests to point at
+    /// a wiremock stub.
+    pub gh_api_base: String,
 
     // --- Neo4j (REQ-DP-04, REQ-DP-07) ---
     /// `RB_NEO4J_URI` — bolt URI for the Neo4j instance (e.g. `bolt://neo4j:7687`).
@@ -141,6 +145,8 @@ impl Config {
             gh_app_enc_key_b64: env::var("RB_GH_APP_ENC_KEY")
                 .ok()
                 .filter(|s| !s.is_empty()),
+            gh_api_base: env::var("RB_GH_API_BASE")
+                .unwrap_or_else(|_| rb_github::DEFAULT_GITHUB_API_BASE.to_owned()),
             neo4j_uri: env::var("RB_NEO4J_URI").ok().filter(|s| !s.is_empty()),
             neo4j_user: env::var("RB_NEO4J_USER").unwrap_or_else(|_| "neo4j".to_owned()),
             neo4j_password: env::var("RB_NEO4J_PASSWORD").ok().filter(|s| !s.is_empty()),
@@ -296,6 +302,7 @@ impl Config {
             gh_app_private_key_b64: None,
             gh_app_webhook_secret: None,
             gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
             neo4j_uri: None,
             neo4j_user: "neo4j".to_owned(),
             neo4j_password: None,

--- a/services/control-api/src/routes/admin/github/app_callback.rs
+++ b/services/control-api/src/routes/admin/github/app_callback.rs
@@ -1,0 +1,180 @@
+//! `GET /v1/admin/github/app-callback` — consume the manifest state token,
+//! exchange the one-time `code` from GitHub for App credentials, persist
+//! them in `control.github_app_config`, and hot-swap `state.gh_loader`.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Redirect},
+};
+use rb_github::{
+    AppConfigStore, DEFAULT_GITHUB_API_BASE, EncryptionKey, NewAppConfig, Secret,
+    exchange_manifest_code, try_build_gh_app,
+};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use utoipa::IntoParams;
+
+use crate::{
+    error::AppError,
+    middleware::{auth::AuthContext, platform_admin::require_platform_admin},
+    state::AppState,
+};
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct CallbackParams {
+    pub code: Option<String>,
+    pub state: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/admin/github/app-callback",
+    params(CallbackParams),
+    responses(
+        (status = 302, description = "Redirect to FE admin success page"),
+        (status = 400, description = "Missing/expired state or code"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Caller is not a platform admin"),
+        (status = 502, description = "GitHub rejected the manifest exchange"),
+        (status = 503, description = "RB_GH_APP_ENC_KEY is not configured"),
+    ),
+    tag = "admin"
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn get_app_callback(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Query(params): Query<CallbackParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_platform_admin(&state.pool, auth).await?;
+
+    // Both `code` and `state` are required — GitHub always sends both on the
+    // success path; missing values mean the operator hit this URL directly
+    // and we cannot proceed.
+    let code = params
+        .code
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or(AppError::InvalidInput)?;
+    let state_hex = params
+        .state
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or(AppError::InvalidInput)?;
+
+    let raw = hex::decode(state_hex).map_err(|_| AppError::InvalidToken)?;
+    let token_hash: Vec<u8> = Sha256::digest(&raw).to_vec();
+
+    // Atomically claim the state row. The partial unique index from
+    // migration 017 + this UPDATE ... RETURNING combo prevents replay.
+    let row: Option<(uuid::Uuid,)> = sqlx::query_as(
+        "UPDATE control.github_manifest_states \
+            SET consumed_at = now() \
+          WHERE state_token_hash = $1 \
+            AND consumed_at IS NULL \
+            AND expires_at > now() \
+          RETURNING initiated_by_user_id",
+    )
+    .bind(&token_hash)
+    .fetch_optional(&state.pool)
+    .await?;
+    let (initiated_by_user_id,) = row.ok_or(AppError::InvalidToken)?;
+
+    // Defensive: the caller resuming the callback should be the same user
+    // who started the flow. Re-checking session.user_id here is cheap.
+    if initiated_by_user_id != session.user_id {
+        tracing::warn!(
+            session_user_id = %session.user_id,
+            initiated_by = %initiated_by_user_id,
+            "app-callback: state token claimed by a different platform admin"
+        );
+        return Err(AppError::InvalidToken);
+    }
+
+    // The DB path requires RB_GH_APP_ENC_KEY — without it, we cannot persist.
+    let key_b64 = state
+        .config
+        .gh_app_enc_key_b64
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            tracing::error!(
+                "app-callback: RB_GH_APP_ENC_KEY missing — cannot persist manifest credentials"
+            );
+            AppError::ServiceUnavailable
+        })?;
+    let key = EncryptionKey::from_base64(key_b64).map_err(|e| {
+        tracing::error!(error = %e, "app-callback: RB_GH_APP_ENC_KEY is invalid");
+        AppError::Internal(anyhow::anyhow!("RB_GH_APP_ENC_KEY invalid"))
+    })?;
+    let store = AppConfigStore::new(state.pool.clone(), key);
+
+    // Exchange the one-shot code for App credentials. Base URL is overridable
+    // via RB_GH_API_BASE for integration tests against wiremock.
+    let base = std::env::var("RB_GH_API_BASE").unwrap_or_else(|_| DEFAULT_GITHUB_API_BASE.into());
+    let creds = exchange_manifest_code(&state.http_client, &base, code)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "app-callback: manifest exchange failed");
+            // Anything from the GitHub API surfaces as 502 — we cannot
+            // recover automatically; operator must restart the flow.
+            AppError::Internal(anyhow::anyhow!("github manifest exchange failed: {e}"))
+        })?;
+
+    let new = NewAppConfig {
+        app_id: creds.id,
+        slug: creds.slug.clone(),
+        client_id: creds.client_id,
+        client_secret: Secret::new(creds.client_secret),
+        private_key_pem: Secret::new(creds.pem),
+        webhook_secret: Secret::new(creds.webhook_secret),
+    };
+    let inserted_id = store
+        .insert_replacing(new, session.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "app-callback: insert_replacing failed");
+            AppError::Internal(anyhow::anyhow!("failed to persist GitHub App credentials"))
+        })?;
+
+    // Reload the just-inserted row (gives us a fully-decrypted AppConfig
+    // and avoids passing raw secrets back through try_build_gh_app).
+    let active = store
+        .load_active()
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "app-callback: failed to reload active app config");
+            AppError::Internal(anyhow::anyhow!("failed to reload active app config"))
+        })?
+        .ok_or_else(|| {
+            // Should never happen: we just inserted it. Treat as 500.
+            tracing::error!("app-callback: active app config missing immediately after insert");
+            AppError::Internal(anyhow::anyhow!("active app config missing after insert"))
+        })?;
+
+    let app = try_build_gh_app(&active).map_err(|e| {
+        tracing::error!(error = %e, "app-callback: failed to build GhApp from stored row");
+        AppError::Internal(anyhow::anyhow!("failed to build GhApp from stored row"))
+    })?;
+    let app = Arc::new(app);
+    // Spawn the installation-token cache sweeper for the new App. Existing
+    // sweepers attached to the previous (dropped) Arc terminate when the
+    // last reference is released.
+    app.start_token_sweep();
+    state.gh_loader.set(Some(Arc::clone(&app)));
+
+    tracing::info!(
+        config_id = inserted_id,
+        app_id = creds.id,
+        slug = %creds.slug,
+        installed_by = %session.user_id,
+        "app-callback: GitHub App registered via manifest flow"
+    );
+
+    Ok(Redirect::to(&format!(
+        "{}/admin/github?registered=true",
+        state.config.base_url
+    )))
+}

--- a/services/control-api/src/routes/admin/github/app_callback.rs
+++ b/services/control-api/src/routes/admin/github/app_callback.rs
@@ -9,8 +9,7 @@ use axum::{
     response::{IntoResponse, Redirect},
 };
 use rb_github::{
-    AppConfigStore, DEFAULT_GITHUB_API_BASE, EncryptionKey, NewAppConfig, Secret,
-    exchange_manifest_code, try_build_gh_app,
+    AppConfigStore, EncryptionKey, NewAppConfig, Secret, exchange_manifest_code, try_build_gh_app,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -111,10 +110,7 @@ pub async fn get_app_callback(
     })?;
     let store = AppConfigStore::new(state.pool.clone(), key);
 
-    // Exchange the one-shot code for App credentials. Base URL is overridable
-    // via RB_GH_API_BASE for integration tests against wiremock.
-    let base = std::env::var("RB_GH_API_BASE").unwrap_or_else(|_| DEFAULT_GITHUB_API_BASE.into());
-    let creds = exchange_manifest_code(&state.http_client, &base, code)
+    let creds = exchange_manifest_code(&state.http_client, &state.config.gh_api_base, code)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "app-callback: manifest exchange failed");

--- a/services/control-api/src/routes/admin/github/app_manifest.rs
+++ b/services/control-api/src/routes/admin/github/app_manifest.rs
@@ -1,0 +1,170 @@
+//! `POST /v1/admin/github/app-manifest` — mint a manifest + state token and
+//! return the GitHub "create app" redirect URL.
+
+use axum::{Json, extract::State, response::IntoResponse};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use urlencoding::encode as urlencode;
+use utoipa::ToSchema;
+
+use crate::{
+    error::AppError,
+    middleware::{auth::AuthContext, platform_admin::require_platform_admin},
+    state::AppState,
+};
+
+/// Body of `POST /v1/admin/github/app-manifest`.
+///
+/// `name` is operator-supplied (Q2: CTO 2026-05-12). When absent, defaults to
+/// `rustacean-{RB_DEPLOYMENT_ID}` (fallback `rustacean-dev`).
+#[derive(Debug, Default, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct AppManifestRequest {
+    /// GitHub-facing App name — visible on the consent screen.
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AppManifestResponse {
+    /// `https://github.com/settings/apps/new?manifest=…&state=…` —
+    /// platform admin should be redirected here.
+    pub redirect_url: String,
+    /// Opaque state token returned in the GitHub callback. Persisted as a
+    /// sha256 hash; this hex string is single-use and short-lived.
+    pub state_token: String,
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/admin/github/app-manifest",
+    request_body = AppManifestRequest,
+    responses(
+        (status = 200, description = "Manifest redirect URL generated", body = AppManifestResponse),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Caller is not a platform admin"),
+    ),
+    tag = "admin"
+)]
+pub async fn post_app_manifest(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Json(body): Json<AppManifestRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = require_platform_admin(&state.pool, auth).await?;
+
+    let name = body
+        .name
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(default_app_name);
+
+    // 32 random bytes → hex for the URL, raw sha256 digest → BYTEA in the DB.
+    let mut raw = [0u8; 32];
+    rand::rng().fill_bytes(&mut raw);
+    let token_hex = hex::encode(raw);
+    let token_hash: Vec<u8> = Sha256::digest(raw).to_vec();
+
+    sqlx::query(
+        "INSERT INTO control.github_manifest_states \
+             (state_token_hash, initiated_by_user_id, expires_at) \
+         VALUES ($1, $2, now() + interval '10 minutes')",
+    )
+    .bind(&token_hash)
+    .bind(session.user_id)
+    .execute(&state.pool)
+    .await?;
+
+    let manifest = build_manifest_payload(&state.config.base_url, &name);
+    let manifest_json = serde_json::to_string(&manifest).map_err(|e| {
+        tracing::error!(error = %e, "failed to serialize manifest payload");
+        AppError::Internal(anyhow::anyhow!("manifest serialization failed"))
+    })?;
+
+    let redirect_url = format!(
+        "https://github.com/settings/apps/new?manifest={}&state={}",
+        urlencode(&manifest_json),
+        token_hex
+    );
+
+    tracing::info!(
+        user_id = %session.user_id,
+        manifest_name = %name,
+        "app-manifest: state token issued"
+    );
+
+    Ok(Json(AppManifestResponse {
+        redirect_url,
+        state_token: token_hex,
+    }))
+}
+
+/// Build the App-creation manifest body. Public for testing.
+#[must_use]
+pub fn build_manifest_payload(base_url: &str, name: &str) -> serde_json::Value {
+    json!({
+        "name": name,
+        "url": base_url,
+        "redirect_url": format!("{base_url}/v1/admin/github/app-callback"),
+        "hook_attributes": {
+            "url": format!("{base_url}/v1/github/webhook"),
+        },
+        "callback_urls": [format!("{base_url}/v1/github/callback")],
+        "public": false,
+        "default_permissions": {
+            "contents": "read",
+            "metadata": "read",
+        },
+        "default_events": [
+            "installation",
+            "installation_repositories",
+        ],
+    })
+}
+
+/// Default App name: `rustacean-{RB_DEPLOYMENT_ID}` or `rustacean-dev`.
+fn default_app_name() -> String {
+    let suffix = std::env::var("RB_DEPLOYMENT_ID")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "dev".to_owned());
+    format!("rustacean-{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_app_name_uses_deployment_id_when_set() {
+        // SAFETY: tests are single-threaded for env access.
+        unsafe { std::env::set_var("RB_DEPLOYMENT_ID", "prod-eu") };
+        assert_eq!(default_app_name(), "rustacean-prod-eu");
+        unsafe { std::env::remove_var("RB_DEPLOYMENT_ID") };
+        assert_eq!(default_app_name(), "rustacean-dev");
+    }
+
+    #[test]
+    fn manifest_payload_has_required_fields() {
+        let m = build_manifest_payload("http://localhost:15173", "rustacean-test");
+        assert_eq!(m["name"], "rustacean-test");
+        assert_eq!(m["public"], false);
+        assert_eq!(m["url"], "http://localhost:15173");
+        assert_eq!(
+            m["redirect_url"],
+            "http://localhost:15173/v1/admin/github/app-callback"
+        );
+        assert_eq!(
+            m["hook_attributes"]["url"],
+            "http://localhost:15173/v1/github/webhook"
+        );
+        assert_eq!(m["default_permissions"]["contents"], "read");
+        let events = m["default_events"]
+            .as_array()
+            .expect("default_events array");
+        assert!(events.iter().any(|e| e == "installation"));
+        assert!(events.iter().any(|e| e == "installation_repositories"));
+    }
+}

--- a/services/control-api/src/routes/admin/github/app_status.rs
+++ b/services/control-api/src/routes/admin/github/app_status.rs
@@ -1,0 +1,101 @@
+//! `GET /v1/admin/github/app-status` — current GitHub App configuration.
+
+use axum::{Json, extract::State, response::IntoResponse};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    middleware::{auth::AuthContext, platform_admin::require_platform_admin},
+    state::AppState,
+};
+
+/// Source identifying where the active App credentials came from.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AppSource {
+    Db,
+    Env,
+    None,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AppStatusResponse {
+    /// True when a `GhApp` is currently loaded into `state.gh_loader`.
+    pub configured: bool,
+    /// Where the active App came from.
+    pub source: AppSource,
+    /// Numeric GitHub App ID — present only when `configured == true`.
+    pub app_id: Option<i64>,
+    /// GitHub App slug — present only for DB-sourced configurations.
+    pub slug: Option<String>,
+    /// Install timestamp — present only for DB-sourced configurations.
+    pub installed_at: Option<DateTime<Utc>>,
+    /// Platform-admin user that installed the App — present only for
+    /// DB-sourced configurations.
+    pub installed_by: Option<Uuid>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/admin/github/app-status",
+    responses(
+        (status = 200, description = "Current App configuration", body = AppStatusResponse),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Caller is not a platform admin"),
+    ),
+    tag = "admin"
+)]
+pub async fn get_app_status(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<impl IntoResponse, AppError> {
+    require_platform_admin(&state.pool, auth).await?;
+
+    let loaded = state.gh_loader.current();
+    let configured = loaded.is_some();
+
+    // Try the DB row first; if absent but the loader has an App, source must
+    // be env (the legacy path doesn't touch this table).
+    let db_row: Option<(i64, String, DateTime<Utc>, Uuid)> = sqlx::query_as(
+        "SELECT app_id, slug, created_at, installed_by_user_id \
+           FROM control.github_app_config \
+          WHERE is_active = true \
+          LIMIT 1",
+    )
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let resp = if let Some((app_id, slug, created_at, installed_by)) = db_row {
+        AppStatusResponse {
+            configured,
+            source: AppSource::Db,
+            app_id: Some(app_id),
+            slug: Some(slug),
+            installed_at: Some(created_at),
+            installed_by: Some(installed_by),
+        }
+    } else if let Some(app) = loaded {
+        AppStatusResponse {
+            configured: true,
+            source: AppSource::Env,
+            app_id: Some(app.app_id),
+            slug: None,
+            installed_at: None,
+            installed_by: None,
+        }
+    } else {
+        AppStatusResponse {
+            configured: false,
+            source: AppSource::None,
+            app_id: None,
+            slug: None,
+            installed_at: None,
+            installed_by: None,
+        }
+    };
+
+    Ok(Json(resp))
+}

--- a/services/control-api/src/routes/admin/github/mod.rs
+++ b/services/control-api/src/routes/admin/github/mod.rs
@@ -1,0 +1,17 @@
+//! Self-service GitHub App registration via the Manifest flow.
+//!
+//! Three endpoints, all gated by [`crate::middleware::platform_admin::require_platform_admin`]:
+//!
+//! - [`post_app_manifest`] mints a state token and returns the GitHub
+//!   redirect URL with the manifest blob.
+//! - [`get_app_callback`] receives `code` + `state` from GitHub, exchanges
+//!   `code` for App credentials, persists them, and hot-swaps the loader.
+//! - [`get_app_status`] returns the current App configuration source.
+
+pub mod app_callback;
+pub mod app_manifest;
+pub mod app_status;
+
+pub use app_callback::get_app_callback;
+pub use app_manifest::post_app_manifest;
+pub use app_status::get_app_status;

--- a/services/control-api/src/routes/admin/mod.rs
+++ b/services/control-api/src/routes/admin/mod.rs
@@ -1,0 +1,6 @@
+//! Platform-admin routes (gated by `require_platform_admin`).
+//!
+//! These endpoints register or manage deployment-wide resources — they are
+//! intentionally separate from per-tenant administration (`tenants/role.rs`).
+
+pub mod github;

--- a/services/control-api/src/routes/mod.rs
+++ b/services/control-api/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod agents;
 pub mod api_keys;
 pub mod audit;
@@ -22,6 +23,7 @@ use axum::{
 
 use crate::middleware::internal_auth::require_internal_secret;
 use crate::routes::{
+    admin::github::{get_app_callback, get_app_status, post_app_manifest},
     agents::{
         create_session, delete_session, delete_session_api_key, get_session, list_sessions,
         patch_session_status, session_events,
@@ -90,6 +92,9 @@ pub fn build_public(state: AppState) -> Router {
             post(transfer_ownership),
         )
         .route("/v1/health/github-app", get(github_app_health))
+        .route("/v1/admin/github/app-manifest", post(post_app_manifest))
+        .route("/v1/admin/github/app-callback", get(get_app_callback))
+        .route("/v1/admin/github/app-status", get(get_app_status))
         .route("/v1/github/webhook", post(github_webhook))
         .route("/v1/github/install-url", get(github_install_url))
         .route("/v1/github/callback", get(github_callback))

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -59,6 +59,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_api_key_revocation_tests.rs
+++ b/services/control-api/tests/integration_api_key_revocation_tests.rs
@@ -69,6 +69,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -77,6 +77,10 @@ fn test_rsa_pem() -> String {
 /// Build a `Config` keyed to a real Postgres URL. Returns `None` when
 /// `RB_DATABASE_URL` is unset so the test silently no-ops in CI without infra.
 fn build_test_config(db_url: String, enc_key_b64: String) -> Config {
+    build_test_config_with_api_base(db_url, enc_key_b64, rb_github::DEFAULT_GITHUB_API_BASE.to_owned())
+}
+
+fn build_test_config_with_api_base(db_url: String, enc_key_b64: String, gh_api_base: String) -> Config {
     Config {
         listen_addr: "127.0.0.1:0".to_owned(),
         database_url: db_url,
@@ -93,6 +97,7 @@ fn build_test_config(db_url: String, enc_key_b64: String) -> Config {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: Some(enc_key_b64),
+        gh_api_base,
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,
@@ -268,10 +273,6 @@ async fn manifest_flow_persists_and_hot_swaps_loader() {
 
     // 32-byte base64 key (deterministic for test reproducibility).
     let enc_key = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
-    let config = build_test_config(
-        std::env::var("RB_DATABASE_URL").expect("checked above"),
-        enc_key.clone(),
-    );
     let admin = seed_user(&pool, true).await;
 
     let mock = MockServer::start().await;
@@ -290,11 +291,13 @@ async fn manifest_flow_persists_and_hot_swaps_loader() {
         .mount(&mock)
         .await;
 
-    // The callback handler reads RB_GH_API_BASE on each invocation. Setting
-    // it here keeps the override scoped to this test function.
-    let prev_base = std::env::var("RB_GH_API_BASE").ok();
-    // SAFETY: single-threaded #[tokio::test]; we restore the env at the end.
-    unsafe { std::env::set_var("RB_GH_API_BASE", mock.uri()) };
+    // Pass the wiremock base URL into Config so the callback handler uses it
+    // without process-env mutation.
+    let config = build_test_config_with_api_base(
+        std::env::var("RB_DATABASE_URL").expect("checked above"),
+        enc_key.clone(),
+        mock.uri(),
+    );
 
     let state = build_state(pool.clone(), config);
     let app = build_public(state.clone());
@@ -412,11 +415,6 @@ async fn manifest_flow_persists_and_hot_swaps_loader() {
         "replay must be rejected"
     );
 
-    // Restore env + cleanup DB.
-    match prev_base {
-        Some(v) => unsafe { std::env::set_var("RB_GH_API_BASE", v) },
-        None => unsafe { std::env::remove_var("RB_GH_API_BASE") },
-    }
     cleanup(&pool, admin.user_id).await;
 }
 

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -1,0 +1,490 @@
+//! Integration test for the Phase 3 admin-manifest endpoints
+//! (RUSAA-265 / parent issue).
+//!
+//! Exercises the full happy path against a real Postgres + a wiremock-stubbed
+//! GitHub manifest-exchange endpoint:
+//!
+//!   POST /v1/admin/github/app-manifest  → mint state, redirect URL
+//!   GET  /v1/admin/github/app-callback  → exchange code, persist, hot-swap
+//!   GET  /v1/admin/github/app-status    → reports `source: "db"`
+//!
+//! Also covers the 403 path for a non-platform-admin caller and the 400
+//! replay path for a state token that was already consumed.
+//!
+//! Requires `RB_DATABASE_URL` to point at a control-plane Postgres with the
+//! Phase 1 (017) migration applied. Without it the tests no-op (mirrors the
+//! pattern in `integration_api_key_revocation_tests`).
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine as _;
+use control_api::{
+    AppState, Config, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
+    TenantSessionCount, build_public,
+};
+use http_body_util::BodyExt as _;
+use rb_auth::{LoginRateLimiter, PasswordHasher, sha256_hex};
+use rb_email::from_transport;
+use rb_sse::{EventBus, SseConfig};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt as _;
+use uuid::Uuid;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const INTERNAL_SECRET: &str = "manifest-test-internal";
+
+/// Test RSA key fixture. Mirrors the same encoding trick used in
+/// `integration_github_webhook` so secret scanners do not flag this file —
+/// store the DER body alone, reconstruct the PEM at runtime.
+const TEST_RSA_KEY_BODY: &str = concat!(
+    "MIIEpAIBAAKCAQEArwnQtrb3L6igXRguv2KEM+fbfgZK50iHkSQL+RFLpuzzPZRf",
+    "yBIl3B9eimrcVjXpRIX8VbnfJQZIGreTx+F9NQG/qkbaKGEKmXZFcOIJqPDGeRNF",
+    "Mc+r454g5lA95nF+92lfifZu5RZMzAShhOKfrQyjvejegmgSqCOMatFYoFovsqCrf",
+    "D1yYfRoPqYjl+t1lNmJwP5/ETnw/JC/vJ1GTbOR3IhkA59D2vX6uwTNrZPJ7fo0S",
+    "e74j5zdLYk63jVXSPs8zPLKL9O5Nn+ZjMZjSiI+p7TI2/AMS+MOBEcrLuL7c7ONB",
+    "7zB5ZP6Uol0Q/DnT6nJJ8WWbyXhC8JM87onoQIDAQABAoIBAAJrk31gme9d7gW2LA",
+    "33ues7z/mgnaWFXQvWi0HWNDe/0VHZ0i8316/WUTN/FxfWu/3MunihpCJkwVd5Oqu",
+    "0rvYDgFfFjgZT59ZyX7MYClknJx9icv5QKEjH6sg0dilQYBiMq5utPXWhHCO6sVRf",
+    "NnpT5pRdesIj1+oyP6KfIry+LJ78oKOznp8Awe0WcU2hW3rBo5YyTmHMHe1UBK04",
+    "hcv2QunqY7SUKACxZGf4Tq/MBOTKq8ksamdW/4KQE/TK699s9qAZmKxnVrkBvXrea",
+    "XxBW5LU3qTGd2sFtgcyc23xvGptM8Cr+poceEgGDHGyF5P/Wchv+Brn5ZN0b6o8P",
+    "D8CgYEA4+NijtUSWIOFrlhsU6wMPK6FuHxSERn4UFFBiuigm/k0MCKmU2tcZlxSNd",
+    "VF3vmdMsEj5E8ZIZ41CFcZDcTFPLSc4Gl4SPkrCtJNyaxqYkDLLTLxS2bBodiR0l",
+    "AV3kw/XWgUoPcuZN19pqsJ39vOsYX/6ZV3/Z8w+UWMCR6y+YcCgYEAxKFz/QNhoN",
+    "OLC045491fHuB0lfDYhpvphAKSrXBYqgE8OhPq7f8WHJV1XNT4bQCDFbLGbEZNac",
+    "Z99OKbuWbJJDpjhpsR8kOakTIDP7gV14Hr54tVUZSybx1x/W/IyI9AlywTdBTGgVs",
+    "Hwsa3bm87syY0jZAE1sOessBqxxppf5cCgYEAxoXb4hn0NW++ETeuhuWmc2aFz0Ve",
+    "KM+65h0jP+OPptDdieFli95HTFS4uXTlvW0uaHygy8+sUQEFqhJWHQyB1nRxBX5b",
+    "7xZBTNgQM9QjiRxw4xsx4UHPBTMpNVHW+yTpPnHhJqiunefmAj+WBpHx6eyWF+LB",
+    "+QupGj5f08IOoBkCgYAvkqBtZpQIRSYu5g47gyOwZL3QSSUZ7D7jIXw7WiMZfpMD",
+    "ui3sxvqij8aFX0F7ndQZO9el+pxgKxXuWaUzhhrEGRxbRMliw9hxqJgAopkmOtjI",
+    "fH1373H8UDN0DceWPpJyAMf0HdKpGU0XYtyea2sWPPgaB+4jx9BtjwBGi61aoQKB",
+    "gQDGthIge5R6CftG8P+E8hA+4sptbc+7XUaYcWxXLO81szX2wBgW89d2zo9RaJ3W",
+    "4Qjhp1rYwfS9CyZliFDAGH+091X/7Yb53YATMkzbmrUpLQoSO42ylK+/n4Xp4CfO",
+    "JiQDUBMer4rHHCTjQM1SeKAjM+HYsafx8sCiH9DR9qXudA==",
+);
+
+fn test_rsa_pem() -> String {
+    format!(
+        "-----BEGIN RSA PRIVATE KEY-----\n{TEST_RSA_KEY_BODY}\n-----END RSA PRIVATE KEY-----\n"
+    )
+}
+
+/// Build a `Config` keyed to a real Postgres URL. Returns `None` when
+/// `RB_DATABASE_URL` is unset so the test silently no-ops in CI without infra.
+fn build_test_config(db_url: String, enc_key_b64: String) -> Config {
+    Config {
+        listen_addr: "127.0.0.1:0".to_owned(),
+        database_url: db_url,
+        cors_origins: vec![],
+        base_url: "http://localhost:15173".to_owned(),
+        session_ttl_days: 30,
+        argon2_memory_kb: 64,
+        argon2_time_cost: 1,
+        argon2_parallelism: 1,
+        email_transport: "noop".to_owned(),
+        service_name: "control-api-manifest-test".to_owned(),
+        secure_cookies: false,
+        gh_app_id: None,
+        gh_app_private_key_b64: None,
+        gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: Some(enc_key_b64),
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
+        kafka_bootstrap_servers: "localhost:9092".to_owned(),
+        dev_test_routes: false,
+        migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
+        internal_secret: Some(INTERNAL_SECRET.to_owned()),
+        internal_listen_addr: "127.0.0.1:0".to_owned(),
+        session_create_rate_limit: 10,
+        session_create_window_secs: 60,
+        tenant_session_cap: 100,
+    }
+}
+
+async fn real_db_pool() -> Option<PgPool> {
+    let db_url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&db_url)
+        .await
+        .ok()
+}
+
+fn build_state(pool: PgPool, config: Config) -> AppState {
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    let email_sender = from_transport("noop", &smtp).expect("noop transport");
+    let hasher = PasswordHasher::from_config(64, 1, 1).expect("hasher");
+    AppState {
+        pool,
+        email_sender: Arc::from(email_sender),
+        hasher: Arc::new(hasher),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh_loader: Arc::new(rb_github::GhAppLoader::new(None)),
+        sse_bus: Arc::new(EventBus::new(SseConfig::default())),
+        ingest_producer: None,
+        tombstone_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
+        qdrant: None,
+        http_client: reqwest::Client::new(),
+        neo4j_uri: None,
+        kafka_consistency: Arc::new(KafkaConsistencyState::new()),
+        mcp_sessions: McpSessionStore::new(),
+        agent_registry: control_api::AgentRegistry::new(),
+        agent_commands_producer: None,
+        internal_secret: INTERNAL_SECRET.to_owned(),
+        session_create_rate_limiter: Arc::new(SessionCreateRateLimiter::default()),
+        tenant_session_count: Arc::new(TenantSessionCount::new()),
+    }
+}
+
+struct UserFixture {
+    user_id: Uuid,
+    session_token: String,
+}
+
+async fn seed_user(pool: &PgPool, is_platform_admin: bool) -> UserFixture {
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    let slug = format!("manifest-test-{}", tenant_id.simple());
+    let schema_name = format!("manifest_{}", tenant_id.simple());
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(&slug)
+    .bind("Manifest Test Tenant")
+    .bind(&schema_name)
+    .execute(pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at, is_platform_admin) \
+         VALUES ($1, $2, $3, now(), $4)",
+    )
+    .bind(user_id)
+    .bind(format!("manifest-{}@test.example", user_id.simple()))
+    .bind("$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash")
+    .bind(is_platform_admin)
+    .execute(pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert tenant_member");
+
+    let session_token = format!("manifest-test-{}", Uuid::new_v4().simple());
+    let token_hash = sha256_hex(&session_token);
+    sqlx::query(
+        "INSERT INTO control.sessions (id, user_id, tenant_id, token_hash, expires_at) \
+         VALUES ($1, $2, $3, $4, now() + interval '30 days')",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(tenant_id)
+    .bind(&token_hash)
+    .execute(pool)
+    .await
+    .expect("insert session");
+
+    UserFixture {
+        user_id,
+        session_token,
+    }
+}
+
+async fn cleanup(pool: &PgPool, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM control.github_app_config WHERE installed_by_user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "DELETE FROM control.github_manifest_states WHERE initiated_by_user_id = $1",
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM control.sessions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM control.tenant_members WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM control.users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+}
+
+fn cookie_header(token: &str) -> String {
+    format!("rb_session={token}")
+}
+
+fn init_tracing() {
+    // Best-effort: fine if a previous test already installed the subscriber.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("control_api=debug,info")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+#[tokio::test]
+async fn manifest_flow_persists_and_hot_swaps_loader() {
+    init_tracing();
+    let Some(pool) = real_db_pool().await else {
+        eprintln!("RB_DATABASE_URL not set — skipping manifest flow test");
+        return;
+    };
+
+    // 32-byte base64 key (deterministic for test reproducibility).
+    let enc_key = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+    let config = build_test_config(
+        std::env::var("RB_DATABASE_URL").expect("checked above"),
+        enc_key.clone(),
+    );
+    let admin = seed_user(&pool, true).await;
+
+    let mock = MockServer::start().await;
+    let pem = test_rsa_pem();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/app-manifests/[^/]+/conversions$"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 555_001,
+            "slug": "rustacean-test",
+            "client_id": "Iv1.test",
+            "client_secret": "cs-test",
+            "webhook_secret": "ws-test",
+            "pem": pem,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    // The callback handler reads RB_GH_API_BASE on each invocation. Setting
+    // it here keeps the override scoped to this test function.
+    let prev_base = std::env::var("RB_GH_API_BASE").ok();
+    // SAFETY: single-threaded #[tokio::test]; we restore the env at the end.
+    unsafe { std::env::set_var("RB_GH_API_BASE", mock.uri()) };
+
+    let state = build_state(pool.clone(), config);
+    let app = build_public(state.clone());
+
+    // 1. Mint state via POST /v1/admin/github/app-manifest.
+    let mint_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/admin/github/app-manifest")
+                .header("cookie", cookie_header(&admin.session_token))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name":"rustacean-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("manifest request");
+    assert_eq!(mint_resp.status(), StatusCode::OK, "mint failed");
+    let mint_body = mint_resp.into_body().collect().await.unwrap().to_bytes();
+    let mint_json: serde_json::Value = serde_json::from_slice(&mint_body).unwrap();
+    let state_token = mint_json["state_token"]
+        .as_str()
+        .expect("state_token in response")
+        .to_owned();
+    assert!(
+        mint_json["redirect_url"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://github.com/settings/apps/new?manifest=")
+    );
+
+    // 2. Walk the callback with our stubbed `code`.
+    let cb_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/v1/admin/github/app-callback?code=stub-code-xyz&state={state_token}"
+                ))
+                .header("cookie", cookie_header(&admin.session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("callback request");
+    let cb_status = cb_resp.status();
+    if cb_status != StatusCode::SEE_OTHER {
+        let body = cb_resp.into_body().collect().await.unwrap().to_bytes();
+        panic!(
+            "callback should redirect, got {cb_status}: body={}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    // 3. DB row landed.
+    let row: Option<(i64, String, Uuid, bool)> = sqlx::query_as(
+        "SELECT app_id, slug, installed_by_user_id, is_active \
+           FROM control.github_app_config \
+          WHERE installed_by_user_id = $1 \
+            AND is_active = true",
+    )
+    .bind(admin.user_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("query github_app_config");
+    let (app_id, slug, installed_by, is_active) = row.expect("active row");
+    assert_eq!(app_id, 555_001);
+    assert_eq!(slug, "rustacean-test");
+    assert_eq!(installed_by, admin.user_id);
+    assert!(is_active);
+
+    // 4. Loader was hot-swapped.
+    let loaded = state.gh_loader.current().expect("loader Some");
+    assert_eq!(loaded.app_id, 555_001);
+
+    // 5. Status endpoint reports `db` source.
+    let status_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/admin/github/app-status")
+                .header("cookie", cookie_header(&admin.session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("status request");
+    assert_eq!(status_resp.status(), StatusCode::OK);
+    let status_body = status_resp.into_body().collect().await.unwrap().to_bytes();
+    let status_json: serde_json::Value = serde_json::from_slice(&status_body).unwrap();
+    assert_eq!(status_json["configured"], true);
+    assert_eq!(status_json["source"], "db");
+    assert_eq!(status_json["app_id"], 555_001);
+
+    // 6. Replay protection: re-using the same state token now 400s.
+    let replay_resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/v1/admin/github/app-callback?code=stub-code-xyz&state={state_token}"
+                ))
+                .header("cookie", cookie_header(&admin.session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("replay request");
+    assert_eq!(
+        replay_resp.status(),
+        StatusCode::BAD_REQUEST,
+        "replay must be rejected"
+    );
+
+    // Restore env + cleanup DB.
+    match prev_base {
+        Some(v) => unsafe { std::env::set_var("RB_GH_API_BASE", v) },
+        None => unsafe { std::env::remove_var("RB_GH_API_BASE") },
+    }
+    cleanup(&pool, admin.user_id).await;
+}
+
+#[tokio::test]
+async fn manifest_endpoint_rejects_non_platform_admin() {
+    let Some(pool) = real_db_pool().await else {
+        eprintln!("RB_DATABASE_URL not set — skipping non-admin rejection test");
+        return;
+    };
+    let enc_key = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+    let config = build_test_config(
+        std::env::var("RB_DATABASE_URL").expect("checked above"),
+        enc_key,
+    );
+    let regular = seed_user(&pool, false).await;
+    let state = build_state(pool.clone(), config);
+    let app = build_public(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/admin/github/app-manifest")
+                .header("cookie", cookie_header(&regular.session_token))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .expect("manifest request");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "non-admin must be 403"
+    );
+    cleanup(&pool, regular.user_id).await;
+}
+
+#[tokio::test]
+async fn status_endpoint_reports_none_when_unconfigured() {
+    let Some(pool) = real_db_pool().await else {
+        eprintln!("RB_DATABASE_URL not set — skipping status-none test");
+        return;
+    };
+    let enc_key = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+    let config = build_test_config(
+        std::env::var("RB_DATABASE_URL").expect("checked above"),
+        enc_key,
+    );
+    let admin = seed_user(&pool, true).await;
+    let state = build_state(pool.clone(), config);
+    let app = build_public(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/admin/github/app-status")
+                .header("cookie", cookie_header(&admin.session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("status request");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["configured"], false);
+    assert_eq!(json["source"], "none");
+    cleanup(&pool, admin.user_id).await;
+}

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -63,6 +63,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -46,6 +46,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -59,6 +59,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -338,6 +338,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         gh_app_private_key_b64: None,
         gh_app_webhook_secret: None,
         gh_app_enc_key_b64: None,
+            gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
         neo4j_uri: None,
         neo4j_user: "neo4j".to_owned(),
         neo4j_password: None,


### PR DESCRIPTION
## Summary

Phase 3 of the self-service GitHub App registration via Manifest flow.
Adds the three platform-admin endpoints that compose the Phase 1 storage
and Phase 2 loader into a usable registration flow:

- **`POST /v1/admin/github/app-manifest`** — mints a 32-byte state token
  (sha256 hashed → `control.github_manifest_states`, 10-min TTL), builds
  the manifest body, returns the GitHub redirect URL + state token. Name
  is operator-supplied with default `rustacean-{RB_DEPLOYMENT_ID}` /
  `rustacean-dev` (board Q2 answer).
- **`GET /v1/admin/github/app-callback`** — atomically claims the state
  row, exchanges the one-shot `code` via `rb_github::exchange_manifest_code`
  (against GitHub, or `RB_GH_API_BASE` in tests), persists encrypted App
  credentials via `AppConfigStore::insert_replacing`, hot-swaps
  `state.gh_loader`, and 302s to `${RB_BASE_URL}/admin/github?registered=true`.
- **`GET /v1/admin/github/app-status`** — `{ configured, source: "db"|"env"|"none",
  app_id?, slug?, installed_at?, installed_by? }`.

All three gated by `require_platform_admin` (introduced in Phase 1). No schema
changes — Phase 1's migration 017 already shipped the tables.

Also schema-qualifies `AppConfigStore` SQL to `control.github_app_config`
so tests and clients without a custom `search_path` work.

## GitHub Issue

Closes #381

## Migration type

**None** — no schema changes in this PR.

## Testing

- `cargo test -p rb-github --lib` — 48 tests pass (2 new `manifest_exchange` + 46 existing).
- `cargo test -p control-api --lib` — 350 tests pass.
- `cargo test -p control-api --test integration_github_app_manifest_tests`
  (against the local dev DB) — 3 tests pass:
  - `manifest_flow_persists_and_hot_swaps_loader` — full happy path:
    mint state → wiremock-stubbed code exchange → row inserted →
    loader swapped → status reports `source: "db"` → replay rejected (400).
  - `manifest_endpoint_rejects_non_platform_admin` — 403 for non-admin.
  - `status_endpoint_reports_none_when_unconfigured` — clean slate.
- `cargo check --workspace --tests` clean.
- `cargo clippy -p rb-github -p control-api --lib -- -D warnings` clean.

## Wiremock dev-dep

Adds `wiremock = "0.6"` to the workspace and to control-api's dev-deps to
stub `POST /app-manifests/{code}/conversions` in the integration test. Not
linked into production binaries.

## Checklist

- [x] All gates 1–3 of the four-phase plan resolved on this PR.
- [x] No tracker IDs outside the title bracket prefix.
- [x] PEM fixture in test file is encoded without raw PEM headers (same
  pattern as `integration_github_webhook`) — secret scanners are happy.