### PR TITLE
[RUSAA-1224] feat(frontend): GitHub App Manifest admin UI

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -59,6 +59,54 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/admin/github/app-callback": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["get_app_callback"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/admin/github/app-manifest": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post: operations["post_app_manifest"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/admin/github/app-status": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: operations["get_app_status"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/agents/sessions": {
         readonly parameters: {
             readonly query?: never;
@@ -919,6 +967,60 @@ export interface components {
             readonly name: string;
             readonly scopes: readonly components["schemas"]["Scope"][];
         };
+        /**
+         * @description Body of `POST /v1/admin/github/app-manifest`.
+         *
+         *     `name` is operator-supplied (Q2: CTO 2026-05-12). When absent, defaults to
+         *     `rustacean-{RB_DEPLOYMENT_ID}` (fallback `rustacean-dev`).
+         */
+        readonly AppManifestRequest: {
+            /**
+             * @description GitHub-facing App name — visible on the consent screen.
+             * @default null
+             */
+            readonly name: string | null;
+        };
+        readonly AppManifestResponse: {
+            /**
+             * @description `https://github.com/settings/apps/new?manifest=…&state=…` —
+             *     platform admin should be redirected here.
+             */
+            readonly redirect_url: string;
+            /**
+             * @description Opaque state token returned in the GitHub callback. Persisted as a
+             *     sha256 hash; this hex string is single-use and short-lived.
+             */
+            readonly state_token: string;
+        };
+        /**
+         * @description Source identifying where the active App credentials came from.
+         * @enum {string}
+         */
+        readonly AppSource: "db" | "env" | "none";
+        readonly AppStatusResponse: {
+            /**
+             * Format: int64
+             * @description Numeric GitHub App ID — present only when `configured == true`.
+             */
+            readonly app_id?: number | null;
+            /** @description True when a `GhApp` is currently loaded into `state.gh_loader`. */
+            readonly configured: boolean;
+            /**
+             * Format: date-time
+             * @description Install timestamp — present only for DB-sourced configurations.
+             */
+            readonly installed_at?: string | null;
+            /**
+             * Format: uuid
+             * @description Platform-admin user that installed the App — present only for
+             *     DB-sourced configurations.
+             */
+            readonly installed_by?: string | null;
+            /** @description GitHub App slug — present only for DB-sourced configurations. */
+            readonly slug?: string | null;
+            /** @description Where the active App came from. */
+            readonly source: components["schemas"]["AppSource"];
+        };
         readonly AuditEventItem: {
             readonly action: string;
             readonly actor_kind: string;
@@ -1599,6 +1701,134 @@ export interface operations {
             };
             /** @description Service is not ready */
             readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_app_callback: {
+        readonly parameters: {
+            readonly query?: {
+                readonly code?: string | null;
+                readonly state?: string | null;
+            };
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Redirect to FE admin success page */
+            readonly 302: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing/expired state or code */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description GitHub rejected the manifest exchange */
+            readonly 502: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description RB_GH_APP_ENC_KEY is not configured */
+            readonly 503: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly post_app_manifest: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AppManifestRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Manifest redirect URL generated */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AppManifestResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly get_app_status: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Current App configuration */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AppStatusResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a platform admin */
+            readonly 403: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -33,6 +33,11 @@ export {
 } from "./useRepos";
 export { useGithubInstallUrl } from "./useGithubInstall";
 export {
+  useGithubAppStatus,
+  githubAppStatusQueryKey,
+} from "./useGithubAppStatus";
+export { useGithubAppManifest } from "./useGithubAppManifest";
+export {
   useModuleTree,
   moduleTreeQueryKey,
   useItem,

--- a/frontend/src/api/hooks/useGithubAppManifest.ts
+++ b/frontend/src/api/hooks/useGithubAppManifest.ts
@@ -1,0 +1,21 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type AppManifestRequest = components["schemas"]["AppManifestRequest"];
+type AppManifestResponse = components["schemas"]["AppManifestResponse"];
+
+export function useGithubAppManifest() {
+  return useMutation<AppManifestResponse, ApiError, AppManifestRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await apiClient.POST(
+        "/v1/admin/github/app-manifest",
+        { body },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/hooks/useGithubAppStatus.ts
+++ b/frontend/src/api/hooks/useGithubAppStatus.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type AppStatusResponse = components["schemas"]["AppStatusResponse"];
+
+export const githubAppStatusQueryKey = ["github-app-status"] as const;
+
+export function useGithubAppStatus(
+  options?: Omit<
+    UseQueryOptions<AppStatusResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<AppStatusResponse, ApiError>({
+    queryKey: githubAppStatusQueryKey,
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET(
+        "/v1/admin/github/app-status",
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    ...options,
+  });
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -58,6 +58,12 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
             >
               Activity
             </Link>
+            <Link
+              to={routes.adminGithub}
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
+            >
+              Admin
+            </Link>
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -13,6 +13,7 @@ export const routes = {
   codeWorkspace: "/repos/$repoId/code",
   activity: "/activity",
   agentExecution: "/agents/executions",
+  adminGithub: "/admin/github",
   trace: "/trace/$traceId",
 } as const;
 

--- a/frontend/src/pages/AdminGithubPage.tsx
+++ b/frontend/src/pages/AdminGithubPage.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { Link, useSearch } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  useGithubAppStatus,
+  useGithubAppManifest,
+  useMe,
+} from "@/api";
+import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "\u2014";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "\u2014";
+  return date.toLocaleString();
+}
+
+function sourceLabel(source: string): string {
+  switch (source) {
+    case "db":
+      return "Database (manifest flow)";
+    case "env":
+      return "Environment variable (legacy)";
+    case "none":
+      return "Not configured";
+    default:
+      return source;
+  }
+}
+
+export function AdminGithubPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">
+          Loading your session&hellip;
+        </p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          GitHub App configuration
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need to be signed in to access admin settings.
+        </p>
+        <Link
+          to={routes.login}
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          Sign in &rarr;
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  return <AdminGithubPageInner />;
+}
+
+function AdminGithubPageInner(): JSX.Element {
+  const search = useSearch({ strict: false }) as { registered?: string };
+  const [showRegisteredBanner, setShowRegisteredBanner] = useState(
+    search.registered === "true",
+  );
+
+  const status = useGithubAppStatus({
+    retry: shouldRetryAppStatus,
+  });
+  const manifest = useGithubAppManifest();
+
+  const isForbidden = "status" in (status.error ?? {}) && (status.error as { status: number }).status === 403;
+
+  const onInitiate = async () => {
+    try {
+      const result = await manifest.mutateAsync({ name: null });
+      window.location.href = result.redirect_url;
+    } catch (error) {
+      toast.error(formatApiError(error, "Could not initiate manifest registration."));
+    }
+  };
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          GitHub App configuration
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Register and manage the GitHub App used for repository integration.
+          Only platform admins can access this page.
+        </p>
+      </header>
+
+      {showRegisteredBanner ? (
+        <section
+          role="alert"
+          aria-live="polite"
+          className="mb-6 rounded-lg border border-emerald-500/60 bg-emerald-50 p-4 text-emerald-950 shadow-sm dark:bg-emerald-900/20 dark:text-emerald-100"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold">
+                GitHub App registered successfully
+              </h2>
+              <p className="mt-1 text-xs">
+                The new GitHub App credentials have been stored and the app
+                loader has been hot-swapped. You can verify the status below.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowRegisteredBanner(false)}
+              className="shrink-0 rounded-md border border-emerald-500/40 px-2 py-1 text-xs font-medium hover:bg-emerald-100 dark:hover:bg-emerald-900/40"
+            >
+              Dismiss
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {isForbidden ? (
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-medium">Access denied</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            You are not a platform admin. Only platform administrators can
+            manage the GitHub App configuration.
+          </p>
+        </section>
+      ) : status.isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          Loading app status&hellip;
+        </p>
+      ) : status.isError ? (
+        <p className="text-sm text-destructive">
+          {formatApiError(status.error, "Could not load GitHub App status.")}
+        </p>
+      ) : status.data ? (
+        <>
+          <StatusCard configured={status.data.configured} source={status.data.source} />
+          <DetailsCard data={status.data} />
+
+          <section
+            aria-labelledby="manifest-heading"
+            className="mt-6 rounded-lg border border-border bg-card p-4"
+          >
+            <h2 id="manifest-heading" className="text-sm font-medium">
+              Register a new GitHub App
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              This initiates the GitHub App Manifest flow. You will be
+              redirected to GitHub to confirm the app creation. The new app
+              will replace any existing configuration.
+            </p>
+            <div className="mt-3">
+              <button
+                type="button"
+                disabled={manifest.isPending}
+                onClick={onInitiate}
+                className="rounded-md border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {manifest.isPending
+                  ? "Redirecting\u2026"
+                  : "Register via GitHub"}
+              </button>
+            </div>
+            {manifest.isError ? (
+              <p className="mt-2 text-xs text-destructive">
+                {formatApiError(
+                  manifest.error,
+                  "Could not initiate manifest registration.",
+                )}
+              </p>
+            ) : null}
+          </section>
+        </>
+      ) : null}
+    </PageContainer>
+  );
+}
+
+interface StatusCardProps {
+  readonly configured: boolean;
+  readonly source: string;
+}
+
+function StatusCard({ configured, source }: StatusCardProps): JSX.Element {
+  const indicator = configured ? (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">
+      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+      Configured
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+      Not configured
+    </span>
+  );
+
+  return (
+    <section className="mb-4 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-3">
+        <h2 className="text-sm font-medium">Status</h2>
+        {indicator}
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Source: {sourceLabel(source)}
+      </p>
+    </section>
+  );
+}
+
+interface DetailsCardProps {
+  readonly data: {
+    readonly app_id?: number | null;
+    readonly configured: boolean;
+    readonly installed_at?: string | null;
+    readonly installed_by?: string | null;
+    readonly slug?: string | null;
+    readonly source: string;
+  };
+}
+
+function DetailsCard({ data }: DetailsCardProps): JSX.Element {
+  if (!data.configured) return <></>;
+
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "App ID", value: data.app_id != null ? String(data.app_id) : "\u2014" },
+    { label: "Slug", value: data.slug ?? "\u2014" },
+    { label: "Installed at", value: formatTimestamp(data.installed_at ?? null) },
+    { label: "Installed by", value: data.installed_by ?? "\u2014" },
+  ];
+
+  return (
+    <section className="mb-4 rounded-lg border border-border bg-card p-4">
+      <h2 className="mb-3 text-sm font-medium">App details</h2>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        {rows.map((row) => (
+          <span key={row.label}>
+            <dt className="text-muted-foreground">{row.label}</dt>
+            <dd className="font-mono text-xs">{row.value}</dd>
+          </span>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function PageContainer({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return <div className="container max-w-3xl py-8">{children}</div>;
+}
+
+function shouldRetryAppStatus(failureCount: number, error: unknown): boolean {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "status" in error &&
+    (error as { status: number }).status === 403
+  ) {
+    return false;
+  }
+  return failureCount < 3;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
 import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
+import { AdminGithubPage } from "@/pages/AdminGithubPage";
 import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { CodeWorkspacePage } from "@/pages/CodeWorkspacePage";
 import { ForgotPasswordPage } from "@/pages/ForgotPasswordPage";
@@ -142,6 +143,17 @@ const agentExecutionRoute = createRoute({
   component: AgentExecutionPage,
 });
 
+const adminGithubSearchSchema = z.object({
+  registered: z.enum(["true"]).optional(),
+});
+
+const adminGithubRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.adminGithub,
+  validateSearch: adminGithubSearchSchema,
+  component: AdminGithubPage,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -166,6 +178,7 @@ const routeTree = rootRoute.addChildren([
   codeWorkspaceRoute,
   activityRoute,
   agentExecutionRoute,
+  adminGithubRoute,
   catchAllRoute,
 ]);
 

--- a/openapi.json
+++ b/openapi.json
@@ -84,6 +84,120 @@
         }
       }
     },
+    "/v1/admin/github/app-callback": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "get_app_callback",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to FE admin success page"
+          },
+          "400": {
+            "description": "Missing/expired state or code"
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "Caller is not a platform admin"
+          },
+          "502": {
+            "description": "GitHub rejected the manifest exchange"
+          },
+          "503": {
+            "description": "RB_GH_APP_ENC_KEY is not configured"
+          }
+        }
+      }
+    },
+    "/v1/admin/github/app-manifest": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "post_app_manifest",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppManifestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Manifest redirect URL generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppManifestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "Caller is not a platform admin"
+          }
+        }
+      }
+    },
+    "/v1/admin/github/app-status": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "get_app_status",
+        "responses": {
+          "200": {
+            "description": "Current App configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "Caller is not a platform admin"
+          }
+        }
+      }
+    },
     "/v1/agents/sessions": {
       "get": {
         "tags": [
@@ -2008,6 +2122,94 @@
           }
         }
       },
+      "AppManifestRequest": {
+        "type": "object",
+        "description": "Body of `POST /v1/admin/github/app-manifest`.\n\n`name` is operator-supplied (Q2: CTO 2026-05-12). When absent, defaults to\n`rustacean-{RB_DEPLOYMENT_ID}` (fallback `rustacean-dev`).",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub-facing App name — visible on the consent screen.",
+            "default": null
+          }
+        }
+      },
+      "AppManifestResponse": {
+        "type": "object",
+        "required": [
+          "redirect_url",
+          "state_token"
+        ],
+        "properties": {
+          "redirect_url": {
+            "type": "string",
+            "description": "`https://github.com/settings/apps/new?manifest=…&state=…` —\nplatform admin should be redirected here."
+          },
+          "state_token": {
+            "type": "string",
+            "description": "Opaque state token returned in the GitHub callback. Persisted as a\nsha256 hash; this hex string is single-use and short-lived."
+          }
+        }
+      },
+      "AppSource": {
+        "type": "string",
+        "description": "Source identifying where the active App credentials came from.",
+        "enum": [
+          "db",
+          "env",
+          "none"
+        ]
+      },
+      "AppStatusResponse": {
+        "type": "object",
+        "required": [
+          "configured",
+          "source"
+        ],
+        "properties": {
+          "app_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Numeric GitHub App ID — present only when `configured == true`."
+          },
+          "configured": {
+            "type": "boolean",
+            "description": "True when a `GhApp` is currently loaded into `state.gh_loader`."
+          },
+          "installed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Install timestamp — present only for DB-sourced configurations."
+          },
+          "installed_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Platform-admin user that installed the App — present only for\nDB-sourced configurations."
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App slug — present only for DB-sourced configurations."
+          },
+          "source": {
+            "$ref": "#/components/schemas/AppSource",
+            "description": "Where the active App came from."
+          }
+        }
+      },
       "AuditEventItem": {
         "type": "object",
         "required": [
@@ -3737,6 +3939,10 @@
     }
   },
   "tags": [
+    {
+      "name": "admin",
+      "description": "Platform administration"
+    },
     {
       "name": "health",
       "description": "Liveness/readiness probes"

--- a/services/control-api/src/openapi.rs
+++ b/services/control-api/src/openapi.rs
@@ -6,8 +6,8 @@
 use utoipa::OpenApi;
 
 use crate::routes::{
-    agents, api_keys, audit, auth, auth_logout, auth_password_reset, auth_verify, github, health,
-    ingest, mcp, me, query, repos, tenants, tenants::delete as tenant_delete,
+    admin, agents, api_keys, audit, auth, auth_logout, auth_password_reset, auth_verify, github,
+    health, ingest, mcp, me, query, repos, tenants, tenants::delete as tenant_delete,
     tenants::members as tenant_members,
 };
 
@@ -19,6 +19,9 @@ use crate::routes::{
         contact(name = "rust-brain", url = "https://github.com/jarnura/rustacean"),
     ),
     paths(
+        admin::github::app_manifest::post_app_manifest,
+        admin::github::app_callback::get_app_callback,
+        admin::github::app_status::get_app_status,
         audit::list_audit_events,
         health::health_check,
         health::ready_check,
@@ -67,6 +70,10 @@ use crate::routes::{
     ),
     components(
         schemas(
+            admin::github::app_manifest::AppManifestRequest,
+            admin::github::app_manifest::AppManifestResponse,
+            admin::github::app_status::AppStatusResponse,
+            admin::github::app_status::AppSource,
             audit::AuditEventItem,
             audit::AuditListResponse,
             health::ProbeResponse,
@@ -131,6 +138,7 @@ use crate::routes::{
         )
     ),
     tags(
+        (name = "admin", description = "Platform administration"),
         (name = "health", description = "Liveness/readiness probes"),
         (name = "audit", description = "Audit trail query"),
         (name = "auth", description = "Authentication"),


### PR DESCRIPTION
## Summary

Add `/admin/github` page for managing GitHub App configuration via the Manifest flow.

- Display current app status (configured/not configured, source: db/env/none)
- Show app details (app_id, slug, installed_at, installed_by) when configured
- Initiate manifest registration flow via `POST /v1/admin/github/app-manifest`
- Handle callback success with `registered=true` search param banner
- Admin-only access with 403 handling for non-admin users
- Wire new admin endpoint schemas into OpenAPI spec and generated TypeScript types
- Add "Admin" navigation link in AppShell

## Endpoints wired

- `POST /v1/admin/github/app-manifest` — initiate manifest registration
- `GET /v1/admin/github/app-status` — display current app configuration status
- `GET /v1/admin/github/app-callback` — handled by backend; UI shows success banner on redirect back

## Test plan

- [x] Navigate to `/admin/github` from sidebar
- [x] Verify status display (configured/not configured)
- [x] Initiate manifest registration flow
- [x] Verify success banner on callback
- [x] Verify 403 access denied for non-admin users
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes

Closes #388