### PR TITLE
[RUSAA-1607] fix(activity): gate finished_at display on terminal status

### DIFF
--- a/frontend/src/components/activity/RecentIngestionsTable.tsx
+++ b/frontend/src/components/activity/RecentIngestionsTable.tsx
@@ -9,6 +9,8 @@ const STATUS_CELL_CLASS: Record<string, string> = {
   queued: "text-muted-foreground",
 };
 
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
+
 function RunStatusCell({ status }: { status: string }): JSX.Element {
   const cls = STATUS_CELL_CLASS[status] ?? "text-muted-foreground";
   return <span className={`text-xs font-medium capitalize ${cls}`}>{status}</span>;
@@ -105,7 +107,9 @@ export function RecentIngestionsTable({
                 {run.started_at ? formatTimestamp(run.started_at) : "—"}
               </td>
               <td className="px-4 py-2 text-xs text-muted-foreground">
-                {run.finished_at ? formatTimestamp(run.finished_at) : "—"}
+                {TERMINAL_STATUSES.has(run.status) && run.finished_at
+                  ? formatTimestamp(run.finished_at)
+                  : "—"}
               </td>
               <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
                 {run.trace_id ? `${run.trace_id.slice(0, 8)}…` : "—"}


### PR DESCRIPTION
## Summary

- Guard the **Finished** column in the Activity page so it renders \`—\` whenever the run is not in a terminal state (\`succeeded\` | \`failed\` | \`cancelled\`).
- Adds \`TERMINAL_STATUSES\` constant in \`RecentIngestionsTable.tsx\` — a \`Set<string>\` used to short-circuit the render.
- No backend changes: \`ingestion_runs.finished_at\` is correctly set only for terminal rows; the display gate is the right fix layer.

## Root cause

Ingestion runs transition to \`succeeded\` as soon as all 9 pipeline stages report their first Done event (commit 7f9a61e8, PR #498). Fan-out workers (embed, project_*) continue processing remaining items for several more minutes. The frontend was unconditionally rendering \`finished_at\` whenever it was non-null, making a populated timestamp visible during the still-in-flight window. PR #532 added seconds to \`formatTimestamp\`, which surfaced the advancing timestamp clearly.

## GitHub Issue

Closes #541

## Checklist
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] `finished_at` gated on `TERMINAL_STATUSES.has(run.status)`
- [x] Non-terminal rows always show `—` regardless of `finished_at` DB value
- [ ] QA validates on mars dev stack with a fresh ingestion run