### PR TITLE
[RUSAA-1580] fix(frontend): theatre initial-state hydration + activity page polling

### DIFF
--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -59,7 +59,14 @@ function ActivityPageInner({ tenantId }: ActivityPageInnerProps): JSX.Element {
   const allAudit = useAuditEvents(tenantId, { limit: 200 });
   const userAudit = useAuditEvents(tenantId, { limit: 100 });
   const queryAudit = useAuditEvents(tenantId, { action: "search.executed", limit: 50 });
-  const recentIngestions = useRecentIngestions(tenantId);
+  const recentIngestions = useRecentIngestions(tenantId, 50, {
+    refetchInterval: (query) => {
+      const hasActive = query.state.data?.runs.some(
+        (r) => r.status === "running" || r.status === "queued",
+      );
+      return hasActive ? 10_000 : false;
+    },
+  });
   const invalidateIngestions = useInvalidateRecentIngestions();
 
   const { events, readyState } = useEventStream(`${apiBase}/v1/ingest/events`, ["ingest.status"]);

--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -1,6 +1,8 @@
 import { useMe } from "@/api";
+import { apiClient } from "@/api/client";
 import { PageContainer } from "@/components/repos/PageContainer";
 import { useEventStream } from "@/hooks/useEventStream";
+import { useEffect, useState } from "react";
 
 const PIPELINE_STAGES = [
   "clone",
@@ -75,11 +77,25 @@ function mapIngestStatus(status: IngestStatus): StageStatus | null {
   }
 }
 
+function mapRestStageStatus(status: string): StageStatus {
+  switch (status) {
+    case "running":
+      return "running";
+    case "succeeded":
+      return "done";
+    case "failed":
+      return "error";
+    default:
+      return "pending";
+  }
+}
+
 function deriveStageStates(
   events: ReadonlyArray<{ data: string }>,
+  seed?: ReadonlyMap<string, StageStatus>,
 ): StageState[] {
   const byStage = new Map<string, StageStatus>(
-    PIPELINE_STAGES.map((s) => [s, "pending"]),
+    PIPELINE_STAGES.map((s) => [s, seed?.get(s) ?? "pending"]),
   );
 
   for (const raw of events) {
@@ -160,9 +176,48 @@ function IngestionTheatreInner(): JSX.Element {
     ["ingest.status"],
   );
 
+  const [seedStages, setSeedStages] = useState<ReadonlyMap<string, StageStatus> | undefined>(undefined);
+  const [seededRunId, setSeededRunId] = useState<string | null>(null);
+
+  // On mount, hydrate stage state from REST so stages completed before SSE
+  // connection are shown correctly rather than stuck at "Pending".
+  useEffect(() => {
+    let cancelled = false;
+    async function hydrate() {
+      const { data, error } = await apiClient.GET("/v1/ingestions/recent", {
+        params: { query: { limit: 5 } },
+      });
+      if (error || !data || cancelled) return;
+      const activeRun = data.runs.find(
+        (r) => r.status === "running" || r.status === "queued",
+      );
+      if (!activeRun) return;
+      const { data: timeline } = await apiClient.GET(
+        "/v1/ingestions/{ingestion_run_id}/stages",
+        { params: { path: { ingestion_run_id: activeRun.id } } },
+      );
+      if (!timeline || cancelled) return;
+      const map = new Map<string, StageStatus>(
+        timeline.stages.map((s) => [s.stage, mapRestStageStatus(s.status)]),
+      );
+      setSeedStages(map);
+      setSeededRunId(activeRun.id);
+    }
+    void hydrate();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Once SSE delivers events for the seeded run, drop the seed so later runs
+  // don't inherit stale state.
   const ingestEvents = events.filter((e) => e.type === "ingest.status");
-  const stageStates = deriveStageStates(ingestEvents);
-  const hasEvents = ingestEvents.length > 0;
+  const activeSseRunId = ingestEvents.length > 0
+    ? (parseIngestEvent(ingestEvents[ingestEvents.length - 1]!.data)?.ingest_run_id ?? null)
+    : null;
+  const effectiveSeed = activeSseRunId === null || activeSseRunId === seededRunId ? seedStages : undefined;
+
+  const stageStates = deriveStageStates(ingestEvents, effectiveSeed);
+  const hasEvents = ingestEvents.length > 0 || effectiveSeed !== undefined;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -205,7 +205,6 @@ function IngestionTheatreInner(): JSX.Element {
     }
     void hydrate();
     return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Once SSE delivers events for the seeded run, drop the seed so later runs


### PR DESCRIPTION
## Changes

### 1. Theatre initial-state hydration

**Problem**: Opening Ingestion Theatre after an ingestion has started shows all stages as **Pending** — SSE only delivers events from connection time, not replaying earlier ones.

**Fix**: On mount, `IngestionTheatreInner` fetches `/v1/ingestions/recent?limit=5` to find the most recent running/queued run, then fetches `/v1/ingestions/{id}/stages` to seed the stage map. SSE events overlay on top. If the SSE run ID differs from the seeded run, the seed is discarded so state doesn't bleed across runs.

### 2. Activity page polling while run is active

**Problem**: `useRecentIngestions` had `staleTime: 30s` with no `refetchInterval`, so `started_at`/`finished_at` could be stale for up to 30s during an active run.

**Fix**: Added `refetchInterval` that polls every 10s only when a `running` or `queued` run is present. Idle workspaces pay no extra cost. SSE invalidation on completion still fires.

Fixes #519

## Test plan

- [ ] Start ingestion, wait ~30s, navigate away and back to `/theatre` → clone+expand should show Done immediately
- [ ] Theatre continues updating via SSE for remaining stages
- [ ] Empty state correct when no active run
- [ ] Activity `/activity` page: `finished_at` column updates during active ingestion (no longer frozen for 30s)