### PR TITLE
[RUSAA-1476] fix(compose): KRaft metadata log hardening for Kafka

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -79,6 +79,12 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       CLUSTER_ID: MkU3OEVhNTcwNTJENDM2Qk
+      # KRaft metadata log hardening: limit snapshot interval, segment size, and tune
+      # broker heartbeat/session timeouts for resilience under GC pressure.
+      KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS: "300000"
+      KAFKA_METADATA_LOG_SEGMENT_BYTES: "10485760"
+      KAFKA_BROKER_HEARTBEAT_INTERVAL_MS: "2000"
+      KAFKA_BROKER_SESSION_TIMEOUT_MS: "9000"
     volumes:
       - kafka_data:/var/lib/kafka/data
     ports:


### PR DESCRIPTION
## Summary

- Adds four KRaft hardening env vars to the `kafka` service in `compose/dev.yml`
- 5-min snapshot interval (`KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS=300000`) bounds metadata log growth and will compact the existing bloated 566k-entry log on the first post-restart snapshot cycle
- 10 MB segment size prevents single oversized segments
- Tighter heartbeat/session timeout values improve resilience under JVM GC pressure

## Migration type
Not applicable — compose-only change, no schema migration.

## Fix 4 (P2) — KRaft Config Hardening

Env vars added to `kafka` service:
```
KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS: "300000"   # 5-min snapshots
KAFKA_METADATA_LOG_SEGMENT_BYTES: "10485760"             # 10 MB segments
KAFKA_BROKER_HEARTBEAT_INTERVAL_MS: "2000"               # heartbeat more often
KAFKA_BROKER_SESSION_TIMEOUT_MS: "9000"                  # tolerate longer GC
```

## Fix 5 (P0) — Metadata Log Compaction

Setting `KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS=300000` causes Kafka to take a snapshot within 5 minutes of first restart. Once the snapshot is taken, metadata records before the snapshot point are eligible for deletion, reducing the log from 47 MB to well under the 100 MB AC threshold.

**Post-merge ops action required on mars:**
```bash
docker compose restart kafka
# Wait ~5 min for first snapshot cycle, then verify:
docker exec kafka ls -lh /var/lib/kafka/data/__cluster_metadata-0/
```

## Test plan
- [ ] `docker compose up -d kafka` with the new config — broker starts healthy
- [ ] `docker compose restart kafka` — consumers reconnect without wedging
- [ ] After ~5 min: metadata log < 100 MB (ops verify on mars post-merge)

Closes #458