### PR TITLE
[RUSAA-1383] fix(compose): add restart: unless-stopped to all worker services in tailscale overlay

### DIFF
--- a/compose/tailscale.yml
+++ b/compose/tailscale.yml
@@ -52,3 +52,39 @@ services:
 
   kafka-ui:
     restart: unless-stopped
+
+  agent-runner:
+    restart: unless-stopped
+
+  ingest-clone:
+    restart: unless-stopped
+
+  ingest-graph:
+    restart: unless-stopped
+
+  parse-worker:
+    restart: unless-stopped
+
+  expand-worker:
+    restart: unless-stopped
+
+  typecheck-worker:
+    restart: unless-stopped
+
+  embed-worker:
+    restart: unless-stopped
+
+  projector-pg:
+    restart: unless-stopped
+
+  projector-neo4j:
+    restart: unless-stopped
+
+  tombstoner:
+    restart: unless-stopped
+
+  frontend:
+    restart: unless-stopped
+
+  claude-login:
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- All Rust worker services (`agent-runner`, `ingest-graph`, `parse-worker`, `expand-worker`, `typecheck-worker`, `embed-worker`, `projector-pg`, `projector-neo4j`, `tombstoner`) and long-running app services (`ingest-clone`, `frontend`, `claude-login`) were missing from `compose/tailscale.yml`
- Without the overlay entry their Docker restart policy was `no` (default), so a Docker daemon restart on mars left them as `Exited (255)` while infra services auto-recovered
- This caused agent sessions to stay Pending (agent-runner down) and ingestion runs to stay Queued (pipeline workers down)

## Root Cause

`compose/tailscale.yml` only covered infrastructure services (`postgres`, `neo4j`, `kafka`, etc.) and `control-api`. Worker services were never added to the overlay when they were introduced.

## Fix

Add `restart: unless-stopped` for all 12 missing long-running services. Deliberately excludes `kafka-init` and `rb-migrations` (one-shot containers).

## Test Plan

- [x] All 9 exited workers recreated and started with the corrected restart policy
- [x] `docker inspect rustbrain-dev-agent-runner-1` confirms `RestartPolicy.Name = 'unless-stopped'`
- [x] `agent-runner` logs show Kafka consumer connected and immediately processed queued sessions (including session `b3d5593e` from the bug report)
- [ ] QA verify new agent session on http://100.87.157.74:15173 completes end-to-end
- [ ] QA verify ingestion run progresses through all pipeline stages

Closes #447

Generated with Claude Code