### PR TITLE
[RUSAA-1598] fix(agent-runner): pre-install rustbrain-mcp binary and wire correct API base

### DIFF
--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -35,11 +35,21 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p agent-runner && \
     cp target/release/rb-agent-runner /usr/local/bin/
 
-# ── Stage 4: runtime image ────────────────────────────────────────────────────
-# Base on node:20-bookworm-slim so we have node/npm/npx for:
+# ── Stage 4: mcp-server-node builder ─────────────────────────────────────────
+# Compile the TypeScript MCP bridge so the runtime image can install it
+# globally as `rustbrain-mcp` — no npm-registry access needed at session time.
+FROM node:20-bookworm-slim AS mcp-builder
+WORKDIR /mcp
+COPY packages/mcp-server-node/package.json packages/mcp-server-node/package-lock.json ./
+RUN npm ci
+COPY packages/mcp-server-node/src ./src
+COPY packages/mcp-server-node/tsconfig.json ./
+RUN npm run build
+
+# ── Stage 5: runtime image ────────────────────────────────────────────────────
+# Base on node:20-bookworm-slim so we have node/npm for:
 #   • @anthropic-ai/claude-code (CLI binary the ClaudeCode adapter spawns)
-#   • npx -y @rustbrain/mcp-server (MCP server invoked lazily from workspace
-#     .mcp.json — see services/agent-runner/src/adapters/mod.rs)
+#   • rustbrain-mcp (MCP bridge pre-installed from mcp-builder stage)
 FROM node:20-bookworm-slim AS runtime
 
 # Install git, ssh, and the C runtime deps the Rust binary links against.
@@ -76,6 +86,15 @@ RUN npm install --omit=dev --no-fund --no-audit -g \
         opencode-ai@${OPENCODE_VERSION} && \
     npm cache clean --force && \
     opencode --version
+
+# Pre-install the rust-brain MCP bridge from the compiled mcp-builder stage.
+# This makes `rustbrain-mcp` available on PATH inside every spawned session
+# without requiring npm-registry access or npx download at session start time.
+COPY --from=mcp-builder /mcp/package.json /opt/rustbrain/mcp-server/package.json
+COPY --from=mcp-builder /mcp/dist /opt/rustbrain/mcp-server/dist
+RUN npm install -g /opt/rustbrain/mcp-server --omit=dev --no-fund --no-audit && \
+    npm cache clean --force && \
+    which rustbrain-mcp
 
 # Pre-create the agent workspace mount point with nonroot ownership.
 # Docker named volumes inherit ownership/permissions from the image's directory

--- a/services/agent-runner/src/adapters/mod.rs
+++ b/services/agent-runner/src/adapters/mod.rs
@@ -72,7 +72,10 @@ pub async fn write_mcp_config(
     api_key: &str,
     tenant_id: &str,
 ) -> Result<()> {
+    // Prefer an explicit override; fall back to the control-api base URL that
+    // compose already sets as RB_CONTROL_API_BASE_URL; last resort: localhost.
     let api_base = std::env::var("RUST_BRAIN_API_BASE")
+        .or_else(|_| std::env::var("RB_CONTROL_API_BASE_URL"))
         .unwrap_or_else(|_| "http://localhost:8080".to_string());
 
     // C4: Validate URL scheme to prevent SSRF attacks
@@ -80,11 +83,16 @@ pub async fn write_mcp_config(
         anyhow::bail!("RUST_BRAIN_API_BASE must use http:// or https:// scheme, got: {api_base}");
     }
 
+    // Use the binary pre-installed in the Docker image (rustbrain-mcp) so spawned
+    // sessions don't need npm-registry access. MCP_SERVER_CMD lets local dev
+    // or tests override the path without rebuilding the image.
+    let mcp_cmd = std::env::var("MCP_SERVER_CMD").unwrap_or_else(|_| "rustbrain-mcp".to_string());
+
     let mcp_config = serde_json::json!({
         "mcpServers": {
             "rust-brain": {
-                "command": "npx",
-                "args": ["-y", "@rustbrain/mcp-server"],
+                "command": mcp_cmd,
+                "args": [],
                 "env": {
                     "RB_AGENT_API_KEY": api_key,
                     "RB_AGENT_TENANT_ID": tenant_id,
@@ -110,4 +118,118 @@ pub async fn write_mcp_config(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    // Serialize tests that mutate process environment variables.
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    #[tokio::test]
+    async fn write_mcp_config_falls_back_to_rb_control_api_base_url() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: ENV_LOCK serializes all env mutations in this module's tests.
+        unsafe {
+            std::env::remove_var("RUST_BRAIN_API_BASE");
+            std::env::set_var("RB_CONTROL_API_BASE_URL", "http://control-api:8081");
+            std::env::remove_var("MCP_SERVER_CMD");
+        }
+
+        write_mcp_config(tmp.path(), "rb_live_test", "tenant-abc")
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(tmp.path().join(".mcp.json"))
+            .await
+            .unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let server = &cfg["mcpServers"]["rust-brain"];
+        assert_eq!(
+            server["command"], "rustbrain-mcp",
+            "should use pre-installed binary"
+        );
+        assert_eq!(
+            server["args"],
+            serde_json::json!([]),
+            "args must be empty array"
+        );
+        assert_eq!(
+            server["env"]["RB_AGENT_API_BASE"], "http://control-api:8081",
+            "should pick up RB_CONTROL_API_BASE_URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_mcp_config_rust_brain_api_base_takes_priority() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: ENV_LOCK serializes all env mutations in this module's tests.
+        unsafe {
+            std::env::set_var("RUST_BRAIN_API_BASE", "https://explicit.host/api");
+            std::env::set_var("RB_CONTROL_API_BASE_URL", "http://control-api:8081");
+            std::env::remove_var("MCP_SERVER_CMD");
+        }
+
+        write_mcp_config(tmp.path(), "rb_live_test", "tenant-abc")
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(tmp.path().join(".mcp.json"))
+            .await
+            .unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            cfg["mcpServers"]["rust-brain"]["env"]["RB_AGENT_API_BASE"],
+            "https://explicit.host/api",
+            "RUST_BRAIN_API_BASE must take priority over RB_CONTROL_API_BASE_URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_mcp_config_mcp_server_cmd_override() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: ENV_LOCK serializes all env mutations in this module's tests.
+        unsafe {
+            std::env::set_var("RUST_BRAIN_API_BASE", "http://localhost:8080");
+            std::env::set_var("MCP_SERVER_CMD", "/custom/rustbrain-mcp");
+        }
+
+        write_mcp_config(tmp.path(), "rb_live_test", "tenant-abc")
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(tmp.path().join(".mcp.json"))
+            .await
+            .unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            cfg["mcpServers"]["rust-brain"]["command"], "/custom/rustbrain-mcp",
+            "MCP_SERVER_CMD must override the default binary name"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_mcp_config_rejects_non_http_scheme() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: ENV_LOCK serializes all env mutations in this module's tests.
+        unsafe {
+            std::env::set_var("RUST_BRAIN_API_BASE", "file:///etc/passwd");
+            std::env::remove_var("RB_CONTROL_API_BASE_URL");
+        }
+
+        let err = write_mcp_config(tmp.path(), "key", "tenant")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("must use http://"),
+            "expected SSRF validation error, got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (primary):** `.mcp.json` invoked `npx -y @rustbrain/mcp-server`, which requires the package on the npm registry and network access at session startup. If either fails, MCP tools silently disappear from the spawned session. **Fix:** add a `mcp-builder` multi-stage Docker step that compiles `packages/mcp-server-node/` (TypeScript → JS) and installs `rustbrain-mcp` globally in the runtime image. `.mcp.json` now uses `"command": "rustbrain-mcp"` — a stable binary, no network dependency.

- **Bug 2 (secondary):** `RUST_BRAIN_API_BASE` was not set in `compose/dev.yml`, so `write_mcp_config` fell back to `http://localhost:8080` (non-existent in the container). **Fix:** fall back to `RB_CONTROL_API_BASE_URL` (already set in compose as `http://control-api:8081`) before the localhost sentinel. Priority: `RUST_BRAIN_API_BASE` > `RB_CONTROL_API_BASE_URL` > `localhost`.

- **New env var:** `MCP_SERVER_CMD` lets local dev / tests override the binary path without rebuilding the image.

## Changed files

| File | Change |
|---|---|
| `docker/agent-runner/Dockerfile` | Add `mcp-builder` stage; pre-install `rustbrain-mcp` globally before `USER nonroot` |
| `services/agent-runner/src/adapters/mod.rs` | Fix API base fallback; use `rustbrain-mcp` binary; add 4 unit tests |

## GitHub Issue

Closes #533

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] Clippy: no new Rust errors (rdkafka-sys needs `libcurl4-openssl-dev` which is absent on the local dev machine; CI has system deps installed)
- [x] 4 unit tests added covering: API base fallback, priority, cmd override, SSRF validation
- [x] No `RUSAA-XX` outside the title bracket prefix