### PR TITLE
[RUSAA-1609] fix: add RUST_BRAIN_API_BASE to agent-runner compose env

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -544,6 +544,7 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
       RB_AGENT_WORKSPACE_BASE: /data/agent-workspaces
+      RUST_BRAIN_API_BASE: "http://control-api:8080"
       RB_CONTROL_API_BASE_URL: "http://control-api:8081"
       RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
       # Runtime credentials forwarded to the spawned agent CLI. These are


### PR DESCRIPTION
## Summary

- `compose/dev.yml` agent-runner block was missing `RUST_BRAIN_API_BASE`
- `write_mcp_config()` fell back to `RB_CONTROL_API_BASE_URL` (`http://control-api:8081`) which is the internal callback listener; `/mcp` only exists on port 8080
- Every spawned session's `.mcp.json` got the wrong URL, causing `rust-brain` MCP to show **✗ Failed to connect**
- Fix: add `RUST_BRAIN_API_BASE: "http://control-api:8080"` to agent-runner's environment block

## GitHub Issue

Closes #543

## Checklist

- [x] `compose/dev.yml` only — no Rust code changed, no cargo gates needed
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] One-line targeted fix, no scope creep