### PR TITLE
[RUSAA-1216] feat(frontend): wire agent sessions API into execution page

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -59,6 +59,54 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/admin/github/app-callback": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["get_app_callback"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/admin/github/app-manifest": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post: operations["post_app_manifest"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/admin/github/app-status": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["get_app_status"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/agents/sessions": {
         readonly parameters: {
             readonly query?: never;
@@ -919,6 +967,60 @@ export interface components {
             readonly name: string;
             readonly scopes: readonly components["schemas"]["Scope"][];
         };
+        /**
+         * @description Body of `POST /v1/admin/github/app-manifest`.
+         *
+         *     `name` is operator-supplied (Q2: CTO 2026-05-12). When absent, defaults to
+         *     `rustacean-{RB_DEPLOYMENT_ID}` (fallback `rustacean-dev`).
+         */
+        readonly AppManifestRequest: {
+            /**
+             * @description GitHub-facing App name — visible on the consent screen.
+             * @default null
+             */
+            readonly name: string | null;
+        };
+        readonly AppManifestResponse: {
+            /**
+             * @description `https://github.com/settings/apps/new?manifest=…&state=…` —
+             *     platform admin should be redirected here.
+             */
+            readonly redirect_url: string;
+            /**
+             * @description Opaque state token returned in the GitHub callback. Persisted as a
+             *     sha256 hash; this hex string is single-use and short-lived.
+             */
+            readonly state_token: string;
+        };
+        /**
+         * @description Source identifying where the active App credentials came from.
+         * @enum {string}
+         */
+        readonly AppSource: "db" | "env" | "none";
+        readonly AppStatusResponse: {
+            /**
+             * Format: int64
+             * @description Numeric GitHub App ID — present only when `configured == true`.
+             */
+            readonly app_id?: number | null;
+            /** @description True when a `GhApp` is currently loaded into `state.gh_loader`. */
+            readonly configured: boolean;
+            /**
+             * Format: date-time
+             * @description Install timestamp — present only for DB-sourced configurations.
+             */
+            readonly installed_at?: string | null;
+            /**
+             * Format: uuid
+             * @description Platform-admin user that installed the App — present only for
+             *     DB-sourced configurations.
+             */
+            readonly installed_by?: string | null;
+            /** @description GitHub App slug — present only for DB-sourced configurations. */
+            readonly slug?: string | null;
+            /** @description Where the active App came from. */
+            readonly source: components["schemas"]["AppSource"];
+        };
         readonly AuditEventItem: {
             readonly action: string;
             readonly actor_kind: string;
@@ -1599,6 +1701,134 @@ export interface operations {
             };
             /** @description Service is not ready */
             readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_app_callback: {
+        readonly parameters: {
+            readonly query?: {
+                readonly code?: string | null;
+                readonly state?: string | null;
+            };
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Redirect to FE admin success page */
+            readonly 302: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing/expired state or code */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description GitHub rejected the manifest exchange */
+            readonly 502: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description RB_GH_APP_ENC_KEY is not configured */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly post_app_manifest: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AppManifestRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Manifest redirect URL generated */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AppManifestResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_app_status: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Current App configuration */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AppStatusResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -59,6 +59,13 @@ export {
   type AuditEventsParams,
 } from "./useAuditEvents";
 export {
+  useAgentSessions,
+  agentSessionsQueryKey,
+  type SessionItem,
+  type ListSessionsResponse,
+} from "./useAgentSessions";
+export { useCreateSession } from "./useCreateSession";
+export {
   useRecentIngestions,
   useInvalidateRecentIngestions,
   recentIngestionsQueryKey,

--- a/frontend/src/api/hooks/useAgentSessions.ts
+++ b/frontend/src/api/hooks/useAgentSessions.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+export type SessionItem = components["schemas"]["SessionItem"];
+export type ListSessionsResponse = components["schemas"]["ListSessionsResponse"];
+
+export const agentSessionsQueryKey = ["agents", "sessions"] as const;
+
+export function useAgentSessions(
+  options?: Omit<
+    UseQueryOptions<ListSessionsResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<ListSessionsResponse, ApiError>({
+    queryKey: agentSessionsQueryKey,
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET("/v1/agents/sessions");
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    staleTime: 30_000,
+    ...options,
+  });
+}

--- a/frontend/src/api/hooks/useCreateSession.ts
+++ b/frontend/src/api/hooks/useCreateSession.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+import { agentSessionsQueryKey } from "./useAgentSessions";
+
+type CreateSessionRequest = components["schemas"]["CreateSessionRequest"];
+
+export function useCreateSession(
+  options?: Omit<
+    UseMutationOptions<void, ApiError, CreateSessionRequest>,
+    "mutationFn"
+  >,
+) {
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, CreateSessionRequest>({
+    mutationFn: async (body) => {
+      const { error, response } = await apiClient.POST(
+        "/v1/agents/sessions",
+        { body },
+      );
+      if (error) {
+        throw toApiError(response.status, error);
+      }
+    },
+    onSuccess: (...args) => {
+      void qc.invalidateQueries({ queryKey: agentSessionsQueryKey });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+}

--- a/frontend/src/components/agent-execution/CreateSessionDialog.tsx
+++ b/frontend/src/components/agent-execution/CreateSessionDialog.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCreateSession } from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+
+// ---------------------------------------------------------------------------
+// Focus-trap utilities (same pattern as ConnectRepoDialog in ReposPage)
+// ---------------------------------------------------------------------------
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+// ---------------------------------------------------------------------------
+// Form schema
+// ---------------------------------------------------------------------------
+
+const RUNTIME_OPTIONS = ["claude_code", "opencode", "pi"] as const;
+
+const createSessionFormSchema = z.object({
+  runtime: z.enum(RUNTIME_OPTIONS),
+  initial_prompt: z.string().min(1, "Prompt is required").max(4096),
+  workspace_path: z.string().max(512).optional(),
+});
+
+type CreateSessionFormValues = z.infer<typeof createSessionFormSchema>;
+
+// ---------------------------------------------------------------------------
+// Dialog component
+// ---------------------------------------------------------------------------
+
+interface CreateSessionDialogProps {
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+export function CreateSessionDialog({
+  onClose,
+  onSuccess,
+}: CreateSessionDialogProps): JSX.Element {
+  const createSession = useCreateSession();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateSessionFormValues>({
+    resolver: zodResolver(createSessionFormSchema),
+    defaultValues: {
+      runtime: "claude_code",
+      initial_prompt: "",
+      workspace_path: "",
+    },
+  });
+
+  // Focus trap + Escape — same pattern as ConnectRepoDialog
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const focusables = getFocusableElements(dialogRef.current);
+    focusables[0]?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusables = getFocusableElements(dialogRef.current);
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!first || !last) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    try {
+      await createSession.mutateAsync({
+        runtime: values.runtime,
+        initial_prompt: values.initial_prompt,
+        workspace_path: values.workspace_path || null,
+      });
+      onSuccess();
+    } catch (err) {
+      setSubmitError(formatApiError(err, "Could not create session."));
+    }
+  });
+
+  return (
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-session-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="flex w-full max-w-lg flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-xl">
+        <div className="flex items-start justify-between">
+          <h2
+            id="create-session-title"
+            className="text-lg font-semibold tracking-tight"
+          >
+            New Agent Session
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          {/* Runtime selector */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="session-runtime"
+              className="text-sm font-medium text-foreground"
+            >
+              Runtime
+            </label>
+            <select
+              id="session-runtime"
+              {...register("runtime")}
+              aria-invalid={errors.runtime ? "true" : "false"}
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              {RUNTIME_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt.replace("_", " ")}
+                </option>
+              ))}
+            </select>
+            {errors.runtime && (
+              <p id="session-runtime-error" role="alert" className="text-xs text-destructive">
+                {errors.runtime.message}
+              </p>
+            )}
+          </div>
+
+          {/* Initial prompt */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="session-prompt"
+              className="text-sm font-medium text-foreground"
+            >
+              Prompt
+            </label>
+            <textarea
+              id="session-prompt"
+              rows={4}
+              placeholder="Describe what you want the agent to do…"
+              {...register("initial_prompt")}
+              aria-invalid={errors.initial_prompt ? "true" : "false"}
+              aria-describedby={
+                errors.initial_prompt ? "session-prompt-error" : undefined
+              }
+              className="resize-none rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            {errors.initial_prompt && (
+              <p id="session-prompt-error" role="alert" className="text-xs text-destructive">
+                {errors.initial_prompt.message}
+              </p>
+            )}
+          </div>
+
+          {/* Workspace path (optional) */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="session-workspace"
+              className="text-sm font-medium text-foreground"
+            >
+              Workspace path{" "}
+              <span className="font-normal text-muted-foreground">(optional)</span>
+            </label>
+            <input
+              id="session-workspace"
+              type="text"
+              placeholder="tenant_id/session_id"
+              {...register("workspace_path")}
+              aria-invalid={errors.workspace_path ? "true" : "false"}
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            {errors.workspace_path && (
+              <p id="session-workspace-error" role="alert" className="text-xs text-destructive">
+                {errors.workspace_path.message}
+              </p>
+            )}
+          </div>
+
+          {/* Submit error */}
+          {submitError && (
+            <p role="alert" className="text-sm text-destructive">
+              {submitError}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              aria-busy={isSubmitting ? "true" : "false"}
+              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Creating…" : "Create session"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -1,24 +1,31 @@
-import type { RecentIngestionRun } from "@/api";
+import type { SessionItem } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { formatTimestamp } from "@/components/activity/utils";
 
 const STATUS_CELL_CLASS: Record<string, string> = {
   succeeded: "text-green-600 dark:text-green-400",
+  completed: "text-green-600 dark:text-green-400",
   done: "text-green-600 dark:text-green-400",
   failed: "text-destructive",
   running: "text-blue-600 dark:text-blue-400",
   processing: "text-blue-600 dark:text-blue-400",
+  pending: "text-yellow-600 dark:text-yellow-400",
+  cancelled: "text-muted-foreground",
   queued: "text-muted-foreground",
-  pending: "text-muted-foreground",
 };
 
-function RunStatusCell({ status }: { readonly status: string }): JSX.Element {
+function SessionStatusCell({ status }: { readonly status: string }): JSX.Element {
   const cls = STATUS_CELL_CLASS[status] ?? "text-muted-foreground";
   return <span className={`text-xs font-medium capitalize ${cls}`}>{status}</span>;
 }
 
+function formatTokenUsage(used: number, budget: number): string {
+  if (budget === 0) return `${used}`;
+  return `${used.toLocaleString()} / ${budget.toLocaleString()}`;
+}
+
 interface SessionHistoryProps {
-  readonly sessions: readonly RecentIngestionRun[];
+  readonly sessions: readonly SessionItem[];
   readonly isLoading: boolean;
   readonly isError: boolean;
   readonly error: { status: number; body: unknown } | null;
@@ -67,16 +74,19 @@ export function SessionHistory({
               Session
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Runtime
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
               Status
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
               Started
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-              Finished
+              Completed
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-              Trace
+              Tokens
             </th>
           </tr>
         </thead>
@@ -91,35 +101,38 @@ export function SessionHistory({
 }
 
 interface SessionRowProps {
-  readonly session: RecentIngestionRun;
+  readonly session: SessionItem;
 }
 
 function SessionRow({ session }: SessionRowProps): JSX.Element {
   return (
     <tr className="border-b border-border last:border-0 hover:bg-muted/20">
-      <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-        {session.id.slice(0, 8)}…
+      <td className="px-4 py-2">
+        <span className="font-mono text-xs text-muted-foreground" title={session.id}>
+          {session.id.slice(0, 8)}…
+        </span>
+        {session.input_prompt_preview && (
+          <p className="mt-0.5 max-w-[200px] truncate text-xs text-muted-foreground/70">
+            {session.input_prompt_preview}
+          </p>
+        )}
       </td>
       <td className="px-4 py-2">
-        <RunStatusCell status={session.status} />
+        <span className="inline-flex rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
+          {session.runtime_kind}
+        </span>
+      </td>
+      <td className="px-4 py-2">
+        <SessionStatusCell status={session.status} />
       </td>
       <td className="px-4 py-2 text-xs text-muted-foreground">
         {session.started_at ? formatTimestamp(session.started_at) : "—"}
       </td>
       <td className="px-4 py-2 text-xs text-muted-foreground">
-        {session.finished_at ? formatTimestamp(session.finished_at) : "—"}
+        {session.completed_at ? formatTimestamp(session.completed_at) : "—"}
       </td>
-      <td className="px-4 py-2">
-        {session.trace_id ? (
-          <span
-            className="font-mono text-xs text-muted-foreground"
-            title={session.trace_id}
-          >
-            {session.trace_id.slice(0, 8)}…
-          </span>
-        ) : (
-          <span className="font-mono text-xs text-muted-foreground/50">—</span>
-        )}
+      <td className="px-4 py-2 text-xs text-muted-foreground">
+        {formatTokenUsage(session.tokens_used, session.token_budget)}
       </td>
     </tr>
   );

--- a/frontend/src/components/agent-execution/index.ts
+++ b/frontend/src/components/agent-execution/index.ts
@@ -1,2 +1,3 @@
+export { CreateSessionDialog } from "./CreateSessionDialog";
 export { ExecutionStream } from "./ExecutionStream";
 export { SessionHistory } from "./SessionHistory";

--- a/frontend/src/hooks/useEventStream.ts
+++ b/frontend/src/hooks/useEventStream.ts
@@ -16,12 +16,19 @@ export interface UseEventStreamResult {
 
 const RECONNECT_DELAY_MS = 5_000;
 
-export function useEventStream(url: string): UseEventStreamResult {
+const DEFAULT_EVENT_TYPES = ["ingest.status", "session.event", "stream-reset"];
+
+export function useEventStream(
+  url: string,
+  eventTypes: readonly string[] = DEFAULT_EVENT_TYPES,
+): UseEventStreamResult {
   const [events, setEvents] = useState<StreamedEvent[]>([]);
   const [lastEventId, setLastEventId] = useState<string | null>(null);
   const [readyState, setReadyState] = useState<EventStreamReadyState>("connecting");
 
   const cancelledRef = useRef(false);
+  const eventTypesRef = useRef(eventTypes);
+  eventTypesRef.current = eventTypes;
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -52,7 +59,10 @@ export function useEventStream(url: string): UseEventStreamResult {
         setEvents((prev) => [...prev, streamed]);
       };
 
-      es.addEventListener("ingest.status", handleEvent);
+      for (const eventType of eventTypesRef.current) {
+        if (eventType === "stream-reset") continue;
+        es.addEventListener(eventType, handleEvent);
+      }
 
       es.addEventListener("stream-reset", () => {
         if (!cancelledRef.current) setEvents([]);

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -1,9 +1,8 @@
-import { useMe, useRecentIngestions, useInvalidateRecentIngestions } from "@/api";
-import { useEffect } from "react";
+import { useMe, useAgentSessions } from "@/api";
+import { useState } from "react";
 import { PageContainer } from "@/components/repos/PageContainer";
-import { useEventStream } from "@/hooks/useEventStream";
 import { SessionHistory } from "@/components/agent-execution/SessionHistory";
-import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
+import { CreateSessionDialog } from "@/components/agent-execution/CreateSessionDialog";
 
 export function AgentExecutionPage(): JSX.Element {
   const me = useMe({ retry: false });
@@ -27,78 +26,62 @@ export function AgentExecutionPage(): JSX.Element {
     );
   }
 
-  return <AgentExecutionInner tenantId={me.data.current_tenant.id} />;
+  return <AgentExecutionInner />;
 }
 
-interface AgentExecutionInnerProps {
-  readonly tenantId: string;
-}
+function AgentExecutionInner(): JSX.Element {
+  const [dialogOpen, setDialogOpen] = useState(false);
 
-function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Element {
-  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+  const sessions = useAgentSessions({
+    refetchInterval: 10_000,
+  });
 
-  // useRecentIngestions fetches from the backend's ingestion-runs table,
-  // which backs the "Agent Execution" view — each ingestion run corresponds
-  // to an agent execution session.
-  const recentSessions = useRecentIngestions(tenantId);
-  const invalidateSessions = useInvalidateRecentIngestions();
-
-  const { events, lastEventId, readyState } = useEventStream(`${apiBase}/v1/ingest/events`);
-
-  useEffect(() => {
-    const latestIngest = events
-      .filter((e) => e.type === "ingest.status")
-      .at(-1);
-    if (!latestIngest) return;
-    try {
-      const parsed = JSON.parse(latestIngest.data) as { status?: string };
-      if (parsed.status === "succeeded" || parsed.status === "done") {
-        void invalidateSessions(tenantId);
-      }
-    } catch {
-      // malformed event — ignore
-    }
-  }, [events, tenantId, invalidateSessions]);
-
-  const sessions = recentSessions.data?.runs ?? [];
+  const sessionList = sessions.data?.sessions ?? [];
 
   return (
     <PageContainer>
       <header className="mb-6 flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Agent Execution
-        </h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Agent Execution
+          </h1>
+          <button
+            type="button"
+            onClick={() => setDialogOpen(true)}
+            className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            New Session
+          </button>
+        </div>
         <p className="text-sm text-muted-foreground">
-          View execution sessions, live event streams, and trace details.
+          View and manage agent execution sessions.
         </p>
       </header>
 
-      <div className="space-y-8">
-        <section aria-labelledby="sessions-heading">
-          <h2
-            id="sessions-heading"
-            className="mb-3 text-base font-semibold tracking-tight"
-          >
-            Session History
-          </h2>
-          <SessionHistory
-            sessions={sessions}
-            isLoading={recentSessions.isLoading}
-            isError={recentSessions.isError}
-            error={recentSessions.error}
-          />
-        </section>
+      <section aria-labelledby="sessions-heading">
+        <h2
+          id="sessions-heading"
+          className="mb-3 text-base font-semibold tracking-tight"
+        >
+          Session History
+        </h2>
+        <SessionHistory
+          sessions={sessionList}
+          isLoading={sessions.isLoading}
+          isError={sessions.isError}
+          error={sessions.error}
+        />
+      </section>
 
-        <section aria-labelledby="stream-heading">
-          <h2
-            id="stream-heading"
-            className="mb-3 text-base font-semibold tracking-tight"
-          >
-            Execution Stream
-          </h2>
-          <ExecutionStream events={events} lastEventId={lastEventId} readyState={readyState} />
-        </section>
-      </div>
+      {dialogOpen && (
+        <CreateSessionDialog
+          onClose={() => setDialogOpen(false)}
+          onSuccess={() => {
+            setDialogOpen(false);
+            void sessions.refetch();
+          }}
+        />
+      )}
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary

Replace ingestion-based session view with proper agent sessions API. The previous code used `useRecentIngestions` (backed by `/v1/ingestions/recent`) and a non-existent global SSE endpoint. This PR wires the frontend to the actual agent sessions API (`GET/POST /v1/agents/sessions`) with correct types from the generated OpenAPI schema.

## Changes

- **New hooks**: `useAgentSessions` (query), `useCreateSession` (mutation)
- **New component**: `CreateSessionDialog` with runtime selector, prompt, optional workspace path
- **Rewritten**: `SessionHistory` now uses `SessionItem` type with `runtime_kind` and token usage columns
- **Rewired**: `AgentExecutionPage` uses agent sessions API with 10s polling instead of broken global SSE
- **Updated**: `useEventStream` supports configurable event types including `session.event`

## GitHub Issue
Closes #385

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR