### PR TITLE
fix(dev-watch): initialize REBUILD_SERVICE assoc array to avoid nounset crash

### DIFF
--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -182,7 +182,7 @@ ALL_RUST_SERVICES=(
   control-api agent-runner parse-worker typecheck-worker ingest-graph ingest-clone
   expand-worker embed-worker projector-pg projector-neo4j tombstoner
 )
-declare -A REBUILD_SERVICE
+declare -A REBUILD_SERVICE=()
 REBUILD_FRONTEND=false
 
 mark_rust_service() { REBUILD_SERVICE["$1"]=true; }


### PR DESCRIPTION
Closes #493

## Summary

- `declare -A REBUILD_SERVICE` → `declare -A REBUILD_SERVICE=()` in `scripts/dev-stack-auto-rebuild.sh`
- In bash 5.2 (mars), an empty associative array declared without `=()` is treated as unbound when `set -u` is active
- This caused `${#REBUILD_SERVICE[@]}` at line 240 to abort with "unbound variable" on every run where no Rust service changed (e.g. frontend-only PRs)
- Practical impact: PR #492 frontend Zod fix merged at 16:28 UTC but the broken bundle was still live on mars 2+ hours later

## Root cause

```bash
# Reproducer on bash 5.2
bash -c 'set -euo pipefail; declare -A A; echo "${#A[@]}"'
# bash: line 1: A: unbound variable

bash -c 'set -euo pipefail; declare -A A=(); echo "${#A[@]}"'
# 0  ← correct
```

## Migration type

No schema migration.

## Test plan

- [ ] Run `bash -c 'set -euo pipefail; source scripts/dev-stack-auto-rebuild.sh --help 2>&1 || true'` — must not error on "unbound variable"
- [ ] Trigger a frontend-only change to origin/main and confirm dev-watch auto-rebuilds frontend on mars