### PR TITLE
[RUSAA-1320] feat(frontend): SessionReplayPage at /agents/$sessionId

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.59.20",
         "@tanstack/react-router": "^1.168.24",
+        "@tanstack/react-virtual": "^3.13.24",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
@@ -1705,6 +1706,23 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/router-core": {
       "version": "1.168.16",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.16.tgz",
@@ -1913,6 +1931,16 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
       "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.59.20",
     "@tanstack/react-router": "^1.168.24",
+    "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -75,10 +75,13 @@ export {
   useCreateSession,
   useDeleteSession,
   useSessionDetail,
+  useSessionHistory,
   agentSessionsQueryKey,
   type ListSessionsResponse,
   type SessionItem,
   type SessionDetail,
   type CreateSessionRequest,
   type CreateSessionResponse,
+  type EventItem,
+  type HistoryResponse,
 } from "./useAgentSessions";

--- a/frontend/src/api/hooks/useAgentSessions.ts
+++ b/frontend/src/api/hooks/useAgentSessions.ts
@@ -1,4 +1,5 @@
 import {
+  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
@@ -6,6 +7,12 @@ import {
 } from "@tanstack/react-query";
 import { apiClient, toApiError, type ApiError } from "../client";
 import type { components } from "../generated/schema";
+
+type HistoryResponse = {
+  events: components["schemas"]["EventItem"][];
+  next_seq?: number | null;
+};
+type EventItem = components["schemas"]["EventItem"];
 
 type ListSessionsResponse = components["schemas"]["ListSessionsResponse"];
 type SessionItem = components["schemas"]["SessionItem"];
@@ -105,10 +112,41 @@ export function useSessionDetail(
   });
 }
 
+const SESSION_HISTORY_PAGE_SIZE = 200;
+
+export function useSessionHistory(sessionId: string, enabled: boolean) {
+  return useInfiniteQuery<HistoryResponse, ApiError>({
+    queryKey: ["session-history", sessionId],
+    queryFn: async ({ pageParam }) => {
+      const { response } = await apiClient.GET(
+        "/v1/agents/sessions/{id}/events/history",
+        {
+          params: {
+            path: { id: sessionId },
+            query: {
+              limit: SESSION_HISTORY_PAGE_SIZE,
+              ...(pageParam != null ? { after: pageParam as number } : {}),
+            },
+          },
+        },
+      );
+      if (!response.ok) {
+        throw toApiError(response.status, null);
+      }
+      return response.json() as Promise<HistoryResponse>;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_seq ?? undefined,
+    enabled: enabled && sessionId.length > 0,
+  });
+}
+
 export type {
   ListSessionsResponse,
   SessionItem,
   SessionDetail,
   CreateSessionRequest,
   CreateSessionResponse,
+  EventItem,
+  HistoryResponse,
 };

--- a/frontend/src/components/agent-execution/EventVirtualList.tsx
+++ b/frontend/src/components/agent-execution/EventVirtualList.tsx
@@ -1,0 +1,399 @@
+import { useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+// ---------------------------------------------------------------------------
+// Unified display event — normalised from both history rows and SSE envelopes
+// ---------------------------------------------------------------------------
+
+export interface DisplayEvent {
+  readonly key: string;
+  readonly sequence: number;
+  readonly eventType: string;
+  readonly payload: unknown;
+  readonly createdAt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Filter chip types
+// ---------------------------------------------------------------------------
+
+export const EVENT_FILTER_TYPES = [
+  "text",
+  "tool_use",
+  "tool_result",
+  "thinking",
+  "error",
+  "lifecycle",
+] as const;
+export type EventFilterType = (typeof EVENT_FILTER_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Virtual list
+// ---------------------------------------------------------------------------
+
+interface EventVirtualListProps {
+  readonly events: ReadonlyArray<DisplayEvent>;
+}
+
+export function EventVirtualList({ events }: EventVirtualListProps): JSX.Element {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: events.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 80,
+    overscan: 8,
+  });
+
+  if (events.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        No events to display.
+      </div>
+    );
+  }
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={parentRef}
+      className="overflow-y-auto"
+      style={{ height: "60vh" }}
+      role="log"
+      aria-label="Session events"
+      aria-live="polite"
+    >
+      <div
+        style={{
+          height: rowVirtualizer.getTotalSize(),
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const event = events[virtualRow.index] as DisplayEvent | undefined;
+          if (!event) return null;
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+              className="p-1"
+            >
+              <EventRow event={event} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Event row dispatcher
+// ---------------------------------------------------------------------------
+
+interface EventRowProps {
+  readonly event: DisplayEvent;
+}
+
+function EventRow({ event }: EventRowProps): JSX.Element {
+  if (event.eventType === "lifecycle") {
+    return <LifecycleRow event={event} />;
+  }
+
+  const payload = event.payload as Record<string, unknown> | null;
+  if (payload == null || typeof payload !== "object") {
+    return <RawRow event={event} />;
+  }
+
+  switch (payload.type) {
+    case "text":
+      return (
+        <TextRow
+          sequence={event.sequence}
+          text={typeof payload.text === "string" ? payload.text : JSON.stringify(payload.text)}
+        />
+      );
+    case "thinking":
+      return (
+        <ThinkingRow
+          sequence={event.sequence}
+          thinking={
+            typeof payload.thinking === "string"
+              ? payload.thinking
+              : JSON.stringify(payload.thinking)
+          }
+        />
+      );
+    case "tool_use":
+      return (
+        <ToolUseRow
+          sequence={event.sequence}
+          id={typeof payload.id === "string" ? payload.id : "?"}
+          name={typeof payload.name === "string" ? payload.name : "unknown"}
+          input={payload.input}
+        />
+      );
+    case "tool_result":
+      return (
+        <ToolResultRow
+          sequence={event.sequence}
+          toolUseId={
+            typeof payload.tool_use_id === "string" ? payload.tool_use_id : "?"
+          }
+          content={payload.content}
+          isError={payload.is_error === true}
+        />
+      );
+    case "error":
+      return (
+        <ErrorRow
+          sequence={event.sequence}
+          message={typeof payload.message === "string" ? payload.message : "Unknown error"}
+          code={typeof payload.code === "string" ? payload.code : undefined}
+        />
+      );
+    case "user_input":
+      return (
+        <UserInputRow
+          sequence={event.sequence}
+          text={typeof payload.text === "string" ? payload.text : JSON.stringify(payload.text)}
+        />
+      );
+    default:
+      return <RawRow event={event} />;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-type row renderers
+// ---------------------------------------------------------------------------
+
+function SeqBadge({ sequence }: { readonly sequence: number }): JSX.Element {
+  return (
+    <span className="mt-0.5 shrink-0 font-mono text-[10px] text-muted-foreground/50 tabular-nums">
+      #{sequence}
+    </span>
+  );
+}
+
+function TextRow({
+  text,
+  sequence,
+}: {
+  readonly text: string;
+  readonly sequence: number;
+}): JSX.Element {
+  return (
+    <div className="flex gap-2 items-start px-1 py-1.5">
+      <SeqBadge sequence={sequence} />
+      <p className="whitespace-pre-wrap text-sm leading-relaxed break-words min-w-0">{text}</p>
+    </div>
+  );
+}
+
+function ThinkingRow({
+  thinking,
+  sequence,
+}: {
+  readonly thinking: string;
+  readonly sequence: number;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const preview = thinking.slice(0, 80);
+
+  return (
+    <div className="rounded border border-border/40 bg-muted/10 px-3 py-2">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <SeqBadge sequence={sequence} />
+        <span className="text-xs italic text-muted-foreground">
+          {open ? "Thinking" : `Thinking: ${preview}${thinking.length > 80 ? "…" : ""}`}
+        </span>
+        <span className="ml-auto text-xs text-muted-foreground" aria-hidden="true">
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+      {open && (
+        <p className="mt-2 whitespace-pre-wrap text-xs text-muted-foreground">{thinking}</p>
+      )}
+    </div>
+  );
+}
+
+function ToolUseRow({
+  id,
+  name,
+  input,
+  sequence,
+}: {
+  readonly id: string;
+  readonly name: string;
+  readonly input: unknown;
+  readonly sequence: number;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="rounded border border-blue-200 bg-blue-50/60 px-3 py-2 dark:border-blue-900/40 dark:bg-blue-950/20">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <SeqBadge sequence={sequence} />
+        <span className="rounded bg-blue-100 px-1.5 py-0.5 font-mono text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+          {name}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">{id.slice(0, 12)}…</span>
+        <span className="ml-auto text-xs text-muted-foreground" aria-hidden="true">
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+      {open && (
+        <pre className="mt-2 overflow-x-auto whitespace-pre text-xs text-muted-foreground">
+          {JSON.stringify(input, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ToolResultRow({
+  toolUseId,
+  content,
+  isError,
+  sequence,
+}: {
+  readonly toolUseId: string;
+  readonly content: unknown;
+  readonly isError: boolean;
+  readonly sequence: number;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerClass = isError
+    ? "rounded border border-destructive/30 bg-destructive/5 px-3 py-2"
+    : "rounded border border-green-200 bg-green-50/60 px-3 py-2 dark:border-green-900/40 dark:bg-green-950/20";
+  const badgeClass = isError
+    ? "rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive"
+    : "rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/40 dark:text-green-300";
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <SeqBadge sequence={sequence} />
+        <span className={badgeClass}>{isError ? "Error" : "Result"}</span>
+        <span className="font-mono text-[10px] text-muted-foreground">{toolUseId.slice(0, 12)}…</span>
+        <span className="ml-auto text-xs text-muted-foreground" aria-hidden="true">
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+      {open && (
+        <pre className="mt-2 overflow-x-auto whitespace-pre text-xs text-muted-foreground">
+          {typeof content === "string" ? content : JSON.stringify(content, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ErrorRow({
+  message,
+  code,
+  sequence,
+}: {
+  readonly message: string;
+  readonly code: string | undefined;
+  readonly sequence: number;
+}): JSX.Element {
+  return (
+    <div className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2">
+      <div className="flex items-center gap-2">
+        <SeqBadge sequence={sequence} />
+        <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+          Error
+        </span>
+        {code && <span className="font-mono text-xs text-muted-foreground">{code}</span>}
+      </div>
+      <p className="mt-1 text-sm text-destructive">{message}</p>
+    </div>
+  );
+}
+
+function UserInputRow({
+  text,
+  sequence,
+}: {
+  readonly text: string;
+  readonly sequence: number;
+}): JSX.Element {
+  return (
+    <div className="rounded border border-border bg-muted/30 px-3 py-2">
+      <div className="flex items-center gap-2 mb-1">
+        <SeqBadge sequence={sequence} />
+        <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+          User
+        </span>
+      </div>
+      <p className="whitespace-pre-wrap text-sm">{text}</p>
+    </div>
+  );
+}
+
+function LifecycleRow({ event }: { readonly event: DisplayEvent }): JSX.Element {
+  const data = event.payload as Record<string, unknown> | null;
+  const status = typeof data?.status === "string" ? data.status : "lifecycle";
+  const message = typeof data?.message === "string" ? data.message : "";
+  const isError = status !== "terminated" && status !== "cancelled" && status !== "completed";
+
+  return (
+    <div
+      className={
+        isError
+          ? "rounded border border-destructive/30 bg-destructive/5 px-4 py-3 text-center"
+          : "rounded border border-border bg-muted/20 px-4 py-3 text-center"
+      }
+      role="status"
+    >
+      <p className="text-sm font-medium capitalize">{status}</p>
+      {message && <p className="text-xs text-muted-foreground">{message}</p>}
+    </div>
+  );
+}
+
+function RawRow({ event }: { readonly event: DisplayEvent }): JSX.Element {
+  return (
+    <div className="rounded border border-border/50 bg-muted/20 px-3 py-2">
+      <div className="flex items-center gap-2 mb-1">
+        <SeqBadge sequence={event.sequence} />
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
+          {event.eventType}
+        </span>
+      </div>
+      <pre className="whitespace-pre-wrap text-xs text-muted-foreground">
+        {typeof event.payload === "object" && event.payload !== null
+          ? JSON.stringify(event.payload, null, 2)
+          : String(event.payload ?? "")}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/components/agent-execution/SessionHistory.tsx
+++ b/frontend/src/components/agent-execution/SessionHistory.tsx
@@ -132,7 +132,7 @@ function SessionRow({ session, onDelete, deletingId }: SessionRowProps): JSX.Ele
     <tr className="border-b border-border last:border-0 hover:bg-muted/20">
       <td className="px-4 py-2">
         <Link
-          to={routes.agentSessionDetail}
+          to={routes.agentSessionReplay}
           params={{ sessionId: session.id }}
           className="font-mono text-xs text-primary hover:underline"
           title={session.id}

--- a/frontend/src/hooks/useEventStream.ts
+++ b/frontend/src/hooks/useEventStream.ts
@@ -20,6 +20,7 @@ const DEFAULT_EVENT_TYPES = ["message"] as const;
 export function useEventStream(
   url: string,
   eventTypes?: readonly string[],
+  enabled = true,
 ): UseEventStreamResult {
   const [events, setEvents] = useState<StreamedEvent[]>([]);
   const [lastEventId, setLastEventId] = useState<string | null>(null);
@@ -30,6 +31,11 @@ export function useEventStream(
   eventTypesRef.current = eventTypes;
 
   useEffect(() => {
+    if (!enabled) {
+      setReadyState("closed");
+      return;
+    }
+
     cancelledRef.current = false;
 
     let es: EventSource | null = null;
@@ -83,7 +89,7 @@ export function useEventStream(
       es?.close();
       setReadyState("closed");
     };
-  }, [url]);
+  }, [url, enabled]);
 
   return { events, lastEventId, readyState };
 }

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -14,6 +14,7 @@ export const routes = {
   activity: "/activity",
   agentExecution: "/agents/executions",
   agentSessionDetail: "/agents/executions/$sessionId",
+  agentSessionReplay: "/agents/$sessionId",
   adminGithub: "/admin/github",
   trace: "/trace/$traceId",
 } as const;

--- a/frontend/src/pages/SessionReplayPage.tsx
+++ b/frontend/src/pages/SessionReplayPage.tsx
@@ -1,0 +1,521 @@
+import { useMemo, useEffect, useState } from "react";
+import { Link, useParams } from "@tanstack/react-router";
+import { useMe, useSessionDetail, useSessionHistory, apiClient, type EventItem } from "@/api";
+import { useEventStream } from "@/hooks/useEventStream";
+import {
+  EventVirtualList,
+  EVENT_FILTER_TYPES,
+  type DisplayEvent,
+  type EventFilterType,
+} from "@/components/agent-execution/EventVirtualList";
+import { PageContainer } from "@/components/repos/PageContainer";
+import { routes } from "@/lib/routes";
+import { formatTimestamp } from "@/components/activity/utils";
+import { formatApiError } from "@/lib/errors/api";
+
+// ---------------------------------------------------------------------------
+// Status helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_LABEL_CLASS: Record<string, string> = {
+  succeeded: "text-green-600 dark:text-green-400",
+  completed: "text-green-600 dark:text-green-400",
+  done: "text-green-600 dark:text-green-400",
+  failed: "text-destructive",
+  running: "text-blue-600 dark:text-blue-400",
+  processing: "text-blue-600 dark:text-blue-400",
+  pending: "text-muted-foreground",
+  cancelled: "text-muted-foreground",
+};
+
+const RUNNING_STATUSES = new Set(["running", "processing", "pending"]);
+
+// ---------------------------------------------------------------------------
+// SSE event types to subscribe to
+// ---------------------------------------------------------------------------
+
+const AGENT_SESSION_EVENT_TYPES = ["session.event", "session.error"] as const;
+
+// ---------------------------------------------------------------------------
+// Page root — guards auth + param
+// ---------------------------------------------------------------------------
+
+export function SessionReplayPage(): JSX.Element {
+  const me = useMe({ retry: false });
+  const { sessionId } = useParams({ strict: false });
+
+  if (me.isLoading) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </PageContainer>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-muted-foreground">Sign in to view session replay.</p>
+      </PageContainer>
+    );
+  }
+
+  if (!sessionId) {
+    return (
+      <PageContainer>
+        <p className="text-sm text-destructive">Invalid session URL.</p>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <SessionReplayInner
+      tenantId={me.data.current_tenant.id}
+      sessionId={sessionId}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main inner component
+// ---------------------------------------------------------------------------
+
+interface SessionReplayInnerProps {
+  readonly tenantId: string;
+  readonly sessionId: string;
+}
+
+function SessionReplayInner({ tenantId, sessionId }: SessionReplayInnerProps): JSX.Element {
+  const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "";
+  const [activeFilters, setActiveFilters] = useState<Set<EventFilterType>>(new Set());
+
+  // Session metadata — refetch every 5 s while running
+  const session = useSessionDetail(tenantId, sessionId, { refetchInterval: 5_000 });
+
+  // Load all historical event pages
+  const history = useSessionHistory(sessionId, true);
+
+  // Auto-fetch remaining pages once previous page resolves
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = history;
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // Flatten history pages into ordered EventItem array
+  const historyEvents = useMemo<EventItem[]>(() => {
+    if (!history.data) return [];
+    return history.data.pages.flatMap((p) => p.events);
+  }, [history.data]);
+
+  // Last sequence seen in history — SSE connects from here
+  const lastHistorySeq = useMemo<number | null>(() => {
+    if (historyEvents.length === 0) return null;
+    return historyEvents[historyEvents.length - 1]?.sequence ?? null;
+  }, [historyEvents]);
+
+  const isRunning = session.data ? RUNNING_STATUSES.has(session.data.status) : false;
+  const historyFullyLoaded = !history.isFetching && !history.hasNextPage;
+
+  // Connect SSE only after history fully loaded and session is running
+  const sseEnabled = isRunning && historyFullyLoaded;
+  const sseUrl = useMemo(() => {
+    const base = `${apiBase}/v1/agents/sessions/${sessionId}/events`;
+    return lastHistorySeq != null ? `${base}?from_sequence=${lastHistorySeq}` : base;
+  }, [apiBase, sessionId, lastHistorySeq]);
+
+  const { events: sseEvents, readyState } = useEventStream(
+    sseUrl,
+    AGENT_SESSION_EVENT_TYPES,
+    sseEnabled,
+  );
+
+  // Convert SSE events to DisplayEvent
+  const liveEvents = useMemo<DisplayEvent[]>(() => {
+    const result: DisplayEvent[] = [];
+    let lifecycleSeq = (lastHistorySeq ?? 0) + 0.5;
+
+    for (const e of sseEvents) {
+      if (e.type === "stream-reset") continue;
+
+      if (e.type === "session.error") {
+        let payload: unknown = null;
+        try { payload = JSON.parse(e.data); } catch { /* ignore */ }
+        result.push({
+          key: `lifecycle-${lifecycleSeq}`,
+          sequence: lifecycleSeq,
+          eventType: "lifecycle",
+          payload,
+        });
+        lifecycleSeq += 1;
+        continue;
+      }
+
+      // session.event
+      let envelope: Record<string, unknown> | null = null;
+      try { envelope = JSON.parse(e.data) as Record<string, unknown>; } catch { /* ignore */ }
+      if (!envelope || typeof envelope.sequence !== "number") continue;
+
+      result.push({
+        key: `live-${envelope.sequence as number}`,
+        sequence: envelope.sequence as number,
+        eventType: typeof envelope.event_type === "string" ? envelope.event_type : "unknown",
+        payload: envelope.payload,
+      });
+    }
+    return result;
+  }, [sseEvents, lastHistorySeq]);
+
+  // Convert history EventItems to DisplayEvent
+  const historicalDisplayEvents = useMemo<DisplayEvent[]>(() => {
+    return historyEvents.map((e) => ({
+      key: e.id,
+      sequence: e.sequence,
+      eventType: e.event_type,
+      payload: e.payload,
+      createdAt: e.created_at,
+    }));
+  }, [historyEvents]);
+
+  // Deduplicate: prefer history; live events only if sequence > last history seq
+  const allEvents = useMemo<DisplayEvent[]>(() => {
+    const maxHistSeq = lastHistorySeq ?? -1;
+    const uniqueLive = liveEvents.filter((e) => e.sequence > maxHistSeq);
+    return [...historicalDisplayEvents, ...uniqueLive].sort(
+      (a, b) => a.sequence - b.sequence,
+    );
+  }, [historicalDisplayEvents, liveEvents, lastHistorySeq]);
+
+  // Apply filters
+  const filteredEvents = useMemo<DisplayEvent[]>(() => {
+    if (activeFilters.size === 0) return allEvents;
+    return allEvents.filter((e) => activeFilters.has(e.eventType as EventFilterType));
+  }, [allEvents, activeFilters]);
+
+  const toggleFilter = (type: EventFilterType) => {
+    setActiveFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  };
+
+  // NDJSON download
+  const handleDownload = async () => {
+    const { response } = await apiClient.GET("/v1/agents/sessions/{id}/log.ndjson", {
+      params: { path: { id: sessionId } },
+    });
+    if (!response.ok) return;
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = `session-${sessionId}.ndjson`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  return (
+    <PageContainer>
+      {/* Breadcrumb */}
+      <nav aria-label="Breadcrumb" className="mb-4">
+        <Link
+          to={routes.agentExecution}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back to sessions
+        </Link>
+      </nav>
+
+      {/* Page header */}
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight">Session Replay</h1>
+          <p
+            className="mt-1 font-mono text-xs text-muted-foreground"
+            title={sessionId}
+          >
+            {sessionId}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {session.data && (
+            <StatusBadge status={session.data.status} />
+          )}
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Download NDJSON log"
+          >
+            Download NDJSON
+          </button>
+        </div>
+      </header>
+
+      {/* Session metadata */}
+      {session.isLoading ? (
+        <p className="mb-6 text-sm text-muted-foreground">Loading session…</p>
+      ) : session.isError ? (
+        <p className="mb-6 text-sm text-destructive">
+          {formatApiError(session.error, "Could not load session.")}
+        </p>
+      ) : session.data ? (
+        <SessionMeta
+          runtimeKind={session.data.runtime_kind}
+          tokensUsed={session.data.tokens_used}
+          tokenBudget={session.data.token_budget}
+          createdAt={session.data.created_at}
+          startedAt={session.data.started_at ?? null}
+          completedAt={session.data.completed_at ?? null}
+          exitCode={session.data.exit_code ?? null}
+          failureReason={session.data.failure_reason ?? null}
+          promptPreview={session.data.input_prompt_preview ?? null}
+        />
+      ) : null}
+
+      {/* Filter chips */}
+      <FilterChips activeFilters={activeFilters} onToggle={toggleFilter} />
+
+      {/* Event list */}
+      <section
+        className="mt-4 rounded-lg border border-border bg-card"
+        aria-labelledby="events-heading"
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h2 id="events-heading" className="text-sm font-medium">
+            Events
+            {allEvents.length > 0 && (
+              <span className="ml-2 text-xs text-muted-foreground tabular-nums">
+                {filteredEvents.length === allEvents.length
+                  ? allEvents.length.toLocaleString()
+                  : `${filteredEvents.length.toLocaleString()} / ${allEvents.length.toLocaleString()}`}
+              </span>
+            )}
+          </h2>
+          <div className="flex items-center gap-3">
+            {history.isFetching && (
+              <span className="text-xs text-muted-foreground">Loading history…</span>
+            )}
+            {sseEnabled && (
+              <SseIndicator readyState={readyState} />
+            )}
+          </div>
+        </div>
+
+        <div className="p-2">
+          {history.isError ? (
+            <p className="p-4 text-sm text-destructive">
+              {formatApiError(history.error, "Could not load event history.")}
+            </p>
+          ) : (
+            <EventVirtualList events={filteredEvents} />
+          )}
+        </div>
+      </section>
+    </PageContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+interface StatusBadgeProps {
+  readonly status: string;
+}
+
+function StatusBadge({ status }: StatusBadgeProps): JSX.Element {
+  const cls = STATUS_LABEL_CLASS[status] ?? "text-muted-foreground";
+  const isPulsing = RUNNING_STATUSES.has(status);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {isPulsing && (
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 rounded-full bg-blue-500 animate-pulse"
+        />
+      )}
+      <span className={`text-sm font-medium capitalize ${cls}`}>{status}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Session metadata grid
+// ---------------------------------------------------------------------------
+
+interface SessionMetaProps {
+  readonly runtimeKind: string;
+  readonly tokensUsed: number;
+  readonly tokenBudget: number;
+  readonly createdAt: string;
+  readonly startedAt: string | null;
+  readonly completedAt: string | null;
+  readonly exitCode: number | null;
+  readonly failureReason: string | null;
+  readonly promptPreview: string | null;
+}
+
+const RUNTIME_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  opencode: "OpenCode",
+};
+
+function SessionMeta({
+  runtimeKind,
+  tokensUsed,
+  tokenBudget,
+  createdAt,
+  startedAt,
+  completedAt,
+  exitCode,
+  failureReason,
+  promptPreview,
+}: SessionMetaProps): JSX.Element {
+  return (
+    <dl className="mb-6 grid grid-cols-2 gap-x-6 gap-y-3 rounded-lg border border-border bg-card px-4 py-3 text-sm sm:grid-cols-3">
+      <div>
+        <dt className="text-xs text-muted-foreground">Runtime</dt>
+        <dd className="mt-0.5">{RUNTIME_LABELS[runtimeKind] ?? runtimeKind}</dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Tokens</dt>
+        <dd className="mt-0.5 tabular-nums">
+          {tokensUsed.toLocaleString()} / {tokenBudget.toLocaleString()}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Created</dt>
+        <dd className="mt-0.5">{formatTimestamp(createdAt)}</dd>
+      </div>
+      {startedAt ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Started</dt>
+          <dd className="mt-0.5">{formatTimestamp(startedAt)}</dd>
+        </div>
+      ) : null}
+      {completedAt ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Completed</dt>
+          <dd className="mt-0.5">{formatTimestamp(completedAt)}</dd>
+        </div>
+      ) : null}
+      {exitCode != null ? (
+        <div>
+          <dt className="text-xs text-muted-foreground">Exit code</dt>
+          <dd className="mt-0.5 font-mono">{exitCode}</dd>
+        </div>
+      ) : null}
+      {failureReason ? (
+        <div className="col-span-2 sm:col-span-3">
+          <dt className="text-xs text-muted-foreground">Failure reason</dt>
+          <dd className="mt-0.5 text-destructive">{failureReason}</dd>
+        </div>
+      ) : null}
+      {promptPreview ? (
+        <div className="col-span-2 sm:col-span-3">
+          <dt className="text-xs text-muted-foreground">Prompt preview</dt>
+          <dd className="mt-0.5 text-muted-foreground">{promptPreview}</dd>
+        </div>
+      ) : null}
+    </dl>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter chips
+// ---------------------------------------------------------------------------
+
+interface FilterChipsProps {
+  readonly activeFilters: Set<EventFilterType>;
+  readonly onToggle: (type: EventFilterType) => void;
+}
+
+const FILTER_LABELS: Record<EventFilterType, string> = {
+  text: "Text",
+  tool_use: "Tool Use",
+  tool_result: "Tool Result",
+  thinking: "Thinking",
+  error: "Error",
+  lifecycle: "Lifecycle",
+};
+
+function FilterChips({ activeFilters, onToggle }: FilterChipsProps): JSX.Element {
+  const clearAll = () => {
+    for (const t of EVENT_FILTER_TYPES) {
+      if (activeFilters.has(t)) onToggle(t);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by event type">
+      <span className="self-center text-xs text-muted-foreground">Filter:</span>
+      {EVENT_FILTER_TYPES.map((type) => {
+        const isActive = activeFilters.has(type);
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onToggle(type)}
+            aria-pressed={isActive}
+            className={
+              isActive
+                ? "rounded-full border border-primary bg-primary px-3 py-1 text-xs font-medium text-primary-foreground"
+                : "rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground hover:border-primary/50 hover:text-foreground"
+            }
+          >
+            {FILTER_LABELS[type]}
+          </button>
+        );
+      })}
+      {activeFilters.size > 0 && (
+        <button
+          type="button"
+          onClick={clearAll}
+          className="self-center text-xs text-muted-foreground underline hover:text-foreground"
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SSE connection indicator
+// ---------------------------------------------------------------------------
+
+interface SseIndicatorProps {
+  readonly readyState: "connecting" | "open" | "closed";
+}
+
+function SseIndicator({ readyState }: SseIndicatorProps): JSX.Element {
+  const label =
+    readyState === "open"
+      ? "Live"
+      : readyState === "connecting"
+        ? "Connecting…"
+        : "Disconnected";
+  const color =
+    readyState === "open"
+      ? "bg-green-500"
+      : readyState === "connecting"
+        ? "bg-yellow-500 animate-pulse"
+        : "bg-muted-foreground";
+
+  return (
+    <div className="flex items-center gap-1.5" aria-live="polite">
+      <span aria-hidden="true" className={`h-2 w-2 rounded-full ${color}`} />
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,6 +11,7 @@ import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
 import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
 import { AgentSessionDetailPage } from "@/pages/AgentSessionDetailPage";
+import { SessionReplayPage } from "@/pages/SessionReplayPage";
 import { AdminGithubPage } from "@/pages/AdminGithubPage";
 import { ApiKeysPage } from "@/pages/ApiKeysPage";
 import { CodeWorkspacePage } from "@/pages/CodeWorkspacePage";
@@ -150,6 +151,12 @@ const agentSessionDetailRoute = createRoute({
   component: AgentSessionDetailPage,
 });
 
+const agentSessionReplayRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.agentSessionReplay,
+  component: SessionReplayPage,
+});
+
 const adminGithubSearchSchema = z.object({
   registered: z.enum(["true"]).optional(),
 });
@@ -186,6 +193,7 @@ const routeTree = rootRoute.addChildren([
   activityRoute,
   agentExecutionRoute,
   agentSessionDetailRoute,
+  agentSessionReplayRoute,
   adminGithubRoute,
   catchAllRoute,
 ]);


### PR DESCRIPTION
## Summary

- Adds `SessionReplayPage` at route `/agents/$sessionId` with full history + live event replay
- Loads all historical events from `GET /v1/agents/sessions/{id}/events/history` via infinite query with auto-pagination
- Connects SSE from `from_sequence=<last_history_seq>` for gap-free live tail on running sessions; disabled for completed/failed
- Virtualized event list via `@tanstack/react-virtual` — handles 10k+ events without DOM jank
- Filter chips: text, tool_use, tool_result, thinking, error, lifecycle
- NDJSON download button via `apiClient` → blob URL
- Live-updating status badge with pulse animation for running sessions
- Breadcrumb nav back to `/agents/executions`
- Sessions in the execution list now link to the new replay route

## GitHub Issue

Closes #434

## Closes

Closes RUSAA-1320

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR