### PR TITLE
[RUSAA-1636] fix(dev-stack-auto-rebuild): map packages/mcp-server-node to agent-runner rebuild trigger

### DIFF
--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -229,6 +229,8 @@ else
         mark_rust_service projector-neo4j ;;
       services/tombstoner/*|docker/tombstoner/*)
         mark_rust_service tombstoner ;;
+      packages/mcp-server-node/*|packages/*)
+        mark_rust_service agent-runner ;;
       frontend/*|docker/frontend/*)
         REBUILD_FRONTEND=true ;;
       compose/dev.yml|compose/full.yml|compose/tailscale.yml|compose/tailscale.env|compose/scripts/*)


### PR DESCRIPTION
## Summary
- Add `packages/mcp-server-node/*` → `mark_rust_service agent-runner` to the path-classification switch in `scripts/dev-stack-auto-rebuild.sh`
- Add `packages/*` defensive catch-all → `mark_rust_service agent-runner` until a second `packages/` consumer appears with its own mapping

## GitHub Issue
Closes #557

## Verification
Inline bash unit test against the case block confirms:
- `packages/mcp-server-node/README.md` → agent-runner queued ✅
- `packages/mcp-server-node/src/index.ts` → agent-runner queued ✅
- `packages/some-future-pkg/foo.ts` → agent-runner queued ✅
- `services/control-api/src/lib.rs` → control-api queued (regression) ✅
- `frontend/src/app.tsx` → REBUILD_FRONTEND=true (regression) ✅
- `services/agent-runner/src/main.rs` → agent-runner queued (regression) ✅
- `services/embed-worker/src/main.rs` → embed-worker queued (regression) ✅

## Checklist
- [x] Script logic verified via unit test
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] No Cargo changes (no `cargo deny check` needed)
- [x] Docs unchanged (PORT_MAP.md not affected)