### PR TITLE
[RUSAA-1326] fix(frontend): replace window.location.href with hidden form POST for GitHub manifest

### DIFF
--- a/frontend/src/pages/AdminGithubPage.tsx
+++ b/frontend/src/pages/AdminGithubPage.tsx
@@ -80,7 +80,22 @@ function AdminGithubPageInner(): JSX.Element {
   const onInitiate = async () => {
     try {
       const result = await manifest.mutateAsync({ name: null });
-      window.location.href = result.redirect_url;
+      const url = new URL(result.redirect_url);
+      const manifestJson = url.searchParams.get('manifest') ?? '';
+      url.searchParams.delete('manifest');
+
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = url.toString();
+
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'manifest';
+      input.value = manifestJson;
+      form.appendChild(input);
+
+      document.body.appendChild(form);
+      form.submit();
     } catch (error) {
       toast.error(formatApiError(error, "Could not initiate manifest registration."));
     }


### PR DESCRIPTION
## Summary

- Replaces `window.location.href = result.redirect_url` with a hidden-input form POST in the `onInitiate` handler of `AdminGithubPage.tsx`
- GitHub's App Manifest flow only pre-fills the creation form when the manifest is delivered via form POST; GET redirects are silently ignored
- Extracts the `manifest` JSON param from the backend's `redirect_url`, removes it from the query string, then submits a `<form method="POST">` with a hidden `manifest` input so GitHub receives the payload correctly
- No backend changes required; the "Redirecting…" button state and error toast behaviour are unchanged

## GitHub Issue

Closes #418

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR