### PR TITLE
[RUSAA-1561] fix(control-api): return 409 when installation belongs to a deactivated GitHub App

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -3046,7 +3046,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Repository already connected (repo_already_connected) */
+            /** @description Repository already connected (repo_already_connected) OR installation belongs to a deactivated App (installation_for_different_app) */
             readonly 409: {
                 headers: {
                     readonly [name: string]: unknown;

--- a/openapi.json
+++ b/openapi.json
@@ -1322,7 +1322,7 @@
             "description": "Installation not found or not owned by this tenant"
           },
           "409": {
-            "description": "Repository already connected (repo_already_connected)"
+            "description": "Repository already connected (repo_already_connected) OR installation belongs to a deactivated App (installation_for_different_app)"
           },
           "422": {
             "description": "Repository not accessible via installation (repo_not_accessible)"

--- a/services/control-api/src/error.rs
+++ b/services/control-api/src/error.rs
@@ -52,6 +52,8 @@ pub enum AppError {
     GithubInstallationConflict,
     #[error("repository is not accessible via the given installation")]
     RepoNotAccessible,
+    #[error("installation belongs to a different GitHub App; reinstall the active App to continue")]
+    InstallationForDifferentApp { install_url: String },
     #[error("repository is already connected to this tenant")]
     RepoAlreadyConnected,
     #[error("an ingestion run is already in progress for this repository")]
@@ -165,6 +167,14 @@ impl IntoResponse for AppError {
                 "repo_not_accessible",
                 self.to_string(),
             ),
+            AppError::InstallationForDifferentApp { install_url } => {
+                let body = Json(serde_json::json!({
+                    "error": "installation_for_different_app",
+                    "message": self.to_string(),
+                    "install_url": install_url,
+                }));
+                return (StatusCode::CONFLICT, body).into_response();
+            }
             AppError::RepoAlreadyConnected => (
                 StatusCode::CONFLICT,
                 "repo_already_connected",

--- a/services/control-api/src/routes/repos.rs
+++ b/services/control-api/src/routes/repos.rs
@@ -92,7 +92,7 @@ pub struct TriggerIngestResponse {
         (status = 401, description = "Not authenticated or session expired"),
         (status = 403, description = "Email not verified"),
         (status = 404, description = "Installation not found or not owned by this tenant"),
-        (status = 409, description = "Repository already connected (repo_already_connected)"),
+        (status = 409, description = "Repository already connected (repo_already_connected) OR installation belongs to a deactivated App (installation_for_different_app)"),
         (status = 422, description = "Repository not accessible via installation (repo_not_accessible)"),
         (status = 503, description = "GitHub App not configured on this instance"),
     ),
@@ -123,6 +123,35 @@ pub async fn connect_repo(
     .await?;
 
     let (numeric_installation_id,) = row.ok_or(AppError::NotFound)?;
+
+    // Mint the installation token before fetching the repo so that a
+    // "wrong App" failure produces a 409 instead of being swallowed into a
+    // generic 422/500.  If the active App has changed since this installation
+    // was created, GitHub returns 404/401 on the access_tokens endpoint.
+    match gh.installation_token(numeric_installation_id).await {
+        Ok(_) => {} // token is now cached; fetch_repo will reuse it
+        Err(GhError::ApiError {
+            status: 404 | 401, ..
+        }) => {
+            let slug: Option<(String,)> = sqlx::query_as(
+                "SELECT slug FROM control.github_app_config \
+                 WHERE is_active = true LIMIT 1",
+            )
+            .fetch_optional(&state.pool)
+            .await?;
+            let install_url = slug.map_or_else(
+                || "https://github.com/apps".to_owned(),
+                |(s,)| format!("https://github.com/apps/{s}/installations/new"),
+            );
+            tracing::warn!(
+                numeric_installation_id,
+                install_url = %install_url,
+                "installation token mint failed: installation belongs to a deactivated GitHub App"
+            );
+            return Err(AppError::InstallationForDifferentApp { install_url });
+        }
+        Err(other) => return Err(AppError::Internal(anyhow::anyhow!("{other}"))),
+    }
 
     let repo_info = gh
         .fetch_repo(numeric_installation_id, body.github_repo_id)

--- a/services/control-api/src/routes/repos_tests.rs
+++ b/services/control-api/src/routes/repos_tests.rs
@@ -98,6 +98,43 @@ fn github_500_maps_to_internal() {
     assert!(matches!(app_err, AppError::Internal(_)));
 }
 
+// ----- installation_for_different_app (RUSAA-1561) -----
+
+#[test]
+fn installation_for_different_app_returns_409() {
+    let err = AppError::InstallationForDifferentApp {
+        install_url: "https://github.com/apps/rustacean-alpha-2/installations/new".to_owned(),
+    };
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[test]
+fn installation_for_different_app_error_message() {
+    let err = AppError::InstallationForDifferentApp {
+        install_url: "https://github.com/apps/test-app/installations/new".to_owned(),
+    };
+    assert!(err.to_string().contains("different GitHub App"));
+}
+
+#[test]
+fn installation_token_404_maps_to_installation_for_different_app_not_repo_not_accessible() {
+    // A 404 from the token-mint step (wrong App) must NOT map to RepoNotAccessible.
+    // The handler now calls installation_token() first; this test documents the
+    // distinction between "mint failed" (installation_for_different_app) vs
+    // "repo not found" (repo_not_accessible — returned only after a successful mint).
+    let install_url = "https://github.com/apps/rustacean-alpha-2/installations/new".to_owned();
+    let err = AppError::InstallationForDifferentApp {
+        install_url: install_url.clone(),
+    };
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    // The plain RepoNotAccessible is 422, confirming the two errors are distinct.
+    let accessible_err = AppError::RepoNotAccessible;
+    let accessible_resp = accessible_err.into_response();
+    assert_eq!(accessible_resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
 #[test]
 fn default_branch_override_takes_priority() {
     let override_branch = "develop".to_owned();

--- a/services/control-api/src/routes/repos_tests.rs
+++ b/services/control-api/src/routes/repos_tests.rs
@@ -98,7 +98,7 @@ fn github_500_maps_to_internal() {
     assert!(matches!(app_err, AppError::Internal(_)));
 }
 
-// ----- installation_for_different_app (RUSAA-1561) -----
+// ----- installation_for_different_app -----
 
 #[test]
 fn installation_for_different_app_returns_409() {


### PR DESCRIPTION
## Summary

- Fixes a 500 (or misleading 422) on `POST /v1/repos` when the supplied installation belongs to a deactivated GitHub App.
- Adds `AppError::InstallationForDifferentApp { install_url }` → **409 Conflict** with a structured JSON body so the UI can render a one-click reinstall link.
- Splits the token-mint step out of `fetch_repo` in `connect_repo` so orphaned-installation failures are distinguished from repo-not-found failures.

## GitHub Issue

Closes #499

## What Changed

**`services/control-api/src/error.rs`**
- New variant `InstallationForDifferentApp { install_url: String }` with a custom 409 response body that includes `install_url`.

**`services/control-api/src/routes/repos.rs`**
- In `connect_repo`: explicitly calls `gh.installation_token()` before `gh.fetch_repo()`.  
  On 404/401 from the token endpoint: queries `control.github_app_config` for the active App slug, builds the install URL, returns `InstallationForDifferentApp`.
- Updated `utoipa` doc comment to document the 409 variant.

**`services/control-api/src/routes/repos_tests.rs`**
- 3 new unit tests covering: 409 status code, error message text, and distinction from `RepoNotAccessible` (422).

## Response shape

```json
{
  "error": "installation_for_different_app",
  "message": "installation belongs to a different GitHub App; reinstall the active App to continue",
  "install_url": "https://github.com/apps/rustacean-alpha-2/installations/new"
}
```

## Checklist
- [x] `cargo clippy -p control-api --lib -- -D warnings` passes
- [x] `cargo-locked test -p control-api --lib` passes (397 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes
- [x] No tracker IDs in source or commits