### PR TITLE
[RUSAA-1551] fix(dev-watch): quote RB_SSH_AUTHORIZED_KEYS + add rebuild observability

### DIFF
--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -64,7 +64,7 @@ KAFKA_UI_HOST_PORT=18082
 # Public key(s) written to authorized_keys in the claude-login container.
 # The entrypoint refuses to start sshd if this is empty (security guard).
 # In production mount the key from a secret instead of committing it here.
-RB_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCUdbE1pviGKfQVGvmq0PZHXb8mqmmFSIy9vVQezU9f jarnura@mars-claude-login
+RB_SSH_AUTHORIZED_KEYS="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCUdbE1pviGKfQVGvmq0PZHXb8mqmmFSIy9vVQezU9f jarnura@mars-claude-login"
 
 # --- GitHub App ---
 # AES-256-GCM key used by control-api to encrypt GitHub App credentials before

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -31,22 +31,13 @@ LOG_DIR="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}"
 LOG_FILE="$LOG_DIR/dev-stack-rebuilds.ndjson"
 BYPASS_FILE="$REPO_ROOT/compose/.no-auto-rebuild"
 
-# Source the compose env-file into the shell so host-port overrides
-# (e.g. CONTROL_API_HOST_PORT=18080 on mars) are visible during health checks.
-# docker compose's --env-file flag only passes vars to containers, not to this shell.
-if [[ -n "${COMPOSE_ENV_FILE:-}" && -f "$COMPOSE_ENV_FILE" ]]; then
-  set -a
-  # shellcheck source=/dev/null
-  source "$COMPOSE_ENV_FILE"
-  set +a
-fi
-
 # -- Helpers -----------------------------------------------------------------
 
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 log_record() {
   local result="$1" health="$2" rebuilt_json="$3" reason="$4"
+  _LOG_WRITTEN=true
   local elapsed=$(( $(date +%s) - ELAPSED_START ))
   python3 -c "
 import json, sys
@@ -62,6 +53,57 @@ print(json.dumps({
 }))
 " "$START_TS" "$PREV_SHA" "$NEW_SHA" "$result" "$health" "$rebuilt_json" "$reason" "$elapsed" >> "$LOG_FILE"
 }
+
+# -- Early init: must precede COMPOSE_ENV_FILE sourcing so the EXIT trap can
+#    write a log record even when sourcing fails (e.g. unquoted values in env
+#    file that bash misparses as commands).
+# ---------------------------------------------------------------------------
+
+# Default SHAs for trap reporting; overwritten by flag parsing below.
+PREV_SHA="unknown"
+NEW_SHA="unknown"
+START_TS="$(ts)"
+ELAPSED_START="$(date +%s)"
+_LOG_WRITTEN=false
+mkdir -p "$LOG_DIR"
+
+_on_early_exit() {
+  local rc=$?
+  [[ $rc -eq 0 || "$_LOG_WRITTEN" == "true" ]] && return
+  local ts_now; ts_now="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")"
+  echo "[dev-stack-auto-rebuild] early exit rc=$rc at $ts_now (prev=${PREV_SHA} new=${NEW_SHA})" >&2
+  local elapsed=$(( $(date +%s) - ELAPSED_START ))
+  python3 -c "
+import json, sys
+print(json.dumps({
+  'timestamp': sys.argv[1],
+  'prev_sha':  sys.argv[2],
+  'new_sha':   sys.argv[3],
+  'result':    'failed',
+  'health':    '',
+  'rebuilt':   [],
+  'reason':    'early exit rc=' + sys.argv[4],
+  'elapsed_s': int(sys.argv[5]),
+}))
+" "$ts_now" "$PREV_SHA" "$NEW_SHA" "$rc" "$elapsed" >> "$LOG_FILE" 2>/dev/null || true
+}
+trap '_on_early_exit' EXIT
+
+# -- Source compose env-file -------------------------------------------------
+# docker compose's --env-file flag only passes vars to containers, not to this
+# shell. Source it here so host-port overrides (e.g. CONTROL_API_HOST_PORT=18080
+# on mars) are visible during health checks.
+#
+# IMPORTANT: values with spaces MUST be double-quoted in the env file
+# (e.g. RB_SSH_AUTHORIZED_KEYS="ssh-ed25519 …"). Unquoted multi-word values
+# are mis-parsed by bash as "VAR=first-word COMMAND args", causing a
+# command-not-found error that silently kills this script under set -e.
+if [[ -n "${COMPOSE_ENV_FILE:-}" && -f "$COMPOSE_ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$COMPOSE_ENV_FILE"
+  set +a
+fi
 
 post_gh_status() {
   local state="$1" desc="$2"
@@ -122,10 +164,6 @@ if [[ -z "$PREV_SHA" || -z "$NEW_SHA" ]]; then
   NEW_SHA="$(git rev-parse HEAD)"
   PREV_SHA="$(git rev-parse HEAD^1 2>/dev/null || git rev-parse "$(git rev-list --max-parents=0 HEAD)")"
 fi
-
-START_TS="$(ts)"
-ELAPSED_START="$(date +%s)"
-mkdir -p "$LOG_DIR"
 
 echo "[dev-stack-auto-rebuild] $START_TS  $PREV_SHA → $NEW_SHA"
 

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -33,6 +33,22 @@ REBUILD_SCRIPT="$SCRIPT_DIR/dev-stack-auto-rebuild.sh"
 # This is needed to inspect running container counts for cold-start detection.
 COMPOSE_CMD="${COMPOSE_CMD:-docker compose -f $REPO_ROOT/compose/dev.yml}"
 
+# Runs the rebuild script with all output tee'd to a timestamped log file so
+# failures are visible even when the rebuild script exits before its first echo.
+# Propagates the rebuild script's exit code to the caller.
+run_rebuild() {
+  local log="$STATE_DIR/rebuild-$(date +%Y%m%dT%H%M%S)-$$.log"
+  local rc
+  set +e
+  "$REBUILD_SCRIPT" "$@" 2>&1 | tee "$log"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    echo "[dev-stack-watch] rebuild exited $rc — log: $log" >&2
+  fi
+  return $rc
+}
+
 # Returns exit code 0 when zero compose services are currently running.
 stack_is_cold() {
   local running_ids
@@ -76,7 +92,7 @@ if stack_is_cold; then
   _cs_delay="${COLD_START_RETRY_DELAY:-30}"
   _cs_max="${COLD_START_MAX_ATTEMPTS:-5}"
   while [[ $_cs_attempt -le $_cs_max ]]; do
-    if "$REBUILD_SCRIPT" --cold-start "$LAST_KNOWN_SHA" "$LAST_KNOWN_SHA"; then
+    if run_rebuild --cold-start "$LAST_KNOWN_SHA" "$LAST_KNOWN_SHA"; then
       echo "[dev-stack-watch] cold start succeeded on attempt $_cs_attempt"
       break
     fi
@@ -125,12 +141,10 @@ while true; do
   # If the stack is fully stopped, force a cold start so infra services come up too.
   if stack_is_cold; then
     echo "[dev-stack-watch] stack is not running — triggering cold start: $PREV_SHA → $NEW_SHA"
-    "$REBUILD_SCRIPT" --cold-start "$PREV_SHA" "$NEW_SHA" || \
-      echo "[dev-stack-watch] cold start exited non-zero — see logs for details" >&2
+    run_rebuild --cold-start "$PREV_SHA" "$NEW_SHA" || true
   else
     echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
     # Never let a rebuild failure crash the watch loop.
-    "$REBUILD_SCRIPT" "$PREV_SHA" "$NEW_SHA" || \
-      echo "[dev-stack-watch] rebuild exited non-zero — see logs for details" >&2
+    run_rebuild "$PREV_SHA" "$NEW_SHA" || true
   fi
 done


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `compose/tailscale.env` `RB_SSH_AUTHORIZED_KEYS` was unquoted; bash mis-parsed the SSH key blob as a command when `dev-stack-auto-rebuild.sh` sourced it with `set -a` + `set -euo pipefail`, exiting rc=127 before any log output
- **Observability added**: `run_rebuild()` helper in `dev-stack-watch.sh` tees all output to `$STATE_DIR/rebuild-<ts>-<pid>.log`; EXIT trap in `dev-stack-auto-rebuild.sh` writes a NDJSON record on any unhandled early exit

## Migration type
N/A — no schema changes.

## What broke and why

`ba5c8d3` ([RUSAA-1537]) added `COMPOSE_ENV_FILE` to the systemd unit. This caused the rebuild script to `source compose/tailscale.env` for the first time in a systemd context. The unquoted line:
```
RB_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAA... jarnura@mars-claude-login
```
is valid for `docker compose --env-file` (which treats the whole RHS as a string), but bash parses it as `VAR=ssh-ed25519 COMMAND ARG`, so `AAAA...` is run as a command → not found → exit 127 under `set -e`. The script exited before its first `echo`, leaving no journal output and no NDJSON record. Five consecutive commits failed to deploy.

## Test plan

- [x] `bash -c 'set -euo pipefail; set -a; source compose/tailscale.env; set +a; echo OK'` → prints `OK`
- [x] `bash -n scripts/dev-stack-watch.sh` and `bash -n scripts/dev-stack-auto-rebuild.sh` → syntax OK
- [ ] After merge, the next poll cycle on mars will detect this commit, rebuild the stack, and append a successful NDJSON record — verified by `scripts/dev-stack-auto-rebuild.sh --logs 1`

Fixes #489