### PR TITLE
[RUSAA-1386] fix(agent-runner): wire EventRelay so Claude events reach the DB

### DIFF
--- a/services/agent-runner/src/consumer.rs
+++ b/services/agent-runner/src/consumer.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use metrics::counter;
@@ -31,10 +32,19 @@ pub fn spawn(
     control_api_base: String,
     http_client: reqwest::Client,
 ) -> Result<ConsumerHandle> {
+    let relay_sender = agent_runner::spawn(agent_runner::RelayConfig {
+        capacity: agent_runner::DEFAULT_CAPACITY,
+        batch_size: agent_runner::DEFAULT_BATCH_SIZE,
+        flush_interval: Duration::from_millis(agent_runner::DEFAULT_FLUSH_INTERVAL_MS),
+        control_api_base: control_api_base.clone(),
+        http_client: http_client.clone(),
+    });
+
     let session_manager = Arc::new(SessionManager::new(
         workspace_base.clone(),
         control_api_base,
         http_client,
+        relay_sender,
     ));
     let producer = Arc::new(Producer::<AgentEvent>::new(&ProducerCfg::default())?);
 

--- a/services/agent-runner/src/event_relay.rs
+++ b/services/agent-runner/src/event_relay.rs
@@ -41,21 +41,6 @@ const BASE_RETRY_DELAY_MS: u64 = 100;
 const BASE_RETRY_DELAY_MS: u64 = 1; // fast retries in unit tests
 
 // ---------------------------------------------------------------------------
-// Event-type mapping
-// ---------------------------------------------------------------------------
-
-fn event_type_str(event: &RuntimeEvent) -> &'static str {
-    match event {
-        RuntimeEvent::Text { .. } => "session.message",
-        RuntimeEvent::Thinking { .. } => "session.thinking",
-        RuntimeEvent::ToolUse { .. } => "session.tool_call",
-        RuntimeEvent::ToolResult { .. } => "session.tool_result",
-        RuntimeEvent::UserInput { .. } => "session.user_input",
-        RuntimeEvent::Error { .. } => "session.error",
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -212,15 +197,12 @@ async fn flush_session(
     let tenant_id = &items[0].tenant_id;
     let url = format!("{control_api_base}/internal/agent/sessions/{session_id}/events");
 
+    // Serialize each RuntimeEvent directly so the body matches IngestEventsRequest.events:
+    // Vec<RuntimeEvent> with serde tag {"type": "text", "text": "..."}
     let events_body: Vec<serde_json::Value> = items
         .iter()
         .filter_map(|i| match serde_json::to_value(&i.event) {
-            Ok(payload) => Some(serde_json::json!({
-                "seq": i.seq,
-                "event_type": event_type_str(&i.event),
-                "payload": payload,
-                "emitted_at_ms": i.emitted_at_ms,
-            })),
+            Ok(v) => Some(v),
             Err(e) => {
                 tracing::warn!(
                     session_id = %session_id,

--- a/services/agent-runner/src/event_relay.rs
+++ b/services/agent-runner/src/event_relay.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use chrono::Utc;
 use metrics::counter;
 use rb_schemas::RuntimeEvent;
 use tokio::sync::Notify;
@@ -82,6 +83,26 @@ impl EventSender {
         buf.push_back(item);
         drop(buf);
         self.notify.notify_one();
+    }
+}
+
+/// Normalize `line` from agent stdout and relay all resulting [`RuntimeEvent`]s.
+pub fn relay_stdout_events(
+    relay_sender: &EventSender,
+    session_id: &str,
+    tenant_id: &str,
+    seq: i64,
+    line: &str,
+) {
+    let now_ms = Utc::now().timestamp_millis();
+    for runtime_event in crate::StreamJsonNormalizer::normalize_line(line) {
+        relay_sender.send(RelayItem {
+            session_id: session_id.to_string(),
+            tenant_id: tenant_id.to_string(),
+            seq,
+            event: runtime_event,
+            emitted_at_ms: now_ms,
+        });
     }
 }
 

--- a/services/agent-runner/src/lib.rs
+++ b/services/agent-runner/src/lib.rs
@@ -3,6 +3,6 @@ mod normalizer;
 
 pub use event_relay::{
     DEFAULT_BATCH_SIZE, DEFAULT_CAPACITY, DEFAULT_FLUSH_INTERVAL_MS, EventSender, RelayConfig,
-    RelayItem, spawn,
+    RelayItem, relay_stdout_events, spawn,
 };
 pub use normalizer::StreamJsonNormalizer;

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -481,21 +481,7 @@ impl SessionManager {
                                 tracing::error!(session_id = %sid_stdout, error = %e, "Failed to send stdout event (channel full or closed)");
                             }
                         }
-
-                        // Normalize the raw stdout line into typed RuntimeEvents and relay
-                        // them to control-api via HTTP so they appear in the DB / NDJSON.
-                        let now_ms = chrono::Utc::now().timestamp_millis();
-                        for runtime_event in
-                            agent_runner::StreamJsonNormalizer::normalize_line(&line)
-                        {
-                            relay_sender.send(agent_runner::RelayItem {
-                                session_id: sid_stdout.clone(),
-                                tenant_id: tenant_id.to_string(),
-                                seq,
-                                event: runtime_event,
-                                emitted_at_ms: now_ms,
-                            });
-                        }
+                        agent_runner::relay_stdout_events(&relay_sender, &sid_stdout, &tenant_id.to_string(), seq, &line);
                     }
                 }
             }
@@ -607,7 +593,6 @@ impl SessionManager {
         }
     }
 }
-
 pub use crate::workspace_gc::spawn_workspace_gc;
 
 #[cfg(test)]

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -37,6 +37,7 @@ pub struct SessionManager {
     seq_counter_timestamps: Arc<Mutex<HashMap<String, Instant>>>,
     control_api_base: String,
     http_client: reqwest::Client,
+    relay_sender: agent_runner::EventSender,
 }
 
 struct SessionHandle {
@@ -72,6 +73,7 @@ impl SessionManager {
         workspace_base: PathBuf,
         control_api_base: String,
         http_client: reqwest::Client,
+        relay_sender: agent_runner::EventSender,
     ) -> Self {
         let seq_counters = Arc::new(Mutex::new(HashMap::new()));
         let seq_counter_timestamps: Arc<Mutex<HashMap<String, Instant>>> =
@@ -110,6 +112,7 @@ impl SessionManager {
             seq_counter_timestamps,
             control_api_base,
             http_client,
+            relay_sender,
         }
     }
 
@@ -440,6 +443,7 @@ impl SessionManager {
     ) -> (JoinHandle<()>, JoinHandle<()>) {
         let seq_counters = self.seq_counters.clone();
         let seq_timestamps = self.seq_counter_timestamps.clone();
+        let relay_sender = self.relay_sender.clone();
         let sid_stdout = session_id.clone();
         let span_out = tracing::info_span!("stdout_handler", session_id = %sid_stdout);
 
@@ -476,6 +480,21 @@ impl SessionManager {
                             if let Err(e) = es.try_send((tenant_id, event)) {
                                 tracing::error!(session_id = %sid_stdout, error = %e, "Failed to send stdout event (channel full or closed)");
                             }
+                        }
+
+                        // Normalize the raw stdout line into typed RuntimeEvents and relay
+                        // them to control-api via HTTP so they appear in the DB / NDJSON.
+                        let now_ms = chrono::Utc::now().timestamp_millis();
+                        for runtime_event in
+                            agent_runner::StreamJsonNormalizer::normalize_line(&line)
+                        {
+                            relay_sender.send(agent_runner::RelayItem {
+                                session_id: sid_stdout.clone(),
+                                tenant_id: tenant_id.to_string(),
+                                seq,
+                                event: runtime_event,
+                                emitted_at_ms: now_ms,
+                            });
                         }
                     }
                 }

--- a/services/agent-runner/src/session/tests.rs
+++ b/services/agent-runner/src/session/tests.rs
@@ -101,6 +101,16 @@ async fn start_session_marks_failed_on_adapter_spawn_error() {
     let (addr, captured, server_handle) = spawn_status_capture_server().await;
     let tmp = tempfile::tempdir().unwrap();
 
+    let relay_sender = agent_runner::spawn(agent_runner::RelayConfig {
+        capacity: agent_runner::DEFAULT_CAPACITY,
+        batch_size: agent_runner::DEFAULT_BATCH_SIZE,
+        flush_interval: Duration::from_millis(agent_runner::DEFAULT_FLUSH_INTERVAL_MS),
+        control_api_base: format!("http://{addr}"),
+        http_client: reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap(),
+    });
     let manager = SessionManager::new(
         tmp.path().to_path_buf(),
         format!("http://{addr}"),
@@ -108,6 +118,7 @@ async fn start_session_marks_failed_on_adapter_spawn_error() {
             .timeout(Duration::from_secs(2))
             .build()
             .unwrap(),
+        relay_sender,
     );
 
     let (tx, _rx) = tokio::sync::mpsc::channel(16);


### PR DESCRIPTION
## Summary

- **Root cause**: Claude stdout events were published only to Kafka `rb.agent.events` (no consumer group reads it) and never written to `agents.agent_events` or the SSE bus. Completed sessions showed only lifecycle sentinels (`session.running`, `session.completed`) in the NDJSON download.
- **Fix 1 — `event_relay.rs`**: `flush_session` was serialising each event as `{seq, event_type, payload, emitted_at_ms}` instead of the `Vec<RuntimeEvent>` format that `IngestEventsRequest` expects. Changed to serialise `RuntimeEvent` directly (`{"type":"text","text":"…"}` etc.).
- **Fix 2 — `session/mod.rs`**: After the existing Kafka path in `spawn_output_handlers`, now also calls `StreamJsonNormalizer::normalize_line` on every raw stdout line and sends each resulting `RuntimeEvent` to the `EventSender` relay buffer.
- **Fix 3 — `consumer.rs`**: Creates the `EventRelay` background task on startup via `agent_runner::spawn(RelayConfig{…})` and passes the `EventSender` into `SessionManager::new`.

## Test plan

- [x] `cargo test -p agent-runner` — all 14 tests pass
- [x] Docker image built and `agent-runner` container restarted
- [ ] Create a new agent session and confirm NDJSON contains actual Claude conversation events (text, thinking, tool_use, tool_result) in addition to lifecycle sentinels
- [ ] Verify `session.event` SSE frames received by the frontend during live replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #450