### PR TITLE
[RUSAA-1616] fix(dev-stack-watch): sync changed files from origin/main when on feature branch

### DIFF
--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -138,6 +138,24 @@ while true; do
   LAST_KNOWN_SHA="$NEW_SHA"
   echo "$LAST_KNOWN_SHA" > "$SHA_STATE_FILE"
 
+  # When on a feature branch the fast-forward above is skipped, leaving the
+  # working tree at the branch HEAD. Docker build context comes from the working
+  # tree, so stale files cause Docker to hit cached layers for code that changed
+  # on main. Fix this by temporarily checking out changed files from origin/main
+  # before building, then restoring them afterwards so the branch stays clean.
+  _WK_CHECKED_OUT=()
+  if [[ "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+    mapfile -t _WK_DELTA < <(git diff --name-only "$PREV_SHA" "$NEW_SHA" 2>/dev/null || true)
+    if [[ ${#_WK_DELTA[@]} -gt 0 ]]; then
+      echo "[dev-stack-watch] on branch $CURRENT_BRANCH — syncing ${#_WK_DELTA[@]} changed file(s) from $REMOTE/$BRANCH into working tree"
+      for _f in "${_WK_DELTA[@]}"; do
+        if git checkout "$REMOTE/$BRANCH" -- "$_f" 2>/dev/null; then
+          _WK_CHECKED_OUT+=("$_f")
+        fi
+      done
+    fi
+  fi
+
   # If the stack is fully stopped, force a cold start so infra services come up too.
   if stack_is_cold; then
     echo "[dev-stack-watch] stack is not running — triggering cold start: $PREV_SHA → $NEW_SHA"
@@ -146,5 +164,14 @@ while true; do
     echo "[dev-stack-watch] triggering rebuild: $PREV_SHA → $NEW_SHA"
     # Never let a rebuild failure crash the watch loop.
     run_rebuild "$PREV_SHA" "$NEW_SHA" || true
+  fi
+
+  # Restore any files temporarily checked out from main so the working tree
+  # stays consistent with the current feature branch.
+  if [[ ${#_WK_CHECKED_OUT[@]} -gt 0 ]]; then
+    echo "[dev-stack-watch] restoring ${#_WK_CHECKED_OUT[@]} file(s) to $CURRENT_BRANCH"
+    for _f in "${_WK_CHECKED_OUT[@]}"; do
+      git checkout HEAD -- "$_f" 2>/dev/null || git rm --cached "$_f" 2>/dev/null || true
+    done
   fi
 done


### PR DESCRIPTION
## Summary

- **Root cause**: when the repo is checked out on a feature branch, `dev-stack-watch.sh` skips the `git merge --ff-only` step, leaving the working tree at branch HEAD. Docker build context comes from the working tree, so unchanged file hashes cause Docker to hit cached layers for code that actually changed on `main`. Containers report healthy but run pre-merge binaries.
- **Fix**: before each rebuild, temporarily `git checkout origin/main -- <changed files>` into the working tree; restore them to `HEAD` after the rebuild completes so the branch stays clean.
- **Evidence**: frontend bundle stayed at `index-BTiFYG_N.js` despite PR #542 merging; rebuild log showed `elapsed_s: 19` with all layers CACHED.

## GitHub Issue

Closes #545

## Changes

- `scripts/dev-stack-watch.sh`: when `CURRENT_BRANCH != BRANCH`, compute `git diff --name-only PREV_SHA NEW_SHA`, checkout those files from `origin/main`, run rebuild, restore files to `HEAD`.

## Checklist
- [ ] Watcher restarted on mars and running with updated script
- [ ] No `RUSAA-XX` outside title bracket prefix
- [ ] No new dependencies