### PR TITLE
[RUSAA-1479] fix(control-api): live ingestion reconciler — background healer every 2 min

### DIFF
--- a/services/control-api/src/jobs/mod.rs
+++ b/services/control-api/src/jobs/mod.rs
@@ -10,6 +10,9 @@ use crate::state::AppState;
 
 const CLONE_COMMANDS_TOPIC: &str = "rb.ingest.clone.commands";
 
+/// Interval between reconciler passes.
+const RECONCILER_INTERVAL: Duration = Duration::from_secs(120);
+
 struct OrphanedRun {
     id: Uuid,
     tenant_id: Uuid,
@@ -17,13 +20,34 @@ struct OrphanedRun {
     commit_sha: Option<String>,
 }
 
-/// On startup, re-dispatch any ingestion runs that are stuck in `queued`
-/// for more than 5 minutes without a Kafka message being produced.
+/// Spawns a background tokio task that calls [`reconcile_orphaned_ingest_runs`]
+/// every 2 minutes.
 ///
-/// This recovers from the failure mode where control-api crashed or was
-/// restarted after the DB row was committed but before (or during) the
-/// Kafka publish.  The trigger handler normally rolls back the transaction
-/// on Kafka failure, but a mid-flight process death can leave an orphan.
+/// The first tick fires immediately so recently-stuck runs are healed without
+/// waiting a full interval.  Missed ticks are skipped (no burst catch-up) to
+/// prevent thundering-herd on a recovering Kafka broker.
+///
+/// The returned [`tokio::task::JoinHandle`] can be kept for graceful shutdown
+/// or dropped — dropping does not cancel the task.
+pub fn spawn_reconciler_loop(state: AppState) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(RECONCILER_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            reconcile_orphaned_ingest_runs(&state).await;
+        }
+    })
+}
+
+/// Re-dispatch any ingestion runs that are stuck in `queued` for more than
+/// 2 minutes without a Kafka message being produced.
+///
+/// Called periodically by [`spawn_reconciler_loop`].  Recovers from the
+/// failure mode where control-api crashed or was restarted after the DB row
+/// was committed but before (or during) the Kafka publish.  The trigger
+/// handler normally rolls back the transaction on Kafka failure, but a
+/// mid-flight process death can leave an orphan.
 ///
 /// Recovery strategy:
 /// - Kafka producer available → re-publish `IngestRequest` with a new
@@ -31,25 +55,25 @@ struct OrphanedRun {
 /// - Kafka producer unavailable → mark the run `failed` with a clear
 ///   error so the user can re-trigger without manual DB surgery.
 ///
-/// Bounded: processes at most 100 runs per restart (oldest first) to cap
-/// startup time after a prolonged outage.
+/// Bounded: processes at most 100 runs per pass (oldest first) to cap
+/// work per interval after a prolonged outage.
 pub async fn reconcile_orphaned_ingest_runs(state: &AppState) {
     let runs = match fetch_orphaned_runs(&state.pool).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(error = %e, "startup reconciler: failed to query orphaned runs");
+            tracing::error!(error = %e, "reconciler: failed to query orphaned runs");
             return;
         }
     };
 
     if runs.is_empty() {
-        tracing::debug!("startup reconciler: no orphaned queued ingestion runs");
+        tracing::debug!("reconciler: no orphaned queued ingestion runs");
         return;
     }
 
     tracing::warn!(
         count = runs.len(),
-        "startup reconciler: found orphaned queued ingestion runs — recovering"
+        "reconciler: found orphaned queued ingestion runs — recovering"
     );
 
     for run in runs {
@@ -63,7 +87,7 @@ async fn fetch_orphaned_runs(pool: &sqlx::PgPool) -> Result<Vec<OrphanedRun>, sq
          FROM control.ingestion_runs \
          WHERE status = 'queued' \
            AND started_at IS NULL \
-           AND created_at < now() - interval '5 minutes' \
+           AND created_at < now() - interval '2 minutes' \
          ORDER BY created_at ASC \
          LIMIT 100",
     )
@@ -112,7 +136,7 @@ async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
         Ok(false) => {
             tracing::debug!(
                 run_id = %run.id,
-                "startup reconciler: run already claimed by another instance; skipping"
+                "reconciler: run already claimed by another instance; skipping"
             );
             return;
         }
@@ -120,7 +144,7 @@ async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
             tracing::error!(
                 run_id = %run.id,
                 error = %e,
-                "startup reconciler: failed to claim run; skipping"
+                "reconciler: failed to claim run; skipping"
             );
             return;
         }
@@ -134,12 +158,12 @@ async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
             tracing::warn!(
                 run_id = %run.id,
                 tenant_id = %run.tenant_id,
-                "startup reconciler: Kafka broker unreachable; marking run failed"
+                "reconciler: Kafka broker unreachable; marking run failed"
             );
             mark_failed(
                 &state.pool,
                 run.id,
-                "startup reconciler: Kafka broker unreachable on recovery; re-trigger to start ingestion",
+                "reconciler: Kafka broker unreachable on recovery; re-trigger to start ingestion",
             )
             .await;
             return;
@@ -172,19 +196,19 @@ async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
                     run_id = %run.id,
                     tenant_id = %run.tenant_id,
                     repo_id = %run.repo_id,
-                    "startup reconciler: re-published orphaned ingestion run"
+                    "reconciler: re-published orphaned ingestion run"
                 );
             }
             Err(e) => {
                 tracing::warn!(
                     run_id = %run.id,
                     error = %e,
-                    "startup reconciler: re-publish failed; marking run failed"
+                    "reconciler: re-publish failed; marking run failed"
                 );
                 mark_failed(
                     &state.pool,
                     run.id,
-                    "startup reconciler: Kafka publish failed during recovery; re-trigger to start ingestion",
+                    "reconciler: Kafka publish failed during recovery; re-trigger to start ingestion",
                 )
                 .await;
             }
@@ -194,12 +218,12 @@ async fn handle_orphaned_run(state: &AppState, run: OrphanedRun) {
             run_id = %run.id,
             tenant_id = %run.tenant_id,
             repo_id = %run.repo_id,
-            "startup reconciler: no Kafka producer configured; marking orphaned run failed"
+            "reconciler: no Kafka producer configured; marking orphaned run failed"
         );
         mark_failed(
             &state.pool,
             run.id,
-            "startup reconciler: control-api restarted with no Kafka producer before message was published; re-trigger to start ingestion",
+            "reconciler: control-api restarted with no Kafka producer before message was published; re-trigger to start ingestion",
         )
         .await;
     }
@@ -219,7 +243,7 @@ async fn mark_failed(pool: &sqlx::PgPool, run_id: Uuid, error: &str) {
         tracing::error!(
             run_id = %run_id,
             error = %e,
-            "startup reconciler: failed to mark run as failed"
+            "reconciler: failed to mark run as failed"
         );
     }
 }

--- a/services/control-api/src/jobs/tests.rs
+++ b/services/control-api/src/jobs/tests.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use rb_auth::{LoginRateLimiter, PasswordHasher};
 use rb_email::from_transport;
@@ -444,5 +445,58 @@ async fn reconcile_dead_broker_marks_orphans_failed() {
     assert_eq!(
         status, "failed",
         "orphaned run must be marked failed when configured broker is unreachable"
+    );
+}
+
+/// The background loop spawned by `spawn_reconciler_loop` must heal a stuck
+/// queued run within its first tick (which fires immediately on interval
+/// creation, before any 2-minute delay).
+///
+/// In the no-producer test environment, "healed" means the run transitions to
+/// `failed`.  The test polls with a 5 s wall-clock timeout so it fails fast
+/// rather than hanging indefinitely on a broken CI environment.
+#[tokio::test]
+async fn reconciler_loop_heals_stuck_queued_run_on_first_tick() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let (tenant_id, user_id, repo_id) = insert_fixtures(&pool).await;
+    // Insert a run that is 10 minutes old — well past the 2-minute threshold.
+    let run_id = insert_queued_run(&pool, tenant_id, repo_id, user_id, true).await;
+
+    let state = make_state(pool.clone());
+    let handle = spawn_reconciler_loop(state);
+
+    // Poll until the run transitions out of `queued`, with a 5 s timeout.
+    // The first tick of the interval fires immediately, so this should
+    // complete in milliseconds under normal conditions.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM control.ingestion_runs WHERE id = $1")
+                .bind(run_id)
+                .fetch_one(&pool)
+                .await
+                .expect("fetch status");
+        if status != "queued" {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            handle.abort();
+            panic!("reconciler loop did not heal the stuck run within 5 s");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    handle.abort();
+
+    let final_status: String =
+        sqlx::query_scalar("SELECT status FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch final status");
+    assert_eq!(
+        final_status, "failed",
+        "stuck-queued run must be marked failed by the background reconciler (no producer in test)"
     );
 }

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -160,9 +160,10 @@ pub async fn run(config: Config) -> Result<()> {
         tenant_session_count: Arc::new(TenantSessionCount::new()),
     };
 
-    // Reconcile any ingestion runs that were left in `queued` state by a prior
-    // crash or restart before their Kafka message was produced.
-    jobs::reconcile_orphaned_ingest_runs(&state).await;
+    // Spawn the periodic reconciler that heals ingestion runs left in `queued`
+    // by a crash or Kafka publish failure.  Runs every 2 minutes throughout
+    // the lifetime of the process (not just on startup).
+    drop(jobs::spawn_reconciler_loop(state.clone()));
 
     // Spawn the Kafka → SSE fan-out consumer.  Errors here are logged but do
     // not prevent the HTTP server from starting — the SSE endpoint degrades


### PR DESCRIPTION
## Summary

- Converts `reconcile_orphaned_ingest_runs()` from a one-shot startup call into a `tokio::spawn` loop running every **2 minutes** for the lifetime of the process
- Tightens the orphan threshold from 5 min → **2 min** (matching the loop cadence per AC)
- Sets `MissedTickBehavior::Skip` to prevent burst catch-up after a Kafka outage
- First tick fires immediately so runs stuck before the next interval are healed fast
- Renames log span from `"startup reconciler"` → `"reconciler"` to reflect periodic nature
- Adds integration test `reconciler_loop_heals_stuck_queued_run_on_first_tick`

## AC checklist

- [x] Reconciler runs on `tokio::time::interval` every 2 min inside control-api process
- [x] Integration test confirms stuck-queued run is healed within first tick (< 2 min)
- [x] Old one-shot startup call removed and replaced

## Files changed

| File | Change |
|------|--------|
| `services/control-api/src/jobs/mod.rs` | Add `spawn_reconciler_loop`; 5 min → 2 min threshold; rename log spans |
| `services/control-api/src/server.rs` | Replace `.await` one-shot with `drop(spawn_reconciler_loop(...))` |
| `services/control-api/src/jobs/tests.rs` | New loop integration test (11/11 passing) |

## Gates

- `cargo clippy -p control-api --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo deny check` ✅
- `cargo-locked test -p control-api --lib -- jobs::tests` ✅ 11/11 passed

Closes #462