### PR TITLE
[RUSAA-1574] fix(control-api): return 409 for orphaned installation on available-repos endpoint

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -2687,6 +2687,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Installation belongs to a deactivated App (installation_for_different_app) */
+            readonly 409: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description GitHub App not configured on this instance */
             readonly 503: {
                 headers: {

--- a/openapi.json
+++ b/openapi.json
@@ -1000,6 +1000,9 @@
           "404": {
             "description": "Installation not found or not owned by this tenant"
           },
+          "409": {
+            "description": "Installation belongs to a deactivated App (installation_for_different_app)"
+          },
           "503": {
             "description": "GitHub App not configured on this instance"
           }

--- a/services/control-api/src/routes/github/repos.rs
+++ b/services/control-api/src/routes/github/repos.rs
@@ -5,6 +5,7 @@ use axum::{
     extract::{Path, Query, State},
     response::IntoResponse,
 };
+use rb_github::GhError;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -65,6 +66,7 @@ pub struct ListReposResponse {
         (status = 401, description = "Not authenticated or session expired"),
         (status = 403, description = "Email not verified"),
         (status = 404, description = "Installation not found or not owned by this tenant"),
+        (status = 409, description = "Installation belongs to a deactivated App (installation_for_different_app)"),
         (status = 503, description = "GitHub App not configured on this instance"),
     ),
     tag = "github"
@@ -99,6 +101,35 @@ pub async fn list_available_repos(
         return Err(AppError::NotFound);
     };
 
+    // Mint the installation token first so a "wrong App" failure produces a
+    // 409 instead of being swallowed into a generic 500.  If the active App
+    // has changed since this installation was created, GitHub returns 404/401
+    // on the access_tokens endpoint.
+    match gh.installation_token(github_installation_id).await {
+        Ok(_) => {} // token is now cached; list_installation_repos will reuse it
+        Err(GhError::ApiError {
+            status: 404 | 401, ..
+        }) => {
+            let slug: Option<(String,)> = sqlx::query_as(
+                "SELECT slug FROM control.github_app_config \
+                 WHERE is_active = true LIMIT 1",
+            )
+            .fetch_optional(&state.pool)
+            .await?;
+            let install_url = slug.map_or_else(
+                || "https://github.com/apps".to_owned(),
+                |(s,)| format!("https://github.com/apps/{s}/installations/new"),
+            );
+            tracing::warn!(
+                github_installation_id,
+                install_url = %install_url,
+                "installation token mint failed: installation belongs to a deactivated GitHub App"
+            );
+            return Err(AppError::InstallationForDifferentApp { install_url });
+        }
+        Err(other) => return Err(AppError::Internal(anyhow::anyhow!("{other}"))),
+    }
+
     let page_data = gh
         .list_installation_repos(github_installation_id, page, per_page)
         .await
@@ -125,4 +156,89 @@ pub async fn list_available_repos(
         per_page,
         repositories,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use crate::error::AppError;
+
+    #[test]
+    fn installation_for_different_app_returns_409() {
+        let err = AppError::InstallationForDifferentApp {
+            install_url: "https://github.com/apps/rustacean-dev-4/installations/new".to_owned(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn token_mint_404_maps_to_installation_for_different_app_not_internal() {
+        // A 404 from the token-mint step must map to InstallationForDifferentApp
+        // (409), not Internal (500).  This mirrors the same invariant tested in
+        // routes/repos_tests.rs for the POST /v1/repos endpoint.
+        use rb_github::GhError;
+        let err = GhError::ApiError {
+            status: 404,
+            body: r#"{"message":"Integration not found"}"#.to_owned(),
+        };
+        let app_err = match err {
+            GhError::ApiError {
+                status: 404 | 401, ..
+            } => AppError::InstallationForDifferentApp {
+                install_url: "https://github.com/apps/test/installations/new".to_owned(),
+            },
+            other => AppError::Internal(anyhow::anyhow!("{other}")),
+        };
+        assert!(matches!(
+            app_err,
+            AppError::InstallationForDifferentApp { .. }
+        ));
+        assert_eq!(app_err.into_response().status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn token_mint_401_maps_to_installation_for_different_app() {
+        use rb_github::GhError;
+        let err = GhError::ApiError {
+            status: 401,
+            body: r#"{"message":"Not Found"}"#.to_owned(),
+        };
+        let app_err = match err {
+            GhError::ApiError {
+                status: 404 | 401, ..
+            } => AppError::InstallationForDifferentApp {
+                install_url: "https://github.com/apps/test/installations/new".to_owned(),
+            },
+            other => AppError::Internal(anyhow::anyhow!("{other}")),
+        };
+        assert!(matches!(
+            app_err,
+            AppError::InstallationForDifferentApp { .. }
+        ));
+    }
+
+    #[test]
+    fn token_mint_500_maps_to_internal() {
+        use rb_github::GhError;
+        let err = GhError::ApiError {
+            status: 500,
+            body: "Server Error".to_owned(),
+        };
+        let app_err = match err {
+            GhError::ApiError {
+                status: 404 | 401, ..
+            } => AppError::InstallationForDifferentApp {
+                install_url: "https://github.com/apps/test/installations/new".to_owned(),
+            },
+            other => AppError::Internal(anyhow::anyhow!("{other}")),
+        };
+        assert!(matches!(app_err, AppError::Internal(_)));
+        assert_eq!(
+            app_err.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `GET /v1/github/installations/{id}/available-repos` was returning 500 for
  orphaned installations (where the installation was created against a now-deactivated
  GitHub App).
- Added the same orphan-detection pattern used in `POST /v1/repos` (PR #500):
  call `gh.installation_token()` before `list_installation_repos()`, map
  GitHub 404/401 responses to `AppError::InstallationForDifferentApp` (409).
- Added 409 to the utoipa path docs and four unit tests documenting the
  error-mapping invariants.

## GitHub Issue

Closes #510

## Checklist

- [x] `cargo test -p control-api --lib` passes (405 tests)
- [x] `cargo clippy -p control-api --lib -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes
- [x] No tracker IDs outside the title bracket prefix