### PR TITLE
[RUSAA-1567] fix(frontend): track per-stage state in ingestion theatre, show all 9 pipeline stages

### DIFF
--- a/frontend/e2e/ingestion-theatre.spec.ts
+++ b/frontend/e2e/ingestion-theatre.spec.ts
@@ -26,6 +26,18 @@ async function setupPage(page: import("@playwright/test").Page): Promise<void> {
   await mockSseStream(page);
 }
 
+const STAGE_LABELS: Array<[stage: string, label: string]> = [
+  ["clone", "Clone"],
+  ["expand", "Expand"],
+  ["parse", "Parse"],
+  ["typecheck", "Typecheck"],
+  ["extract", "Extract"],
+  ["embed", "Embed"],
+  ["project_pg", "Project (PostgreSQL)"],
+  ["project_neo4j", "Project (Neo4j)"],
+  ["project_qdrant", "Project (Qdrant)"],
+];
+
 test.describe("Ingestion Theatre — empty state", () => {
   test("renders empty state when no events on the bus", async ({ page }) => {
     await setupPage(page);
@@ -42,16 +54,15 @@ test.describe("Ingestion Theatre — empty state", () => {
     ).toBeVisible();
   });
 
-  test("empty state shows all 6 pipeline stages as pending", async ({
+  test("empty state shows all 9 pipeline stages as pending", async ({
     page,
   }) => {
     await setupPage(page);
     await page.goto("/ingestion");
 
-    const stages = ["clone", "expand", "parse", "typecheck", "graph", "embed"];
-    for (const stage of stages) {
+    for (const [, label] of STAGE_LABELS) {
       await expect(
-        page.getByRole("listitem").filter({ hasText: stage }),
+        page.getByRole("listitem").filter({ hasText: label }),
       ).toBeVisible();
     }
   });
@@ -84,37 +95,37 @@ test.describe("Ingestion Theatre — live events", () => {
     await mockSseStream(page, [
       "id: evt-1\n",
       "event: ingest.status\n",
-      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","error_message":"","occurred_at_ms":1700000001000}\n',
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","stage":"clone","stage_seq":0,"ingest_run_id":"run-1","error_message":"","occurred_at_ms":1700000001000}\n',
       "\n",
     ]);
 
     await page.goto("/ingestion");
     await expect(page.getByTestId("ingestion-active-state")).toBeVisible();
 
-    const cloneItem = page.getByRole("listitem").filter({ hasText: "clone" });
+    const cloneItem = page.getByRole("listitem").filter({ hasText: "Clone" });
     await expect(cloneItem).toBeVisible();
     await expect(
-      cloneItem.getByRole("img", { name: "clone stage: Running" }),
+      cloneItem.getByRole("img", { name: "Clone stage: Running" }),
     ).toBeVisible();
   });
 
-  test("done event flips all stages to done", async ({ page }) => {
+  test("done events per stage show each stage as done", async ({ page }) => {
     await mockAuthenticatedSession(page);
-    await mockSseStream(page, [
-      "id: evt-2\n",
-      "event: ingest.status\n",
-      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"done","error_message":"","occurred_at_ms":1700000002000}\n',
-      "\n",
+    const stageEvents: string[] = STAGE_LABELS.flatMap(([stage], i) => [
+      `id: evt-${i + 1}\n`,
+      `event: ingest.status\n`,
+      `data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"done","stage":"${stage}","stage_seq":${i},"ingest_run_id":"run-1","error_message":"","occurred_at_ms":${1700000002000 + i}}\n`,
+      `\n`,
     ]);
+    await mockSseStream(page, stageEvents);
 
     await page.goto("/ingestion");
     await expect(page.getByTestId("ingestion-active-state")).toBeVisible();
 
-    const stages = ["clone", "expand", "parse", "typecheck", "graph", "embed"];
-    for (const stage of stages) {
-      const item = page.getByRole("listitem").filter({ hasText: stage });
+    for (const [, label] of STAGE_LABELS) {
+      const item = page.getByRole("listitem").filter({ hasText: label });
       await expect(
-        item.getByRole("img", { name: `${stage} stage: Done` }),
+        item.getByRole("img", { name: `${label} stage: Done` }),
       ).toBeVisible();
     }
   });
@@ -126,7 +137,7 @@ test.describe("Ingestion Theatre — live events", () => {
     await mockSseStream(page, [
       "id: evt-3\n",
       "event: ingest.status\n",
-      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","error_message":"","occurred_at_ms":1700000003000}\n',
+      'data: {"ingest_request_id":"req-1","tenant_id":"tenant-1","status":"processing","stage":"clone","stage_seq":0,"ingest_run_id":"run-1","error_message":"","occurred_at_ms":1700000003000}\n',
       "\n",
     ]);
 
@@ -155,4 +166,3 @@ test.describe("Ingestion Theatre — auth gate", () => {
     await expect(page.locator("text=Sign in to view ingestion progress")).toBeVisible();
   });
 });
-

--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -7,8 +7,11 @@ const PIPELINE_STAGES = [
   "expand",
   "parse",
   "typecheck",
-  "graph",
+  "extract",
   "embed",
+  "project_pg",
+  "project_neo4j",
+  "project_qdrant",
 ] as const;
 
 type PipelineStage = (typeof PIPELINE_STAGES)[number];
@@ -27,12 +30,29 @@ interface IngestStatusEvent {
   status: IngestStatus;
   error_message: string;
   occurred_at_ms: number;
+  stage: string | null;
+  stage_seq: number;
+  ingest_run_id: string;
 }
 
 interface StageState {
   readonly stage: PipelineStage;
   readonly status: StageStatus;
 }
+
+const STAGE_LABELS: Record<PipelineStage, string> = {
+  clone: "Clone",
+  expand: "Expand",
+  parse: "Parse",
+  typecheck: "Typecheck",
+  extract: "Extract",
+  embed: "Embed",
+  project_pg: "Project (PostgreSQL)",
+  project_neo4j: "Project (Neo4j)",
+  project_qdrant: "Project (Qdrant)",
+};
+
+const PIPELINE_STAGE_SET = new Set<string>(PIPELINE_STAGES);
 
 function parseIngestEvent(raw: string): IngestStatusEvent | null {
   try {
@@ -42,41 +62,36 @@ function parseIngestEvent(raw: string): IngestStatusEvent | null {
   }
 }
 
+function mapIngestStatus(status: IngestStatus): StageStatus | null {
+  switch (status) {
+    case "processing":
+      return "running";
+    case "done":
+      return "done";
+    case "failed":
+      return "error";
+    default:
+      return null;
+  }
+}
+
 function deriveStageStates(
   events: ReadonlyArray<{ data: string }>,
 ): StageState[] {
-  const initial: StageState[] = PIPELINE_STAGES.map((stage) => ({
-    stage,
-    status: "pending",
-  }));
+  const byStage = new Map<string, StageStatus>(
+    PIPELINE_STAGES.map((s) => [s, "pending"]),
+  );
 
-  if (events.length === 0) return initial;
-
-  const parsed = events
-    .map((e) => parseIngestEvent(e.data))
-    .filter((e): e is IngestStatusEvent => e !== null);
-
-  if (parsed.length === 0) return initial;
-
-  const latest = parsed[parsed.length - 1];
-  if (!latest) return initial;
-
-  switch (latest.status) {
-    case "processing":
-      return PIPELINE_STAGES.map((stage, i) => ({
-        stage,
-        status: i === 0 ? "running" : "pending",
-      }));
-    case "done":
-      return PIPELINE_STAGES.map((stage) => ({ stage, status: "done" }));
-    case "failed":
-      return PIPELINE_STAGES.map((stage, i) => ({
-        stage,
-        status: i === 0 ? "error" : "pending",
-      }));
-    default:
-      return initial;
+  for (const raw of events) {
+    const e = parseIngestEvent(raw.data);
+    if (!e || !e.stage || !PIPELINE_STAGE_SET.has(e.stage)) continue;
+    const stageStatus = mapIngestStatus(e.status);
+    if (stageStatus !== null) {
+      byStage.set(e.stage, stageStatus);
+    }
   }
+
+  return PIPELINE_STAGES.map((s) => ({ stage: s, status: byStage.get(s)! }));
 }
 
 const STATUS_LABEL: Record<StageStatus, string> = {
@@ -108,12 +123,13 @@ interface StageRowProps {
 }
 
 function StageRow({ state, index, isLast }: StageRowProps): JSX.Element {
+  const label = STAGE_LABELS[state.stage];
   return (
     <li className="flex items-start gap-4">
       <div className="flex flex-col items-center">
         <div
           role="img"
-          aria-label={`${state.stage} stage: ${STATUS_LABEL[state.status]}`}
+          aria-label={`${label} stage: ${STATUS_LABEL[state.status]}`}
           className={STATUS_INDICATOR[state.status]}
         />
         {!isLast && (
@@ -124,13 +140,13 @@ function StageRow({ state, index, isLast }: StageRowProps): JSX.Element {
         )}
       </div>
       <div className="pb-8 last:pb-0">
-        <p className="text-sm font-medium capitalize">{state.stage}</p>
+        <p className="text-sm font-medium">{label}</p>
         <p className={`text-xs ${STATUS_COLOR[state.status]}`}>
           {STATUS_LABEL[state.status]}
         </p>
       </div>
       <span className="sr-only">
-        Step {index + 1} of {PIPELINE_STAGES.length}: {state.stage},{" "}
+        Step {index + 1} of {PIPELINE_STAGES.length}: {label},{" "}
         {STATUS_LABEL[state.status]}
       </span>
     </li>


### PR DESCRIPTION
## Summary

- Replace 6-stage placeholder list (`clone, expand, parse, typecheck, graph, embed`) with the real 9 backend stages matching `trigger.rs PIPELINE_STAGES`: `clone, expand, parse, typecheck, extract, embed, project_pg, project_neo4j, project_qdrant`
- Rewrite `deriveStageStates` to maintain a `Map<stage, StageStatus>` updated per `event.stage`, instead of deriving all stages from the latest event's `status` field
- Add `STAGE_LABELS` map with human-readable names for `extract`, `project_pg`, `project_neo4j`, `project_qdrant`
- Add `mapIngestStatus` helper; `PIPELINE_STAGE_SET` for O(1) membership check

**Root cause of flicker**: every `processing` event previously reset clone to running and all others to pending; every `done` event flipped all stages to done. With 9 real stages emitting processing/done pairs, that alternation fired continuously and left the UI in the wrong state for 8 minutes after the displayed 6 stages completed.

## GitHub Issue

Closes #503

## Before / After

**Before**: 6 stages, `graph` placeholder, whole-pipeline resets on every event.

**After**: 9 stages, each stage tracks its own last-seen status, UI moves stage-by-stage pending → running → done with no jumps.

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR