### PR TITLE
[RUSAA-1220] fix(frontend): review and correct agent execution code

### DIFF
--- a/frontend/e2e/ingestion-theatre.spec.ts
+++ b/frontend/e2e/ingestion-theatre.spec.ts
@@ -9,7 +9,6 @@ async function mockSseStream(
   events: string[] = [],
 ): Promise<void> {
   await page.route("**/v1/ingest/events", async (route) => {
-    const body = events.join("") || "";
     await route.fulfill({
       status: 200,
       headers: {
@@ -17,7 +16,7 @@ async function mockSseStream(
         "Cache-Control": "no-cache",
         Connection: "keep-alive",
       },
-      body,
+      body: events.join(""),
     });
   });
 }

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -65,3 +65,15 @@ export {
   type RecentIngestionRun,
   type RecentIngestionsResponse,
 } from "./useRecentIngestions";
+export {
+  useAgentSessions,
+  useCreateSession,
+  useDeleteSession,
+  useSessionDetail,
+  agentSessionsQueryKey,
+  type ListSessionsResponse,
+  type SessionItem,
+  type SessionDetail,
+  type CreateSessionRequest,
+  type CreateSessionResponse,
+} from "./useAgentSessions";

--- a/frontend/src/api/hooks/useAgentSessions.ts
+++ b/frontend/src/api/hooks/useAgentSessions.ts
@@ -1,0 +1,113 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+type ListSessionsResponse = components["schemas"]["ListSessionsResponse"];
+type SessionItem = components["schemas"]["SessionItem"];
+type SessionDetail = components["schemas"]["SessionDetail"];
+type CreateSessionRequest = components["schemas"]["CreateSessionRequest"];
+type CreateSessionResponse = components["schemas"]["CreateSessionResponse"];
+
+// Tenant-scoped query key prevents stale rows from a previous tenant flashing
+// while the active tenant's refetch is in flight.
+export const agentSessionsQueryKey = (tenantId: string) =>
+  ["tenants", tenantId, "agent-sessions"] as const;
+
+export function useAgentSessions(
+  tenantId: string,
+  options?: Omit<
+    UseQueryOptions<ListSessionsResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<ListSessionsResponse, ApiError>({
+    queryKey: agentSessionsQueryKey(tenantId),
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET(
+        "/v1/agents/sessions",
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0,
+    staleTime: 15_000,
+    ...options,
+  });
+}
+
+export function useCreateSession(tenantId: string) {
+  const qc = useQueryClient();
+  return useMutation<CreateSessionResponse, ApiError, CreateSessionRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await apiClient.POST(
+        "/v1/agents/sessions",
+        { body },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: agentSessionsQueryKey(tenantId) });
+    },
+  });
+}
+
+export function useDeleteSession(tenantId: string) {
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, string>({
+    mutationFn: async (id) => {
+      const { error, response } = await apiClient.DELETE(
+        "/v1/agents/sessions/{id}",
+        { params: { path: { id } } },
+      );
+      if (error) {
+        throw toApiError(response.status, error);
+      }
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: agentSessionsQueryKey(tenantId) });
+    },
+  });
+}
+
+export function useSessionDetail(
+  tenantId: string,
+  sessionId: string,
+  options?: Omit<
+    UseQueryOptions<SessionDetail, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<SessionDetail, ApiError>({
+    queryKey: [...agentSessionsQueryKey(tenantId), sessionId] as const,
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET(
+        "/v1/agents/sessions/{id}",
+        { params: { path: { id: sessionId } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0 && sessionId.length > 0,
+    ...options,
+  });
+}
+
+export type {
+  ListSessionsResponse,
+  SessionItem,
+  SessionDetail,
+  CreateSessionRequest,
+  CreateSessionResponse,
+};

--- a/frontend/src/api/hooks/useAgentSessions.ts
+++ b/frontend/src/api/hooks/useAgentSessions.ts
@@ -38,6 +38,7 @@ export function useAgentSessions(
     },
     enabled: tenantId.length > 0,
     staleTime: 15_000,
+    refetchInterval: 10_000,
     ...options,
   });
 }

--- a/frontend/src/components/agent-execution/CreateSessionDialog.tsx
+++ b/frontend/src/components/agent-execution/CreateSessionDialog.tsx
@@ -30,6 +30,8 @@ export function CreateSessionDialog({
 }: CreateSessionDialogProps): JSX.Element {
   const dialogRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     previousFocusRef.current = document.activeElement as HTMLElement | null;
@@ -43,7 +45,7 @@ export function CreateSessionDialog({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (e.key === "Tab") {
@@ -67,7 +69,7 @@ export function CreateSessionDialog({
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
+  }, []);
 
   const {
     handleSubmit,

--- a/frontend/src/components/agent-execution/CreateSessionDialog.tsx
+++ b/frontend/src/components/agent-execution/CreateSessionDialog.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  createSessionFormSchema,
+  RUNTIME_OPTIONS,
+  type CreateSessionFormValues,
+} from "@/lib/validation/agentSessions";
+import { formatApiError } from "@/lib/errors/api";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+interface CreateSessionDialogProps {
+  readonly isPending: boolean;
+  readonly onSubmit: (values: CreateSessionFormValues) => Promise<void>;
+  readonly onClose: () => void;
+}
+
+export function CreateSessionDialog({
+  isPending,
+  onSubmit,
+  onClose,
+}: CreateSessionDialogProps): JSX.Element {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const focusables = getFocusableElements(dialogRef.current);
+    focusables[0]?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusables = getFocusableElements(dialogRef.current);
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!first || !last) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm<CreateSessionFormValues>({
+    resolver: zodResolver(createSessionFormSchema),
+    defaultValues: {
+      runtime: "claude_code",
+      initial_prompt: "",
+      workspace_path: "",
+    },
+  });
+
+  const handleFormSubmit = handleSubmit(async (values) => {
+    try {
+      await onSubmit(values);
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not create session."));
+    }
+  });
+
+  return (
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-session-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="flex w-full max-w-lg flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-xl">
+        <div className="flex items-start justify-between">
+          <h2
+            id="create-session-title"
+            className="text-lg font-semibold tracking-tight"
+          >
+            New agent session
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="session-runtime" className="text-sm font-medium">
+              Runtime <span className="text-destructive">*</span>
+            </label>
+            <select
+              id="session-runtime"
+              {...register("runtime")}
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-describedby={errors.runtime ? "runtime-error" : undefined}
+              aria-invalid={errors.runtime ? "true" : undefined}
+            >
+              {RUNTIME_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            {errors.runtime ? (
+              <p id="runtime-error" className="text-xs text-destructive" role="alert">
+                {errors.runtime.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="session-prompt" className="text-sm font-medium">
+              Initial prompt
+            </label>
+            <textarea
+              id="session-prompt"
+              {...register("initial_prompt")}
+              rows={3}
+              placeholder="Optional prompt to start the agent session…"
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-describedby={errors.initial_prompt ? "prompt-error" : undefined}
+              aria-invalid={errors.initial_prompt ? "true" : undefined}
+            />
+            {errors.initial_prompt ? (
+              <p id="prompt-error" className="text-xs text-destructive" role="alert">
+                {errors.initial_prompt.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="session-workspace" className="text-sm font-medium">
+              Workspace path
+            </label>
+            <input
+              id="session-workspace"
+              type="text"
+              {...register("workspace_path")}
+              placeholder="Defaults to tenant_id/session_id"
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-describedby={errors.workspace_path ? "workspace-error" : undefined}
+              aria-invalid={errors.workspace_path ? "true" : undefined}
+            />
+            {errors.workspace_path ? (
+              <p id="workspace-error" className="text-xs text-destructive" role="alert">
+                {errors.workspace_path.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isPending ? "Creating…" : "Create session"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -1,27 +1,42 @@
-import type { RecentIngestionRun } from "@/api";
+import type { SessionItem } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { formatTimestamp } from "@/components/activity/utils";
 
 const STATUS_CELL_CLASS: Record<string, string> = {
   succeeded: "text-green-600 dark:text-green-400",
+  completed: "text-green-600 dark:text-green-400",
   done: "text-green-600 dark:text-green-400",
   failed: "text-destructive",
   running: "text-blue-600 dark:text-blue-400",
   processing: "text-blue-600 dark:text-blue-400",
-  queued: "text-muted-foreground",
   pending: "text-muted-foreground",
+  cancelled: "text-muted-foreground",
 };
 
-function RunStatusCell({ status }: { readonly status: string }): JSX.Element {
+function StatusCell({ status }: { readonly status: string }): JSX.Element {
   const cls = STATUS_CELL_CLASS[status] ?? "text-muted-foreground";
   return <span className={`text-xs font-medium capitalize ${cls}`}>{status}</span>;
 }
 
+function RuntimeBadge({ kind }: { readonly kind: string }): JSX.Element {
+  const labels: Record<string, string> = {
+    claude_code: "Claude Code",
+    opencode: "OpenCode",
+  };
+  return (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+      {labels[kind] ?? kind}
+    </span>
+  );
+}
+
 interface SessionHistoryProps {
-  readonly sessions: readonly RecentIngestionRun[];
+  readonly sessions: readonly SessionItem[];
   readonly isLoading: boolean;
   readonly isError: boolean;
   readonly error: { status: number; body: unknown } | null;
+  readonly onDelete: (id: string) => void;
+  readonly isDeleting: boolean;
 }
 
 export function SessionHistory({
@@ -29,6 +44,8 @@ export function SessionHistory({
   isLoading,
   isError,
   error,
+  onDelete,
+  isDeleting,
 }: SessionHistoryProps): JSX.Element {
   if (isLoading) {
     return (
@@ -41,10 +58,8 @@ export function SessionHistory({
   if (isError) {
     return (
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="text-sm text-muted-foreground">
-          {error?.status === 404
-            ? "Agent execution endpoint not yet available. Waiting on backend."
-            : formatApiError(error, "Could not load session history.")}
+        <p className="text-sm text-destructive">
+          {formatApiError(error, "Could not load session history.")}
         </p>
       </div>
     );
@@ -67,22 +82,33 @@ export function SessionHistory({
               Session
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Runtime
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
               Status
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Created
             </th>
             <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
               Started
             </th>
-            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-              Finished
+            <th scope="col" className="px-4 py-2 text-right font-medium text-muted-foreground">
+              Tokens
             </th>
-            <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-              Trace
+            <th scope="col" className="px-4 py-2 text-right font-medium text-muted-foreground">
+              Actions
             </th>
           </tr>
         </thead>
         <tbody>
           {sessions.map((session) => (
-            <SessionRow key={session.id} session={session} />
+            <SessionRow
+              key={session.id}
+              session={session}
+              onDelete={onDelete}
+              isDeleting={isDeleting}
+            />
           ))}
         </tbody>
       </table>
@@ -91,34 +117,54 @@ export function SessionHistory({
 }
 
 interface SessionRowProps {
-  readonly session: RecentIngestionRun;
+  readonly session: SessionItem;
+  readonly onDelete: (id: string) => void;
+  readonly isDeleting: boolean;
 }
 
-function SessionRow({ session }: SessionRowProps): JSX.Element {
+function SessionRow({ session, onDelete, isDeleting }: SessionRowProps): JSX.Element {
+  const canDelete = session.status === "pending" || session.status === "running";
+
   return (
     <tr className="border-b border-border last:border-0 hover:bg-muted/20">
-      <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-        {session.id.slice(0, 8)}…
+      <td className="px-4 py-2">
+        <span className="font-mono text-xs text-muted-foreground" title={session.id}>
+          {session.id.slice(0, 8)}…
+        </span>
+        {session.input_prompt_preview && (
+          <p className="mt-0.5 max-w-[200px] truncate text-xs text-muted-foreground/70" title={session.input_prompt_preview}>
+            {session.input_prompt_preview}
+          </p>
+        )}
       </td>
       <td className="px-4 py-2">
-        <RunStatusCell status={session.status} />
+        <RuntimeBadge kind={session.runtime_kind} />
+      </td>
+      <td className="px-4 py-2">
+        <StatusCell status={session.status} />
+      </td>
+      <td className="px-4 py-2 text-xs text-muted-foreground">
+        {formatTimestamp(session.created_at)}
       </td>
       <td className="px-4 py-2 text-xs text-muted-foreground">
         {session.started_at ? formatTimestamp(session.started_at) : "—"}
       </td>
-      <td className="px-4 py-2 text-xs text-muted-foreground">
-        {session.finished_at ? formatTimestamp(session.finished_at) : "—"}
+      <td className="px-4 py-2 text-right text-xs tabular-nums text-muted-foreground">
+        {session.tokens_used.toLocaleString()} / {session.token_budget.toLocaleString()}
       </td>
-      <td className="px-4 py-2">
-        {session.trace_id ? (
-          <span
-            className="font-mono text-xs text-muted-foreground"
-            title={session.trace_id}
+      <td className="px-4 py-2 text-right">
+        {canDelete ? (
+          <button
+            type="button"
+            onClick={() => onDelete(session.id)}
+            disabled={isDeleting}
+            className="rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={`Terminate session ${session.id.slice(0, 8)}`}
           >
-            {session.trace_id.slice(0, 8)}…
-          </span>
+            {isDeleting ? "Stopping…" : "Stop"}
+          </button>
         ) : (
-          <span className="font-mono text-xs text-muted-foreground/50">—</span>
+          <span className="text-xs text-muted-foreground/50">—</span>
         )}
       </td>
     </tr>

--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -36,7 +36,7 @@ interface SessionHistoryProps {
   readonly isError: boolean;
   readonly error: { status: number; body: unknown } | null;
   readonly onDelete: (id: string) => void;
-  readonly isDeleting: boolean;
+  readonly deletingId: string | null;
 }
 
 export function SessionHistory({
@@ -45,7 +45,7 @@ export function SessionHistory({
   isError,
   error,
   onDelete,
-  isDeleting,
+  deletingId,
 }: SessionHistoryProps): JSX.Element {
   if (isLoading) {
     return (
@@ -107,7 +107,7 @@ export function SessionHistory({
               key={session.id}
               session={session}
               onDelete={onDelete}
-              isDeleting={isDeleting}
+              deletingId={deletingId}
             />
           ))}
         </tbody>
@@ -119,11 +119,12 @@ export function SessionHistory({
 interface SessionRowProps {
   readonly session: SessionItem;
   readonly onDelete: (id: string) => void;
-  readonly isDeleting: boolean;
+  readonly deletingId: string | null;
 }
 
-function SessionRow({ session, onDelete, isDeleting }: SessionRowProps): JSX.Element {
+function SessionRow({ session, onDelete, deletingId }: SessionRowProps): JSX.Element {
   const canDelete = session.status === "pending" || session.status === "running";
+  const isThisRowDeleting = deletingId === session.id;
 
   return (
     <tr className="border-b border-border last:border-0 hover:bg-muted/20">
@@ -157,11 +158,11 @@ function SessionRow({ session, onDelete, isDeleting }: SessionRowProps): JSX.Ele
           <button
             type="button"
             onClick={() => onDelete(session.id)}
-            disabled={isDeleting}
+            disabled={isThisRowDeleting}
             className="rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label={`Terminate session ${session.id.slice(0, 8)}`}
           >
-            {isDeleting ? "Stopping…" : "Stop"}
+            {isThisRowDeleting ? "Stopping…" : "Stop"}
           </button>
         ) : (
           <span className="text-xs text-muted-foreground/50">—</span>

--- a/frontend/src/components/agent-execution/index.ts
+++ b/frontend/src/components/agent-execution/index.ts
@@ -1,2 +1,3 @@
 export { ExecutionStream } from "./ExecutionStream";
 export { SessionHistory } from "./SessionHistory";
+export { CreateSessionDialog } from "./CreateSessionDialog";

--- a/frontend/src/hooks/useEventStream.ts
+++ b/frontend/src/hooks/useEventStream.ts
@@ -15,13 +15,19 @@ export interface UseEventStreamResult {
 }
 
 const RECONNECT_DELAY_MS = 5_000;
+const DEFAULT_EVENT_TYPES = ["message"] as const;
 
-export function useEventStream(url: string): UseEventStreamResult {
+export function useEventStream(
+  url: string,
+  eventTypes?: readonly string[],
+): UseEventStreamResult {
   const [events, setEvents] = useState<StreamedEvent[]>([]);
   const [lastEventId, setLastEventId] = useState<string | null>(null);
   const [readyState, setReadyState] = useState<EventStreamReadyState>("connecting");
 
   const cancelledRef = useRef(false);
+  const eventTypesRef = useRef(eventTypes);
+  eventTypesRef.current = eventTypes;
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -52,7 +58,10 @@ export function useEventStream(url: string): UseEventStreamResult {
         setEvents((prev) => [...prev, streamed]);
       };
 
-      es.addEventListener("ingest.status", handleEvent);
+      const typesToListen = eventTypesRef.current ?? DEFAULT_EVENT_TYPES;
+      for (const type of typesToListen) {
+        es.addEventListener(type, handleEvent);
+      }
 
       es.addEventListener("stream-reset", () => {
         if (!cancelledRef.current) setEvents([]);

--- a/frontend/src/lib/validation/agentSessions.ts
+++ b/frontend/src/lib/validation/agentSessions.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const RUNTIME_KINDS = ["claude_code", "opencode"] as const;
+
+export const createSessionFormSchema = z.object({
+  runtime: z.enum(RUNTIME_KINDS, {
+    message: "Runtime is required",
+  }),
+  initial_prompt: z
+    .string()
+    .max(4096, "Prompt must be under 4,096 characters")
+    .optional()
+    .or(z.literal("")),
+  workspace_path: z
+    .string()
+    .max(512, "Workspace path must be under 512 characters")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type CreateSessionFormValues = z.infer<typeof createSessionFormSchema>;
+
+export const RUNTIME_OPTIONS: ReadonlyArray<{
+  readonly value: (typeof RUNTIME_KINDS)[number];
+  readonly label: string;
+}> = [
+  { value: "claude_code", label: "Claude Code" },
+  { value: "opencode", label: "OpenCode" },
+];

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -62,7 +62,7 @@ function ActivityPageInner({ tenantId }: ActivityPageInnerProps): JSX.Element {
   const recentIngestions = useRecentIngestions(tenantId);
   const invalidateIngestions = useInvalidateRecentIngestions();
 
-  const { events, readyState } = useEventStream(`${apiBase}/v1/ingest/events`);
+  const { events, readyState } = useEventStream(`${apiBase}/v1/ingest/events`, ["ingest.status"]);
 
   useEffect(() => {
     const latestIngest = events

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -1,9 +1,15 @@
-import { useMe, useRecentIngestions, useInvalidateRecentIngestions } from "@/api";
-import { useEffect } from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useMe, useAgentSessions, useCreateSession, useDeleteSession } from "@/api";
+import type { CreateSessionFormValues } from "@/lib/validation/agentSessions";
+import { formatApiError } from "@/lib/errors/api";
 import { PageContainer } from "@/components/repos/PageContainer";
 import { useEventStream } from "@/hooks/useEventStream";
 import { SessionHistory } from "@/components/agent-execution/SessionHistory";
 import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
+import { CreateSessionDialog } from "@/components/agent-execution/CreateSessionDialog";
+
+const SESSION_EVENT_TYPES = ["session.event"] as const;
 
 export function AgentExecutionPage(): JSX.Element {
   const me = useMe({ retry: false });
@@ -36,41 +42,59 @@ interface AgentExecutionInnerProps {
 
 function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Element {
   const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+  const [showCreate, setShowCreate] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  // useRecentIngestions fetches from the backend's ingestion-runs table,
-  // which backs the "Agent Execution" view — each ingestion run corresponds
-  // to an agent execution session.
-  const recentSessions = useRecentIngestions(tenantId);
-  const invalidateSessions = useInvalidateRecentIngestions();
+  const sessions = useAgentSessions(tenantId);
+  const createSession = useCreateSession(tenantId);
+  const deleteSession = useDeleteSession(tenantId);
 
-  const { events, lastEventId, readyState } = useEventStream(`${apiBase}/v1/ingest/events`);
+  const sseUrl = `${apiBase}/v1/agents/sessions/events`;
+  const { events, lastEventId, readyState } = useEventStream(sseUrl, SESSION_EVENT_TYPES);
 
-  useEffect(() => {
-    const latestIngest = events
-      .filter((e) => e.type === "ingest.status")
-      .at(-1);
-    if (!latestIngest) return;
+  const handleCreate = async (values: CreateSessionFormValues) => {
+    const body: { runtime: string; initial_prompt?: string; workspace_path?: string | null } = {
+      runtime: values.runtime,
+    };
+    if (values.initial_prompt) body.initial_prompt = values.initial_prompt;
+    if (values.workspace_path) body.workspace_path = values.workspace_path;
+    const result = await createSession.mutateAsync(body);
+    toast.success(`Session ${result.session_id.slice(0, 8)}… created.`);
+    setShowCreate(false);
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
     try {
-      const parsed = JSON.parse(latestIngest.data) as { status?: string };
-      if (parsed.status === "succeeded" || parsed.status === "done") {
-        void invalidateSessions(tenantId);
-      }
-    } catch {
-      // malformed event — ignore
+      await deleteSession.mutateAsync(id);
+      toast.success("Session terminated.");
+    } catch (err) {
+      toast.error(formatApiError(err, "Could not terminate session."));
+    } finally {
+      setDeletingId(null);
     }
-  }, [events, tenantId, invalidateSessions]);
+  };
 
-  const sessions = recentSessions.data?.runs ?? [];
+  const sessionList = sessions.data?.sessions ?? [];
 
   return (
     <PageContainer>
-      <header className="mb-6 flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Agent Execution
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          View execution sessions, live event streams, and trace details.
-        </p>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Agent Execution
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            View execution sessions, live event streams, and manage agents.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          New session
+        </button>
       </header>
 
       <div className="space-y-8">
@@ -82,10 +106,12 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
             Session History
           </h2>
           <SessionHistory
-            sessions={sessions}
-            isLoading={recentSessions.isLoading}
-            isError={recentSessions.isError}
-            error={recentSessions.error}
+            sessions={sessionList}
+            isLoading={sessions.isLoading}
+            isError={sessions.isError}
+            error={sessions.error}
+            onDelete={handleDelete}
+            isDeleting={deletingId !== null}
           />
         </section>
 
@@ -99,6 +125,14 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
           <ExecutionStream events={events} lastEventId={lastEventId} readyState={readyState} />
         </section>
       </div>
+
+      {showCreate ? (
+        <CreateSessionDialog
+          isPending={createSession.isPending}
+          onSubmit={handleCreate}
+          onClose={() => setShowCreate(false)}
+        />
+      ) : null}
     </PageContainer>
   );
 }

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { useMe, useAgentSessions, useCreateSession, useDeleteSession } from "@/api";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMe, useAgentSessions, useCreateSession, useDeleteSession, agentSessionsQueryKey } from "@/api";
+import type { CreateSessionRequest } from "@/api";
 import type { CreateSessionFormValues } from "@/lib/validation/agentSessions";
 import { formatApiError } from "@/lib/errors/api";
 import { PageContainer } from "@/components/repos/PageContainer";
@@ -9,7 +11,7 @@ import { SessionHistory } from "@/components/agent-execution/SessionHistory";
 import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
 import { CreateSessionDialog } from "@/components/agent-execution/CreateSessionDialog";
 
-const SESSION_EVENT_TYPES = ["session.event"] as const;
+const INGEST_EVENT_TYPES = ["ingest.status"] as const;
 
 export function AgentExecutionPage(): JSX.Element {
   const me = useMe({ retry: false });
@@ -44,20 +46,40 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
   const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
   const [showCreate, setShowCreate] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const qc = useQueryClient();
 
   const sessions = useAgentSessions(tenantId);
   const createSession = useCreateSession(tenantId);
   const deleteSession = useDeleteSession(tenantId);
 
-  const sseUrl = `${apiBase}/v1/agents/sessions/events`;
-  const { events, lastEventId, readyState } = useEventStream(sseUrl, SESSION_EVENT_TYPES);
+  // Use the ingest SSE endpoint — the global /v1/agents/sessions/events endpoint
+  // does not exist; per-session events live at /v1/agents/sessions/{id}/events.
+  // Keep the ingest stream for live activity and use it to invalidate the session list.
+  const { events, lastEventId, readyState } = useEventStream(
+    `${apiBase}/v1/ingest/events`,
+    INGEST_EVENT_TYPES,
+  );
+
+  // Invalidate sessions when ingest events arrive (belt-and-suspenders with refetchInterval)
+  useEffect(() => {
+    const latest = events.filter((e) => e.type === "ingest.status").at(-1);
+    if (!latest) return;
+    try {
+      const parsed = JSON.parse(latest.data) as { status?: string };
+      if (parsed.status === "succeeded" || parsed.status === "done" || parsed.status === "failed") {
+        void qc.invalidateQueries({ queryKey: agentSessionsQueryKey(tenantId) });
+      }
+    } catch {
+      // malformed event — ignore
+    }
+  }, [events, tenantId, qc]);
 
   const handleCreate = async (values: CreateSessionFormValues) => {
-    const body: { runtime: string; initial_prompt?: string; workspace_path?: string | null } = {
+    const body: CreateSessionRequest = {
       runtime: values.runtime,
+      ...(values.initial_prompt ? { initial_prompt: values.initial_prompt } : {}),
+      ...(values.workspace_path ? { workspace_path: values.workspace_path } : {}),
     };
-    if (values.initial_prompt) body.initial_prompt = values.initial_prompt;
-    if (values.workspace_path) body.workspace_path = values.workspace_path;
     const result = await createSession.mutateAsync(body);
     toast.success(`Session ${result.session_id.slice(0, 8)}… created.`);
     setShowCreate(false);
@@ -111,7 +133,7 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
             isError={sessions.isError}
             error={sessions.error}
             onDelete={handleDelete}
-            isDeleting={deletingId !== null}
+            deletingId={deletingId}
           />
         </section>
 

--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -141,6 +141,7 @@ function IngestionTheatreInner(): JSX.Element {
   const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
   const { events, readyState } = useEventStream(
     `${apiBase}/v1/ingest/events`,
+    ["ingest.status"],
   );
 
   const ingestEvents = events.filter((e) => e.type === "ingest.status");


### PR DESCRIPTION
## Summary

Review and correct CTO-authored frontend code for the agent execution feature. The original code used the wrong API (ingestion runs instead of agent sessions) and was missing several required files.

## Issues Found & Fixed

| Issue | Before | After |
|-------|--------|-------|
| API hooks missing | No `useAgentSessions` / `useCreateSession` | Full CRUD hooks following `useApiKeys` pattern |
| Wrong data type | `SessionHistory` used `RecentIngestionRun` | Uses `SessionItem` from generated schema |
| Wrong API call | `AgentExecutionPage` called `useRecentIngestions` | Calls `useAgentSessions` |
| Hardcoded SSE events | `useEventStream` only listened for `ingest.status` | Accepts configurable `eventTypes` param |
| No session creation | No dialog component | `CreateSessionDialog` with focus trap, ARIA, Zod |
| No validation | No form schema | `agentSessions.ts` Zod schema |

## Files Changed

- `frontend/src/api/hooks/useAgentSessions.ts` (new) — list, create, delete, detail hooks
- `frontend/src/api/hooks/index.ts` — export new hooks
- `frontend/src/components/agent-execution/SessionHistory.tsx` — rewritten for `SessionItem`
- `frontend/src/components/agent-execution/CreateSessionDialog.tsx` (new) — session creation form
- `frontend/src/components/agent-execution/index.ts` — export new dialog
- `frontend/src/pages/AgentExecutionPage.tsx` — rewired to agent sessions API
- `frontend/src/hooks/useEventStream.ts` — configurable event types
- `frontend/src/lib/validation/agentSessions.ts` (new) — Zod form schema

## GitHub Issue

Closes #389

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR