### PR TITLE
[RUSAA-1307] fix(frontend): wire ExecutionStream to agent session events, not ingest stream

### DIFF
--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -1,6 +1,8 @@
+import { Link } from "@tanstack/react-router";
 import type { SessionItem } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { formatTimestamp } from "@/components/activity/utils";
+import { routes } from "@/lib/routes";
 
 const STATUS_CELL_CLASS: Record<string, string> = {
   succeeded: "text-green-600 dark:text-green-400",
@@ -129,9 +131,14 @@ function SessionRow({ session, onDelete, deletingId }: SessionRowProps): JSX.Ele
   return (
     <tr className="border-b border-border last:border-0 hover:bg-muted/20">
       <td className="px-4 py-2">
-        <span className="font-mono text-xs text-muted-foreground" title={session.id}>
+        <Link
+          to={routes.agentSessionDetail}
+          params={{ sessionId: session.id }}
+          className="font-mono text-xs text-primary hover:underline"
+          title={session.id}
+        >
           {session.id.slice(0, 8)}…
-        </span>
+        </Link>
         {session.input_prompt_preview && (
           <p className="mt-0.5 max-w-[200px] truncate text-xs text-muted-foreground/70" title={session.input_prompt_preview}>
             {session.input_prompt_preview}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -13,6 +13,7 @@ export const routes = {
   codeWorkspace: "/repos/$repoId/code",
   activity: "/activity",
   agentExecution: "/agents/executions",
+  agentSessionDetail: "/agents/executions/$sessionId",
   adminGithub: "/admin/github",
   trace: "/trace/$traceId",
 } as const;

--- a/frontend/src/pages/AgentExecutionPage.tsx
+++ b/frontend/src/pages/AgentExecutionPage.tsx
@@ -1,17 +1,12 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
-import { useMe, useAgentSessions, useCreateSession, useDeleteSession, agentSessionsQueryKey } from "@/api";
+import { useMe, useAgentSessions, useCreateSession, useDeleteSession } from "@/api";
 import type { CreateSessionRequest } from "@/api";
 import type { CreateSessionFormValues } from "@/lib/validation/agentSessions";
 import { formatApiError } from "@/lib/errors/api";
 import { PageContainer } from "@/components/repos/PageContainer";
-import { useEventStream } from "@/hooks/useEventStream";
 import { SessionHistory } from "@/components/agent-execution/SessionHistory";
-import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
 import { CreateSessionDialog } from "@/components/agent-execution/CreateSessionDialog";
-
-const INGEST_EVENT_TYPES = ["ingest.status"] as const;
 
 export function AgentExecutionPage(): JSX.Element {
   const me = useMe({ retry: false });
@@ -43,36 +38,12 @@ interface AgentExecutionInnerProps {
 }
 
 function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Element {
-  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
   const [showCreate, setShowCreate] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  const qc = useQueryClient();
 
   const sessions = useAgentSessions(tenantId);
   const createSession = useCreateSession(tenantId);
   const deleteSession = useDeleteSession(tenantId);
-
-  // Use the ingest SSE endpoint — the global /v1/agents/sessions/events endpoint
-  // does not exist; per-session events live at /v1/agents/sessions/{id}/events.
-  // Keep the ingest stream for live activity and use it to invalidate the session list.
-  const { events, lastEventId, readyState } = useEventStream(
-    `${apiBase}/v1/ingest/events`,
-    INGEST_EVENT_TYPES,
-  );
-
-  // Invalidate sessions when ingest events arrive (belt-and-suspenders with refetchInterval)
-  useEffect(() => {
-    const latest = events.filter((e) => e.type === "ingest.status").at(-1);
-    if (!latest) return;
-    try {
-      const parsed = JSON.parse(latest.data) as { status?: string };
-      if (parsed.status === "succeeded" || parsed.status === "done" || parsed.status === "failed") {
-        void qc.invalidateQueries({ queryKey: agentSessionsQueryKey(tenantId) });
-      }
-    } catch {
-      // malformed event — ignore
-    }
-  }, [events, tenantId, qc]);
 
   const handleCreate = async (values: CreateSessionFormValues) => {
     const body: CreateSessionRequest = {
@@ -137,15 +108,6 @@ function AgentExecutionInner({ tenantId }: AgentExecutionInnerProps): JSX.Elemen
           />
         </section>
 
-        <section aria-labelledby="stream-heading">
-          <h2
-            id="stream-heading"
-            className="mb-3 text-base font-semibold tracking-tight"
-          >
-            Execution Stream
-          </h2>
-          <ExecutionStream events={events} lastEventId={lastEventId} readyState={readyState} />
-        </section>
       </div>
 
       {showCreate ? (

--- a/frontend/src/pages/AgentSessionDetailPage.tsx
+++ b/frontend/src/pages/AgentSessionDetailPage.tsx
@@ -1,0 +1,178 @@
+import { Link, useParams } from "@tanstack/react-router";
+import { useMe, useSessionDetail } from "@/api";
+import type { SessionDetail } from "@/api";
+import { useEventStream } from "@/hooks/useEventStream";
+import { ExecutionStream } from "@/components/agent-execution/ExecutionStream";
+import { PageContainer } from "@/components/repos/PageContainer";
+import { routes } from "@/lib/routes";
+import { formatTimestamp } from "@/components/activity/utils";
+import { formatApiError } from "@/lib/errors/api";
+
+const AGENT_SESSION_EVENT_TYPES = ["message"] as const;
+
+export function AgentSessionDetailPage(): JSX.Element {
+  const me = useMe({ retry: false });
+  const { sessionId } = useParams({ strict: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Sign in to view session details.</p>
+      </PageContainer>
+    );
+  }
+
+  if (!sessionId) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-destructive">Invalid session URL.</p>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <AgentSessionDetailInner
+      tenantId={me.data.current_tenant.id}
+      sessionId={sessionId}
+    />
+  );
+}
+
+interface AgentSessionDetailInnerProps {
+  readonly tenantId: string;
+  readonly sessionId: string;
+}
+
+function AgentSessionDetailInner({ tenantId, sessionId }: AgentSessionDetailInnerProps): JSX.Element {
+  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+  const session = useSessionDetail(tenantId, sessionId, { refetchInterval: 5_000 });
+  const { events, lastEventId, readyState } = useEventStream(
+    `${apiBase}/v1/agents/sessions/${sessionId}/events`,
+    AGENT_SESSION_EVENT_TYPES,
+  );
+
+  return (
+    <PageContainer>
+      <div className="mb-4">
+        <Link
+          to={routes.agentExecution}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back to sessions
+        </Link>
+      </div>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Session Detail</h1>
+        <p className="mt-1 font-mono text-xs text-muted-foreground" title={sessionId}>
+          {sessionId}
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        {session.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading session…</p>
+        ) : session.isError ? (
+          <p className="text-sm text-destructive">
+            {formatApiError(session.error, "Could not load session.")}
+          </p>
+        ) : session.data ? (
+          <SessionMetadata session={session.data} />
+        ) : null}
+
+        <section aria-labelledby="stream-heading">
+          <h2 id="stream-heading" className="mb-3 text-base font-semibold tracking-tight">
+            Execution Stream
+          </h2>
+          <ExecutionStream events={events} lastEventId={lastEventId} readyState={readyState} />
+        </section>
+      </div>
+    </PageContainer>
+  );
+}
+
+const STATUS_LABEL_CLASS: Record<string, string> = {
+  succeeded: "text-green-600 dark:text-green-400",
+  completed: "text-green-600 dark:text-green-400",
+  done: "text-green-600 dark:text-green-400",
+  failed: "text-destructive",
+  running: "text-blue-600 dark:text-blue-400",
+  processing: "text-blue-600 dark:text-blue-400",
+  pending: "text-muted-foreground",
+  cancelled: "text-muted-foreground",
+};
+
+const RUNTIME_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  opencode: "OpenCode",
+};
+
+interface SessionMetadataProps {
+  readonly session: SessionDetail;
+}
+
+function SessionMetadata({ session }: SessionMetadataProps): JSX.Element {
+  const statusClass = STATUS_LABEL_CLASS[session.status] ?? "text-muted-foreground";
+  const runtimeLabel = RUNTIME_LABELS[session.runtime_kind] ?? session.runtime_kind;
+
+  return (
+    <dl className="grid grid-cols-2 gap-x-6 gap-y-3 rounded-lg border border-border bg-card px-4 py-3 text-sm sm:grid-cols-3">
+      <div>
+        <dt className="text-xs text-muted-foreground">Status</dt>
+        <dd className={`mt-0.5 font-medium capitalize ${statusClass}`}>{session.status}</dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Runtime</dt>
+        <dd className="mt-0.5">{runtimeLabel}</dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Tokens</dt>
+        <dd className="mt-0.5 tabular-nums">
+          {session.tokens_used.toLocaleString()} / {session.token_budget.toLocaleString()}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Created</dt>
+        <dd className="mt-0.5">{formatTimestamp(session.created_at)}</dd>
+      </div>
+      {session.started_at ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Started</dt>
+          <dd className="mt-0.5">{formatTimestamp(session.started_at)}</dd>
+        </div>
+      ) : null}
+      {session.completed_at ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Completed</dt>
+          <dd className="mt-0.5">{formatTimestamp(session.completed_at)}</dd>
+        </div>
+      ) : null}
+      {session.exit_code != null ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Exit code</dt>
+          <dd className="mt-0.5 font-mono">{session.exit_code}</dd>
+        </div>
+      ) : null}
+      {session.failure_reason ? (
+        <div className="col-span-2 sm:col-span-3">
+          <dt className="text-xs text-muted-foreground">Failure reason</dt>
+          <dd className="mt-0.5 text-destructive">{session.failure_reason}</dd>
+        </div>
+      ) : null}
+      {session.input_prompt_preview ? (
+        <div className="col-span-2 sm:col-span-3">
+          <dt className="text-xs text-muted-foreground">Prompt preview</dt>
+          <dd className="mt-0.5 text-muted-foreground">{session.input_prompt_preview}</dd>
+        </div>
+      ) : null}
+    </dl>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
 import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
+import { AgentSessionDetailPage } from "@/pages/AgentSessionDetailPage";
 import { AdminGithubPage } from "@/pages/AdminGithubPage";
 import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { CodeWorkspacePage } from "@/pages/CodeWorkspacePage";
@@ -143,6 +144,12 @@ const agentExecutionRoute = createRoute({
   component: AgentExecutionPage,
 });
 
+const agentSessionDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.agentSessionDetail,
+  component: AgentSessionDetailPage,
+});
+
 const adminGithubSearchSchema = z.object({
   registered: z.enum(["true"]).optional(),
 });
@@ -178,6 +185,7 @@ const routeTree = rootRoute.addChildren([
   codeWorkspaceRoute,
   activityRoute,
   agentExecutionRoute,
+  agentSessionDetailRoute,
   adminGithubRoute,
   catchAllRoute,
 ]);


### PR DESCRIPTION
## Summary

- `AgentExecutionPage` was subscribing `ExecutionStream` to `/v1/ingest/events` (ingest pipeline), which never receives agent session events — causing the Live Stream panel to show "No events yet" forever.
- This PR implements **Option A** (minimal correct fix): a per-session detail page that subscribes SSE to the correct endpoint `/v1/agents/sessions/{id}/events`.

## Changes

- `frontend/src/lib/routes.ts` — add `agentSessionDetail: "/agents/executions/$sessionId"`
- `frontend/src/pages/AgentSessionDetailPage.tsx` *(new)* — per-session detail page with session metadata and `ExecutionStream` wired to `/v1/agents/sessions/{sessionId}/events`
- `frontend/src/components/agent-execution/SessionHistory.tsx` — session ID cells are now `Link` components navigating to the detail page
- `frontend/src/pages/AgentExecutionPage.tsx` — remove broken ingest SSE section; list page shows sessions only
- `frontend/src/router.tsx` — register `agentSessionDetailRoute` at `/agents/executions/$sessionId`

## Verification

- `npm run typecheck` — ✅ clean
- `npm run lint` — ✅ clean

## Test plan

- [ ] Navigate to `/agents/executions`; confirm session list renders
- [ ] Click a session ID; confirm navigation to `/agents/executions/{id}`
- [ ] Detail page shows session metadata (status, runtime, tokens, timestamps)
- [ ] `ExecutionStream` on detail page connects to `/v1/agents/sessions/{id}/events` (visible in DevTools → Network → EventSource)
- [ ] Events appear in the stream when a session is active

Closes #412