### PR TITLE
[RUSAA-1403] fix(control-api): reconcile orphaned queued ingestion runs on startup

### DIFF
--- a/services/control-api/src/jobs/mod.rs
+++ b/services/control-api/src/jobs/mod.rs
@@ -1,1 +1,228 @@
-// OAuth token key rotation removed (ADR-009 Option B: no more oauth_tokens table).
+//! Background and startup jobs for control-api.
+
+use std::time::Duration;
+
+use rb_kafka::EventEnvelope;
+use rb_schemas::{IngestRequest, TenantId};
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+const CLONE_COMMANDS_TOPIC: &str = "rb.ingest.clone.commands";
+
+struct OrphanedRun {
+    id: Uuid,
+    tenant_id: Uuid,
+    repo_id: Uuid,
+    commit_sha: Option<String>,
+}
+
+/// On startup, re-dispatch any ingestion runs that are stuck in `queued`
+/// for more than 5 minutes without a Kafka message being produced.
+///
+/// This recovers from the failure mode where control-api crashed or was
+/// restarted after the DB row was committed but before (or during) the
+/// Kafka publish.  The trigger handler normally rolls back the transaction
+/// on Kafka failure, but a mid-flight process death can leave an orphan.
+///
+/// Recovery strategy:
+/// - Kafka producer available → re-publish `IngestRequest` with a new
+///   `event_id`; the clone worker processes it normally.
+/// - Kafka producer unavailable → mark the run `failed` with a clear
+///   error so the user can re-trigger without manual DB surgery.
+///
+/// Bounded: processes at most 100 runs per restart (oldest first) to cap
+/// startup time after a prolonged outage.
+pub async fn reconcile_orphaned_ingest_runs(state: &AppState) {
+    let runs = match fetch_orphaned_runs(&state.pool).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "startup reconciler: failed to query orphaned runs");
+            return;
+        }
+    };
+
+    if runs.is_empty() {
+        tracing::debug!("startup reconciler: no orphaned queued ingestion runs");
+        return;
+    }
+
+    tracing::warn!(
+        count = runs.len(),
+        "startup reconciler: found orphaned queued ingestion runs — recovering"
+    );
+
+    for run in runs {
+        handle_orphaned_run(state, run).await;
+    }
+}
+
+async fn fetch_orphaned_runs(pool: &sqlx::PgPool) -> Result<Vec<OrphanedRun>, sqlx::Error> {
+    let rows: Vec<(Uuid, Uuid, Uuid, Option<String>)> = sqlx::query_as(
+        "SELECT id, tenant_id, repo_id, commit_sha \
+         FROM control.ingestion_runs \
+         WHERE status = 'queued' \
+           AND started_at IS NULL \
+           AND created_at < now() - interval '5 minutes' \
+         ORDER BY created_at ASC \
+         LIMIT 100",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(id, tenant_id, repo_id, commit_sha)| OrphanedRun {
+            id,
+            tenant_id,
+            repo_id,
+            commit_sha,
+        })
+        .collect())
+}
+
+/// Attempt to claim an orphaned run by stamping `started_at = now()`.
+///
+/// Returns `true` if this process won the race (the row had `started_at IS NULL`
+/// at the time of the UPDATE), `false` if another instance already claimed it.
+/// This gives mutual exclusion when multiple control-api pods restart
+/// simultaneously and all try to re-dispatch the same orphan.
+///
+/// The clone worker uses `COALESCE(started_at, now())` in `maybe_start_run`,
+/// so a pre-set `started_at` is preserved without a separate migration.
+async fn try_claim_run(pool: &sqlx::PgPool, run_id: Uuid) -> Result<bool, sqlx::Error> {
+    let rows_affected = sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET started_at = now() \
+         WHERE id = $1 AND status = 'queued' AND started_at IS NULL",
+    )
+    .bind(run_id)
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
+    // Claim before dispatching — prevents double-publish when multiple
+    // control-api instances restart simultaneously.
+    match try_claim_run(&state.pool, run.id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                run_id = %run.id,
+                "startup reconciler: run already claimed by another instance; skipping"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::error!(
+                run_id = %run.id,
+                error = %e,
+                "startup reconciler: failed to claim run; skipping"
+            );
+            return;
+        }
+    }
+
+    if let Some(producer) = &state.ingest_producer {
+        // Probe broker before building the envelope so we fall through
+        // to the fail path quickly instead of waiting the full delivery
+        // timeout (120 s) on a dead broker.
+        if !producer.check_ready(Duration::from_millis(500)).await {
+            tracing::warn!(
+                run_id = %run.id,
+                tenant_id = %run.tenant_id,
+                "startup reconciler: Kafka broker unreachable; marking run failed"
+            );
+            mark_failed(
+                &state.pool,
+                run.id,
+                "startup reconciler: Kafka broker unreachable on recovery; re-trigger to start ingestion",
+            )
+            .await;
+            return;
+        }
+
+        let event_id = Uuid::new_v4();
+        let ingest_req = IngestRequest {
+            tenant_id: run.tenant_id.to_string(),
+            event_id: event_id.to_string(),
+            source: "reconciler".to_string(),
+            payload: vec![],
+            created_at_ms: chrono::Utc::now().timestamp_millis(),
+            repo_id: run.repo_id.to_string(),
+            ingest_run_id: run.id.to_string(),
+            // Preserve the commit SHA from the original request.  Empty
+            // branch tells the clone stage to use the repo's default branch.
+            commit_sha: run.commit_sha.unwrap_or_default(),
+            branch: String::new(),
+        };
+        let envelope =
+            EventEnvelope::new(TenantId::from(run.tenant_id), ingest_req).with_event_id(event_id);
+        let partition_key = format!("{}.{}", run.tenant_id, run.repo_id);
+
+        match producer
+            .publish(CLONE_COMMANDS_TOPIC, partition_key.as_bytes(), envelope)
+            .await
+        {
+            Ok(_) => {
+                tracing::info!(
+                    run_id = %run.id,
+                    tenant_id = %run.tenant_id,
+                    repo_id = %run.repo_id,
+                    "startup reconciler: re-published orphaned ingestion run"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    run_id = %run.id,
+                    error = %e,
+                    "startup reconciler: re-publish failed; marking run failed"
+                );
+                mark_failed(
+                    &state.pool,
+                    run.id,
+                    "startup reconciler: Kafka publish failed during recovery; re-trigger to start ingestion",
+                )
+                .await;
+            }
+        }
+    } else {
+        tracing::warn!(
+            run_id = %run.id,
+            tenant_id = %run.tenant_id,
+            repo_id = %run.repo_id,
+            "startup reconciler: no Kafka producer configured; marking orphaned run failed"
+        );
+        mark_failed(
+            &state.pool,
+            run.id,
+            "startup reconciler: control-api restarted with no Kafka producer before message was published; re-trigger to start ingestion",
+        )
+        .await;
+    }
+}
+
+async fn mark_failed(pool: &sqlx::PgPool, run_id: Uuid, error: &str) {
+    if let Err(e) = sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'failed', finished_at = now(), error = $2 \
+         WHERE id = $1 AND status = 'queued'",
+    )
+    .bind(run_id)
+    .bind(error)
+    .execute(pool)
+    .await
+    {
+        tracing::error!(
+            run_id = %run_id,
+            error = %e,
+            "startup reconciler: failed to mark run as failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/services/control-api/src/jobs/tests.rs
+++ b/services/control-api/src/jobs/tests.rs
@@ -1,0 +1,448 @@
+use std::sync::Arc;
+
+use rb_auth::{LoginRateLimiter, PasswordHasher};
+use rb_email::from_transport;
+use rb_sse::{EventBus, SseConfig};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+use super::*;
+use crate::{
+    AppState, Config, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
+    TenantSessionCount, state::AgentRegistry,
+};
+
+/// Connect to the real Postgres instance.
+/// Returns `None` when `RB_DATABASE_URL` is absent — callers skip gracefully.
+async fn test_pool() -> Option<PgPool> {
+    let url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+/// Insert the minimal control-schema rows needed to satisfy FK constraints
+/// on `ingestion_runs`: tenant → user → `github_installation` → repo.
+/// Returns `(tenant_id, user_id, repo_id)`.
+async fn insert_fixtures(pool: &PgPool) -> (Uuid, Uuid, Uuid) {
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let install_id = Uuid::new_v4();
+    let repo_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(format!("rec-test-{}", tenant_id.simple()))
+    .bind("Reconciler Test Tenant")
+    .bind(format!("rec_{}", tenant_id.simple()))
+    .execute(pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, $3, now())",
+    )
+    .bind(user_id)
+    .bind(format!("rec-{}@test.example", user_id.simple()))
+    .bind("$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash")
+    .execute(pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) \
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert tenant_member");
+
+    let github_install_id = i64::from_ne_bytes(install_id.as_bytes()[0..8].try_into().unwrap());
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(install_id)
+    .bind(tenant_id)
+    .bind(github_install_id)
+    .bind("test-org")
+    .bind("Organization")
+    .bind(42_i64)
+    .execute(pool)
+    .await
+    .expect("insert github_installation");
+
+    let github_repo_id = i64::from_ne_bytes(repo_id.as_bytes()[0..8].try_into().unwrap());
+    sqlx::query(
+        "INSERT INTO control.repos \
+         (id, tenant_id, installation_id, github_repo_id, full_name, default_branch, connected_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .bind(install_id)
+    .bind(github_repo_id)
+    .bind("test-org/test-repo")
+    .bind("main")
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert repo");
+
+    (tenant_id, user_id, repo_id)
+}
+
+/// Insert a `queued` ingestion run.
+/// `old = true` → `created_at = now() - 10 minutes` (past the 5-min threshold).
+/// `old = false` → `created_at = now() - 1 minute` (within threshold; not an orphan).
+async fn insert_queued_run(
+    pool: &PgPool,
+    tenant_id: Uuid,
+    repo_id: Uuid,
+    user_id: Uuid,
+    old: bool,
+) -> Uuid {
+    let run_id = Uuid::new_v4();
+    let sql = if old {
+        "INSERT INTO control.ingestion_runs \
+         (id, tenant_id, repo_id, status, requested_by, created_at) \
+         VALUES ($1, $2, $3, 'queued', $4, now() - interval '10 minutes')"
+    } else {
+        "INSERT INTO control.ingestion_runs \
+         (id, tenant_id, repo_id, status, requested_by, created_at) \
+         VALUES ($1, $2, $3, 'queued', $4, now() - interval '1 minute')"
+    };
+    sqlx::query(sql)
+        .bind(run_id)
+        .bind(tenant_id)
+        .bind(repo_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("insert ingestion_run");
+    run_id
+}
+
+/// Insert a `queued` run with `started_at` already set — simulates a run
+/// already claimed by a previous reconciler pass or the clone worker.
+async fn insert_claimed_run(pool: &PgPool, tenant_id: Uuid, repo_id: Uuid, user_id: Uuid) -> Uuid {
+    let run_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.ingestion_runs \
+         (id, tenant_id, repo_id, status, requested_by, created_at, started_at) \
+         VALUES ($1, $2, $3, 'queued', $4, now() - interval '10 minutes', now() - interval '1 minute')",
+    )
+    .bind(run_id)
+    .bind(tenant_id)
+    .bind(repo_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert claimed run");
+    run_id
+}
+
+/// Build an `AppState` with a real Postgres pool and no Kafka producer.
+fn make_state(pool: PgPool) -> AppState {
+    let db_url = std::env::var("RB_DATABASE_URL").unwrap_or_default();
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    let email_sender = from_transport("noop", &smtp).expect("noop transport");
+    let hasher = PasswordHasher::from_config(64, 1, 1).expect("hasher");
+    let config = Config {
+        listen_addr: "127.0.0.1:0".to_owned(),
+        database_url: db_url,
+        cors_origins: vec![],
+        base_url: "http://localhost".to_owned(),
+        session_ttl_days: 30,
+        argon2_memory_kb: 64,
+        argon2_time_cost: 1,
+        argon2_parallelism: 1,
+        email_transport: "noop".to_owned(),
+        service_name: "jobs-test".to_owned(),
+        secure_cookies: false,
+        gh_app_id: None,
+        gh_app_private_key_b64: None,
+        gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
+        gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
+        kafka_bootstrap_servers: "127.0.0.1:19999".to_owned(),
+        dev_test_routes: false,
+        migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
+        internal_secret: Some("test".to_owned()),
+        internal_listen_addr: "127.0.0.1:0".to_owned(),
+        session_create_rate_limit: 10,
+        session_create_window_secs: 60,
+        tenant_session_cap: 100,
+    };
+    AppState {
+        pool,
+        email_sender: Arc::from(email_sender),
+        hasher: Arc::new(hasher),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh_loader: Arc::new(rb_github::GhAppLoader::new(None)),
+        sse_bus: Arc::new(EventBus::new(SseConfig::default())),
+        ingest_producer: None,
+        tombstone_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
+        qdrant: None,
+        http_client: reqwest::Client::new(),
+        neo4j_uri: None,
+        kafka_consistency: Arc::new(KafkaConsistencyState::new()),
+        mcp_sessions: McpSessionStore::new(),
+        agent_registry: AgentRegistry::new(),
+        agent_commands_producer: None,
+        internal_secret: "test".to_owned(),
+        session_create_rate_limiter: Arc::new(SessionCreateRateLimiter::default()),
+        tenant_session_count: Arc::new(TenantSessionCount::new()),
+    }
+}
+
+fn make_state_with_dead_producer(pool: PgPool) -> AppState {
+    let cfg = rb_kafka::ProducerCfg {
+        bootstrap_servers: "127.0.0.1:19999".to_owned(),
+        compression_type: "none".to_owned(),
+        linger_ms: 0,
+        delivery_timeout_ms: 1_000,
+        queue_buffering_max_kbytes: 1_024,
+    };
+    let producer = rb_kafka::Producer::new(&cfg).expect("create dead producer");
+    let mut state = make_state(pool);
+    state.ingest_producer = Some(Arc::new(producer));
+    state
+}
+
+// -----------------------------------------------------------------------
+// Behavioral tests — require RB_DATABASE_URL; skip gracefully when absent
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn fetch_returns_old_queued_runs() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    let runs = fetch_orphaned_runs(&pool).await.expect("fetch");
+    assert!(
+        runs.iter().any(|r| r.id == run_id),
+        "old queued run must appear in orphan results"
+    );
+}
+
+#[tokio::test]
+async fn fetch_ignores_recent_queued_runs() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, false).await;
+
+    let runs = fetch_orphaned_runs(&pool).await.expect("fetch");
+    assert!(
+        !runs.iter().any(|r| r.id == run_id),
+        "recent queued run must NOT appear in orphan results"
+    );
+}
+
+#[tokio::test]
+async fn fetch_ignores_non_queued_runs() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO control.ingestion_runs \
+         (id, tenant_id, repo_id, status, requested_by, created_at) \
+         VALUES ($1, $2, $3, 'failed', $4, now() - interval '10 minutes')",
+    )
+    .bind(run_id)
+    .bind(tenant_id)
+    .bind(repo_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert failed run");
+
+    let runs = fetch_orphaned_runs(&pool).await.expect("fetch");
+    assert!(
+        !runs.iter().any(|r| r.id == run_id),
+        "non-queued run must NOT appear in orphan results"
+    );
+}
+
+#[tokio::test]
+async fn claim_run_is_exclusive() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    let first = try_claim_run(&pool, run_id).await.expect("claim 1");
+    let second = try_claim_run(&pool, run_id).await.expect("claim 2");
+
+    assert!(first, "first claim must succeed");
+    assert!(!second, "second claim must fail — run already claimed");
+}
+
+#[tokio::test]
+async fn mark_failed_transitions_queued_to_failed() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    mark_failed(&pool, run_id, "test error").await;
+
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch status");
+    assert_eq!(status, "failed");
+}
+
+#[tokio::test]
+async fn reconcile_no_producer_marks_orphans_failed() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    let state = make_state(pool.clone());
+    // ingest_producer is None — exercises the no-Kafka path.
+    reconcile_orphaned_ingest_runs(&state).await;
+
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch status");
+    assert_eq!(
+        status, "failed",
+        "orphaned run must be marked failed when no Kafka producer is available"
+    );
+}
+
+/// A `queued` run with `started_at` set must not appear in orphan results.
+/// Verifies that `AND started_at IS NULL` in `fetch_orphaned_runs` prevents
+/// double-dispatch when a previous reconciler pass already claimed the row.
+#[tokio::test]
+async fn fetch_ignores_claimed_runs() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_claimed_run(&pool, tenant_id, repo_id, user_id).await;
+
+    let runs = fetch_orphaned_runs(&pool).await.expect("fetch");
+    assert!(
+        !runs.iter().any(|r| r.id == run_id),
+        "claimed run (started_at IS NOT NULL) must NOT appear in orphan results"
+    );
+}
+
+/// Full reconcile with a pre-claimed run: the reconciler must leave the row
+/// untouched (neither re-publish nor transition it to `failed`).
+#[tokio::test]
+async fn reconcile_skips_already_claimed_run() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_claimed_run(&pool, tenant_id, repo_id, user_id).await;
+
+    let state = make_state(pool.clone());
+    reconcile_orphaned_ingest_runs(&state).await;
+
+    let (status, started_at): (String, Option<chrono::DateTime<chrono::Utc>>) =
+        sqlx::query_as("SELECT status, started_at FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch");
+
+    assert_eq!(status, "queued", "pre-claimed run must remain queued");
+    assert!(
+        started_at.is_some(),
+        "started_at must remain set after skip"
+    );
+}
+
+/// Verify `LIMIT 100` bound: when more than 100 eligible orphaned runs exist,
+/// `fetch_orphaned_runs` returns at most 100.
+#[tokio::test]
+async fn fetch_respects_limit() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+
+    // Seed 101 orphaned runs — one past the LIMIT 100 bound.
+    for _ in 0..101_u32 {
+        insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+    }
+
+    let runs = fetch_orphaned_runs(&pool).await.expect("fetch");
+    assert!(
+        runs.len() <= 100,
+        "fetch_orphaned_runs must return at most 100 rows (returned {})",
+        runs.len()
+    );
+}
+
+/// A producer that is configured but whose broker is unreachable (`check_ready`
+/// returns false) must cause orphaned runs to be marked `failed`, not left
+/// in `queued`.
+#[tokio::test]
+async fn reconcile_dead_broker_marks_orphans_failed() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    let state = make_state_with_dead_producer(pool.clone());
+    reconcile_orphaned_ingest_runs(&state).await;
+
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch");
+    assert_eq!(
+        status, "failed",
+        "orphaned run must be marked failed when configured broker is unreachable"
+    );
+}

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -22,7 +22,7 @@ use rb_schemas::AgentSessionCommand;
 
 use crate::{
     config::Config,
-    ingest_consumer, middleware, routes,
+    ingest_consumer, jobs, middleware, routes,
     state::{
         AgentRegistry, AppState, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
         TenantSessionCount,
@@ -159,6 +159,10 @@ pub async fn run(config: Config) -> Result<()> {
         )),
         tenant_session_count: Arc::new(TenantSessionCount::new()),
     };
+
+    // Reconcile any ingestion runs that were left in `queued` state by a prior
+    // crash or restart before their Kafka message was produced.
+    jobs::reconcile_orphaned_ingest_runs(&state).await;
 
     // Spawn the Kafka → SSE fan-out consumer.  Errors here are logged but do
     // not prevent the HTTP server from starting — the SSE endpoint degrades


### PR DESCRIPTION
## Summary

- On `control-api` startup, query `ingestion_runs WHERE status = 'queued' AND started_at IS NULL AND created_at < now() - interval '5 minutes'` and recover each orphaned run.
- **Kafka available**: re-publish `IngestRequest` to `rb.ingest.clone.commands` with a fresh `event_id`; the clone worker picks it up normally.
- **Kafka unavailable / broker unreachable**: mark the run `failed` with a descriptive error so the user can re-trigger without manual DB surgery.

Idempotency: `try_claim_run()` stamps `started_at = now()` via `UPDATE WHERE started_at IS NULL` — only the first pod to win the row-level CAS proceeds; concurrent restarts skip cleanly.

## Files changed

| File | Change |
|------|--------|
| `services/control-api/src/jobs/mod.rs` | `reconcile_orphaned_ingest_runs` + helpers (production code only, 228 lines) |
| `services/control-api/src/jobs/tests.rs` | 10 behavioral tests (new file, 450 lines) |
| `services/control-api/src/server.rs` | Call reconciler after `AppState` build, before consumer spawn |

## Migration type

None — no schema changes. The reconciler uses existing `ingestion_runs` columns only.

## Test plan

- [x] 10 behavioral tests in `jobs/tests.rs`: 5-min threshold, claimed-run skip, LIMIT 100, dead-broker, no-producer
- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo fmt --all -- --check` green
- [x] `file size (600-line cap)` green: `mod.rs` 228 lines, `tests.rs` 450 lines (both under 600)

Closes #455
