### PR TITLE
[RUSAA-1380] fix(control-api): remove installation events from GitHub App manifest default_events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1606,7 +1606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2236,7 +2236,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2544,9 +2544,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",
@@ -2959,7 +2959,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3701,7 +3701,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4306,7 +4306,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4733,7 +4733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5061,7 +5061,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5965,7 +5965,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/services/control-api/src/routes/admin/github/app_manifest.rs
+++ b/services/control-api/src/routes/admin/github/app_manifest.rs
@@ -116,10 +116,7 @@ pub fn build_manifest_payload(base_url: &str, name: &str) -> serde_json::Value {
             "contents": "read",
             "metadata": "read",
         },
-        "default_events": [
-            "installation",
-            "installation_repositories",
-        ],
+        "default_events": [],
     })
 }
 
@@ -164,7 +161,6 @@ mod tests {
         let events = m["default_events"]
             .as_array()
             .expect("default_events array");
-        assert!(events.iter().any(|e| e == "installation"));
-        assert!(events.iter().any(|e| e == "installation_repositories"));
+        assert!(events.is_empty(), "installation/installation_repositories must not appear in default_events");
     }
 }

--- a/services/control-api/src/routes/admin/github/app_manifest.rs
+++ b/services/control-api/src/routes/admin/github/app_manifest.rs
@@ -161,6 +161,9 @@ mod tests {
         let events = m["default_events"]
             .as_array()
             .expect("default_events array");
-        assert!(events.is_empty(), "installation/installation_repositories must not appear in default_events");
+        assert!(
+            events.is_empty(),
+            "installation/installation_repositories must not appear in default_events"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Removes `installation` and `installation_repositories` from `default_events` in the GitHub App manifest. GitHub rejects these as auto-delivered install-lifecycle events are not subscribable via the manifest — causing "Invalid GitHub App configuration" when admins register the app.

**Fix:**
- Set `"default_events": []` — GitHub auto-delivers installation lifecycle events; no subscription needed
- Unit test updated to assert `events.is_empty()` (previously asserted the invalid events were present)

## Test plan

- [x] `cargo test -p control-api` — 377 passed, 0 failed (including `manifest_payload_has_required_fields`)
- [ ] Manual: platform admin → "Register via GitHub" → GitHub renders app form without "Invalid configuration" error → redirects to `/v1/admin/github/app-callback`

## Related

Closes #441