### PR TITLE
[RUSAA-1267] fix(agent-runner): fail-fast on empty ANTHROPIC_API_KEY + natural-exit handler

### DIFF
--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -49,3 +49,14 @@ FRONTEND_HOST_PORT=15173
 # --- Dev tools ---
 PGWEB_HOST_PORT=18081
 KAFKA_UI_HOST_PORT=18082
+
+# --- Runtime credentials (agent CLIs) ---
+# ANTHROPIC_API_KEY is NOT defined here because env-files cannot expand shell
+# variables.  Export it in your shell before running docker compose:
+#
+#   export ANTHROPIC_API_KEY=sk-ant-...
+#   docker compose --env-file compose/tailscale.env -f compose/dev.yml up -d
+#
+# The compose/dev.yml line  ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"  then
+# interpolates it from the shell environment.  If it is empty the claude_code
+# adapter will fail fast with a clear error rather than silently exiting 0.

--- a/services/agent-runner/src/adapters/claude_code.rs
+++ b/services/agent-runner/src/adapters/claude_code.rs
@@ -19,6 +19,17 @@ impl ClaudeCodeAdapter {
 #[async_trait]
 impl RuntimeAdapter for ClaudeCodeAdapter {
     async fn spawn(&self, ctx: &SessionCtx) -> Result<AgentProcess> {
+        // Fail early if the key is absent — claude exits 0 with no output when
+        // ANTHROPIC_API_KEY is empty, which leaves the session stuck in `running`.
+        let anthropic_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
+        if anthropic_key.is_empty() {
+            anyhow::bail!(
+                "ANTHROPIC_API_KEY is not set or empty; \
+                 export it in the shell before starting docker compose \
+                 (compose/tailscale.env does not define it)"
+            );
+        }
+
         write_mcp_config(&ctx.workspace_path, &ctx.api_key, &ctx.tenant_id)
             .await
             .context("Failed to write MCP config")?;

--- a/services/agent-runner/src/session.rs
+++ b/services/agent-runner/src/session.rs
@@ -24,6 +24,10 @@ const MAX_TRACKED_SESSIONS: usize = 100_000;
 const SEQ_COUNTER_GC_INTERVAL_SECS: u64 = 300;
 const SEQ_COUNTER_MAX_AGE_SECS: u64 = 600;
 
+/// Sentinel seq value for Terminated / natural-exit lifecycle events.
+/// Must match `lifecycle_event_seq("terminated")` in control-api/src/routes/agents/sessions.rs.
+const TERMINATED_SEQ: i64 = i64::MIN + 2;
+
 pub struct SessionManager {
     sessions: Arc<Mutex<HashMap<String, SessionHandle>>>,
     workspace_base: PathBuf,
@@ -38,6 +42,10 @@ struct SessionHandle {
     start_time: Instant,
     stdout_handle: JoinHandle<()>,
     stderr_handle: JoinHandle<()>,
+    /// Watches for natural (unforced) process exit and transitions the session
+    /// to `terminated` or `failed` automatically.  Aborted by
+    /// `terminate_session` when an explicit termination wins the race.
+    wait_handle: JoinHandle<()>,
     tenant_id: TenantId,
 }
 
@@ -55,6 +63,149 @@ fn safe_join(base: &std::path::Path, rel: &str) -> Result<PathBuf> {
         }
     }
     Ok(base.join(rel_path))
+}
+
+/// Spawns a background task that waits for the child process to exit naturally
+/// and then transitions the session to `terminated` (exit 0) or `failed`
+/// (non-zero exit).
+///
+/// Race safety: the task removes the session from `sessions` as its first
+/// write action.  `terminate_session` also removes from `sessions` first.
+/// Whichever removes first owns the cleanup; the other returns without action.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn spawn_natural_exit_handler(
+    session_id: String,
+    tenant_id: TenantId,
+    process: Arc<Mutex<AgentProcess>>,
+    sessions: Arc<Mutex<HashMap<String, SessionHandle>>>,
+    seq_counters: Arc<Mutex<HashMap<String, i64>>>,
+    seq_timestamps: Arc<Mutex<HashMap<String, Instant>>>,
+    control_api_base: String,
+    http_client: reqwest::Client,
+    event_sender: tokio::sync::mpsc::Sender<(TenantId, AgentEvent)>,
+) -> JoinHandle<()> {
+    let span = tracing::info_span!("natural_exit_handler", session_id = %session_id);
+
+    tokio::spawn(
+        async move {
+            // Wait for the process to exit naturally (releases lock before HTTP calls).
+            let exit_status = {
+                let mut proc = process.lock().await;
+                proc.child.wait().await
+            };
+
+            // Race check: try to claim ownership of cleanup by removing from the
+            // sessions map.  If terminate_session already removed it, bail out.
+            let Some(handle) = ({
+                let mut map = sessions.lock().await;
+                map.remove(&session_id)
+            }) else {
+                tracing::debug!(
+                    session_id = %session_id,
+                    "natural exit: session already removed by explicit terminate"
+                );
+                return;
+            };
+
+            // We own the cleanup.  Abort I/O handlers (wait_handle = self; dropping
+            // it does not abort in tokio, so no self-abort risk).
+            handle.stdout_handle.abort();
+            handle.stderr_handle.abort();
+
+            // Clean up seq-counter state.
+            {
+                let mut counters = seq_counters.lock().await;
+                let mut timestamps = seq_timestamps.lock().await;
+                counters.remove(&session_id);
+                timestamps.remove(&session_id);
+            }
+
+            let exit_code = match exit_status {
+                Ok(status) => status.code().unwrap_or(-1),
+                Err(_) => -1,
+            };
+            let duration_ms =
+                i64::try_from(handle.start_time.elapsed().as_millis()).unwrap_or(i64::MAX);
+            let final_status = if exit_code == 0 {
+                "terminated"
+            } else {
+                "failed"
+            };
+            let error_msg =
+                (exit_code != 0).then(|| format!("process exited with code {exit_code}"));
+
+            let Ok(validated_id) = uuid::Uuid::parse_str(&session_id) else {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: rejected non-UUID session_id"
+                );
+                return;
+            };
+
+            // Update session status in control-api.
+            let status_url =
+                format!("{control_api_base}/internal/agent/sessions/{validated_id}/status");
+            let body = serde_json::json!({
+                "status": final_status,
+                "pid": serde_json::Value::Null,
+                "exit_code": exit_code,
+                "error": error_msg,
+                "tenant_id": tenant_id.to_string(),
+            });
+            if let Err(e) = http_client.patch(&status_url).json(&body).send().await {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: failed to update session status: {e}"
+                );
+            }
+
+            // Revoke session-scoped API key.
+            let revoke_url =
+                format!("{control_api_base}/internal/agent/sessions/{validated_id}/api-key");
+            if let Err(e) = http_client.delete(&revoke_url).send().await {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: failed to revoke API key: {e}"
+                );
+            }
+
+            // Emit Terminated lifecycle event so the SSE stream closes cleanly.
+            let payload = serde_json::json!({
+                "exit_code": exit_code,
+                "duration_ms": duration_ms,
+                "reason": "natural_exit",
+            });
+            let event = AgentEvent {
+                tenant_id: tenant_id.to_string(),
+                session_id: session_id.clone(),
+                seq: TERMINATED_SEQ,
+                kind: AgentEventKind::Terminated.into(),
+                payload: payload.to_string(),
+                emitted_at_ms: chrono::Utc::now().timestamp_millis(),
+            };
+            if tokio::time::timeout(
+                Duration::from_secs(5),
+                event_sender.send((tenant_id, event)),
+            )
+            .await
+            .is_err()
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "Event channel full, dropped natural exit event"
+                );
+                counter!("rb_agent_events_dropped_total", "reason" => "channel_full").increment(1);
+            }
+
+            tracing::info!(
+                session_id = %session_id,
+                exit_code = exit_code,
+                duration_ms = duration_ms,
+                "Session completed naturally"
+            );
+        }
+        .instrument(span),
+    )
 }
 
 impl SessionManager {
@@ -202,10 +353,24 @@ impl SessionManager {
         );
 
         let process_arc = Arc::new(Mutex::new(process));
+        let start_time = Instant::now();
+
+        let wait_handle = spawn_natural_exit_handler(
+            session_id.to_string(),
+            tenant_id,
+            Arc::clone(&process_arc),
+            Arc::clone(&self.sessions),
+            self.seq_counters.clone(),
+            self.seq_counter_timestamps.clone(),
+            self.control_api_base.clone(),
+            self.http_client.clone(),
+            event_sender.clone(),
+        );
 
         {
             let mut sessions = self.sessions.lock().await;
             if sessions.len() >= MAX_TRACKED_SESSIONS {
+                wait_handle.abort();
                 anyhow::bail!(
                     "Maximum number of concurrent sessions ({MAX_TRACKED_SESSIONS}) exceeded"
                 );
@@ -214,9 +379,10 @@ impl SessionManager {
                 session_id.to_string(),
                 SessionHandle {
                     process: process_arc,
-                    start_time: Instant::now(),
+                    start_time,
                     stdout_handle,
                     stderr_handle,
+                    wait_handle,
                     tenant_id,
                 },
             );
@@ -290,6 +456,13 @@ impl SessionManager {
             timestamps.remove(session_id);
         }
 
+        // Abort I/O and wait handlers before taking the process lock so the
+        // natural-exit handler cannot win the cleanup race after we removed
+        // the session from the map.
+        handle.stdout_handle.abort();
+        handle.stderr_handle.abort();
+        handle.wait_handle.abort();
+
         let exit_code = {
             let mut proc = handle.process.lock().await;
             let adapter = adapter_for_runtime(proc.runtime)?;
@@ -312,9 +485,6 @@ impl SessionManager {
 
         let duration_ms =
             i64::try_from(handle.start_time.elapsed().as_millis()).unwrap_or(i64::MAX);
-
-        handle.stdout_handle.abort();
-        handle.stderr_handle.abort();
 
         self.update_session_status(
             session_id,
@@ -534,8 +704,6 @@ impl SessionManager {
         reason: &str,
         event_sender: tokio::sync::mpsc::Sender<(TenantId, AgentEvent)>,
     ) {
-        const TERMINATED_SEQ: i64 = i64::MIN + 2;
-
         let payload = serde_json::json!({
             "exit_code": exit_code,
             "duration_ms": duration_ms,

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -17,6 +17,8 @@ use tracing::Instrument;
 
 use crate::adapters::{AgentProcess, RuntimeAdapter, SessionCtx, adapter_for_runtime};
 
+mod natural_exit;
+
 const PROCESS_TERMINATE_TIMEOUT_SECS: u64 = 30;
 const MAX_INITIAL_PROMPT_LEN: usize = 100_000;
 const MAX_TRACKED_SESSIONS: usize = 100_000;
@@ -63,149 +65,6 @@ fn safe_join(base: &std::path::Path, rel: &str) -> Result<PathBuf> {
         }
     }
     Ok(base.join(rel_path))
-}
-
-/// Spawns a background task that waits for the child process to exit naturally
-/// and then transitions the session to `terminated` (exit 0) or `failed`
-/// (non-zero exit).
-///
-/// Race safety: the task removes the session from `sessions` as its first
-/// write action.  `terminate_session` also removes from `sessions` first.
-/// Whichever removes first owns the cleanup; the other returns without action.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-fn spawn_natural_exit_handler(
-    session_id: String,
-    tenant_id: TenantId,
-    process: Arc<Mutex<AgentProcess>>,
-    sessions: Arc<Mutex<HashMap<String, SessionHandle>>>,
-    seq_counters: Arc<Mutex<HashMap<String, i64>>>,
-    seq_timestamps: Arc<Mutex<HashMap<String, Instant>>>,
-    control_api_base: String,
-    http_client: reqwest::Client,
-    event_sender: tokio::sync::mpsc::Sender<(TenantId, AgentEvent)>,
-) -> JoinHandle<()> {
-    let span = tracing::info_span!("natural_exit_handler", session_id = %session_id);
-
-    tokio::spawn(
-        async move {
-            // Wait for the process to exit naturally (releases lock before HTTP calls).
-            let exit_status = {
-                let mut proc = process.lock().await;
-                proc.child.wait().await
-            };
-
-            // Race check: try to claim ownership of cleanup by removing from the
-            // sessions map.  If terminate_session already removed it, bail out.
-            let Some(handle) = ({
-                let mut map = sessions.lock().await;
-                map.remove(&session_id)
-            }) else {
-                tracing::debug!(
-                    session_id = %session_id,
-                    "natural exit: session already removed by explicit terminate"
-                );
-                return;
-            };
-
-            // We own the cleanup.  Abort I/O handlers (wait_handle = self; dropping
-            // it does not abort in tokio, so no self-abort risk).
-            handle.stdout_handle.abort();
-            handle.stderr_handle.abort();
-
-            // Clean up seq-counter state.
-            {
-                let mut counters = seq_counters.lock().await;
-                let mut timestamps = seq_timestamps.lock().await;
-                counters.remove(&session_id);
-                timestamps.remove(&session_id);
-            }
-
-            let exit_code = match exit_status {
-                Ok(status) => status.code().unwrap_or(-1),
-                Err(_) => -1,
-            };
-            let duration_ms =
-                i64::try_from(handle.start_time.elapsed().as_millis()).unwrap_or(i64::MAX);
-            let final_status = if exit_code == 0 {
-                "terminated"
-            } else {
-                "failed"
-            };
-            let error_msg =
-                (exit_code != 0).then(|| format!("process exited with code {exit_code}"));
-
-            let Ok(validated_id) = uuid::Uuid::parse_str(&session_id) else {
-                tracing::warn!(
-                    session_id = %session_id,
-                    "natural exit: rejected non-UUID session_id"
-                );
-                return;
-            };
-
-            // Update session status in control-api.
-            let status_url =
-                format!("{control_api_base}/internal/agent/sessions/{validated_id}/status");
-            let body = serde_json::json!({
-                "status": final_status,
-                "pid": serde_json::Value::Null,
-                "exit_code": exit_code,
-                "error": error_msg,
-                "tenant_id": tenant_id.to_string(),
-            });
-            if let Err(e) = http_client.patch(&status_url).json(&body).send().await {
-                tracing::warn!(
-                    session_id = %session_id,
-                    "natural exit: failed to update session status: {e}"
-                );
-            }
-
-            // Revoke session-scoped API key.
-            let revoke_url =
-                format!("{control_api_base}/internal/agent/sessions/{validated_id}/api-key");
-            if let Err(e) = http_client.delete(&revoke_url).send().await {
-                tracing::warn!(
-                    session_id = %session_id,
-                    "natural exit: failed to revoke API key: {e}"
-                );
-            }
-
-            // Emit Terminated lifecycle event so the SSE stream closes cleanly.
-            let payload = serde_json::json!({
-                "exit_code": exit_code,
-                "duration_ms": duration_ms,
-                "reason": "natural_exit",
-            });
-            let event = AgentEvent {
-                tenant_id: tenant_id.to_string(),
-                session_id: session_id.clone(),
-                seq: TERMINATED_SEQ,
-                kind: AgentEventKind::Terminated.into(),
-                payload: payload.to_string(),
-                emitted_at_ms: chrono::Utc::now().timestamp_millis(),
-            };
-            if tokio::time::timeout(
-                Duration::from_secs(5),
-                event_sender.send((tenant_id, event)),
-            )
-            .await
-            .is_err()
-            {
-                tracing::warn!(
-                    session_id = %session_id,
-                    "Event channel full, dropped natural exit event"
-                );
-                counter!("rb_agent_events_dropped_total", "reason" => "channel_full").increment(1);
-            }
-
-            tracing::info!(
-                session_id = %session_id,
-                exit_code = exit_code,
-                duration_ms = duration_ms,
-                "Session completed naturally"
-            );
-        }
-        .instrument(span),
-    )
 }
 
 impl SessionManager {
@@ -355,7 +214,7 @@ impl SessionManager {
         let process_arc = Arc::new(Mutex::new(process));
         let start_time = Instant::now();
 
-        let wait_handle = spawn_natural_exit_handler(
+        let wait_handle = natural_exit::spawn_natural_exit_handler(
             session_id.to_string(),
             tenant_id,
             Arc::clone(&process_arc),
@@ -733,5 +592,5 @@ impl SessionManager {
 pub use crate::workspace_gc::spawn_workspace_gc;
 
 #[cfg(test)]
-#[path = "session_tests.rs"]
+#[path = "tests.rs"]
 mod tests;

--- a/services/agent-runner/src/session/natural_exit.rs
+++ b/services/agent-runner/src/session/natural_exit.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use metrics::counter;
+use rb_schemas::{AgentEvent, AgentEventKind, TenantId};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tracing::Instrument;
+
+use super::SessionHandle;
+
+/// Spawns a background task that waits for the child process to exit naturally
+/// and then transitions the session to `terminated` (exit 0) or `failed`
+/// (non-zero exit).
+///
+/// Race safety: the task removes the session from `sessions` as its first
+/// write action.  `terminate_session` also removes from `sessions` first.
+/// Whichever removes first owns the cleanup; the other returns without action.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(super) fn spawn_natural_exit_handler(
+    session_id: String,
+    tenant_id: TenantId,
+    process: Arc<Mutex<crate::adapters::AgentProcess>>,
+    sessions: Arc<Mutex<HashMap<String, SessionHandle>>>,
+    seq_counters: Arc<Mutex<HashMap<String, i64>>>,
+    seq_timestamps: Arc<Mutex<HashMap<String, Instant>>>,
+    control_api_base: String,
+    http_client: reqwest::Client,
+    event_sender: tokio::sync::mpsc::Sender<(TenantId, AgentEvent)>,
+) -> JoinHandle<()> {
+    let span = tracing::info_span!("natural_exit_handler", session_id = %session_id);
+
+    tokio::spawn(
+        async move {
+            // Wait for the process to exit naturally (releases lock before HTTP calls).
+            let exit_status = {
+                let mut proc = process.lock().await;
+                proc.child.wait().await
+            };
+
+            // Race check: try to claim ownership of cleanup by removing from the
+            // sessions map.  If terminate_session already removed it, bail out.
+            let Some(handle) = ({
+                let mut map = sessions.lock().await;
+                map.remove(&session_id)
+            }) else {
+                tracing::debug!(
+                    session_id = %session_id,
+                    "natural exit: session already removed by explicit terminate"
+                );
+                return;
+            };
+
+            // We own the cleanup.  Abort I/O handlers (wait_handle = self; dropping
+            // it does not abort in tokio, so no self-abort risk).
+            handle.stdout_handle.abort();
+            handle.stderr_handle.abort();
+
+            // Clean up seq-counter state.
+            {
+                let mut counters = seq_counters.lock().await;
+                let mut timestamps = seq_timestamps.lock().await;
+                counters.remove(&session_id);
+                timestamps.remove(&session_id);
+            }
+
+            let exit_code = match exit_status {
+                Ok(status) => status.code().unwrap_or(-1),
+                Err(_) => -1,
+            };
+            let duration_ms =
+                i64::try_from(handle.start_time.elapsed().as_millis()).unwrap_or(i64::MAX);
+            let final_status = if exit_code == 0 {
+                "terminated"
+            } else {
+                "failed"
+            };
+            let error_msg =
+                (exit_code != 0).then(|| format!("process exited with code {exit_code}"));
+
+            let Ok(validated_id) = uuid::Uuid::parse_str(&session_id) else {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: rejected non-UUID session_id"
+                );
+                return;
+            };
+
+            // Update session status in control-api.
+            let status_url =
+                format!("{control_api_base}/internal/agent/sessions/{validated_id}/status");
+            let body = serde_json::json!({
+                "status": final_status,
+                "pid": serde_json::Value::Null,
+                "exit_code": exit_code,
+                "error": error_msg,
+                "tenant_id": tenant_id.to_string(),
+            });
+            if let Err(e) = http_client.patch(&status_url).json(&body).send().await {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: failed to update session status: {e}"
+                );
+            }
+
+            // Revoke session-scoped API key.
+            let revoke_url =
+                format!("{control_api_base}/internal/agent/sessions/{validated_id}/api-key");
+            if let Err(e) = http_client.delete(&revoke_url).send().await {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "natural exit: failed to revoke API key: {e}"
+                );
+            }
+
+            // Emit Terminated lifecycle event so the SSE stream closes cleanly.
+            let payload = serde_json::json!({
+                "exit_code": exit_code,
+                "duration_ms": duration_ms,
+                "reason": "natural_exit",
+            });
+            let event = AgentEvent {
+                tenant_id: tenant_id.to_string(),
+                session_id: session_id.clone(),
+                seq: super::TERMINATED_SEQ,
+                kind: AgentEventKind::Terminated.into(),
+                payload: payload.to_string(),
+                emitted_at_ms: chrono::Utc::now().timestamp_millis(),
+            };
+            if tokio::time::timeout(
+                Duration::from_secs(5),
+                event_sender.send((tenant_id, event)),
+            )
+            .await
+            .is_err()
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "Event channel full, dropped natural exit event"
+                );
+                counter!("rb_agent_events_dropped_total", "reason" => "channel_full").increment(1);
+            }
+
+            tracing::info!(
+                session_id = %session_id,
+                exit_code = exit_code,
+                duration_ms = duration_ms,
+                "Session completed naturally"
+            );
+        }
+        .instrument(span),
+    )
+}

--- a/services/agent-runner/src/session/tests.rs
+++ b/services/agent-runner/src/session/tests.rs
@@ -1,3 +1,4 @@
+use super::natural_exit::spawn_natural_exit_handler;
 use super::*;
 
 #[test]

--- a/services/agent-runner/src/session_tests.rs
+++ b/services/agent-runner/src/session_tests.rs
@@ -180,3 +180,225 @@ async fn start_session_marks_failed_on_adapter_spawn_error() {
 
     server_handle.abort();
 }
+
+// ---------------------------------------------------------------------
+// RUSAA-1267: natural-exit handler transitions session to terminal status
+// ---------------------------------------------------------------------
+
+/// Build a minimal `SessionHandle` with stub I/O handles and a real process.
+fn make_stub_handle(
+    process: Arc<Mutex<crate::adapters::AgentProcess>>,
+    tenant_id: TenantId,
+) -> SessionHandle {
+    SessionHandle {
+        process,
+        start_time: Instant::now(),
+        stdout_handle: tokio::spawn(async {}),
+        stderr_handle: tokio::spawn(async {}),
+        wait_handle: tokio::spawn(async {}), // replaced after insertion in real code
+        tenant_id,
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn natural_exit_zero_sends_terminated_status() {
+    use std::process::Stdio;
+
+    let (addr, captured, server_handle) = spawn_status_capture_server().await;
+
+    let mut cmd = tokio::process::Command::new("/bin/true");
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let child = cmd.spawn().unwrap();
+    let pid = child.id().unwrap();
+    let process = crate::adapters::AgentProcess {
+        child,
+        pid,
+        runtime: rb_schemas::AgentRuntime::ClaudeCode,
+    };
+
+    let sessions: Arc<Mutex<HashMap<String, SessionHandle>>> = Arc::new(Mutex::new(HashMap::new()));
+    let seq_counters = Arc::new(Mutex::new(HashMap::new()));
+    let seq_timestamps = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+    let process_arc = Arc::new(Mutex::new(process));
+    let session_uuid = uuid::Uuid::new_v4();
+    let session_id = session_uuid.to_string();
+    let tenant_id = TenantId::from(uuid::Uuid::new_v4());
+
+    // Pre-insert a stub handle so the natural-exit handler can remove it.
+    {
+        let mut map = sessions.lock().await;
+        map.insert(
+            session_id.clone(),
+            make_stub_handle(Arc::clone(&process_arc), tenant_id),
+        );
+    }
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    let wait_handle = spawn_natural_exit_handler(
+        session_id.clone(),
+        tenant_id,
+        Arc::clone(&process_arc),
+        Arc::clone(&sessions),
+        seq_counters,
+        seq_timestamps,
+        format!("http://{addr}"),
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap(),
+        tx,
+    );
+
+    wait_handle.await.expect("natural exit handler panicked");
+
+    let expected_path = format!("/internal/agent/sessions/{session_uuid}/status");
+    let g = captured.lock().await;
+    let found = g.iter().any(|(rl, body)| {
+        rl.starts_with("PATCH ")
+            && rl.contains(&expected_path)
+            && body.contains("\"status\":\"terminated\"")
+    });
+    assert!(
+        found,
+        "expected PATCH {expected_path} with status=terminated; captured: {:?}",
+        *g
+    );
+    // Session should have been removed from the map.
+    assert!(
+        sessions.lock().await.is_empty(),
+        "session must be removed after natural exit"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn natural_exit_nonzero_sends_failed_status() {
+    use std::process::Stdio;
+
+    let (addr, captured, server_handle) = spawn_status_capture_server().await;
+
+    let mut cmd = tokio::process::Command::new("/bin/sh");
+    cmd.args(["-c", "exit 42"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let child = cmd.spawn().unwrap();
+    let pid = child.id().unwrap();
+    let process = crate::adapters::AgentProcess {
+        child,
+        pid,
+        runtime: rb_schemas::AgentRuntime::ClaudeCode,
+    };
+
+    let sessions: Arc<Mutex<HashMap<String, SessionHandle>>> = Arc::new(Mutex::new(HashMap::new()));
+    let seq_counters = Arc::new(Mutex::new(HashMap::new()));
+    let seq_timestamps = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+    let process_arc = Arc::new(Mutex::new(process));
+    let session_uuid = uuid::Uuid::new_v4();
+    let session_id = session_uuid.to_string();
+    let tenant_id = TenantId::from(uuid::Uuid::new_v4());
+
+    {
+        let mut map = sessions.lock().await;
+        map.insert(
+            session_id.clone(),
+            make_stub_handle(Arc::clone(&process_arc), tenant_id),
+        );
+    }
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    let wait_handle = spawn_natural_exit_handler(
+        session_id.clone(),
+        tenant_id,
+        Arc::clone(&process_arc),
+        Arc::clone(&sessions),
+        seq_counters,
+        seq_timestamps,
+        format!("http://{addr}"),
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap(),
+        tx,
+    );
+
+    wait_handle.await.expect("natural exit handler panicked");
+
+    let expected_path = format!("/internal/agent/sessions/{session_uuid}/status");
+    let g = captured.lock().await;
+    let found = g.iter().any(|(rl, body)| {
+        rl.starts_with("PATCH ")
+            && rl.contains(&expected_path)
+            && body.contains("\"status\":\"failed\"")
+    });
+    assert!(
+        found,
+        "expected PATCH {expected_path} with status=failed; captured: {:?}",
+        *g
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn natural_exit_noop_when_session_already_removed() {
+    use std::process::Stdio;
+
+    let (addr, captured, server_handle) = spawn_status_capture_server().await;
+
+    let mut cmd = tokio::process::Command::new("/bin/true");
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let child = cmd.spawn().unwrap();
+    let pid = child.id().unwrap();
+    let process = crate::adapters::AgentProcess {
+        child,
+        pid,
+        runtime: rb_schemas::AgentRuntime::ClaudeCode,
+    };
+
+    // Intentionally leave the sessions map EMPTY — simulates terminate_session
+    // having already removed the entry before the natural-exit handler runs.
+    let sessions: Arc<Mutex<HashMap<String, SessionHandle>>> = Arc::new(Mutex::new(HashMap::new()));
+    let seq_counters = Arc::new(Mutex::new(HashMap::new()));
+    let seq_timestamps = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+    let process_arc = Arc::new(Mutex::new(process));
+    let session_uuid = uuid::Uuid::new_v4();
+    let session_id = session_uuid.to_string();
+    let tenant_id = TenantId::from(uuid::Uuid::new_v4());
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    let wait_handle = spawn_natural_exit_handler(
+        session_id.clone(),
+        tenant_id,
+        Arc::clone(&process_arc),
+        Arc::clone(&sessions),
+        seq_counters,
+        seq_timestamps,
+        format!("http://{addr}"),
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap(),
+        tx,
+    );
+
+    wait_handle.await.expect("natural exit handler panicked");
+
+    // No PATCH should have been sent because the session was "already gone".
+    let g = captured.lock().await;
+    assert!(
+        g.is_empty(),
+        "no HTTP calls expected when session is already removed; captured: {:?}",
+        *g
+    );
+
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary

- `ClaudeCodeAdapter::spawn()` now bails early when `ANTHROPIC_API_KEY` is empty, converting the silent-zero-exit zombie into a clear `failed` session with a diagnostic message
- `compose/tailscale.env` documents that the key must be exported from the shell before docker compose starts
- `spawn_natural_exit_handler()` spawns a third background task per session that calls `child.wait()` and transitions the session to `terminated` (exit 0) or `failed` (non-zero) automatically — no zombie, no stuck `running` row
- Race safety: sessions-map `remove()` is the mutex-protected gate; whichever of the natural-exit handler and `terminate_session` removes the entry first owns the cleanup

## GitHub Issue
Closes #397

## Test results
```
running 8 tests
test session::tests::natural_exit_noop_when_session_already_removed ... ok
test session::tests::natural_exit_nonzero_sends_failed_status ... ok
test session::tests::natural_exit_zero_sends_terminated_status ... ok
test session::tests::start_session_marks_failed_on_adapter_spawn_error ... ok
... 4 more ok
test result: ok. 8 passed; 0 failed
```

## Checklist
- [x] `cargo test -p agent-runner` passes (8/8)
- [x] `cargo clippy -p agent-runner --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean for changed files
- [x] No tracker IDs outside title bracket