### PR TITLE
[RUSAA-1577] fix(frontend): show Re-install button on 409 in AvailableReposError

### DIFF
--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -372,6 +372,8 @@ function InstallStep(): JSX.Element {
 function AvailableReposError({ error }: { readonly error: unknown }): JSX.Element {
   const installUrl = useGithubInstallUrl();
   const status = (error as { status?: number } | null)?.status;
+  const bodyInstallUrl = (error as { body?: { install_url?: string } } | null)?.body
+    ?.install_url;
 
   const handleReinstall = async () => {
     try {
@@ -382,20 +384,25 @@ function AvailableReposError({ error }: { readonly error: unknown }): JSX.Elemen
     }
   };
 
-  if (status === 404) {
+  if (status === 404 || status === 409) {
+    const handleClick = bodyInstallUrl
+      ? () => window.location.assign(bodyInstallUrl)
+      : handleReinstall;
+
     return (
       <div className="flex flex-col gap-3">
         <p className="text-sm text-destructive">
-          This GitHub installation is not accessible from your workspace. It may be linked to a
-          different account. Re-install the GitHub App to connect repositories for this workspace.
+          {status === 409
+            ? "This installation belongs to a different GitHub App. Re-install the active App to continue."
+            : "This GitHub installation is not accessible from your workspace. It may be linked to a different account. Re-install the GitHub App to connect repositories for this workspace."}
         </p>
         <button
           type="button"
-          disabled={installUrl.isPending}
-          onClick={handleReinstall}
+          disabled={!bodyInstallUrl && installUrl.isPending}
+          onClick={handleClick}
           className="self-start rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {installUrl.isPending ? "Generating link…" : "Re-install GitHub App →"}
+          {!bodyInstallUrl && installUrl.isPending ? "Generating link…" : "Re-install GitHub App →"}
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary

`AvailableReposError` only rendered the actionable **Re-install GitHub App →** button for 404 responses. After the backend was updated to return 409 for orphaned-installation cases, the component fell through to a plain text error with no path forward for the user.

Changes:
- Extend the actionable branch from `status === 404` to `status === 404 || status === 409`
- Extract `body.install_url` from the 409 response; navigate directly if present, otherwise fall back to `useGithubInstallUrl()` state-token flow
- Show a 409-specific message: _"This installation belongs to a different GitHub App. Re-install the active App to continue."_
- 404 message and button behaviour unchanged

## GitHub Issue

Closes #512

## Screenshots

**Before** (409): Generic one-line error, no button.
**After** (409): Descriptive error + Re-install GitHub App → button that opens the install URL directly from the response body.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] No internal tracker IDs in source, commits, or PR body
- [x] One REQ per PR