### PR TITLE
[RUSAA-1322] fix(compose): warn about kafka data loss on down -v + improve fingerprint errors

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -116,9 +116,20 @@ Full documentation: [docs/dev-stack-auto-rebuild.md](../docs/dev-stack-auto-rebu
 ## Tear down
 
 ```bash
-# Stop (preserves volumes — migrations stay applied)
+# Stop (preserves volumes — migrations stay applied, Kafka offsets retained)
 docker compose -f compose/dev.yml down
 
 # Full reset (drops volumes — migrations will re-run on next up)
 docker compose -f compose/dev.yml down -v
 ```
+
+> **WARNING — mars / deployment-fingerprint gate**: `down -v` deletes the
+> `kafka_data` Docker volume, which resets all Kafka topic log-end offsets to
+> zero.  The deployment-fingerprint gate (`scripts/uat-fingerprint.sh`) requires
+> at least one `sse_offset > 0`; after a volume-clearing reset you **must** run
+> a full pipeline ingest before collecting a fingerprint, otherwise the gate will
+> fail with "all Kafka topic offsets are 0".
+>
+> On mars, prefer the plain `down` (no `-v`) for routine restarts.  Only use
+> `down -v` when you intentionally want to wipe all state and are prepared to
+> re-ingest before the next deployment-fingerprint collection.

--- a/scripts/uat-fingerprint.sh
+++ b/scripts/uat-fingerprint.sh
@@ -193,7 +193,7 @@ for topic in "${KAFKA_TOPICS[@]}"; do
 done
 
 if (( all_zero )); then
-  fail_field "sse_offsets — all Kafka topic offsets are 0; no messages produced (mocked run has no live broker)"
+  fail_field "sse_offsets — all Kafka topic offsets are 0; run a full pipeline ingest before collecting a fingerprint (offsets reset after 'docker compose down -v' or first start)"
 fi
 
 SSE_OFFSETS_JSON=$(python3 -c "
@@ -254,11 +254,15 @@ PYEOF
 
 if [ "${VERDICT_FAILED}" -ne 0 ]; then
   log "FINGERPRINT INVALID (verdict=fail) — required fields missing."
-  log "A mocked or stubbed stack cannot produce a valid fingerprint:"
-  log "  - Containers must be running (docker inspect requires real containers)"
-  log "  - DB counts must be non-zero (requires a completed real ingest)"
-  log "  - Kafka offsets must be non-zero (requires real message production)"
-  log "  - trace_ids must be present (requires live OTEL propagation)"
+  log "All four conditions must hold for a valid fingerprint:"
+  log "  - Containers running    : docker inspect finds real containers (stack must be up)"
+  log "  - DB counts non-zero    : code_symbols > 0 (a real ingest must have completed)"
+  log "  - Kafka offsets non-zero: at least one sse_offset > 0"
+  log "                            -> If all offsets are 0 after 'docker compose down -v' or"
+  log "                               first start, run a full pipeline ingest then re-collect."
+  log "                               The kafka_data volume preserves offsets across normal"
+  log "                               restarts; only 'down -v' resets them."
+  log "  - trace_ids present     : requires live OTEL propagation (real ingestion_runs rows)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `compose/README.md`: adds a WARNING block to the "Full reset" teardown section explaining that `down -v` deletes the `kafka_data` volume, resets all Kafka topic log-end offsets to zero, and requires a pipeline re-ingest before the deployment-fingerprint gate can pass. Recommends plain `down` (no `-v`) on mars for routine restarts.
- `scripts/uat-fingerprint.sh`: replaces the misleading "mocked run / no live broker" error with an actionable message: explains that a pipeline ingest is required after `down -v` or first start, and notes that the `kafka_data` volume already preserves offsets across normal restarts.

The `kafka_data:/var/lib/kafka/data` volume is and was always correctly declared in `compose/dev.yml` — no compose change is needed. The root cause of RUSAA-1322 was an accidental `down -v` on mars that wiped the volume, combined with a misleading fingerprint error that obscured what actually needed to happen.

## GitHub Issue

Closes #416

## Migration type

N/A (no schema changes)

## Checklist

- [x] All tests pass (`cargo test --workspace`)
- [x] No internal references
- [x] Docs updated (README teardown section + fingerprint script error text)