### PR TITLE
[RUSAA-1595] fix(frontend): surface actionable error for email_not_verified on repos callback

### DIFF
--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -25,8 +25,15 @@ import { PageContainer } from "@/components/repos/PageContainer";
 // ReposPage — entry point
 // ---------------------------------------------------------------------------
 
+function isEmailNotVerifiedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const body = (error as { body?: { error?: string } }).body;
+  return body?.error === "email_not_verified";
+}
+
 export function ReposPage(): JSX.Element {
   const me = useMe({ retry: false });
+  const search = useSearch({ from: routes.repos });
 
   if (me.isLoading) {
     return (
@@ -37,6 +44,25 @@ export function ReposPage(): JSX.Element {
   }
 
   if (me.isError || !me.data) {
+    if (isEmailNotVerifiedError(me.error)) {
+      return (
+        <PageContainer>
+          <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {search.install === "success"
+              ? "GitHub App installed — please verify your email to continue."
+              : "Your email isn't verified yet. Please verify it to manage repositories."}
+          </p>
+          <Link
+            to={routes.verifyEmail}
+            className="mt-4 inline-block text-sm text-primary hover:underline"
+          >
+            Verify email →
+          </Link>
+        </PageContainer>
+      );
+    }
+
     return (
       <PageContainer>
         <h1 className="text-2xl font-semibold tracking-tight">Repositories</h1>
@@ -342,7 +368,11 @@ function InstallStep(): JSX.Element {
       const result = await installUrl.mutateAsync();
       window.location.assign(result.url);
     } catch (err) {
-      toast.error(formatApiError(err, "Could not generate install link."));
+      toast.error(
+        isEmailNotVerifiedError(err)
+          ? "Please verify your email before installing the GitHub App."
+          : formatApiError(err, "Could not generate install link."),
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

When an unverified user lands on \`/repos?install=success&installation_uuid=...\` after granting GitHub App access, \`GET /v1/me\` returns HTTP 403 \`email_not_verified\`. Before this fix, \`ReposPageInner\` never mounted (it's gated behind a successful \`useMe()\`), so the install callback \`useEffect\` never fired and the user saw "You need to be signed in to manage repositories" — a misleading dead-end with no recovery path.

**Changes:**

- \`ReposPage\`: call \`useSearch\` at the outer level; narrow the 403 by \`body.error === "email_not_verified"\` and render "Verify email →" (to \`/verify-email\`) instead of "Sign in →"
- When \`install=success\` callback params are in the URL on the unverified path, surface "GitHub App installed — please verify your email to continue."
- \`InstallStep.handleInstall\`: when \`/v1/github/install-url\` returns \`email_not_verified\`, show an actionable toast instead of the generic "Could not generate install link."

## GitHub Issue

Closes #529

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR