### PR TITLE
[RUSAA-1386] fix(claude-login): background OAuth token-refresh loop

### DIFF
--- a/docker/claude-login/Dockerfile
+++ b/docker/claude-login/Dockerfile
@@ -28,6 +28,7 @@ RUN sed -i \
     echo 'AllowUsers loginuser' >> /etc/ssh/sshd_config
 
 COPY docker/claude-login/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/claude-login/token-refresh.js /usr/local/bin/token-refresh.js
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 22

--- a/docker/claude-login/entrypoint.sh
+++ b/docker/claude-login/entrypoint.sh
@@ -24,4 +24,9 @@ chown loginuser:loginuser "${CLAUDE_CONFIG_DIR:-/home/loginuser/.claude}" 2>/dev
 # Generate SSH host keys on first start (persist via named volume if desired).
 ssh-keygen -A
 
+# Launch background OAuth token-refresh loop (runs as root, writes via realpath).
+# Keeps credentials.json fresh so agent-runner sessions always start with a valid
+# access token without relaxing the read-only mount on the agent side.
+node /usr/local/bin/token-refresh.js &
+
 exec /usr/sbin/sshd -D -e

--- a/docker/claude-login/token-refresh.js
+++ b/docker/claude-login/token-refresh.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Background OAuth token refresh for claude-login container.
+//
+// Reads credentials.json from CLAUDE_CONFIG_DIR, refreshes the access token
+// using the refresh token when it is within REFRESH_BEFORE_EXPIRY_MS of
+// expiry, then writes the updated credentials back.  Runs continuously,
+// sleeping POLL_INTERVAL_MS between checks.
+//
+// Why this is needed: agent-runner mounts the credentials volume read-only
+// and copies credentials into a per-session dir before spawning claude.
+// Claude can refresh its in-session copy, but those refreshed tokens never
+// reach the shared volume — so every new session starts from the original,
+// eventually-expired credentials.  By keeping the shared copy fresh here
+// (in claude-login, which has write access), sessions always start with a
+// valid token without relaxing the read-only mount security boundary.
+
+'use strict';
+
+const fs = require('fs');
+const https = require('https');
+const path = require('path');
+
+const CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || '/home/loginuser/.claude';
+const CREDS_FILE = path.join(CONFIG_DIR, '.credentials.json');
+const CREDS_LINK = path.join(CONFIG_DIR, 'credentials.json');
+const POLL_INTERVAL_MS = 60 * 60 * 1000;          // check every hour
+const REFRESH_BEFORE_EXPIRY_MS = 2 * 60 * 60 * 1000; // refresh when < 2h left
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const TOKEN_ENDPOINT_HOST = 'platform.claude.com';
+const TOKEN_ENDPOINT_PATH = '/v1/oauth/token';
+
+function log(msg) {
+    process.stdout.write(`[token-refresh] ${new Date().toISOString()} ${msg}\n`);
+}
+
+function readCreds() {
+    // Resolve the symlink to the actual file so writes hit the real path.
+    const realPath = (() => {
+        try {
+            return fs.realpathSync(CREDS_LINK);
+        } catch {
+            return CREDS_FILE;
+        }
+    })();
+    if (!fs.existsSync(realPath)) return null;
+    try {
+        return { data: JSON.parse(fs.readFileSync(realPath, 'utf8')), realPath };
+    } catch {
+        return null;
+    }
+}
+
+function postRefresh(refreshToken) {
+    return new Promise((resolve, reject) => {
+        const body = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: CLIENT_ID,
+        }).toString();
+
+        const req = https.request({
+            hostname: TOKEN_ENDPOINT_HOST,
+            path: TOKEN_ENDPOINT_PATH,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Length': Buffer.byteLength(body),
+            },
+        }, (res) => {
+            let raw = '';
+            res.on('data', chunk => { raw += chunk; });
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        resolve(JSON.parse(raw));
+                    } catch (e) {
+                        reject(new Error(`Failed to parse token response: ${e.message}`));
+                    }
+                } else {
+                    reject(new Error(`HTTP ${res.statusCode}: ${raw.substring(0, 300)}`));
+                }
+            });
+        });
+        req.on('error', reject);
+        req.write(body);
+        req.end();
+    });
+}
+
+async function maybeRefresh() {
+    const result = readCreds();
+    if (!result) {
+        log('No credentials file found — waiting for claude /login via SSH.');
+        return;
+    }
+    const { data: creds, realPath } = result;
+    const oauth = creds.claudeAiOauth;
+    if (!oauth || !oauth.refreshToken) {
+        log('No OAuth section in credentials — skipping.');
+        return;
+    }
+
+    const now = Date.now();
+    const remaining = oauth.expiresAt - now;
+    if (remaining > REFRESH_BEFORE_EXPIRY_MS) {
+        const mins = Math.round(remaining / 60000);
+        log(`Token valid for ${mins} min — no refresh needed.`);
+        return;
+    }
+
+    const expired = remaining <= 0;
+    log(expired
+        ? `Token expired ${Math.round(-remaining / 60000)} min ago — refreshing.`
+        : `Token expires in ${Math.round(remaining / 60000)} min — refreshing early.`);
+
+    let tokens;
+    try {
+        tokens = await postRefresh(oauth.refreshToken);
+    } catch (err) {
+        log(`ERROR: Token refresh failed: ${err.message}`);
+        log('Re-login required: ssh -p 12222 loginuser@<host> → claude /login');
+        return;
+    }
+
+    oauth.accessToken = tokens.access_token;
+    if (tokens.refresh_token) oauth.refreshToken = tokens.refresh_token;
+    oauth.expiresAt = now + (tokens.expires_in * 1000);
+
+    fs.writeFileSync(realPath, JSON.stringify(creds), { mode: 0o600 });
+    log(`Token refreshed. New expiry: ${new Date(oauth.expiresAt).toISOString()}`);
+}
+
+async function loop() {
+    while (true) {
+        try {
+            await maybeRefresh();
+        } catch (err) {
+            log(`Unhandled error in refresh loop: ${err.message}`);
+        }
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+}
+
+loop().catch(err => {
+    log(`Fatal: ${err.message}`);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Root cause**: Claude Code copies shared credentials (`:ro` volume) to a per-session dir before spawning. When Claude refreshes an expired access token in-session, the rotated refresh token writes only to the per-session copy — the shared volume retains the stale refresh token. Every subsequent session starts with an invalid refresh token and fails with 401 / exit code 1.
- **Fix**: add `token-refresh.js` to the `claude-login` image (which has write access to the shared volume). The script runs as a background process from `entrypoint.sh`, wakes every hour, and proactively refreshes the access token when within 2 hours of expiry via the `platform.claude.com/v1/oauth/token` endpoint.
- **On failure**: logs a clear `Re-login required: ssh -p 12222 loginuser@<host> → claude /login` message so the operator knows what to do.

## Immediate action still required

This PR prevents future token expirations but cannot self-heal the **currently-expired** credentials (the refresh token is already `invalid_grant`).

**Jarnura must SSH in and re-login once:**
```bash
ssh -p 12222 loginuser@100.87.157.74
# inside the container:
claude /login
```

The new `claude-login` image is already deployed on mars (rebuilt and restarted as part of this investigation). The refresh loop is running and will keep tokens fresh after the one-time re-login.

## Test plan

- [ ] SSH into claude-login (`ssh -p 12222 loginuser@100.87.157.74`) and run `claude /login`
- [ ] Create a new agent session at http://100.87.157.74:15173 — verify it transitions Pending → Running → Completed with tokens > 0
- [ ] `docker compose logs claude-login --tail 20` — verify `[token-refresh]` lines show "Token valid for N min" (not "Re-login required")
- [ ] Wait 11+ hours (or fast-forward by temporarily lowering `POLL_INTERVAL_MS`) — verify token auto-refreshes without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #449