### PR TITLE
[RUSAA-1477] fix(rb-kafka): static consumer group membership via group.instance.id

### DIFF
--- a/crates/rb-kafka/src/config.rs
+++ b/crates/rb-kafka/src/config.rs
@@ -32,25 +32,40 @@ impl Default for ProducerCfg {
 pub struct ConsumerCfg {
     pub bootstrap_servers: String,
     pub group_id: String,
+    /// Static membership identifier for KRaft/rebalance stability.
+    /// When set, `group.instance.id` is sent to the broker so that a consumer
+    /// restart does not trigger a full partition rebalance.  Auto-generated in
+    /// [`ConsumerCfg::new`] from the `HOSTNAME` env var (pod name in K8s/Docker).
+    pub instance_id: Option<String>,
     pub enable_auto_commit: bool,
     pub isolation_level: String,
     pub auto_offset_reset: String,
     pub max_poll_interval: Duration,
     pub session_timeout: Duration,
+    pub heartbeat_interval: Duration,
 }
 
 impl ConsumerCfg {
     #[must_use]
     pub fn new(group_id: impl Into<String>) -> Self {
+        let group_id = group_id.into();
+        // Use $HOSTNAME (set by Docker/K8s to the container/pod name) so that each
+        // replica gets a stable, unique group.instance.id across restarts without
+        // hitting the full-rebalance path on every reconnect.
+        let hostname = std::env::var("HOSTNAME")
+            .unwrap_or_else(|_| format!("pid-{}", std::process::id()));
+        let instance_id = Some(format!("{group_id}-{hostname}"));
         Self {
             bootstrap_servers: std::env::var("KAFKA_BOOTSTRAP_SERVERS")
                 .unwrap_or_else(|_| "kafka:9092".to_owned()),
-            group_id: group_id.into(),
+            group_id,
+            instance_id,
             enable_auto_commit: false,
             isolation_level: "read_committed".to_owned(),
             auto_offset_reset: "earliest".to_owned(),
-            max_poll_interval: Duration::from_secs(300),
-            session_timeout: Duration::from_secs(30),
+            max_poll_interval: Duration::from_secs(600),
+            session_timeout: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(10),
         }
     }
 }

--- a/crates/rb-kafka/src/config.rs
+++ b/crates/rb-kafka/src/config.rs
@@ -52,8 +52,8 @@ impl ConsumerCfg {
         // Use $HOSTNAME (set by Docker/K8s to the container/pod name) so that each
         // replica gets a stable, unique group.instance.id across restarts without
         // hitting the full-rebalance path on every reconnect.
-        let hostname = std::env::var("HOSTNAME")
-            .unwrap_or_else(|_| format!("pid-{}", std::process::id()));
+        let hostname =
+            std::env::var("HOSTNAME").unwrap_or_else(|_| format!("pid-{}", std::process::id()));
         let instance_id = Some(format!("{group_id}-{hostname}"));
         Self {
             bootstrap_servers: std::env::var("KAFKA_BOOTSTRAP_SERVERS")

--- a/crates/rb-kafka/src/consumer.rs
+++ b/crates/rb-kafka/src/consumer.rs
@@ -31,7 +31,8 @@ pub struct Consumer<E: ProstMessage + Default> {
 #[allow(clippy::used_underscore_binding, clippy::unused_async)]
 impl<E: ProstMessage + Default> Consumer<E> {
     pub fn new(cfg: &ConsumerCfg) -> Result<Self, KafkaError> {
-        let consumer: StreamConsumer = ClientConfig::new()
+        let mut client_cfg = ClientConfig::new();
+        client_cfg
             .set("bootstrap.servers", &cfg.bootstrap_servers)
             .set("group.id", &cfg.group_id)
             .set("enable.auto.commit", cfg.enable_auto_commit.to_string())
@@ -45,6 +46,14 @@ impl<E: ProstMessage + Default> Consumer<E> {
                 "session.timeout.ms",
                 cfg.session_timeout.as_millis().to_string(),
             )
+            .set(
+                "heartbeat.interval.ms",
+                cfg.heartbeat_interval.as_millis().to_string(),
+            );
+        if let Some(ref iid) = cfg.instance_id {
+            client_cfg.set("group.instance.id", iid);
+        }
+        let consumer: StreamConsumer = client_cfg
             // Dev brokers can take >100ms for first-fetch offset requests;
             // 30 s matches librdkafka's protocol default and silences REQTMOUT noise.
             .set("socket.timeout.ms", "30000")
@@ -428,11 +437,13 @@ mod tests {
         let cfg = ConsumerCfg {
             bootstrap_servers: "127.0.0.1:1".to_owned(), // no kafka here
             group_id: "rb-kafka-wait-for-topics-test".to_owned(),
+            instance_id: None,
             enable_auto_commit: false,
             isolation_level: "read_committed".to_owned(),
             auto_offset_reset: "earliest".to_owned(),
-            max_poll_interval: Duration::from_secs(300),
-            session_timeout: Duration::from_secs(30),
+            max_poll_interval: Duration::from_secs(600),
+            session_timeout: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(10),
         };
         let consumer: Consumer<AgentSessionCommand> =
             Consumer::new(&cfg).expect("consumer construction");


### PR DESCRIPTION
## Summary

- Adds `instance_id: Option<String>` and `heartbeat_interval: Duration` to `ConsumerCfg` in `crates/rb-kafka/src/config.rs`
- `ConsumerCfg::new` auto-generates `instance_id` as `"{group_id}-{HOSTNAME}"` using the `$HOSTNAME` env var (set to pod/container name in Docker/K8s), falling back to `pid-{pid}`
- `Consumer::new` wires `group.instance.id`, `heartbeat.interval.ms` into the rdkafka `ClientConfig`
- Defaults updated: `session.timeout.ms` 30s → 60s, `max.poll.interval.ms` 300s → 600s, `heartbeat.interval.ms` 10s (new)
- All nine consumer groups inherit the fix via `ConsumerCfg::new` — no service changes required

Closes #460

## Test plan

- [ ] `cargo clippy -p rb-kafka --all-targets -- -D warnings` passes
- [ ] All services that depend on `rb-kafka` compile without errors
- [ ] Integration: `docker compose restart kafka` — all consumers reconnect within 30s without manual restart (static membership bypasses rebalance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)