### PR TITLE
[RUSAA-1483] fix(compose): KRaft hardening parity for test and e2e kafka

### DIFF
--- a/compose/e2e.yml
+++ b/compose/e2e.yml
@@ -74,6 +74,12 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       CLUSTER_ID: VGVzdENsdXN0ZXJJZEtleQ
+      # KRaft metadata log hardening: limit snapshot interval, segment size, and tune
+      # broker heartbeat/session timeouts for resilience under GC pressure.
+      KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS: "300000"
+      KAFKA_METADATA_LOG_SEGMENT_BYTES: "10485760"
+      KAFKA_BROKER_HEARTBEAT_INTERVAL_MS: "2000"
+      KAFKA_BROKER_SESSION_TIMEOUT_MS: "9000"
     networks: [rb-e2e-net]
     healthcheck:
       test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -36,6 +36,12 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       CLUSTER_ID: VGVzdENsdXN0ZXJJZEtleQ
+      # KRaft metadata log hardening: limit snapshot interval, segment size, and tune
+      # broker heartbeat/session timeouts for resilience under GC pressure.
+      KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS: "300000"
+      KAFKA_METADATA_LOG_SEGMENT_BYTES: "10485760"
+      KAFKA_BROKER_HEARTBEAT_INTERVAL_MS: "2000"
+      KAFKA_BROKER_SESSION_TIMEOUT_MS: "9000"
     volumes:
       - test_kafka_data:/var/lib/kafka/data
     ports:


### PR DESCRIPTION
## Summary

Mirrors the four KRaft metadata log hardening env vars added to `compose/dev.yml` in #459 into `compose/test.yml` and `compose/e2e.yml`. CI and smoke-test Kafka instances can hit the same metadata-log bloat and heartbeat-wedge failure modes as the dev stack; this brings them to parity.

## Migration type

N/A — compose-only, no schema changes.

## Changes

- `compose/test.yml`: added 4 env vars to `kafka` service (env block after `CLUSTER_ID`)
- `compose/e2e.yml`: added 4 env vars to `kafka` service (env block after `CLUSTER_ID`)

Diff: +12 / -0, no other files touched.

## Vars added (both files)

```yaml
KAFKA_METADATA_LOG_MAX_SNAPSHOT_INTERVAL_MS: "300000"
KAFKA_METADATA_LOG_SEGMENT_BYTES: "10485760"
KAFKA_BROKER_HEARTBEAT_INTERVAL_MS: "2000"
KAFKA_BROKER_SESSION_TIMEOUT_MS: "9000"
```

## Out of scope

- `compose/dev.yml` — already done in #459
- `compose/full.yml` — no `kafka` service
- Rust source, Cargo.toml, migrations

Closes #463