### PR TITLE
[RUSAA-1235] feat: install opencode binary in agent-runner container

### DIFF
--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -67,6 +67,16 @@ RUN npm install --omit=dev --no-fund --no-audit -g \
     # spawn claude at runtime.
     claude --version
 
+# Install the opencode CLI. The opencode-ai package ships the `opencode` binary
+# used by the OpenCode adapter (services/agent-runner/src/adapters/opencode.rs).
+# Pin to the version this image is tested against; bumps go through a separate
+# chore PR. See the registry for the latest: https://registry.npmjs.org/opencode-ai
+ARG OPENCODE_VERSION=1.14.48
+RUN npm install --omit=dev --no-fund --no-audit -g \
+        opencode-ai@${OPENCODE_VERSION} && \
+    npm cache clean --force && \
+    opencode --version
+
 # Pre-create the agent workspace mount point with nonroot ownership.
 # Docker named volumes inherit ownership/permissions from the image's directory
 # on first mount, so this ensures the runner (UID 65532) can write to


### PR DESCRIPTION
## Summary
The OpenCode adapter expects an \`opencode\` binary in PATH, but it was missing from the agent-runner container, causing session spawn to fail with os error 2. This adds \`opencode-ai@1.14.48\` (the npm package that ships the \`opencode\` binary) to the runtime stage, alongside the existing claude CLI install. A \`opencode --version\` probe after install ensures the build fails fast if the binary is absent.

## GitHub Issue
Closes #392

## Checklist
- [x] `cargo test --workspace` not required (Dockerfile-only change)
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Both claude_code and opencode adapters now have their binaries present in the image