### PR TITLE
[RUSAA-1550] fix(frontend/nginx): re-resolve control-api DNS on each request

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -3,9 +3,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker's embedded DNS resolver. valid=10s causes nginx to re-resolve
+    # after 10 s rather than caching the IP for the container lifetime.
+    # Combined with the $upstream variable below, this prevents 502s when
+    # control-api is recreated and assigned a new bridge IP by the watcher.
+    resolver 127.0.0.11 valid=10s;
+
     # Proxy API, health, and readiness endpoints to control-api
     location /v1/ {
-        proxy_pass http://control-api:8080;
+        set $upstream control-api:8080;
+        proxy_pass http://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -13,13 +20,15 @@ server {
     }
 
     location = /health {
-        proxy_pass http://control-api:8080;
+        set $upstream control-api:8080;
+        proxy_pass http://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }
 
     location = /ready {
-        proxy_pass http://control-api:8080;
+        set $upstream control-api:8080;
+        proxy_pass http://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }

--- a/docs/dev-stack-health-alerting.md
+++ b/docs/dev-stack-health-alerting.md
@@ -125,3 +125,29 @@ sudo systemctl stop rustbrain-dev-health.timer
 # ... maintenance ...
 sudo systemctl start rustbrain-dev-health.timer
 ```
+
+## Known pitfall: nginx caches upstream IP at startup
+
+**Symptom**: after the auto-rebuild watcher recreates `control-api` (new Docker bridge IP),
+all `/v1/*` requests through the frontend return `502 Bad Gateway` until the frontend
+container is manually restarted. nginx error log shows the dead IP:
+
+```
+connect() failed (111: Connection refused) ... upstream: "http://172.25.0.XX:8080/v1/..."
+```
+
+**Root cause**: plain `proxy_pass http://control-api:8080;` causes nginx to resolve the
+hostname once at startup and cache the IP for the container lifetime.
+
+**Fix** (shipped in `docker/frontend/nginx.conf`): use Docker's embedded DNS resolver with
+a 10-second TTL and route `proxy_pass` through a variable:
+
+```nginx
+resolver 127.0.0.11 valid=10s;
+set $upstream control-api:8080;
+proxy_pass http://$upstream;
+```
+
+When `proxy_pass` references a variable nginx re-resolves via the configured resolver on
+each request (within the TTL), so a recreated `control-api` is picked up within 10 seconds
+without any manual restart.


### PR DESCRIPTION
## Summary

- Adds `resolver 127.0.0.11 valid=10s` to nginx server block (Docker embedded DNS, 10-second TTL)
- Routes all three proxy locations (`/v1/`, `/health`, `/ready`) through a `$upstream` variable so nginx re-resolves the hostname on each request rather than caching the IP at container startup
- Documents the pitfall and fix in `docs/dev-stack-health-alerting.md`

## Migration type

N/A — no schema changes.

## Root cause

`proxy_pass http://control-api:8080;` causes nginx to resolve the hostname once at startup. When the dev-stack watcher recreates `control-api` with a new Docker bridge IP, nginx keeps forwarding to the dead IP → 502 on all `/v1/*` until a manual `docker compose restart frontend`. Incident: 2026-05-19 08:05–14:35 UTC (parent incident).

## Fix (Option 2 from RUSAA-1550)

```nginx
resolver 127.0.0.11 valid=10s;
set $upstream control-api:8080;
proxy_pass http://$upstream;
```

Using a variable in `proxy_pass` forces nginx to consult the resolver on every request (cached for `valid` seconds). Docker's embedded DNS (`127.0.0.11`) always returns the current container IP.

## Test plan

- [ ] Rebuild only `control-api` on dev stack (new IP assigned)
- [ ] `curl http://100.87.157.74:15173/v1/auth/providers` → 200/redirect within 10s, not 502
- [ ] Frontend static assets still served correctly

Closes #487