### PR TITLE
[RUSAA-1372] chore(build): cap agent heartbeat memory — cargo config + mold + flock

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,29 @@
+# ── Cargo workspace configuration ─────────────────────────────────────────────
+# Memory-cap strategy: prevents rust-lld fanout that OOM-kills the Paperclip
+# Node server when multiple agent heartbeats compile in parallel.
+#
+# Levers applied in this file (workspace-level, applies to CI too):
+#   1. debug = "line-tables-only" — smallest debug info; cuts lld RSS ~40%
+#
+# Levers applied user-level only (written by scripts/setup-mold.sh on mars):
+#   2. jobs = 1        — one codegen unit / linker invocation per cargo call
+#   3. mold linker     — peaks at ~200MB vs rust-lld's ~1.4GB per invocation
+#
+# jobs = 1 lives in ~/.cargo/config.toml so CI runners keep parallel builds.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[profile.dev]
+# Emit only line-number tables instead of full DWARF; sufficient for backtraces
+# and most debugger workflows.  Reduces lld input size ≈40% → proportional RSS drop.
+debug = "line-tables-only"
+
+[profile.test]
+# Inherit from dev; explicitly stated so the reduction applies to `cargo test` as well.
+debug = "line-tables-only"
+
+# ── Linker (mars dev environment only) ────────────────────────────────────────
+# The [target.x86_64-unknown-linux-gnu] linker override for mold lives in
+# ~/.cargo/config.toml on the mars machine, written by scripts/setup-mold.sh.
+# It is NOT in this workspace file so that GitHub Actions runners (ubuntu-latest,
+# no mold at the hardcoded ~/.local/bin path) are not affected.
+# Run:  bash scripts/setup-mold.sh   to install mold and configure it per-user.

--- a/scripts/cargo-locked.sh
+++ b/scripts/cargo-locked.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# cargo-locked.sh — Serialize cargo invocations across all Rustacean agent heartbeats.
+#
+# Problem: multiple Paperclip agent heartbeats run concurrently; each calls
+# `cargo test/build/check`.  Even with CARGO_BUILD_JOBS=1, two simultaneous
+# cargo invocations both spin up codegen+link jobs → combined RSS exceeds the
+# Paperclip Node server memory ceiling.
+#
+# Solution: flock on /tmp/rusaa-cargo.lock so that only one cargo invocation
+# runs at a time company-wide on the mars machine.
+#
+# Usage (install once):
+#   sudo install -m 755 scripts/cargo-locked.sh /usr/local/bin/cargo-locked
+# Or for non-root install:
+#   install -m 755 scripts/cargo-locked.sh ~/.local/bin/cargo-locked
+#
+# Then agents replace:   cargo test --workspace
+#              with:     cargo-locked test --workspace
+#
+# The lock is advisory; direct `cargo` calls (e.g. from other tools) still run
+# without waiting.  Agents that load this script via their heartbeat env will
+# serialize correctly.
+
+LOCK_FILE="${RUSAA_CARGO_LOCK_FILE:-/tmp/rusaa-cargo.lock}"
+
+exec flock --exclusive --wait 300 "$LOCK_FILE" cargo "$@"

--- a/scripts/setup-mold.sh
+++ b/scripts/setup-mold.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# setup-mold.sh — Install mold linker and configure user-level Cargo to use it.
+#
+# Run once on the mars dev machine to wire up mold for all agents.
+# Safe to re-run (idempotent).  Does not touch the workspace .cargo/config.toml
+# so that GitHub Actions runners are not affected.
+#
+# How it works:
+#   1. Downloads mold to ~/.local/bin/mold
+#   2. Copies mold as ld.mold into the active Rust toolchain's gcc-ld directory
+#      (the path the C driver searches when passed -fuse-ld=mold)
+#   3. Writes ~/.cargo/config.toml to pass -fuse-ld=mold for x86_64-linux builds
+
+set -euo pipefail
+
+MOLD_VERSION="2.34.1"
+INSTALL_DIR="$HOME/.local/bin"
+USER_CARGO_CONFIG="$HOME/.cargo/config.toml"
+
+# ── 1. Install mold ────────────────────────────────────────────────────────────
+if "$INSTALL_DIR/mold" --version &>/dev/null; then
+    installed_ver=$("$INSTALL_DIR/mold" --version | awk '{print $2}')
+    echo "mold already installed: $installed_ver"
+else
+    echo "Downloading mold $MOLD_VERSION..."
+    TMP=$(mktemp -d)
+    curl -fsSL \
+        "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+        -o "$TMP/mold.tar.gz"
+    tar -xzf "$TMP/mold.tar.gz" -C "$TMP"
+    mkdir -p "$INSTALL_DIR"
+    cp "$TMP/mold-${MOLD_VERSION}-x86_64-linux/bin/mold"    "$INSTALL_DIR/mold"
+    cp "$TMP/mold-${MOLD_VERSION}-x86_64-linux/bin/ld.mold" "$INSTALL_DIR/ld.mold"
+    chmod +x "$INSTALL_DIR/mold" "$INSTALL_DIR/ld.mold"
+    rm -rf "$TMP"
+    echo "mold installed to $INSTALL_DIR/mold"
+fi
+
+"$INSTALL_DIR/mold" --version
+
+# ── 2. Place ld.mold in the active toolchain's gcc-ld directory ───────────────
+# The Rust toolchain passes -B<toolchain>/lib/rustlib/<target>/bin/gcc-ld to the
+# C compiler.  GCC resolves -fuse-ld=mold by looking for ld.mold in that -B dir.
+TOOLCHAIN_ROOT=$(rustup which rustc | sed 's|/bin/rustc||')
+GCC_LD_DIR="$TOOLCHAIN_ROOT/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld"
+
+if [[ -d "$GCC_LD_DIR" ]]; then
+    if [[ -f "$GCC_LD_DIR/ld.mold" ]]; then
+        echo "ld.mold already in toolchain gcc-ld dir."
+    else
+        cp "$INSTALL_DIR/mold" "$GCC_LD_DIR/ld.mold"
+        echo "Placed ld.mold in $GCC_LD_DIR"
+    fi
+else
+    echo "WARNING: gcc-ld dir not found at $GCC_LD_DIR — skipping toolchain wiring."
+    echo "You may need to run this again after installing the x86_64-unknown-linux-gnu target."
+fi
+
+# ── 3. Write user-level Cargo config ──────────────────────────────────────────
+mkdir -p "$(dirname "$USER_CARGO_CONFIG")"
+
+# Only write the [target] block if it isn't already there.
+if grep -q 'fuse-ld=mold\|linker.*mold' "$USER_CARGO_CONFIG" 2>/dev/null; then
+    echo "Cargo user config already references mold — no changes made."
+else
+    cat >> "$USER_CARGO_CONFIG" <<'EOF'
+
+# ── mold linker (written by scripts/setup-mold.sh) ────────────────────────────
+# Replaces rust-lld/LLD (~1.4 GB peak RSS per link) with mold (~200 MB peak RSS).
+# mold is installed at ~/.local/bin/mold; ld.mold is wired into the toolchain
+# gcc-ld directory so -fuse-ld=mold resolves correctly at link time.
+# Applies only to builds run as this user on this machine (not CI).
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+EOF
+    echo "Wrote mold linker config to $USER_CARGO_CONFIG"
+fi
+
+# Only write [build] jobs = 1 if it isn't already there.
+# CI runners use the workspace .cargo/config.toml which deliberately omits this
+# setting so parallel builds on GitHub Actions are unaffected.
+if grep -q 'jobs\s*=' "$USER_CARGO_CONFIG" 2>/dev/null; then
+    echo "Cargo user config already sets jobs — no changes made."
+else
+    cat >> "$USER_CARGO_CONFIG" <<'EOF'
+
+# ── serialized linking (written by scripts/setup-mold.sh) ─────────────────────
+# Limits each cargo invocation to one linker process.  Cross-agent serialization
+# is handled by the cargo-locked flock wrapper; this setting ensures a single
+# agent doesn't itself fan out N linker processes at once.
+# Applies only to this user on this machine (not CI).
+[build]
+jobs = 1
+EOF
+    echo "Wrote jobs = 1 to $USER_CARGO_CONFIG"
+fi
+
+echo ""
+echo "Done.  Verify with:"
+echo "  cargo check -p rb-tracing 2>&1 | tail -3"

--- a/scripts/smoke-cargo-rss.sh
+++ b/scripts/smoke-cargo-rss.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# smoke-cargo-rss.sh — Validate that cargo invocations stay within the RSS budget.
+#
+# Acceptance criteria:
+#   - No single rust-lld/mold process exceeds 2 GB RSS
+#   - Peak combined RSS across all concurrent cargo invocations stays under 4 GB
+#   - No more than one cargo build/test runs concurrently (enforced by cargo-locked)
+#
+# Run from the workspace root:
+#   bash scripts/smoke-cargo-rss.sh
+#
+# Requires: cargo-locked in PATH, /usr/bin/time (GNU time for --format)
+
+set -euo pipefail
+
+WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
+RESULTS_DIR="/tmp/rusaa-rss-smoke-$$"
+mkdir -p "$RESULTS_DIR"
+
+LOCK_FILE="${RUSAA_CARGO_LOCK_FILE:-/tmp/rusaa-cargo.lock}"
+PEAK_RSS_MB_LIMIT=2048     # per-linker RSS cap
+COMBINED_RSS_MB_LIMIT=4096 # combined RSS cap across all concurrent invocations
+
+echo "=== Cargo RSS Smoke Test ==="
+echo "Workspace: $WORKSPACE_ROOT"
+echo "Lock file: $LOCK_FILE"
+echo ""
+
+# ── Helper: measure peak RSS of a command ─────────────────────────────────────
+measure_rss() {
+    local label="$1"
+    shift
+    local out="$RESULTS_DIR/$label.txt"
+    # GNU time reports max RSS in KB
+    /usr/bin/time -f "%M" -o "$out" "$@" 2>/dev/null
+    local rss_kb
+    rss_kb=$(cat "$out")
+    echo "$((rss_kb / 1024))"  # MB
+}
+
+# ── 1. Serial check: single cargo-locked invocation stays under 2 GB ──────────
+echo "--- Test 1: Single cargo-locked check (expect < ${PEAK_RSS_MB_LIMIT} MB peak) ---"
+cd "$WORKSPACE_ROOT"
+rss_mb=$(measure_rss "single" cargo-locked check -p rb-tracing 2>/dev/null)
+echo "Peak RSS: ${rss_mb} MB"
+if (( rss_mb > PEAK_RSS_MB_LIMIT )); then
+    echo "FAIL: ${rss_mb} MB exceeds ${PEAK_RSS_MB_LIMIT} MB cap"
+    exit 1
+else
+    echo "PASS"
+fi
+echo ""
+
+# ── 2. Parallel probe: 3 concurrent cargo-locked invocations serialize ─────────
+echo "--- Test 2: 3 parallel cargo-locked invocations (flock ensures serial execution) ---"
+
+PIDS=()
+LABELS=(alpha beta gamma)
+CRATES=(rb-tracing rb-kafka rb-tenant)
+
+for i in 0 1 2; do
+    label="${LABELS[$i]}"
+    crate="${CRATES[$i]}"
+    (
+        # Each agent sets jobs=1 via user-level ~/.cargo/config.toml (setup-mold.sh);
+        # cargo-locked additionally serializes cross-agent via flock.
+        rss=$(measure_rss "$label" cargo-locked check -p "$crate" 2>/dev/null)
+        echo "$rss" > "$RESULTS_DIR/${label}.rss"
+    ) &
+    PIDS+=($!)
+done
+
+# Wait for all three
+for pid in "${PIDS[@]}"; do
+    wait "$pid"
+done
+
+# Collect results
+total_rss=0
+all_pass=true
+for label in "${LABELS[@]}"; do
+    rss_file="$RESULTS_DIR/${label}.rss"
+    if [[ -f "$rss_file" ]]; then
+        rss=$(cat "$rss_file")
+        echo "  Agent $label peak RSS: ${rss} MB"
+        total_rss=$((total_rss + rss))
+        if (( rss > PEAK_RSS_MB_LIMIT )); then
+            echo "  FAIL: ${rss} MB exceeds ${PEAK_RSS_MB_LIMIT} MB per-agent cap"
+            all_pass=false
+        fi
+    else
+        echo "  WARN: No RSS result for $label"
+        all_pass=false
+    fi
+done
+
+echo "Combined RSS across 3 agents: ${total_rss} MB"
+if (( total_rss > COMBINED_RSS_MB_LIMIT )); then
+    echo "FAIL: Combined ${total_rss} MB exceeds ${COMBINED_RSS_MB_LIMIT} MB company-wide cap"
+    all_pass=false
+fi
+
+if $all_pass; then
+    echo "PASS: all 3 agents within budget"
+else
+    exit 1
+fi
+
+echo ""
+echo "=== Smoke test PASS ==="
+rm -rf "$RESULTS_DIR"


### PR DESCRIPTION
## Summary

Prevents `rust-lld` fanout OOM-killing the Paperclip Node server. Root cause: agent heartbeats invoke `cargo build`/`cargo test`, each spawning multiple `rust-lld` processes at ~1.4 GB each. Nine concurrent linkers → ~12 GB combined RSS inside Paperclip's cgroup.

## Changes

### `.cargo/config.toml` (new — workspace-level, CI-safe)

| Setting | Value | Effect |
|---|---|---|
| `[profile.dev/test] debug` | `"line-tables-only"` | ~40% smaller linker input → proportional RSS reduction |

`jobs = 1` lives in user-level `~/.cargo/config.toml` (written by `setup-mold.sh`) so CI runners retain parallel builds.

### `scripts/setup-mold.sh` (new — run once on mars)

- Downloads mold 2.34.1 to `~/.local/bin/mold`
- Places `ld.mold` into the active Rust toolchain's `gcc-ld` dir so `-fuse-ld=mold` resolves
- Writes `~/.cargo/config.toml` with `rustflags = ["-fuse-ld=mold"]` and `jobs = 1`
- **mold: ~200 MB peak RSS vs rust-lld's ~1.4 GB**
- Already executed on mars; mold 2.34.1 active

### `scripts/cargo-locked.sh` (new — cross-agent flock serializer)

```bash
exec flock --exclusive --wait 300 /tmp/rusaa-cargo.lock cargo "$@"
```

Installed to `~/.local/bin/cargo-locked`. Agent heartbeat docs updated across QA, Services Engineer, Platform Engineer, PR Reviewer, Architect, and Technical Writer to use `cargo-locked test` for all linking operations.

### `scripts/smoke-cargo-rss.sh` (new — RSS budget validation)

- Test 1: single `cargo-locked check` stays under 2 GB
- Test 2: 3 parallel `cargo-locked` invocations combined stay under 4 GB

## Migration type

This PR contains no database schema changes.

## Test plan

- [ ] `cargo check -p rb-tracing` completes with mold active (verified locally: 26s, mold ~200 MB)
- [ ] `bash scripts/smoke-cargo-rss.sh` passes all assertions
- [ ] `cargo-locked test --workspace` acquires flock and serializes correctly
- [ ] CI `cargo test` and `clippy` jobs unaffected (no workspace linker override)

## Governance note

No GitHub issue required per parent issue description: runtime/operational change to agent execution environments, not a code change. Governance repo agent docs updated in a companion commit.

Closes #438