### PR TITLE
[RUSAA-1621] fix(activity): freeze finished_at at terminal status and cap embed composite length

### DIFF
--- a/crates/rb-kafka-health/src/watcher_tests.rs
+++ b/crates/rb-kafka-health/src/watcher_tests.rs
@@ -71,7 +71,10 @@ impl<E: ProstMessage + Default + Send + Sync + 'static> ConsumerOps<E> for MockC
     }
 
     async fn assigned_partition_count(&self) -> usize {
-        self.assignment_count.load(Ordering::Relaxed) as usize
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            self.assignment_count.load(Ordering::Relaxed) as usize
+        }
     }
 }
 
@@ -80,6 +83,7 @@ fn dummy_cfg() -> ConsumerCfg {
     ConsumerCfg::new("test-group")
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn make_stream_error<E: ProstMessage + Default + Send + Sync + 'static>()
 -> Option<Result<EventEnvelope<E>, KafkaError>> {
     // Use a generic broker error to simulate any stream error (REQTMOUT cascade,
@@ -334,8 +338,7 @@ async fn error_cascade_at_threshold_triggers_recreate() {
 
     assert!(
         recreate_counter.load(Ordering::Relaxed) >= 1,
-        "factory must be called after {} consecutive error(s)",
-        threshold
+        "factory must be called after {threshold} consecutive error(s)"
     );
     assert!(
         healthy.recreate_count >= 1,

--- a/services/control-api/src/ingest_consumer/db.rs
+++ b/services/control-api/src/ingest_consumer/db.rs
@@ -9,44 +9,6 @@ use super::sse::stage_label;
 
 pub(crate) const TOTAL_PIPELINE_STAGES: i64 = 9;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn processing_maps_to_running() {
-        let result = stage_db_params(IngestStatus::Processing, "");
-        assert_eq!(result, Some(("running", None)));
-    }
-
-    #[test]
-    fn done_maps_to_succeeded() {
-        assert_eq!(
-            stage_db_params(IngestStatus::Done, ""),
-            Some(("succeeded", None))
-        );
-    }
-
-    #[test]
-    fn pending_and_unspecified_produce_no_db_update() {
-        assert!(stage_db_params(IngestStatus::Pending, "").is_none());
-        assert!(stage_db_params(IngestStatus::Unspecified, "").is_none());
-    }
-
-    /// RUSAA-1560: maybe_complete_run must issue two UPDATEs — one gated on
-    /// `status IN ('queued', 'running')` for the transition, and one always
-    /// fired on `status = 'succeeded'` to advance finished_at.  The threshold
-    /// must remain TOTAL_PIPELINE_STAGES so all 9 stages must have succeeded
-    /// before either UPDATE fires.
-    #[test]
-    fn total_pipeline_stages_gates_completion_and_finished_at_update() {
-        assert_eq!(
-            TOTAL_PIPELINE_STAGES, 9,
-            "gate must cover all 9 pipeline stages; bump if a new stage is added"
-        );
-    }
-}
-
 /// Returns the `pipeline_stage_runs.status` string and optional error
 /// for a given [`IngestStatus`], or `None` if no DB update is warranted.
 pub(crate) fn stage_db_params(
@@ -173,34 +135,26 @@ pub(crate) async fn maybe_complete_run(pool: &PgPool, ingest_run_id: &str) -> Re
     .context("failed to count succeeded stages")?;
 
     if succeeded >= TOTAL_PIPELINE_STAGES {
+        // Single UPDATE gated on running/queued so finished_at is written once
+        // and frozen — subsequent Done events from fan-out stages after the run
+        // reaches terminal status no longer advance it (RUSAA-1621).
         // COALESCE backfills started_at when Processing events were lost or
         // arrived after Done events on a fast pipeline.
         sqlx::query(
             "UPDATE control.ingestion_runs \
-             SET status = 'succeeded', started_at = COALESCE(started_at, now()) \
+             SET status = 'succeeded', \
+                 started_at = COALESCE(started_at, now()), \
+                 finished_at = (\
+                   SELECT MAX(psr.finished_at) \
+                   FROM control.pipeline_stage_runs psr \
+                   WHERE psr.ingestion_run_id = $1\
+                 ) \
              WHERE id = $1 AND status IN ('queued', 'running')",
         )
         .bind(run_id)
         .execute(pool)
         .await
         .context("failed to mark ingestion_run succeeded")?;
-
-        // Advance finished_at to the latest stage completion time. This runs
-        // after every Done event from a fan-out stage, so finished_at converges
-        // to the true end time once the last projection item is processed.
-        sqlx::query(
-            "UPDATE control.ingestion_runs \
-             SET finished_at = (\
-               SELECT MAX(psr.finished_at) \
-               FROM control.pipeline_stage_runs psr \
-               WHERE psr.ingestion_run_id = $1\
-             ) \
-             WHERE id = $1 AND status = 'succeeded'",
-        )
-        .bind(run_id)
-        .execute(pool)
-        .await
-        .context("failed to advance ingestion_run finished_at")?;
     }
 
     Ok(())
@@ -264,4 +218,42 @@ pub(crate) async fn handle_db_updates(pool: &PgPool, ev: &IngestStatusEvent) -> 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processing_maps_to_running() {
+        let result = stage_db_params(IngestStatus::Processing, "");
+        assert_eq!(result, Some(("running", None)));
+    }
+
+    #[test]
+    fn done_maps_to_succeeded() {
+        assert_eq!(
+            stage_db_params(IngestStatus::Done, ""),
+            Some(("succeeded", None))
+        );
+    }
+
+    #[test]
+    fn pending_and_unspecified_produce_no_db_update() {
+        assert!(stage_db_params(IngestStatus::Pending, "").is_none());
+        assert!(stage_db_params(IngestStatus::Unspecified, "").is_none());
+    }
+
+    /// `maybe_complete_run` issues a single UPDATE gated on `status IN ('queued',
+    /// 'running')` that sets status, `started_at`, AND `finished_at` atomically.
+    /// `finished_at` is frozen at the moment of the first transition to succeeded
+    /// and does not advance on subsequent Done events from fan-out stages.
+    /// All 9 stages must have succeeded before the UPDATE fires.
+    #[test]
+    fn total_pipeline_stages_gates_completion_and_finished_at_update() {
+        assert_eq!(
+            TOTAL_PIPELINE_STAGES, 9,
+            "gate must cover all 9 pipeline stages; bump if a new stage is added"
+        );
+    }
 }

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -18,7 +18,7 @@ use sqlx::postgres::PgPoolOptions;
 use tower::ServiceExt as _;
 use uuid::Uuid;
 
-use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build};
+use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build_public};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -211,7 +211,7 @@ async fn ac1_events_stream_without_session_returns_401() {
     };
 
     let session_id = Uuid::new_v4();
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("GET")
@@ -245,7 +245,7 @@ async fn ac2_events_stream_returns_sse_for_session_owner() {
 
     let fixtures = insert_agent_session_fixtures(&pool).await;
 
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("GET")
@@ -276,8 +276,7 @@ async fn ac2_events_stream_returns_sse_for_session_owner() {
         .unwrap();
     assert!(
         content_type.contains("text/event-stream"),
-        "AC2: content-type must be text/event-stream, got {}",
-        content_type
+        "AC2: content-type must be text/event-stream, got {content_type}"
     );
 }
 
@@ -296,13 +295,12 @@ async fn ac3_events_stream_nonexistent_session_returns_404() {
     let fixtures = insert_agent_session_fixtures(&pool).await;
     let nonexistent_session_id = Uuid::new_v4();
 
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("GET")
                 .uri(format!(
-                    "/v1/agents/sessions/{}/events",
-                    nonexistent_session_id
+                    "/v1/agents/sessions/{nonexistent_session_id}/events"
                 ))
                 .header("accept", "text/event-stream")
                 .header("cookie", format!("rb_session={}", fixtures.session_token))
@@ -410,11 +408,11 @@ async fn ac4_events_stream_cross_tenant_access_denied() {
     .expect("insert agent_session B");
 
     // User A tries to access User B's session
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/v1/agents/sessions/{}/events", agent_session_b_id))
+                .uri(format!("/v1/agents/sessions/{agent_session_b_id}/events"))
                 .header("accept", "text/event-stream")
                 .header("cookie", format!("rb_session={}", fixtures_a.session_token))
                 .body(Body::empty())

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -269,6 +269,7 @@ fn init_tracing() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn manifest_flow_persists_and_hot_swaps_loader() {
     init_tracing();
     let Some(pool) = real_db_pool().await else {

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build};
+use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build_public};
 use hmac::{Hmac, Mac};
 use http_body_util::BodyExt as _;
 use jsonwebtoken::EncodingKey;
@@ -187,7 +187,7 @@ async fn body_is_empty(resp: axum::response::Response) -> bool {
 
 #[tokio::test]
 async fn webhook_returns_503_when_app_not_configured() {
-    let app = build(state_without_gh());
+    let app = build_public(state_without_gh());
     let req = webhook_request(
         b"{}".to_vec(),
         Some("sha256=00".into()),
@@ -201,7 +201,7 @@ async fn webhook_returns_503_when_app_not_configured() {
 
 #[tokio::test]
 async fn webhook_returns_401_for_missing_signature() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let req = webhook_request(b"{}".to_vec(), None, Some("d"), Some("ping"));
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -209,7 +209,7 @@ async fn webhook_returns_401_for_missing_signature() {
 
 #[tokio::test]
 async fn webhook_returns_400_for_missing_delivery() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = b"{}".to_vec();
     let sig = sign(&body, b"shh");
     let req = webhook_request(body, Some(sig), None, Some("ping"));
@@ -219,7 +219,7 @@ async fn webhook_returns_400_for_missing_delivery() {
 
 #[tokio::test]
 async fn webhook_returns_400_for_missing_event() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = b"{}".to_vec();
     let sig = sign(&body, b"shh");
     let req = webhook_request(body, Some(sig), Some("d"), None);
@@ -229,7 +229,7 @@ async fn webhook_returns_400_for_missing_event() {
 
 #[tokio::test]
 async fn webhook_returns_401_for_bad_signature_format() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let req = webhook_request(
         b"{}".to_vec(),
         Some("not-a-sig".into()),
@@ -242,7 +242,7 @@ async fn webhook_returns_401_for_bad_signature_format() {
 
 #[tokio::test]
 async fn webhook_returns_401_for_signature_mismatch() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = b"{}".to_vec();
     let sig = sign(&body, b"WRONG-SECRET");
     let req = webhook_request(body, Some(sig), Some("d"), Some("ping"));
@@ -254,7 +254,7 @@ async fn webhook_returns_401_for_signature_mismatch() {
 /// retrying.
 #[tokio::test]
 async fn webhook_returns_202_for_unmodelled_event() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = b"{}".to_vec();
     let sig = sign(&body, b"shh");
     let req = webhook_request(body, Some(sig), Some("d-ping"), Some("ping"));
@@ -266,7 +266,7 @@ async fn webhook_returns_202_for_unmodelled_event() {
 /// so it cannot be probed by an unauthenticated attacker.
 #[tokio::test]
 async fn webhook_returns_400_for_malformed_installation_body() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = br#"{"action":"created"}"#.to_vec(); // missing `installation`
     let sig = sign(&body, b"shh");
     let req = webhook_request(body, Some(sig), Some("d-bad"), Some("installation"));
@@ -279,7 +279,7 @@ async fn webhook_returns_400_for_malformed_installation_body() {
 /// here proves the replay short-circuit fired before the SQL dispatch.
 #[tokio::test]
 async fn webhook_returns_200_on_replay_without_sql_dispatch() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = b"{}".to_vec();
     let sig = sign(&body, b"shh");
     let delivery = "d-replay";
@@ -312,7 +312,7 @@ async fn webhook_returns_200_on_replay_without_sql_dispatch() {
 /// the no-op fast-path that GitHub may legitimately exercise.
 #[tokio::test]
 async fn webhook_returns_200_for_empty_removed_list() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = serde_json::to_vec(&serde_json::json!({
         "action": "removed",
         "installation": {
@@ -337,7 +337,7 @@ async fn webhook_returns_200_for_empty_removed_list() {
 /// dispatched, so the lazy pool is never touched and the response is 200.
 #[tokio::test]
 async fn webhook_returns_200_for_repos_added_no_auto_connect() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = serde_json::to_vec(&serde_json::json!({
         "action": "added",
         "installation": {
@@ -364,7 +364,7 @@ async fn webhook_returns_200_for_repos_added_no_auto_connect() {
 /// `new_permissions_accepted`) are accepted with 202 to stop GitHub retries.
 #[tokio::test]
 async fn webhook_returns_202_for_unmodelled_installation_action() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = serde_json::to_vec(&serde_json::json!({
         "action": "new_permissions_accepted",
         "installation": {
@@ -383,7 +383,7 @@ async fn webhook_returns_202_for_unmodelled_installation_action() {
 
 #[tokio::test]
 async fn callback_returns_503_when_app_not_configured() {
-    let app = build(state_without_gh());
+    let app = build_public(state_without_gh());
     let req = Request::builder()
         .method("GET")
         .uri("/v1/github/callback?installation_id=1&state=aabbcc")
@@ -395,7 +395,7 @@ async fn callback_returns_503_when_app_not_configured() {
 
 #[tokio::test]
 async fn callback_returns_400_for_invalid_hex_state() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let req = Request::builder()
         .method("GET")
         .uri("/v1/github/callback?installation_id=1&state=not-valid-hex!")
@@ -409,7 +409,7 @@ async fn callback_returns_400_for_invalid_hex_state() {
 /// future GitHub additions) returns 202.
 #[tokio::test]
 async fn webhook_returns_202_for_unmodelled_repos_action() {
-    let app = build(state_with_gh(b"shh"));
+    let app = build_public(state_with_gh(b"shh"));
     let body = serde_json::to_vec(&serde_json::json!({
         "action": "future_action",
         "installation": {

--- a/services/control-api/tests/integration_ingest_activity_tests.rs
+++ b/services/control-api/tests/integration_ingest_activity_tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for ingestion-run activity timestamps (started_at backfill).
+//! Integration tests for ingestion-run activity timestamps (`started_at` backfill).
 //!
 //! These tests require a running Postgres instance accessible via
 //! `RB_DATABASE_URL`. When that variable is absent the tests skip gracefully.
@@ -140,6 +140,7 @@ async fn fail_run_sets_started_at_when_null() {
 /// runs that complete before any Processing event is processed always have a
 /// non-NULL `started_at`.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn complete_run_sets_started_at_when_null() {
     let Some(pool) = real_pool().await else {
         return; // skip: no DB
@@ -240,31 +241,24 @@ async fn complete_run_sets_started_at_when_null() {
             .unwrap_or_else(|e| panic!("insert stage {stage}: {e}"));
     }
 
-    // Execute the first UPDATE from maybe_complete_run (mirrors ingest_consumer/db.rs).
+    // Execute the single UPDATE from maybe_complete_run (mirrors ingest_consumer/db.rs).
+    // status, started_at, and finished_at are set atomically so finished_at is
+    // frozen at transition time and does not advance on subsequent Done events.
     sqlx::query(
         "UPDATE control.ingestion_runs \
-         SET status = 'succeeded', started_at = COALESCE(started_at, now()) \
+         SET status = 'succeeded', \
+             started_at = COALESCE(started_at, now()), \
+             finished_at = (\
+               SELECT MAX(psr.finished_at) \
+               FROM control.pipeline_stage_runs psr \
+               WHERE psr.ingestion_run_id = $1\
+             ) \
          WHERE id = $1 AND status IN ('queued', 'running')",
     )
     .bind(run_id)
     .execute(&pool)
     .await
-    .expect("status transition");
-
-    // Execute the second UPDATE (advance finished_at).
-    sqlx::query(
-        "UPDATE control.ingestion_runs \
-         SET finished_at = (\
-           SELECT MAX(psr.finished_at) \
-           FROM control.pipeline_stage_runs psr \
-           WHERE psr.ingestion_run_id = $1\
-         ) \
-         WHERE id = $1 AND status = 'succeeded'",
-    )
-    .bind(run_id)
-    .execute(&pool)
-    .await
-    .expect("advance finished_at");
+    .expect("status transition with finished_at");
 
     let (started_at, finished_at, created_at): (
         Option<chrono::DateTime<chrono::Utc>>,
@@ -289,5 +283,177 @@ async fn complete_run_sets_started_at_when_null() {
         finished > created_at,
         "finished_at must be > created_at (non-zero duration); \
          got created={created_at}, finished={finished}"
+    );
+}
+
+/// AC: `finished_at` must NOT advance after the run reaches terminal status.
+/// Simulates fan-out stage Done events arriving after the run is `succeeded`:
+/// re-fires the second UPDATE with a later stage timestamp and asserts that
+/// `ingestion_runs.finished_at` does not change.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn finished_at_frozen_after_terminal_status() {
+    let Some(pool) = real_pool().await else {
+        return; // skip: no DB
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let repo_id = Uuid::new_v4();
+    let run_id = Uuid::new_v4();
+
+    let slug = format!("act1621-{}", tenant_id.simple());
+    let schema_name = format!("act1621_{}", tenant_id.simple());
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(&slug)
+    .bind("Activity 1621 Freeze Test Tenant")
+    .bind(&schema_name)
+    .execute(&pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, $3, now())",
+    )
+    .bind(user_id)
+    .bind(format!("act1621-{}@test.example", user_id.simple()))
+    .bind("$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash")
+    .execute(&pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert tenant_member");
+
+    sqlx::query(
+        "INSERT INTO control.repos \
+         (id, tenant_id, github_repo_id, full_name, default_branch, connected_by) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .bind(15963_i64)
+    .bind("test-org/act1621-repo")
+    .bind("main")
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert repo");
+
+    sqlx::query(
+        "INSERT INTO control.ingestion_runs (id, tenant_id, repo_id, status, requested_by) \
+         VALUES ($1, $2, $3, 'queued', $4)",
+    )
+    .bind(run_id)
+    .bind(tenant_id)
+    .bind(repo_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert ingestion_run");
+
+    // Seed all 9 stages as succeeded with known timestamps.
+    let stages: &[(&str, &str)] = &[
+        ("clone", "now() - interval '10 seconds'"),
+        ("expand", "now() - interval '9 seconds'"),
+        ("parse", "now() - interval '8 seconds'"),
+        ("typecheck", "now() - interval '7 seconds'"),
+        ("extract", "now() - interval '6 seconds'"),
+        ("embed", "now() - interval '5 seconds'"),
+        ("project_pg", "now() - interval '4 seconds'"),
+        ("project_neo4j", "now() - interval '3 seconds'"),
+        ("project_qdrant", "now() - interval '2 seconds'"),
+    ];
+    for (stage, ts_expr) in stages {
+        let sql = format!(
+            "INSERT INTO control.pipeline_stage_runs \
+             (id, ingestion_run_id, stage, status, finished_at) \
+             VALUES (gen_random_uuid(), $1, $2, 'succeeded', {ts_expr})"
+        );
+        sqlx::query(&sql)
+            .bind(run_id)
+            .bind(*stage)
+            .execute(&pool)
+            .await
+            .unwrap_or_else(|e| panic!("insert stage {stage}: {e}"));
+    }
+
+    // Transition to succeeded (the single atomic UPDATE from maybe_complete_run).
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'succeeded', \
+             started_at = COALESCE(started_at, now()), \
+             finished_at = (\
+               SELECT MAX(psr.finished_at) \
+               FROM control.pipeline_stage_runs psr \
+               WHERE psr.ingestion_run_id = $1\
+             ) \
+         WHERE id = $1 AND status IN ('queued', 'running')",
+    )
+    .bind(run_id)
+    .execute(&pool)
+    .await
+    .expect("first transition");
+
+    let finished_at_first: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT finished_at FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch finished_at after first transition");
+    let frozen = finished_at_first.expect("finished_at must be set after transition");
+
+    // Simulate a fan-out Done event arriving after terminal status: advance a
+    // stage's finished_at to a future timestamp then re-fire the UPDATE.
+    sqlx::query(
+        "UPDATE control.pipeline_stage_runs \
+         SET finished_at = now() + interval '60 seconds' \
+         WHERE ingestion_run_id = $1 AND stage = 'project_pg'",
+    )
+    .bind(run_id)
+    .execute(&pool)
+    .await
+    .expect("simulate late Done event");
+
+    // Re-fire the transition UPDATE as maybe_complete_run would on a late Done event.
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'succeeded', \
+             started_at = COALESCE(started_at, now()), \
+             finished_at = (\
+               SELECT MAX(psr.finished_at) \
+               FROM control.pipeline_stage_runs psr \
+               WHERE psr.ingestion_run_id = $1\
+             ) \
+         WHERE id = $1 AND status IN ('queued', 'running')",
+    )
+    .bind(run_id)
+    .execute(&pool)
+    .await
+    .expect("re-fire after late Done");
+
+    let finished_at_second: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT finished_at FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch finished_at after re-fire");
+    let after = finished_at_second.expect("finished_at must still be set");
+
+    assert_eq!(
+        frozen, after,
+        "finished_at must not advance after run reaches terminal status; \
+         frozen={frozen}, after re-fire={after}"
     );
 }

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -23,7 +23,7 @@ use sqlx::postgres::PgPoolOptions;
 use tower::ServiceExt as _;
 use uuid::Uuid;
 
-use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build};
+use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build_public};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -257,7 +257,7 @@ async fn ac5_trigger_returns_503_when_broker_unreachable() {
         ..
     } = insert_ingest_fixtures(&pool).await;
 
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -310,7 +310,7 @@ async fn ac6_trigger_rolls_back_db_on_kafka_failure() {
         tenant_id,
     } = insert_ingest_fixtures(&pool).await;
 
-    let resp = build(state)
+    let resp = build_public(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -378,6 +378,7 @@ async fn ac6_trigger_rolls_back_db_on_kafka_failure() {
 /// This test does NOT call Kafka; it exercises the DB queries directly to confirm
 /// the SQL semantics of the fix.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn rusaa_1560_finished_at_equals_max_stage_finished_at() {
     let Some((_state, pool)) = real_db_state().await else {
         return; // skip: no DB

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -11,7 +11,7 @@ use sqlx::postgres::PgPoolOptions;
 use tower::ServiceExt as _;
 use uuid::Uuid;
 
-use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build};
+use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build_public};
 use rb_sse::{EventBus, SseConfig};
 
 async fn real_db_state() -> Option<(AppState, PgPool)> {
@@ -100,7 +100,7 @@ async fn integration_logout_full_flow() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-logout-{}@test.example", Uuid::new_v4().simple());
     let password = "correct-horse-battery-staple";
 

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -12,7 +12,7 @@ use sqlx::postgres::PgPoolOptions;
 use tower::ServiceExt as _;
 use uuid::Uuid;
 
-use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build};
+use control_api::{AppState, Config, SessionCreateRateLimiter, TenantSessionCount, build_public};
 use rb_sse::{EventBus, SseConfig};
 
 async fn collect_body(body: Body) -> Vec<u8> {
@@ -180,7 +180,7 @@ async fn integration_me_returns_user_and_tenant_for_active_session() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-me-ok-{}@test.example", Uuid::new_v4().simple());
     let token = signup_and_login(
         app.clone(),
@@ -225,7 +225,7 @@ async fn integration_me_extends_session_last_seen_at() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-me-refresh-{}@test.example", Uuid::new_v4().simple());
     let token = signup_and_login(
         app.clone(),
@@ -287,7 +287,7 @@ async fn integration_me_returns_session_expired_for_expired_cookie() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-me-expired-{}@test.example", Uuid::new_v4().simple());
     let token = signup_and_login(
         app.clone(),
@@ -332,7 +332,7 @@ async fn integration_me_anonymous_returns_unauthorized() {
     let Some((state, _pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
 
     let resp = app
         .oneshot(
@@ -355,7 +355,7 @@ async fn integration_me_with_unverified_email_returns_email_not_verified() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!(
         "integ-me-unverified-{}@test.example",
         Uuid::new_v4().simple()

--- a/services/control-api/tests/integration_resend_verification_tests.rs
+++ b/services/control-api/tests/integration_resend_verification_tests.rs
@@ -299,7 +299,7 @@ async fn integration_resend_verification_already_verified_returns_204() {
     );
 }
 
-/// Dev-mode auto-verify: signup with noop transport returns email_verification_required: false.
+/// Dev-mode auto-verify: signup with noop transport returns `email_verification_required: false`.
 #[tokio::test]
 async fn integration_signup_noop_transport_auto_verifies() {
     let Some((state, pool)) = real_db_state().await else {
@@ -332,8 +332,7 @@ async fn integration_signup_noop_transport_auto_verifies() {
     let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(
         body["email_verification_required"], false,
-        "noop transport must auto-verify: got {:?}",
-        body
+        "noop transport must auto-verify: got {body:?}"
     );
 
     // DB row must have email_verified_at set.
@@ -371,7 +370,6 @@ async fn integration_signup_noop_transport_auto_verifies() {
     let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(
         body["email_verification_required"], false,
-        "login after noop signup must not require verification: got {:?}",
-        body
+        "login after noop signup must not require verification: got {body:?}"
     );
 }

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use sqlx::postgres::PgPoolOptions;
 use tower::ServiceExt as _;
 use uuid::Uuid;
 
-use control_api::{AppState, Config, build};
+use control_api::{AppState, Config, build_public};
 use rb_sse::{EventBus, SseConfig};
 
 fn test_state() -> AppState {
@@ -55,7 +55,7 @@ fn test_state() -> AppState {
 }
 
 fn app() -> axum::Router {
-    build(test_state())
+    build_public(test_state())
 }
 
 async fn collect_body(body: Body) -> Vec<u8> {
@@ -390,7 +390,7 @@ async fn integration_login_full_flow() {
     let Some((state, pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-login-{}@test.example", Uuid::new_v4().simple());
     let password = "correct-horse-battery-staple";
 
@@ -468,7 +468,7 @@ async fn integration_login_rate_limit() {
     let Some((state, _pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!("integ-ratelimit-{}@test.example", Uuid::new_v4().simple());
     let password = "correct-horse-battery-staple";
 
@@ -546,7 +546,7 @@ async fn integration_signup_cookie_has_secure_flag() {
     let Some((state, _pool)) = real_db_state().await else {
         return;
     };
-    let app = build(state);
+    let app = build_public(state);
     let email = format!(
         "integ-signup-secure-{}@test.example",
         Uuid::new_v4().simple()

--- a/services/embed-worker/src/embedder.rs
+++ b/services/embed-worker/src/embedder.rs
@@ -9,10 +9,29 @@
 use anyhow::{Context as _, Result};
 use serde_json::json;
 
+/// Hard character limits for each composite field.
+///
+/// `nomic-embed-text` context: 8192 `WordPiece` tokens.  Code tokenises at
+/// roughly 2–4 chars per token; complex generic signatures can tokenise as
+/// low as 1 char per token.  Conservative per-field caps keep the total
+/// well inside the model limit even in the worst case.
+///
+/// Budget (chars):
+///   fqn              ≤   300  (generous for deep module paths)
+///   `type_signature` ≤ 2 000  (complex generics in macro-generated items)
+///   `trait_bounds`   ≤ 1 000  (joined; individual bounds are shorter)
+///   source           ≤ 4 000  (most of the semantic content lives here)
+///   labels/newlines  ≤    50
+///   total            ≤ 7 350  → worst-case 7 350 tokens < 8 192 limit
+const MAX_SIGNATURE_CHARS: usize = 2_000;
+const MAX_BOUNDS_CHARS: usize = 1_000;
+const MAX_SOURCE_CHARS: usize = 4_000;
+
 /// Build the §3.5.7 composite embedding prompt for one item.
 ///
-/// Fields that are empty or absent are omitted to avoid polluting the
-/// embedding with uninformative whitespace lines.
+/// Fields that are empty or absent are omitted. Each field is capped at its
+/// constant limit (see above) so the composite fits within the embedding
+/// model context window on any tokeniser.
 pub(crate) fn build_composite(
     fqn: &str,
     type_signature: &str,
@@ -24,17 +43,36 @@ pub(crate) fn build_composite(
     parts.push(format!("fqn: {fqn}"));
 
     if !type_signature.is_empty() {
-        parts.push(format!("signature: {type_signature}"));
+        if type_signature.len() > MAX_SIGNATURE_CHARS {
+            parts.push(format!(
+                "signature: {}[...]",
+                &type_signature[..MAX_SIGNATURE_CHARS]
+            ));
+        } else {
+            parts.push(format!("signature: {type_signature}"));
+        }
     }
 
     if !trait_bounds.is_empty() {
-        parts.push(format!("bounds: {}", trait_bounds.join(", ")));
+        let joined = trait_bounds.join(", ");
+        if joined.len() > MAX_BOUNDS_CHARS {
+            parts.push(format!("bounds: {}[...]", &joined[..MAX_BOUNDS_CHARS]));
+        } else {
+            parts.push(format!("bounds: {joined}"));
+        }
     }
 
     if let Some(src) = source_text {
         let trimmed = src.trim();
         if !trimmed.is_empty() {
-            parts.push(format!("source:\n{trimmed}"));
+            if trimmed.len() > MAX_SOURCE_CHARS {
+                parts.push(format!(
+                    "source:\n{}\n[... truncated]",
+                    &trimmed[..MAX_SOURCE_CHARS]
+                ));
+            } else {
+                parts.push(format!("source:\n{trimmed}"));
+            }
         }
     }
 
@@ -137,5 +175,38 @@ mod tests {
     fn composite_skips_whitespace_only_source() {
         let composite = build_composite("x::y", "", &[], Some("   \n  "));
         assert!(!composite.contains("source"));
+    }
+
+    #[test]
+    fn composite_truncates_long_source() {
+        let long_src = "x".repeat(MAX_SOURCE_CHARS + 100);
+        let composite = build_composite("x::y", "", &[], Some(&long_src));
+        assert!(
+            composite.contains("[... truncated]"),
+            "must append truncation marker"
+        );
+        let source_line = composite.lines().skip(1).collect::<Vec<_>>().join("\n");
+        assert!(
+            source_line.len() <= MAX_SOURCE_CHARS + 50,
+            "source section must not exceed MAX_SOURCE_CHARS by more than the marker"
+        );
+    }
+
+    #[test]
+    fn composite_does_not_truncate_source_within_limit() {
+        let short_src = "fn foo() {}";
+        let composite = build_composite("x::y", "", &[], Some(short_src));
+        assert!(!composite.contains("[... truncated]"));
+        assert!(composite.contains("fn foo() {}"));
+    }
+
+    #[test]
+    fn composite_truncates_exactly_at_boundary() {
+        let exact_src = "a".repeat(MAX_SOURCE_CHARS);
+        let composite = build_composite("x::y", "", &[], Some(&exact_src));
+        assert!(
+            !composite.contains("[... truncated]"),
+            "exact limit must not truncate"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Symptom B**: `ingestion_runs.finished_at` kept advancing after a run reached `succeeded`/`failed`. Root cause: `maybe_complete_run` used two separate UPDATEs — the second (advancing `finished_at` to `MAX(stage.finished_at)`) was gated only on `status = 'succeeded'`, so every fan-out Done event after terminal kept advancing it. Fix: merge into a single atomic UPDATE gated on `status IN ('queued', 'running')`.
- **Symptom A**: New ingestion failures on repos with macro-generated items (e.g. `monadify`). Root cause: `build_composite` in the embed-worker sent unbounded prompts to Ollama's `nomic-embed-text` (8192-token context). Fix: cap all variable-length fields (`MAX_SIGNATURE_CHARS=2000`, `MAX_BOUNDS_CHARS=1000`, `MAX_SOURCE_CHARS=4000`), worst-case total ~7350 chars.
- Also removes the pre-existing `deprecated control_api::build` warnings across all integration test files (was masking other clippy errors).

## GitHub Issue
Closes #549

## Checklist
- [x] `cargo-locked test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes (warnings only, no errors)
- [x] Live verification: jarnura/monadify ingestion succeeded, `finished_at` frozen post-terminal
- [x] No `RUSAA-XX` outside the title bracket prefix