### PR TITLE
[RUSAA-1491] ops(dev): set RB_GH_APP_ENC_KEY in tailscale.env

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -11,3 +11,6 @@ ed45745ba598f205130a4cba0ddd2bb1b0fa79af:crates/rb-github/tests/fixtures/test_rs
 # 2048-bit RSA test-only key inlined as TEST_RSA_PEM const in app_config_store.rs unit tests.
 # Pure test fixture generated with openssl genrsa; no production usage.
 34089ebf49f0cad9e191fd52b043ad03ae680a5b:crates/rb-github/src/app_config_store.rs:private-key:451
+# Dev AES-256-GCM key first introduced in f4b74704 without gitleaks:allow annotation.
+# Annotated in 9cd3bcf4; historical diff still trips the scanner. Dev fixture only.
+f4b74704ded45b8ac5933633e1416a6418a4e2eb:compose/tailscale.env:generic-api-key:74

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -65,3 +65,10 @@ KAFKA_UI_HOST_PORT=18082
 # The entrypoint refuses to start sshd if this is empty (security guard).
 # In production mount the key from a secret instead of committing it here.
 RB_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCUdbE1pviGKfQVGvmq0PZHXb8mqmmFSIy9vVQezU9f jarnura@mars-claude-login
+
+# --- GitHub App ---
+# AES-256-GCM key used by control-api to encrypt GitHub App credentials before
+# persisting to control.github_app_config. Generated with: openssl rand 32 | base64 -w0
+# WARNING: do NOT rotate this key without first re-encrypting existing rows.
+# Prod must use a separate key injected via the secret manager.
+RB_GH_APP_ENC_KEY=z3YrdZfhH18CV4fyJWqa0rPivsRR8qS7oqm8MusXLHM=

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -71,4 +71,4 @@ RB_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCUdbE1pviGKfQVGvmq0
 # persisting to control.github_app_config. Generated with: openssl rand 32 | base64 -w0
 # WARNING: do NOT rotate this key without first re-encrypting existing rows.
 # Prod must use a separate key injected via the secret manager.
-RB_GH_APP_ENC_KEY=z3YrdZfhH18CV4fyJWqa0rPivsRR8qS7oqm8MusXLHM=
+RB_GH_APP_ENC_KEY=z3YrdZfhH18CV4fyJWqa0rPivsRR8qS7oqm8MusXLHM= # gitleaks:allow


### PR DESCRIPTION
## Summary

- Appends `RB_GH_APP_ENC_KEY` (AES-256-GCM, 32 bytes, base64-encoded) to `compose/tailscale.env` so `control-api` can encrypt GitHub App credentials at the manifest-flow callback.
- Without this key `app_callback.rs` returns 503 (`service_unavailable`) because `AppConfigStore` cannot seal secrets before writing to `control.github_app_config`.

Closes #469

## Root cause

`compose/tailscale.env` had no `RB_GH_APP_ENC_KEY` entry. The handler at `services/control-api/src/routes/admin/github/app_callback.rs:96-106` calls `AppConfigStore::insert_replacing`, which requires a live `EncryptionKey`. Missing key → immediate 503.

## Additional cleanup (runtime, not in this PR)

The dev DB had a stale active row in `control.github_app_config` (id=5, `rustacean-manifest-dev`) that was encrypted with an old, unknown key. Introducing the new key caused a `github_app_config crypto failure` crash-loop at startup (see `server.rs:271-278` — boot fails fast on decrypt error rather than silently falling through). The row was deactivated directly in the dev DB (`UPDATE … SET is_active=false`) so the service can start cleanly. A fresh active row will be created by re-running the manifest flow.

## Verification

```
# Container recreated with new env var
docker exec rustbrain-dev-control-api-1 sh -c '[ -n "$RB_GH_APP_ENC_KEY" ] && echo set'
# → set

curl -s http://localhost:18080/health
# → {"status":"ok","stores":{"postgres":"ok","neo4j":"ok","qdrant":"ok","kafka":"unknown"}}
```

## Migration type

N/A — no schema migration in this PR.

## Test plan

- [ ] `docker exec rustbrain-dev-control-api-1 sh -c '[ -n "$RB_GH_APP_ENC_KEY" ] && echo set'` → `set`
- [ ] `curl localhost:18080/health` → `{"status":"ok",...}`
- [ ] Re-run admin manifest flow → callback returns 302 redirect to `/admin/github?registered=true`