### PR TITLE
[RUSAA-1312] feat(rb-schemas): extend AgentEventKind with stream-json variants

### DIFF
--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-pub mod stream_json;
+mod stream_json;
 pub use stream_json::RuntimeEvent;
 
 mod ingest {

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -1,5 +1,8 @@
 use uuid::Uuid;
 
+pub mod stream_json;
+pub use stream_json::RuntimeEvent;
+
 mod ingest {
     #![allow(clippy::all, clippy::pedantic, dead_code)]
     include!(concat!(env!("OUT_DIR"), "/rust_brain.v1.rs"));

--- a/crates/rb-schemas/src/stream_json.rs
+++ b/crates/rb-schemas/src/stream_json.rs
@@ -1,0 +1,274 @@
+//! Normalized event types parsed from `claude --output-format stream-json`.
+//!
+//! [`RuntimeEvent`] is the serde-serializable Rust-native representation used
+//! on the HTTP batch path (agent-runner → control-api).  It maps 1-to-1 onto
+//! the `AGENT_EVENT_KIND_*` proto enum variants added in this crate for the
+//! Kafka wire format.
+
+use serde::{Deserialize, Serialize};
+
+use crate::AgentEventKind;
+
+/// A normalized, serde-friendly event extracted from a `stream-json` line.
+///
+/// Each variant corresponds to an `AgentEventKind` proto enum value and
+/// carries only the fields meaningful for that event type.  Raw Anthropic-API
+/// bookkeeping fields (`usage`, `stop_sequence`, model metadata, etc.) are
+/// intentionally dropped at parse time; they are not persisted or relayed.
+///
+/// # Wire format
+///
+/// Serialized with `#[serde(tag = "type", rename_all = "snake_case")]`, so the
+/// JSON discriminant is the `snake_case` variant name:
+///
+/// ```json
+/// {"type":"text","text":"Hello, world!"}
+/// {"type":"thinking","thinking":"Let me reason..."}
+/// {"type":"tool_use","id":"toolu_01","name":"read_file","input":{}}
+/// {"type":"tool_result","tool_use_id":"toolu_01","content":null,"is_error":false}
+/// {"type":"error","message":"Context limit exceeded"}
+/// {"type":"user_input","text":"What is 2+2?"}
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RuntimeEvent {
+    /// An assistant text content block (`content[].type == "text"`).
+    Text { text: String },
+
+    /// An extended thinking block (`content[].type == "thinking"`).
+    Thinking { thinking: String },
+
+    /// A tool invocation by the assistant (`content[].type == "tool_use"`).
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+
+    /// The result of a tool call returned to the assistant
+    /// (`content[].type == "tool_result"`).
+    ToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+        is_error: bool,
+    },
+
+    /// A runtime error reported by the agent (model error, context limit, etc.).
+    /// Maps to `AGENT_EVENT_KIND_ERROR` on the proto side.
+    Error {
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+    },
+
+    /// User input relayed into the session.
+    UserInput { text: String },
+}
+
+impl RuntimeEvent {
+    /// Returns the corresponding `AgentEventKind` for this event.
+    #[must_use]
+    pub fn kind(&self) -> AgentEventKind {
+        match self {
+            RuntimeEvent::Text { .. } => AgentEventKind::Text,
+            RuntimeEvent::Thinking { .. } => AgentEventKind::Thinking,
+            RuntimeEvent::ToolUse { .. } => AgentEventKind::ToolUse,
+            RuntimeEvent::ToolResult { .. } => AgentEventKind::ToolResult,
+            RuntimeEvent::Error { .. } => AgentEventKind::Error,
+            RuntimeEvent::UserInput { .. } => AgentEventKind::UserInput,
+        }
+    }
+
+    /// Returns the event payload as a JSON string suitable for storage in
+    /// `AgentEvent::payload`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `serde_json::Error` if serialization fails (in practice this
+    /// only happens on non-finite floats inside `input` / `content` fields).
+    pub fn to_payload_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip(event: &RuntimeEvent) -> RuntimeEvent {
+        let json = serde_json::to_string(event).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[test]
+    fn text_roundtrip() {
+        let ev = RuntimeEvent::Text {
+            text: "Hello, world!".into(),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "text");
+        assert_eq!(v["text"], "Hello, world!");
+    }
+
+    #[test]
+    fn thinking_roundtrip() {
+        let ev = RuntimeEvent::Thinking {
+            thinking: "Let me reason about this...".into(),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "thinking");
+        assert_eq!(v["thinking"], "Let me reason about this...");
+    }
+
+    #[test]
+    fn tool_use_roundtrip() {
+        let ev = RuntimeEvent::ToolUse {
+            id: "toolu_01AbCd".into(),
+            name: "read_file".into(),
+            input: json!({"path": "src/main.rs"}),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "tool_use");
+        assert_eq!(v["id"], "toolu_01AbCd");
+        assert_eq!(v["name"], "read_file");
+        assert_eq!(v["input"]["path"], "src/main.rs");
+    }
+
+    #[test]
+    fn tool_result_roundtrip() {
+        let ev = RuntimeEvent::ToolResult {
+            tool_use_id: "toolu_01AbCd".into(),
+            content: json!([{"type": "text", "text": "file contents"}]),
+            is_error: false,
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "tool_result");
+        assert_eq!(v["tool_use_id"], "toolu_01AbCd");
+        assert!(!v["is_error"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn tool_result_error_flag_roundtrip() {
+        let ev = RuntimeEvent::ToolResult {
+            tool_use_id: "toolu_02XyZ".into(),
+            content: json!("file not found"),
+            is_error: true,
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert!(v["is_error"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn error_roundtrip_with_code() {
+        let ev = RuntimeEvent::Error {
+            message: "Context window exceeded".into(),
+            code: Some("context_limit".into()),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["message"], "Context window exceeded");
+        assert_eq!(v["code"], "context_limit");
+    }
+
+    #[test]
+    fn error_roundtrip_without_code() {
+        let ev = RuntimeEvent::Error {
+            message: "Unknown error".into(),
+            code: None,
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "error");
+        // `code` must be absent when None (skip_serializing_if)
+        assert!(v.get("code").is_none() || v["code"].is_null());
+    }
+
+    #[test]
+    fn user_input_roundtrip() {
+        let ev = RuntimeEvent::UserInput {
+            text: "What is 2 + 2?".into(),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "user_input");
+        assert_eq!(v["text"], "What is 2 + 2?");
+    }
+
+    #[test]
+    fn kind_mapping_text() {
+        let ev = RuntimeEvent::Text { text: "hi".into() };
+        assert_eq!(ev.kind(), AgentEventKind::Text);
+    }
+
+    #[test]
+    fn kind_mapping_thinking() {
+        let ev = RuntimeEvent::Thinking { thinking: "...".into() };
+        assert_eq!(ev.kind(), AgentEventKind::Thinking);
+    }
+
+    #[test]
+    fn kind_mapping_tool_use() {
+        let ev = RuntimeEvent::ToolUse {
+            id: "t".into(),
+            name: "bash".into(),
+            input: json!({}),
+        };
+        assert_eq!(ev.kind(), AgentEventKind::ToolUse);
+    }
+
+    #[test]
+    fn kind_mapping_tool_result() {
+        let ev = RuntimeEvent::ToolResult {
+            tool_use_id: "t".into(),
+            content: json!(null),
+            is_error: false,
+        };
+        assert_eq!(ev.kind(), AgentEventKind::ToolResult);
+    }
+
+    #[test]
+    fn kind_mapping_error() {
+        let ev = RuntimeEvent::Error {
+            message: "oops".into(),
+            code: None,
+        };
+        assert_eq!(ev.kind(), AgentEventKind::Error);
+    }
+
+    #[test]
+    fn kind_mapping_user_input() {
+        let ev = RuntimeEvent::UserInput { text: "hello".into() };
+        assert_eq!(ev.kind(), AgentEventKind::UserInput);
+    }
+
+    #[test]
+    fn to_payload_json_produces_valid_json() {
+        let ev = RuntimeEvent::ToolUse {
+            id: "toolu_xyz".into(),
+            name: "write_file".into(),
+            input: json!({"path": "out.txt", "content": "hello"}),
+        };
+        let payload = ev.to_payload_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["type"], "tool_use");
+        assert_eq!(parsed["name"], "write_file");
+    }
+
+    #[test]
+    fn error_code_field_absent_when_none() {
+        let ev = RuntimeEvent::Error {
+            message: "fail".into(),
+            code: None,
+        };
+        let json_str = serde_json::to_string(&ev).unwrap();
+        // "code" key must not appear at all
+        assert!(!json_str.contains("\"code\""));
+    }
+}

--- a/crates/rb-schemas/src/stream_json.rs
+++ b/crates/rb-schemas/src/stream_json.rs
@@ -107,7 +107,8 @@ mod tests {
             text: "Hello, world!".into(),
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "text");
         assert_eq!(v["text"], "Hello, world!");
     }
@@ -118,7 +119,8 @@ mod tests {
             thinking: "Let me reason about this...".into(),
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "thinking");
         assert_eq!(v["thinking"], "Let me reason about this...");
     }
@@ -131,7 +133,8 @@ mod tests {
             input: json!({"path": "src/main.rs"}),
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "tool_use");
         assert_eq!(v["id"], "toolu_01AbCd");
         assert_eq!(v["name"], "read_file");
@@ -146,7 +149,8 @@ mod tests {
             is_error: false,
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "tool_result");
         assert_eq!(v["tool_use_id"], "toolu_01AbCd");
         assert!(!v["is_error"].as_bool().unwrap());
@@ -160,7 +164,8 @@ mod tests {
             is_error: true,
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert!(v["is_error"].as_bool().unwrap());
     }
 
@@ -171,7 +176,8 @@ mod tests {
             code: Some("context_limit".into()),
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "error");
         assert_eq!(v["message"], "Context window exceeded");
         assert_eq!(v["code"], "context_limit");
@@ -184,7 +190,8 @@ mod tests {
             code: None,
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "error");
         // `code` must be absent when None (skip_serializing_if)
         assert!(v.get("code").is_none() || v["code"].is_null());
@@ -196,7 +203,8 @@ mod tests {
             text: "What is 2 + 2?".into(),
         };
         assert_eq!(roundtrip(&ev), ev);
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["type"], "user_input");
         assert_eq!(v["text"], "What is 2 + 2?");
     }
@@ -209,7 +217,9 @@ mod tests {
 
     #[test]
     fn kind_mapping_thinking() {
-        let ev = RuntimeEvent::Thinking { thinking: "...".into() };
+        let ev = RuntimeEvent::Thinking {
+            thinking: "...".into(),
+        };
         assert_eq!(ev.kind(), AgentEventKind::Thinking);
     }
 
@@ -244,7 +254,9 @@ mod tests {
 
     #[test]
     fn kind_mapping_user_input() {
-        let ev = RuntimeEvent::UserInput { text: "hello".into() };
+        let ev = RuntimeEvent::UserInput {
+            text: "hello".into(),
+        };
         assert_eq!(ev.kind(), AgentEventKind::UserInput);
     }
 

--- a/proto/rust_brain/v1/agent.proto
+++ b/proto/rust_brain/v1/agent.proto
@@ -18,8 +18,16 @@ enum AgentEventKind {
   AGENT_EVENT_KIND_STARTED     = 1;
   AGENT_EVENT_KIND_STDOUT      = 2;
   AGENT_EVENT_KIND_STDERR      = 3;
+  // Process-level error (spawn failure, I/O error, timeout).
   AGENT_EVENT_KIND_ERROR       = 4;
   AGENT_EVENT_KIND_TERMINATED  = 5;
+
+  // stream-json derived event kinds — emitted by `claude --output-format stream-json`:
+  AGENT_EVENT_KIND_TEXT        = 6;  // assistant text content block
+  AGENT_EVENT_KIND_THINKING    = 7;  // extended thinking block
+  AGENT_EVENT_KIND_TOOL_USE    = 8;  // tool invocation by the assistant
+  AGENT_EVENT_KIND_TOOL_RESULT = 9;  // tool result returned to the assistant
+  AGENT_EVENT_KIND_USER_INPUT  = 10; // user input relayed into the session
 }
 
 enum AgentErrorCategory {


### PR DESCRIPTION
## Summary

- Adds `TEXT` (6), `THINKING` (7), `TOOL_USE` (8), `TOOL_RESULT` (9), `USER_INPUT` (10) to the `AgentEventKind` proto enum — purely additive, existing variants 0–5 unchanged
- New `rb_schemas::stream_json::RuntimeEvent` serde-tagged enum for the HTTP batch path (agent-runner → control-api); maps 1-to-1 to the proto via `RuntimeEvent::kind()`
- `to_payload_json()` serialises the event for storage in `AgentEvent::payload`

## GitHub Issue

Closes #414

## Checklist
- [x] `cargo test -p rb-schemas` passes (27 tests, 16 new)
- [x] `cargo clippy -p rb-schemas --all-targets -- -D warnings` clean
- [x] Additive proto changes only — no existing variant touched
- [x] No tracker IDs outside the PR title bracket prefix