### PR TITLE
[RUSAA-1566] fix(frontend/nginx): add Cache-Control headers to prevent stale HTML caching

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -33,8 +33,24 @@ server {
         proxy_set_header Host $host;
     }
 
-    # SPA fallback: unknown paths serve index.html
+    # index.html must always revalidate so deploys are immediately visible.
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        try_files $uri =404;
+    }
+
+    # Content-hashed assets are immutable — safe to cache forever.
+    # Vite outputs filenames like index-CoKgYETv.js; a new deploy changes the
+    # hash, the new HTML references the new name, so the old entry is never hit.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    # SPA fallback: unknown paths serve index.html with the same no-cache rule.
     location / {
+        add_header Cache-Control "no-cache, must-revalidate" always;
         try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## Summary

Without `Cache-Control` headers, browsers apply RFC 7234 heuristic caching (10% × age since `Last-Modified`). HTML served ~3 hours after a deploy got a ~20-minute heuristic TTL, causing users to see stale HTML referencing old content-hashed bundle filenames.

This adds a three-location cache policy to `docker/frontend/nginx.conf`:

| Location | Policy | Rationale |
|---|---|---|
| `= /index.html` | `no-cache, must-revalidate` | Revalidate on every navigation; deploy is immediately visible |
| `/assets/` | `public, max-age=31536000, immutable` | Vite content-hashes guarantee stale-free permanent caching |
| `/` (SPA fallback) | `no-cache, must-revalidate` | Same as index.html for any path that falls through |

`Pragma: no-cache` added to `index.html` location for HTTP/1.0 proxy compat.

## GitHub Issue
Closes #501

## Checklist
- [x] No Rust changes — no `cargo test` / `cargo clippy` needed
- [x] Config-only change to `docker/frontend/nginx.conf`
- [x] Acceptance criteria from issue verified locally (curl checks below)

## Acceptance Verification

After rebuild:
```
curl -I http://<frontend>/
# → Cache-Control: no-cache, must-revalidate

curl -I http://<frontend>/admin/github
# → Cache-Control: no-cache, must-revalidate

curl -I http://<frontend>/assets/index-<hash>.js
# → Cache-Control: public, max-age=31536000, immutable
```

## Migration type
N/A — config-only, no schema changes.