### PR TITLE
[RUSAA-1573] fix(dev-stack-auto-rebuild): init REBUILD_SERVICE as empty array to prevent unbound variable crash

### DIFF
--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -182,7 +182,7 @@ ALL_RUST_SERVICES=(
   control-api agent-runner parse-worker typecheck-worker ingest-graph ingest-clone
   expand-worker embed-worker projector-pg projector-neo4j tombstoner
 )
-declare -A REBUILD_SERVICE
+declare -A REBUILD_SERVICE=()
 REBUILD_FRONTEND=false
 
 mark_rust_service() { REBUILD_SERVICE["$1"]=true; }


### PR DESCRIPTION
## Summary

- `declare -A REBUILD_SERVICE` → `declare -A REBUILD_SERVICE=()`: one character fix
- bash `set -u` treats an uninitialised associative array as unbound when `${#arr[@]}` is evaluated; explicit `=()` prevents this
- Frontend-only commits (no Rust service file touched) never populate `REBUILD_SERVICE`; `${#REBUILD_SERVICE[@]}` on line 240 raised early exit rc=1, silently skipping the frontend rebuild

## GitHub Issue

Closes #507

## Checklist

- [x] No Rust compilation changes — shell-only fix
- [x] No `RUSAA-XX` outside the title bracket prefix