### PR TITLE
[RUSAA-1404] fix(control-api): skip malformed Kafka messages with empty ingest_run_id

### DIFF
--- a/services/control-api/src/ingest_consumer/mod.rs
+++ b/services/control-api/src/ingest_consumer/mod.rs
@@ -55,6 +55,22 @@ pub fn spawn(
                     let ev = &envelope.payload;
                     let tenant_id = envelope.tenant_id;
 
+                    // Reject malformed messages before hitting the DB. Legacy
+                    // Kafka producers can emit an empty ingest_run_id; parsing
+                    // that as a UUID would produce a misleading DB error and
+                    // leave the offset uncommitted (causing replays on restart).
+                    if ev.ingest_run_id.parse::<uuid::Uuid>().is_err() {
+                        tracing::warn!(
+                            raw_ingest_run_id = %ev.ingest_run_id,
+                            tenant_id = %tenant_id,
+                            "ingest_consumer: skipping malformed message (invalid ingest_run_id)"
+                        );
+                        if let Err(e) = consumer.commit(&envelope).await {
+                            tracing::warn!("ingest_consumer: commit failed after skip: {e}");
+                        }
+                        continue;
+                    }
+
                     if let Err(e) = db::handle_db_updates(&pool, ev).await {
                         tracing::error!(
                             ingest_run_id = %ev.ingest_run_id,
@@ -321,6 +337,12 @@ mod tests {
     #[test]
     fn invalid_uuid_errors() {
         assert!("not-a-uuid".parse::<Uuid>().is_err());
+    }
+
+    #[test]
+    fn empty_ingest_run_id_fails_uuid_parse() {
+        // The consumer guard relies on this to reject legacy malformed messages.
+        assert!("".parse::<Uuid>().is_err());
     }
 
     // ── stage_db_params: all terminal states produce consistent output ────────


### PR DESCRIPTION
## Summary

- Validates `ingest_run_id` in `ingest_consumer` before attempting any DB update; messages whose `ingest_run_id` fails UUID parsing are now logged at WARN and committed (so the offset advances), rather than propagating an error that left the offset uncommitted and caused replay on restart.
- Adds `empty_ingest_run_id_fails_uuid_parse` unit test confirming the guard condition the production code depends on.

## Root cause

Legacy/malformed Kafka producers emit an empty `ingest_run_id`. The consumer passed this to `handle_db_updates`, which called `ingest_run_id.parse::<Uuid>()` — that returned `Err("invalid ingest_run_id UUID")`, triggering an `ERROR` log, a 1-second sleep, and a `continue` that **skipped the commit**. On every restart the same message replayed, producing the three repeated errors seen at 2026-05-14T18:23:50–52.

## Migration type

N/A — no schema changes.

## Test plan

- [x] `cargo-locked test -p control-api --lib ingest_consumer` — 34 tests pass including new `empty_ingest_run_id_fails_uuid_parse`
- [x] `cargo clippy -p control-api --lib -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #456