### PR TITLE
[RUSAA-1573] fix: REBUILD_SERVICE unbound variable on frontend-only commits

### DIFF
--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -182,7 +182,7 @@ ALL_RUST_SERVICES=(
   control-api agent-runner parse-worker typecheck-worker ingest-graph ingest-clone
   expand-worker embed-worker projector-pg projector-neo4j tombstoner
 )
-declare -A REBUILD_SERVICE
+declare -A REBUILD_SERVICE=()
 REBUILD_FRONTEND=false
 
 mark_rust_service() { REBUILD_SERVICE["$1"]=true; }


### PR DESCRIPTION
## Summary

- `declare -A REBUILD_SERVICE` without `=()` is treated as unbound by bash `set -u` when the array is never populated (frontend-only commits)
- Fixes the early-exit crash that prevented frontend rebuilds for PRs #502 and #504
- One-character change: add explicit empty initializer `=()`

## GitHub Issue

Closes #506

## Migration type

N/A — script-only change, no schema migrations.

## Checklist
- [x] No Rust source changes — no cargo test/clippy needed
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Docs unchanged (no architecture change)