### PR TITLE
[RUSAA-1554] fix(frontend): accept boolean registered param on admin/github route

### DIFF
--- a/frontend/src/pages/AdminGithubPage.tsx
+++ b/frontend/src/pages/AdminGithubPage.tsx
@@ -65,9 +65,9 @@ export function AdminGithubPage(): JSX.Element {
 }
 
 function AdminGithubPageInner(): JSX.Element {
-  const search = useSearch({ strict: false }) as { registered?: string };
+  const search = useSearch({ strict: false }) as { registered?: boolean };
   const [showRegisteredBanner, setShowRegisteredBanner] = useState(
-    search.registered === "true",
+    search.registered === true,
   );
 
   const status = useGithubAppStatus({

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -158,7 +158,7 @@ const agentSessionReplayRoute = createRoute({
 });
 
 const adminGithubSearchSchema = z.object({
-  registered: z.enum(["true"]).optional(),
+  registered: z.boolean().optional(),
 });
 
 const adminGithubRoute = createRoute({


### PR DESCRIPTION
## Summary

- `router.tsx`: change `adminGithubSearchSchema` from `z.enum(["true"])` to `z.boolean()` — TanStack Router's `defaultParseSearch` coerces `?registered=true` to boolean `true`, not the string `"true"`, causing the Zod schema to reject it on every post-manifest redirect.
- `AdminGithubPage.tsx`: update the `useSearch` cast from `{ registered?: string }` to `{ registered?: boolean }` and the comparison from `=== "true"` to `=== true` so the success banner renders correctly.

No backend change required.

## GitHub Issue

Closes #491

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR