### PR TITLE
[RUSAA-1540] feat(agent-runner): wire @rustbrain/mcp-server + local-session docs

### DIFF
--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -38,8 +38,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ── Stage 4: runtime image ────────────────────────────────────────────────────
 # Base on node:20-bookworm-slim so we have node/npm/npx for:
 #   • @anthropic-ai/claude-code (CLI binary the ClaudeCode adapter spawns)
-#   • npx @modelcontextprotocol/server-rust-brain (MCP server invoked from
-#     workspace .mcp.json — see services/agent-runner/src/adapters/mod.rs)
+#   • npx -y @rustbrain/mcp-server (MCP server invoked lazily from workspace
+#     .mcp.json — see services/agent-runner/src/adapters/mod.rs)
 FROM node:20-bookworm-slim AS runtime
 
 # Install git, ssh, and the C runtime deps the Rust binary links against.

--- a/docs/mcp-local-setup.md
+++ b/docs/mcp-local-setup.md
@@ -1,0 +1,102 @@
+# Local MCP Setup for Claude Code
+
+This guide walks you through connecting Claude Code to Rust Brain via the
+`@rustbrain/mcp-server` MCP bridge so you can call Rust Brain tools
+(`search_items`, `get_item`) directly from a local Claude Code session.
+
+---
+
+## Prerequisites
+
+- Node.js 18+ (needed for `npx`)
+- Claude Code CLI installed: `npm install -g @anthropic-ai/claude-code`
+- A Rust Brain account with API access
+
+---
+
+## 1. Create a Read-scoped API key
+
+1. Open the Rust Brain dashboard and navigate to **Settings → API Keys**.
+2. Click **Create Key**, choose scope **Read**, and give it a memorable label
+   (e.g., `claude-code-local`).
+3. Copy the key — it starts with `rb_live_`.
+
+> The MCP server only needs `Read` scope. Narrower scope limits blast radius if
+> the key is ever exposed.
+
+---
+
+## 2. Export environment variables
+
+```bash
+export RB_AGENT_API_KEY=rb_live_<your-key>
+export RB_AGENT_API_BASE=https://<your-host>   # e.g. https://app.rustbrain.io
+```
+
+Add these to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to make them
+permanent.
+
+---
+
+## 3. Register the MCP server with Claude Code
+
+```bash
+claude mcp add rust-brain -- npx -y @rustbrain/mcp-server
+```
+
+This writes a `rust-brain` entry into Claude Code's global MCP config
+(`~/.claude/mcp_servers.json`). The `npx -y` prefix means the bridge is
+resolved lazily on first use — no separate install step required.
+
+---
+
+## 4. Verify the connection
+
+Start a new Claude Code session and run:
+
+```
+/mcp
+```
+
+You should see `rust-brain` listed with status **connected**.
+
+To list available tools:
+
+```
+tools/list
+```
+
+Expected output includes at least:
+
+```
+search_items   Search Rust Brain items by keyword or semantic query
+get_item       Fetch a single Rust Brain item by ID
+```
+
+To smoke-test a tool call:
+
+```
+tools/call search_items {"query": "hello world", "limit": 3}
+```
+
+A successful call returns a JSON array of item results.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `rust-brain` server listed as **error** in `/mcp` | `RB_AGENT_API_KEY` not set or empty | Run `echo $RB_AGENT_API_KEY` and re-export |
+| `401 Unauthorized` from tool call | Key expired or revoked | Regenerate the API key in the dashboard |
+| `TENANT_DRIFT` error in tool response | Session tenant does not match the key's tenant | Ensure `RB_AGENT_API_BASE` points to the same host the key was created on |
+| `npx: command not found` | Node.js not installed or not on PATH | Install Node.js 18+ and verify `which npx` |
+| Tools list returns 0 tools | Outdated package cached by npx | Run `npx --yes @rustbrain/mcp-server --version` to force a cache refresh |
+
+---
+
+## See also
+
+- Agent-runner MCP config: `services/agent-runner/src/adapters/mod.rs` (`write_mcp_config`)
+- MCP server source: `packages/mcp-server-node/` (npm: `@rustbrain/mcp-server`)
+- ADR-009: MCP server design invariants (`docs/decisions/ADR-009-*.md`)

--- a/services/agent-runner/src/adapters/mod.rs
+++ b/services/agent-runner/src/adapters/mod.rs
@@ -84,7 +84,7 @@ pub async fn write_mcp_config(
         "mcpServers": {
             "rust-brain": {
                 "command": "npx",
-                "args": ["-y", "@modelcontextprotocol/server-rust-brain"],
+                "args": ["-y", "@rustbrain/mcp-server"],
                 "env": {
                     "RB_AGENT_API_KEY": api_key,
                     "RB_AGENT_TENANT_ID": tenant_id,


### PR DESCRIPTION
## Summary

- **`services/agent-runner/src/adapters/mod.rs`** — one-line change in `write_mcp_config`: replaces the old scoped package `@modelcontextprotocol/server-rust-brain` with the published `@rustbrain/mcp-server` (shipped in #484).
- **`docker/agent-runner/Dockerfile`** — comment on lines 39-42 updated to match; no `RUN npm install` added (npx resolves lazily per session, consistent with the existing comment intent).
- **`docs/mcp-local-setup.md`** — new doc covering: API key creation (Read scope), env-var export, `claude mcp add rust-brain -- npx -y @rustbrain/mcp-server`, `tools/list` verification, and a troubleshooting matrix (missing env var, expired key, `TENANT_DRIFT`, npx-not-found, stale cache).

No changes to `crates/rb-mcp` (preserves ADR-009 §1 invariant). No changes to `services/control-api/`.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo deny check` ✅ (`advisories ok, bans ok, licenses ok, sources ok`)
- Pre-existing `rdkafka-sys` debug-build failure (missing `libcurl-dev` on bare dev machine; CI/Dockerfile builder stage has it) — unrelated to this change, confirmed by reproducing on unmodified `main`.

## Test plan

- [ ] Existing `write_mcp_config` tests stay green in CI
- [ ] Agent-runner Docker image builds (Dockerfile builder stage installs `libcurl4-openssl-dev`)
- [ ] Smoke test: agent-runner spawns a Claude Code session, `.mcp.json` resolves `@rustbrain/mcp-server`, `tools/list` returns `search_items` + `get_item`
- [ ] Local-session smoke test: developer follows `docs/mcp-local-setup.md` end-to-end

Closes #482
Closes RUSAA-1540