### PR TITLE
[RUSAA-1605] fix(control-api): add setup_url to GitHub App manifest for install redirect

### DIFF
--- a/services/control-api/src/routes/admin/github/app_manifest.rs
+++ b/services/control-api/src/routes/admin/github/app_manifest.rs
@@ -111,6 +111,8 @@ pub fn build_manifest_payload(base_url: &str, name: &str) -> serde_json::Value {
             "url": format!("{base_url}/v1/github/webhook"),
         },
         "callback_urls": [format!("{base_url}/v1/github/callback")],
+        "setup_url": format!("{base_url}/v1/github/callback"),
+        "setup_on_update": true,
         "public": false,
         "default_permissions": {
             "contents": "read",
@@ -157,6 +159,8 @@ mod tests {
             m["hook_attributes"]["url"],
             "http://localhost:15173/v1/github/webhook"
         );
+        assert_eq!(m["setup_url"], "http://localhost:15173/v1/github/callback");
+        assert_eq!(m["setup_on_update"], true);
         assert_eq!(m["default_permissions"]["contents"], "read");
         assert!(
             m["default_events"]


### PR DESCRIPTION
## Summary

- Without `setup_url` in the GitHub App manifest, GitHub has no post-install redirect configured. After a user grants access on GitHub, they are left on `github.com/settings/installations/<id>` rather than being returned to Rustacean.
- Add `setup_url` (pointing to `{base_url}/v1/github/callback`) and `setup_on_update: true` to `build_manifest_payload()`. The existing `github_callback` handler already handles this path — it reads `installation_id` + `state` from query params and issues a 302 to `/repos?install=success`.
- Update the `manifest_payload_has_required_fields` unit test to assert both new fields.

## Root cause

`build_manifest_payload()` in `app_manifest.rs` was missing `setup_url`. A prior attempt to add it (local commit `db997b86`) was never merged. The bug was latent until RUSAA-1595 was resolved and the board ran fresh UAT.

## Operational action required (not in this PR)

The already-deployed GitHub App on mars does **not** automatically pick up the manifest change — that only applies to future app registrations. To unblock the board UAT immediately, the platform admin must update the Setup URL in GitHub App settings:

> `https://github.com/settings/apps/<app-slug>` → **Post installation** → **Setup URL** = `http://100.87.157.74:8080/v1/github/callback`

Alternatively, re-run the manifest registration flow from the Admin UI after this PR merges.

## GitHub Issue
Closes #535

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] Unit test updated to assert `setup_url` and `setup_on_update`
- [x] No `RUSAA-XX` outside the title bracket prefix