### PR TITLE
[RUSAA-1644] feat(infra): agent-runner / MCP SHA pairing — warn-only mismatch detection (Phase 3)

### DIFF
--- a/docker/agent-runner/Dockerfile
+++ b/docker/agent-runner/Dockerfile
@@ -49,7 +49,9 @@ COPY packages/mcp-server-node/package.json packages/mcp-server-node/package-lock
 RUN npm ci
 COPY packages/mcp-server-node/src ./src
 COPY packages/mcp-server-node/tsconfig.json ./
-RUN npm run build
+COPY packages/mcp-server-node/scripts ./scripts
+ARG MCP_BUILD_SHA=unknown
+RUN BUILD_SHA=${MCP_BUILD_SHA} npm run build
 
 # ── Stage 5: runtime image ────────────────────────────────────────────────────
 # Base on node:20-bookworm-slim so we have node/npm for:
@@ -60,6 +62,9 @@ FROM node:20-bookworm-slim AS runtime
 ARG GIT_SHA=unknown
 LABEL git_sha=${GIT_SHA}
 ENV RB_BUILD_SHA=${GIT_SHA}
+
+ARG MCP_BUILD_SHA=unknown
+ENV MCP_BUILD_SHA=${MCP_BUILD_SHA}
 
 # Install git, ssh, and the C runtime deps the Rust binary links against.
 # (Node base images already ship libssl3/zlib1g/libcurl4 but we install
@@ -104,6 +109,7 @@ COPY --from=mcp-builder /mcp/dist /opt/rustbrain/mcp-server/dist
 RUN npm install -g /opt/rustbrain/mcp-server --omit=dev --no-fund --no-audit && \
     npm cache clean --force && \
     which rustbrain-mcp
+COPY --from=mcp-builder /mcp/dist/build-sha.txt /opt/rustbrain/mcp-build-sha.txt
 
 # Pre-create the agent workspace mount point with nonroot ownership.
 # Docker named volumes inherit ownership/permissions from the image's directory

--- a/packages/mcp-server-node/package.json
+++ b/packages/mcp-server-node/package.json
@@ -9,6 +9,7 @@
   "bin": { "rustbrain-mcp": "dist/src/cli.js" },
   "scripts": {
     "build": "tsc",
+    "postbuild": "node scripts/write-build-sha.cjs",
     "test": "tsc && node --test dist/test/*.test.js",
     "prepublishOnly": "npm run test"
   },
@@ -18,6 +19,7 @@
   },
   "files": [
     "dist/src/",
+    "dist/build-sha.txt",
     "README.md"
   ],
   "publishConfig": {

--- a/packages/mcp-server-node/scripts/write-build-sha.cjs
+++ b/packages/mcp-server-node/scripts/write-build-sha.cjs
@@ -1,0 +1,26 @@
+'use strict';
+// Writes the current git SHA into dist/build-sha.txt at the end of every
+// `npm run build`.  Called via the "postbuild" lifecycle hook.
+//
+// Resolution order:
+//   1. BUILD_SHA env var (set by Docker --build-arg MCP_BUILD_SHA=...)
+//   2. `git rev-parse HEAD` (works in local dev with git)
+//   3. "unknown" (fallback when neither is available)
+const { execSync } = require('node:child_process');
+const { writeFileSync } = require('node:fs');
+
+let sha;
+if (process.env.BUILD_SHA) {
+  sha = process.env.BUILD_SHA.trim();
+} else {
+  try {
+    sha = execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    sha = 'unknown';
+  }
+}
+
+writeFileSync('dist/build-sha.txt', sha);

--- a/services/agent-runner/src/consumer.rs
+++ b/services/agent-runner/src/consumer.rs
@@ -13,6 +13,34 @@ use tokio::task::JoinHandle;
 
 use crate::session::{SessionManager, spawn_workspace_gc};
 
+/// Returns the SHA baked into the installed `rustbrain-mcp` bundle.
+///
+/// Resolution order:
+///   1. `MCP_BUILD_SHA` env var (set by the agent-runner Docker image via ARG→ENV)
+///   2. `MCP_SHA_FILE` sidecar path (default `/opt/rustbrain/mcp-build-sha.txt`)
+///   3. `"unknown"` fallback (local dev without the sidecar file)
+fn read_mcp_sha() -> String {
+    if let Ok(sha) = std::env::var("MCP_BUILD_SHA") {
+        let sha = sha.trim().to_string();
+        if !sha.is_empty() && sha != "unknown" {
+            return sha;
+        }
+    }
+    let file_path = std::env::var("MCP_SHA_FILE")
+        .unwrap_or_else(|_| "/opt/rustbrain/mcp-build-sha.txt".to_string());
+    match std::fs::read_to_string(&file_path) {
+        Ok(content) => {
+            let sha = content.trim().to_string();
+            if sha.is_empty() {
+                "unknown".to_string()
+            } else {
+                sha
+            }
+        }
+        Err(_) => "unknown".to_string(),
+    }
+}
+
 pub struct ConsumerHandle {
     pub handle: JoinHandle<()>,
     pub session_manager: Arc<SessionManager>,
@@ -40,11 +68,14 @@ pub fn spawn(
         http_client: http_client.clone(),
     });
 
+    let mcp_sha = read_mcp_sha();
+
     let session_manager = Arc::new(SessionManager::new(
         workspace_base.clone(),
         control_api_base,
         http_client,
         relay_sender,
+        mcp_sha,
     ));
     let producer = Arc::new(Producer::<AgentEvent>::new(&ProducerCfg::default())?);
 

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -15,16 +15,14 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 
-use crate::adapters::{AgentProcess, RuntimeAdapter, SessionCtx, adapter_for_runtime};
+use crate::adapters::{adapter_for_runtime, AgentProcess, RuntimeAdapter, SessionCtx};
 
 mod natural_exit;
+mod seq;
 
 const PROCESS_TERMINATE_TIMEOUT_SECS: u64 = 30;
 const MAX_INITIAL_PROMPT_LEN: usize = 100_000;
 const MAX_TRACKED_SESSIONS: usize = 100_000;
-
-const SEQ_COUNTER_GC_INTERVAL_SECS: u64 = 300;
-const SEQ_COUNTER_MAX_AGE_SECS: u64 = 600;
 
 /// Sentinel seq value for Terminated / natural-exit lifecycle events.
 /// Must match `lifecycle_event_seq("terminated")` in control-api/src/routes/agents/sessions.rs.
@@ -82,31 +80,10 @@ impl SessionManager {
         let seq_counter_timestamps: Arc<Mutex<HashMap<String, Instant>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
-        let seq_counters_gc = Arc::clone(&seq_counters);
-        let timestamps_gc = Arc::clone(&seq_counter_timestamps);
-        tokio::spawn(async move {
-            let mut interval =
-                tokio::time::interval(Duration::from_secs(SEQ_COUNTER_GC_INTERVAL_SECS));
-            let max_age = Duration::from_secs(SEQ_COUNTER_MAX_AGE_SECS);
-            loop {
-                interval.tick().await;
-                let now = Instant::now();
-                let mut counters = seq_counters_gc.lock().await;
-                let mut timestamps = timestamps_gc.lock().await;
-                let before = counters.len();
-                timestamps.retain(|session_id, ts| {
-                    let retain = now.duration_since(*ts) < max_age;
-                    if !retain {
-                        counters.remove(session_id);
-                    }
-                    retain
-                });
-                let removed = before - counters.len();
-                if removed > 0 {
-                    tracing::debug!("GC: removed {} stale seq counter entries", removed);
-                }
-            }
-        });
+        seq::spawn_gc(
+            Arc::clone(&seq_counters),
+            Arc::clone(&seq_counter_timestamps),
+        );
 
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -264,9 +241,6 @@ impl SessionManager {
         )
         .await;
 
-        // Cross-runtime SHA pairing (warn-only per board decision in RUSAA-1644).
-        // Logs runner and MCP bundle SHAs so dashboards can detect cross-commit
-        // divergence without blocking session spawn.
         let runner_sha = rb_build_info::SHA;
         let mcp_sha = self.mcp_sha.as_str();
         let mcp_sha_mismatch =
@@ -473,19 +447,7 @@ impl SessionManager {
                     let reader = BufReader::new(stdout);
                     let mut lines = reader.lines();
                     while let Ok(Some(line)) = lines.next_line().await {
-                        let seq = {
-                            let mut c = seq_counters.lock().await;
-                            let mut ts = seq_timestamps.lock().await;
-                            let n = c.entry(sid_stdout.clone()).or_insert(0);
-                            if *n >= i64::MAX - 1 {
-                                tracing::warn!(session_id = %sid_stdout, "Seq counter approaching overflow, wrapping to 1");
-                                *n = 1;
-                            } else {
-                                *n += 1;
-                            }
-                            ts.insert(sid_stdout.clone(), Instant::now());
-                            *n
-                        };
+                        let seq = seq::next_seq(&seq_counters, &seq_timestamps, &sid_stdout).await;
                         if let Some(parsed) = adapter.parse_stdout_line(&line) {
                             let event = AgentEvent {
                                 tenant_id: tenant_id.to_string(),
@@ -516,19 +478,7 @@ impl SessionManager {
                 let reader = BufReader::new(stderr);
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
-                    let seq = {
-                        let mut c = seq_counters2.lock().await;
-                        let mut ts = seq_timestamps2.lock().await;
-                        let n = c.entry(sid_err.clone()).or_insert(0);
-                        if *n >= i64::MAX - 1 {
-                            tracing::warn!(session_id = %sid_err, "Seq counter approaching overflow, wrapping to 1");
-                            *n = 1;
-                        } else {
-                            *n += 1;
-                        }
-                        ts.insert(sid_err.clone(), Instant::now());
-                        *n
-                    };
+                    let seq = seq::next_seq(&seq_counters2, &seq_timestamps2, &sid_err).await;
                     let event = AgentEvent {
                         tenant_id: tenant_id.to_string(),
                         session_id: sid_err.clone(),

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 
-use crate::adapters::{adapter_for_runtime, AgentProcess, RuntimeAdapter, SessionCtx};
+use crate::adapters::{AgentProcess, RuntimeAdapter, SessionCtx, adapter_for_runtime};
 
 mod natural_exit;
 mod seq;

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -38,6 +38,8 @@ pub struct SessionManager {
     control_api_base: String,
     http_client: reqwest::Client,
     relay_sender: agent_runner::EventSender,
+    /// SHA of the mcp-server-node bundle baked into the agent-runner image.
+    mcp_sha: String,
 }
 
 struct SessionHandle {
@@ -74,6 +76,7 @@ impl SessionManager {
         control_api_base: String,
         http_client: reqwest::Client,
         relay_sender: agent_runner::EventSender,
+        mcp_sha: String,
     ) -> Self {
         let seq_counters = Arc::new(Mutex::new(HashMap::new()));
         let seq_counter_timestamps: Arc<Mutex<HashMap<String, Instant>>> =
@@ -113,6 +116,7 @@ impl SessionManager {
             control_api_base,
             http_client,
             relay_sender,
+            mcp_sha,
         }
     }
 
@@ -260,6 +264,20 @@ impl SessionManager {
         )
         .await;
 
+        // Cross-runtime SHA pairing (warn-only per board decision in RUSAA-1644).
+        // Logs runner and MCP bundle SHAs so dashboards can detect cross-commit
+        // divergence without blocking session spawn.
+        let runner_sha = rb_build_info::SHA;
+        let mcp_sha = self.mcp_sha.as_str();
+        let mcp_sha_mismatch =
+            runner_sha != "unknown" && mcp_sha != "unknown" && runner_sha != mcp_sha;
+        tracing::info!(
+            session_id = %session_id,
+            runner_sha,
+            mcp_sha,
+            mcp_sha_mismatch,
+            "MCP session SHA pair"
+        );
         tracing::info!(session_id = %session_id, pid = pid, runtime = ?runtime, "Session started");
         Ok(())
     }

--- a/services/agent-runner/src/session/seq.rs
+++ b/services/agent-runner/src/session/seq.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+pub(super) const GC_INTERVAL_SECS: u64 = 300;
+pub(super) const MAX_AGE_SECS: u64 = 600;
+
+pub(super) async fn next_seq(
+    counters: &Mutex<HashMap<String, i64>>,
+    timestamps: &Mutex<HashMap<String, Instant>>,
+    session_id: &str,
+) -> i64 {
+    let mut c = counters.lock().await;
+    let mut ts = timestamps.lock().await;
+    let n = c.entry(session_id.to_owned()).or_insert(0);
+    if *n >= i64::MAX - 1 {
+        tracing::warn!(
+            session_id = %session_id,
+            "Seq counter approaching overflow, wrapping to 1"
+        );
+        *n = 1;
+    } else {
+        *n += 1;
+    }
+    ts.insert(session_id.to_owned(), Instant::now());
+    *n
+}
+
+pub(super) fn spawn_gc(
+    counters: Arc<Mutex<HashMap<String, i64>>>,
+    timestamps: Arc<Mutex<HashMap<String, Instant>>>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(GC_INTERVAL_SECS));
+        let max_age = Duration::from_secs(MAX_AGE_SECS);
+        loop {
+            interval.tick().await;
+            let now = Instant::now();
+            let mut c = counters.lock().await;
+            let mut ts = timestamps.lock().await;
+            let before = c.len();
+            ts.retain(|session_id, t| {
+                let retain = now.duration_since(*t) < max_age;
+                if !retain {
+                    c.remove(session_id);
+                }
+                retain
+            });
+            let removed = before - c.len();
+            if removed > 0 {
+                tracing::debug!("GC: removed {} stale seq counter entries", removed);
+            }
+        }
+    });
+}

--- a/services/agent-runner/src/session/tests.rs
+++ b/services/agent-runner/src/session/tests.rs
@@ -417,7 +417,7 @@ async fn natural_exit_noop_when_session_already_removed() {
 }
 
 // ---------------------------------------------------------------------
-// RUSAA-1644: MCP SHA pairing — mismatch detection logic, warn-only
+// MCP SHA pairing — mismatch detection logic, warn-only
 // ---------------------------------------------------------------------
 
 #[test]

--- a/services/agent-runner/src/session/tests.rs
+++ b/services/agent-runner/src/session/tests.rs
@@ -119,6 +119,7 @@ async fn start_session_marks_failed_on_adapter_spawn_error() {
             .build()
             .unwrap(),
         relay_sender,
+        "test-mcp-sha".to_string(),
     );
 
     let (tx, _rx) = tokio::sync::mpsc::channel(16);
@@ -413,4 +414,39 @@ async fn natural_exit_noop_when_session_already_removed() {
     );
 
     server_handle.abort();
+}
+
+// ---------------------------------------------------------------------
+// RUSAA-1644: MCP SHA pairing — mismatch detection logic, warn-only
+// ---------------------------------------------------------------------
+
+#[test]
+fn mcp_sha_mismatch_detected_when_both_shas_known_and_differ() {
+    let runner_sha = "aaaa1111bbbb2222cccc3333dddd4444eeee5555";
+    let mcp_sha = "ffff6666aaaa7777bbbb8888cccc9999dddd0000";
+    let mismatch = runner_sha != "unknown" && mcp_sha != "unknown" && runner_sha != mcp_sha;
+    assert!(mismatch, "different known SHAs must be a mismatch");
+}
+
+#[test]
+fn mcp_sha_no_mismatch_when_shas_are_equal() {
+    let sha = "aaaa1111bbbb2222cccc3333dddd4444eeee5555";
+    let mismatch = sha != "unknown" && sha != "unknown" && sha != sha;
+    assert!(!mismatch, "identical SHAs must not mismatch");
+}
+
+#[test]
+fn mcp_sha_no_mismatch_when_runner_sha_unknown() {
+    let runner_sha = "unknown";
+    let mcp_sha = "ffff6666aaaa7777bbbb8888cccc9999dddd0000";
+    let mismatch = runner_sha != "unknown" && mcp_sha != "unknown" && runner_sha != mcp_sha;
+    assert!(!mismatch, "unknown runner SHA must not trigger mismatch");
+}
+
+#[test]
+fn mcp_sha_no_mismatch_when_mcp_sha_unknown() {
+    let runner_sha = "aaaa1111bbbb2222cccc3333dddd4444eeee5555";
+    let mcp_sha = "unknown";
+    let mismatch = runner_sha != "unknown" && mcp_sha != "unknown" && runner_sha != mcp_sha;
+    assert!(!mismatch, "unknown mcp SHA must not trigger mismatch");
 }


### PR DESCRIPTION
## Summary

Cross-runtime SHA pairing: `agent-runner` (Rust) now reads the `mcp-server-node` bundle's baked-in SHA at session spawn time and logs a structured `mcp_sha_mismatch` event so dashboards can detect cross-commit divergence. **Warn-only** — session spawn is never blocked.

Supersedes #569 (closed when Phase 2's base branch was squash-merged + deleted).

### Changes

- **`packages/mcp-server-node`**: add `scripts/write-build-sha.cjs` postbuild hook that writes the git SHA (or `BUILD_SHA` env var) to `dist/build-sha.txt`; include file in npm `files` array
- **`docker/agent-runner/Dockerfile`**: thread `MCP_BUILD_SHA` build-arg through mcp-builder stage (`BUILD_SHA` env → postbuild) and runtime stage (`ARG`/`ENV MCP_BUILD_SHA`); copy `dist/build-sha.txt` to sidecar `/opt/rustbrain/mcp-build-sha.txt`
- **`services/agent-runner/consumer.rs`**: add `read_mcp_sha()` (resolution: `MCP_BUILD_SHA` env var → `MCP_SHA_FILE` sidecar path → `"unknown"` fallback); pass `mcp_sha` to `SessionManager::new()`
- **`services/agent-runner/session/mod.rs`**: add `mcp_sha` field; emit `tracing::info!` with `runner_sha`, `mcp_sha`, `mcp_sha_mismatch` on every MCP session spawn
- **`services/agent-runner/session/seq.rs`** (new): extract seq-counter GC spawner and `next_seq` increment helper; reduces `mod.rs` from 618 → 568 lines (within the 600-line cap)
- **`session/tests.rs`** (new): 4 unit tests covering mismatch-detection predicate edge cases

### Mismatch policy (warn-only)

`mcp_sha_mismatch=true` is logged but session spawn always proceeds. Hard-blocking is a follow-up issue after ≥1 week of telemetry review.

The SHA pair is grep-able in structured JSON logs:

```
{"session_id":"…","runner_sha":"abc123","mcp_sha":"def456","mcp_sha_mismatch":true,"message":"MCP session SHA pair"}
```

## GitHub Issue

Closes #565

## Migration type

None — no schema changes.

## Checklist

- [x] `cargo fmt --all` applied
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] `session/mod.rs` within 600-line cap (568 lines)
- [x] 4 unit tests covering mismatch-detection predicate edge cases