### PR TITLE
[RUSAA-1290] fix(agent-runner): --verbose flag + writable session config

### DIFF
--- a/docker/claude-login/entrypoint.sh
+++ b/docker/claude-login/entrypoint.sh
@@ -16,6 +16,11 @@ printf '%s\n' "${RB_SSH_AUTHORIZED_KEYS}" > /home/loginuser/.ssh/authorized_keys
 chmod 600 /home/loginuser/.ssh/authorized_keys
 chown -R loginuser:loginuser /home/loginuser/.ssh
 
+# Ensure the shared credentials volume directory is writable by loginuser.
+# Docker creates named volumes as root; loginuser needs write access for
+# `claude /login` to persist .credentials.json.
+chown loginuser:loginuser "${CLAUDE_CONFIG_DIR:-/home/loginuser/.claude}" 2>/dev/null || true
+
 # Generate SSH host keys on first start (persist via named volume if desired).
 ssh-keygen -A
 

--- a/services/agent-runner/src/adapters/claude_code.rs
+++ b/services/agent-runner/src/adapters/claude_code.rs
@@ -24,10 +24,10 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         // Auth mode: prefer ANTHROPIC_API_KEY (direct API key); if absent, require
         // credentials.json written by `claude /login` in the SSH sidecar (OAuth/Max mode).
         let anthropic_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
+        let ro_config_dir = std::env::var("CLAUDE_CONFIG_DIR")
+            .unwrap_or_else(|_| DEFAULT_CLAUDE_CONFIG_DIR.to_string());
         if anthropic_key.is_empty() {
-            let config_dir = std::env::var("CLAUDE_CONFIG_DIR")
-                .unwrap_or_else(|_| DEFAULT_CLAUDE_CONFIG_DIR.to_string());
-            let creds = std::path::PathBuf::from(&config_dir).join("credentials.json");
+            let creds = std::path::PathBuf::from(&ro_config_dir).join("credentials.json");
             if !creds.exists() {
                 anyhow::bail!(
                     "claude_not_logged_in: {} not found. \
@@ -41,9 +41,28 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .await
             .context("Failed to write MCP config")?;
 
+        // The shared credentials volume is mounted read-only to prevent the
+        // spawned claude child from rewriting credentials.  Create a per-session
+        // writable config directory and copy credential files into it so the CLI
+        // can write session state (.claude.json) without hitting EROFS.
+        let session_config = ctx.workspace_path.join(".claude-config");
+        tokio::fs::create_dir_all(&session_config)
+            .await
+            .context("Failed to create session config dir")?;
+        let ro_dir = std::path::PathBuf::from(&ro_config_dir);
+        for name in [".credentials.json", "credentials.json", ".claude.json"] {
+            let src = ro_dir.join(name);
+            if tokio::fs::metadata(&src).await.is_ok() {
+                tokio::fs::copy(&src, session_config.join(name))
+                    .await
+                    .with_context(|| format!("Failed to copy {name} to session config"))?;
+            }
+        }
+
         let mut cmd = build_base_command("claude", &ctx.workspace_path);
-        cmd.args(["-p", "--output-format", "stream-json"])
+        cmd.args(["-p", "--output-format", "stream-json", "--verbose"])
             .arg("--dangerously-skip-permissions")
+            .env("CLAUDE_CONFIG_DIR", &session_config)
             .env("RB_AGENT_API_KEY", &ctx.api_key)
             .env("RB_AGENT_TENANT_ID", &ctx.tenant_id);
 


### PR DESCRIPTION
## Summary
- Add `--verbose` flag required by claude CLI v2.1.139 when using `--output-format stream-json` (caused immediate exit code 1 on every session spawn)
- Create per-session writable config directory: copy credential files from the RO-mounted shared volume to `{workspace}/.claude-config` and override `CLAUDE_CONFIG_DIR` for the child process, so claude CLI can write session state without hitting EROFS
- Fix `claude-login` entrypoint: `chown loginuser` on shared credentials volume so OAuth credential writes succeed

## Context
The shared `claude-credentials` volume is intentionally mounted `:ro` in agent-runner to prevent spawned claude processes from rewriting credentials via tool-call injection. However, claude CLI also needs to write `.claude.json` (session state) to the same directory. The fix creates per-session isolation: credentials are copied to a writable workspace subdirectory, preserving the security boundary.

## Test plan
- [x] `cargo check --package agent-runner` — compiles clean
- [x] `cargo test --package agent-runner` — 14/14 tests pass
- [ ] Smoke test: create claude_code session → verify `pending → running → completed` lifecycle
- [ ] Verify credentials are not written back to the RO volume

Closes #409