### PR TITLE
[RUSAA-1213] feat(agent-runner): install claude CLI in container

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -522,6 +522,11 @@ services:
       RB_AGENT_WORKSPACE_BASE: /data/agent-workspaces
       RB_CONTROL_API_BASE_URL: "http://control-api:8081"
       RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
+      # Runtime credentials forwarded to the spawned agent CLI. These are
+      # *not* required for the runner itself to start; they are read by
+      # claude / opencode subprocesses. Set per host (compose env file or
+      # shell export) — never commit a real key.
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_SERVICE_NAME: agent-runner
       RUST_LOG: "info,agent_runner=debug"

--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -35,16 +35,37 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p agent-runner && \
     cp target/release/rb-agent-runner /usr/local/bin/
 
-# ── Stage 4: minimal runtime image ────────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+# ── Stage 4: runtime image ────────────────────────────────────────────────────
+# Base on node:20-bookworm-slim so we have node/npm/npx for:
+#   • @anthropic-ai/claude-code (CLI binary the ClaudeCode adapter spawns)
+#   • npx @modelcontextprotocol/server-rust-brain (MCP server invoked from
+#     workspace .mcp.json — see services/agent-runner/src/adapters/mod.rs)
+FROM node:20-bookworm-slim AS runtime
 
-# Install git and ssh for cloning during agent execution.
+# Install git, ssh, and the C runtime deps the Rust binary links against.
+# (Node base images already ship libssl3/zlib1g/libcurl4 but we install
+# explicitly so the contract is obvious and survives base bumps.)
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd --gid 65532 nonroot && \
     useradd --uid 65532 --gid 65532 --no-create-home --system nonroot
+
+# Install the claude CLI. The package ships a thin wrapper and pulls the
+# correct native binary via the linux-x64 optionalDependency in postinstall.
+# Pin to the version this image is tested against; bumps go through a separate
+# chore PR. See the registry for the latest: https://registry.npmjs.org/@anthropic-ai/claude-code
+ARG CLAUDE_CODE_VERSION=2.1.139
+RUN npm install --omit=dev --no-fund --no-audit -g \
+        @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && \
+    npm cache clean --force && \
+    # Sanity-check that the postinstall replaced the placeholder shim with the
+    # native binary. `claude --version` works without an API key, so we use it
+    # as the canonical install probe — if the optionalDependency was skipped,
+    # this fails the build instead of producing an image that silently can't
+    # spawn claude at runtime.
+    claude --version
 
 # Pre-create the agent workspace mount point with nonroot ownership.
 # Docker named volumes inherit ownership/permissions from the image's directory


### PR DESCRIPTION
## Summary

The agent-runner Docker image is built on `debian:bookworm-slim` and ships only the Rust binary `rb-agent-runner`. The `ClaudeCode` adapter spawns `claude --jsonl …`, which is not present in the image — every session created via `POST /v1/agents/sessions` fails immediately with:

```
Failed to spawn ClaudeCode adapter: ... No such file or directory (os error 2)
```

This PR installs the `claude` CLI into the runtime stage and wires the `ANTHROPIC_API_KEY` env var through compose. It is the gating fix for Wave 7 UAT (all downstream MCP / E2E validation depends on a working runtime).

## GitHub Issue

Closes #383

## Changes

- `docker/agent-runner/Dockerfile`
  - Runtime base changed from `debian:bookworm-slim` to `node:20-bookworm-slim` (Node is needed for both the claude wrapper postinstall **and** the `npx @modelcontextprotocol/server-rust-brain` MCP server spawn).
  - `npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}` with `CLAUDE_CODE_VERSION=2.1.139` pinned via `ARG`. Build-time `claude --version` probe so a missing optional native dep fails the build instead of silently producing a broken image.
  - Same nonroot UID 65532 + `/data/agent-workspaces` ownership as before; no surface change for the runner itself.
- `compose/dev.yml`
  - `ANTHROPIC_API_KEY: \"\${ANTHROPIC_API_KEY:-}\"` forwarded into the `agent-runner` container; empty by default. Operator sets the real key in `compose/<env>.env` (gitignored) or via a shell export; never committed.

## Migration type

No schema migrations. Image rebuild only.

## Verification (mars)

1. `$COMPOSE_CMD build agent-runner` succeeds; `claude --version` prints `2.1.139 (Claude Code)` inside the build.
2. `$COMPOSE_CMD up -d --no-deps --force-recreate agent-runner` recreates the container.
3. Inside the container as UID 65532: `command -v claude` → `/usr/local/bin/claude`; `command -v npx` → `/usr/local/bin/npx`.
4. Created a real session via `POST /v1/agents/sessions` with `{\"runtime\":\"claude_code\",\"initial_prompt\":\"hello\"}`. DB row for the session went `pending → running` with `pid` recorded, agent-runner emitted:

   ```
   Session started pid=75 runtime=ClaudeCode session_id=2b587a49-…
   ```

5. `DELETE /v1/agents/sessions/{id}` transitioned the session to `terminated` with `exit_code=1`. No `Failed to spawn ClaudeCode adapter` error in logs.

## Test plan

- [ ] CI build matrix passes (agent-runner image build is the new path)
- [ ] QA: full UI session lifecycle via http://100.87.157.74:15173/agents/executions — `pending → running → completed/terminated` ( follow-up)

## Out of scope

- `opencode` and `pi` runtimes. Opencode is not currently installed; its adapter is wired but the binary is missing — separate follow-up. `pi` bails by design until ADR-009 Phase 3.