### PR TITLE
[RUSAA-1579] fix(frontend): always use state-token flow for Re-install button

### DIFF
--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -372,8 +372,6 @@ function InstallStep(): JSX.Element {
 function AvailableReposError({ error }: { readonly error: unknown }): JSX.Element {
   const installUrl = useGithubInstallUrl();
   const status = (error as { status?: number } | null)?.status;
-  const bodyInstallUrl = (error as { body?: { install_url?: string } } | null)?.body
-    ?.install_url;
 
   const handleReinstall = async () => {
     try {
@@ -385,10 +383,6 @@ function AvailableReposError({ error }: { readonly error: unknown }): JSX.Elemen
   };
 
   if (status === 404 || status === 409) {
-    const handleClick = bodyInstallUrl
-      ? () => window.location.assign(bodyInstallUrl)
-      : handleReinstall;
-
     return (
       <div className="flex flex-col gap-3">
         <p className="text-sm text-destructive">
@@ -398,11 +392,11 @@ function AvailableReposError({ error }: { readonly error: unknown }): JSX.Elemen
         </p>
         <button
           type="button"
-          disabled={!bodyInstallUrl && installUrl.isPending}
-          onClick={handleClick}
+          disabled={installUrl.isPending}
+          onClick={handleReinstall}
           className="self-start rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {!bodyInstallUrl && installUrl.isPending ? "Generating link…" : "Re-install GitHub App →"}
+          {installUrl.isPending ? "Generating link…" : "Re-install GitHub App →"}
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary

- Drop the `bodyInstallUrl` branch in `AvailableReposError` — the 409 response body's `install_url` is a plain GitHub URL with no `?state=` parameter
- The callback's no-state-token branch short-circuits to `/repos` without creating a `github_installations` row, leaving the user in the same broken state
- Always route through `useGithubInstallUrl()` so a state token is minted and the callback creates the installation row

## Root cause

`AvailableReposError` preferred `body.install_url` from the 409 when present. Backend builds this as the plain install URL with no state. `github_callback` requires a valid state token to create the installation row; without one it redirects silently to `/repos`.

## GitHub Issue

Closes #514

## Checklist

- [x] `npm run typecheck` passes (pre-existing `EventVirtualList` errors unrelated to this change)
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes — schema in sync
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR