### PR TITLE
[RUSAA-1608] fix(frontend): prevent fan-out stage status regression in ingestion theatre

### DIFF
--- a/frontend/src/pages/IngestionTheatre.tsx
+++ b/frontend/src/pages/IngestionTheatre.tsx
@@ -90,6 +90,8 @@ function mapRestStageStatus(status: string): StageStatus {
   }
 }
 
+const TERMINAL_STAGE_STATUSES = new Set<StageStatus>(["done", "error"]);
+
 function deriveStageStates(
   events: ReadonlyArray<{ data: string }>,
   seed?: ReadonlyMap<string, StageStatus>,
@@ -103,7 +105,12 @@ function deriveStageStates(
     if (!e || !e.stage || !PIPELINE_STAGE_SET.has(e.stage)) continue;
     const stageStatus = mapIngestStatus(e.status);
     if (stageStatus !== null) {
-      byStage.set(e.stage, stageStatus);
+      // Fan-out stages (extract, embed, project_*) emit one processing+done
+      // pair per item. Once a stage is terminal, ignore any further processing
+      // events so the UI doesn't flip done→running between items.
+      if (!TERMINAL_STAGE_STATUSES.has(byStage.get(e.stage)!)) {
+        byStage.set(e.stage, stageStatus);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fan-out pipeline stages (extract, embed, project_pg, project_neo4j, project_qdrant) emit one `{status: processing}` + `{status: done}` SSE event pair **per item**, not per stage.
- PR #528 introduced seeding from terminal runs — on mount, `hydrate()` snapshots the REST stage timeline into `seedStages` (all "done"). When the same run's subsequent SSE events arrive with a matching `ingest_run_id`, the `effectiveSeed` includes that snapshot. Each `{status: processing}` event then overwrites the seed's "done" value, flipping the stage to **Running** until the paired "done" arrives.
- Fix: add `TERMINAL_STAGE_STATUSES` monotonic guard in `deriveStageStates` — once a stage reaches `done` or `error`, ignore events that would regress it.

## Root cause trace

```
1. hydrate() → REST stages all "succeeded" → seedStages = all "done", seededRunId = "run-A"
2. SSE arrives, activeSseRunId === seededRunId → effectiveSeed = seedStages
3. deriveStageStates([{extract=processing}, ...], seedStages):
     init: all done (from seed)
     apply extract=processing → extract=RUNNING  ← bug
     apply extract=done       → extract=done
     apply extract=processing → extract=RUNNING  ← flips per item
```

## Files changed

- `frontend/src/pages/IngestionTheatre.tsx` — add `TERMINAL_STAGE_STATUSES` constant and monotonic guard in `deriveStageStates`

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR

## GitHub Issue

Closes #537