### PR TITLE
[RUSAA-1473] fix(control-api): remove installation events from GitHub App manifest default_events

### DIFF
--- a/services/control-api/src/routes/admin/github/app_manifest.rs
+++ b/services/control-api/src/routes/admin/github/app_manifest.rs
@@ -116,10 +116,7 @@ pub fn build_manifest_payload(base_url: &str, name: &str) -> serde_json::Value {
             "contents": "read",
             "metadata": "read",
         },
-        "default_events": [
-            "installation",
-            "installation_repositories",
-        ],
+        "default_events": [],
     })
 }
 
@@ -161,10 +158,12 @@ mod tests {
             "http://localhost:15173/v1/github/webhook"
         );
         assert_eq!(m["default_permissions"]["contents"], "read");
-        let events = m["default_events"]
-            .as_array()
-            .expect("default_events array");
-        assert!(events.iter().any(|e| e == "installation"));
-        assert!(events.iter().any(|e| e == "installation_repositories"));
+        assert!(
+            m["default_events"]
+                .as_array()
+                .expect("default_events array")
+                .is_empty(),
+            "installation/installation_repositories must not appear in default_events"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Removes `installation` and `installation_repositories` from `default_events` in the GitHub App manifest payload — GitHub rejects these as unsupported selectable events, causing the `Invalid GitHub App configuration` error seen in UAT.
- Updates the unit test `manifest_payload_has_required_fields` to assert the array is empty rather than asserting the removed events are present.

Closes #441

## Context

Regression from the original feature commit (`6983c2de`). A fix was authored in the abandoned branch `feature/rusaa-1380-remove-invalid-manifest-events` (PR #442, closed-not-merged) but never landed on `main`. This PR opens a fresh branch from `main` HEAD (`38ce4f9c`) with only the two required changes.

## Test plan

- [x] `cargo test -p control-api --lib -- routes::admin::github::app_manifest::tests` — 2/2 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p control-api -- -D warnings` — clean
- [x] Full integration tests (`cargo-locked test -p control-api`) — confirmed by CI
- [x] UAT: trigger admin manifest flow → GitHub renders App-creation form without `Default events unsupported` error