### PR TITLE
[RUSAA-1654] fix(dev-stack): pin auto-rebuild watcher to canonical repo compose dir

### DIFF
--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -232,6 +232,39 @@ scripts/dev-stack-auto-rebuild.sh --cold-start <prev_sha> <new_sha>  # with expl
 
 The watcher (`dev-stack-watch.sh`) automatically detects a stopped stack at startup and on each new-commit cycle, and passes `--cold-start` to the rebuild script when needed. The `COMPOSE_CMD` environment variable must be set (or accept the default) for cold-start detection to work correctly.
 
+## Reconciling working_dir drift
+
+Each `rustbrain-dev-*` container stores the compose project working directory as a label
+(`com.docker.compose.project.working_dir`). Bind-mount paths like `../migrations:/migrations:ro`
+resolve **relative to that label**. If the label ever points to a non-canonical path (e.g.
+`/tmp/phase2-deploy/compose`) the bind fails when that directory is cleaned up.
+
+**Detect drift:**
+
+```bash
+scripts/check-compose-working-dir.sh
+```
+
+Prints a per-container `OK` / `DRIFT` report and exits non-zero when any container has a
+working_dir label that diverges from `<repo>/compose/`.
+
+**Fix drift (force-recreate):**
+
+```bash
+# On mars — use the full tailscale COMPOSE_CMD so ports are correct
+COMPOSE_CMD="docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml" \
+  scripts/check-compose-working-dir.sh --fix
+```
+
+`--fix` runs `docker compose up -d --force-recreate`, which re-creates every container and
+re-stamps the correct label. Health checks in the rebuild log confirm recovery.
+
+**Automatic prevention:** `dev-stack-watch.sh` and `dev-stack-auto-rebuild.sh` now refuse to
+run when their own directory or `REPO_ROOT` resolves under `/tmp/`; the watcher exits with a
+non-zero code and a fatal journal entry, which triggers the `Restart=on-failure` cycle in
+systemd. The systemd unit also carries `ConditionPathNotEmpty=…/compose/active-env` so it will
+not start at all if that sentinel file is missing or empty.
+
 ## Troubleshooting
 
 **Rebuild never triggers**

--- a/infra/systemd/rustbrain-dev-watch.service
+++ b/infra/systemd/rustbrain-dev-watch.service
@@ -2,6 +2,10 @@
 Description=Rustbrain dev-stack auto-rebuild watcher
 After=network-online.target
 Wants=network-online.target
+# Refuse to start when compose/active-env is absent or empty. The watcher script
+# enforces the same check at runtime, but the systemd condition prevents a failed-start
+# restart cycle before the file is created.
+ConditionPathNotEmpty=%h/projects/rustacean/compose/active-env
 
 [Service]
 Type=simple

--- a/scripts/check-compose-working-dir.sh
+++ b/scripts/check-compose-working-dir.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Detects and optionally fixes compose project.working_dir label drift on rustbrain-dev
+# containers. Containers whose working_dir label diverges from the canonical repo compose/
+# directory have stale bind-mount resolution: paths like ../migrations:/migrations resolve
+# relative to the label, so if the original working directory was cleaned up the bind
+# fails at container start.
+#
+# Usage:
+#   scripts/check-compose-working-dir.sh [--fix]
+#
+# Without --fix: print a report and exit non-zero if drift is detected.
+# With --fix:    force-recreate all rustbrain-dev containers so Docker re-labels them
+#                with the canonical compose working_dir.
+#
+# Environment:
+#   COMPOSE_CMD  Full docker compose invocation (default: docker compose -f <repo>/compose/dev.yml)
+#                On mars: "docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml"
+#
+# See docs/dev-stack-auto-rebuild.md § Reconciling working_dir drift for details.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CANONICAL_DIR="$REPO_ROOT/compose"
+COMPOSE_CMD="${COMPOSE_CMD:-docker compose -f "$REPO_ROOT/compose/dev.yml"}"
+
+FIX=false
+if [[ "${1:-}" == "--fix" ]]; then
+  FIX=true
+fi
+
+echo "[check-compose-working-dir] canonical dir: $CANONICAL_DIR"
+
+CONTAINERS="$(docker ps -a \
+  --filter "label=com.docker.compose.project=rustbrain-dev" \
+  --format "{{.Names}}" 2>/dev/null)" || true
+
+if [[ -z "$CONTAINERS" ]]; then
+  echo "[check-compose-working-dir] no rustbrain-dev containers found — nothing to check"
+  exit 0
+fi
+
+DRIFT_FOUND=false
+
+while IFS= read -r container; do
+  WORKING_DIR="$(docker inspect \
+    --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' \
+    "$container" 2>/dev/null)" || WORKING_DIR=""
+  if [[ "$WORKING_DIR" != "$CANONICAL_DIR" ]]; then
+    echo "[check-compose-working-dir] DRIFT: $container" >&2
+    echo "[check-compose-working-dir]   have: $WORKING_DIR" >&2
+    echo "[check-compose-working-dir]   want: $CANONICAL_DIR" >&2
+    DRIFT_FOUND=true
+  else
+    echo "[check-compose-working-dir] OK:    $container"
+  fi
+done <<< "$CONTAINERS"
+
+if [[ "$DRIFT_FOUND" == "false" ]]; then
+  echo "[check-compose-working-dir] all containers are aligned with the canonical compose dir"
+  exit 0
+fi
+
+if [[ "$FIX" == "false" ]]; then
+  echo "" >&2
+  echo "[check-compose-working-dir] Drift detected. To fix, run:" >&2
+  echo "  COMPOSE_CMD=\"$COMPOSE_CMD\" $0 --fix" >&2
+  exit 1
+fi
+
+echo "[check-compose-working-dir] force-recreating all services to re-anchor working_dir label..."
+$COMPOSE_CMD up -d --force-recreate
+
+echo "[check-compose-working-dir] done. Verify with:"
+echo "  docker ps -a --filter label=com.docker.compose.project=rustbrain-dev --format '{{.Names}}' \\"
+echo "    | xargs -I{} docker inspect --format '{{index .Config.Labels \"com.docker.compose.project.working_dir\"}} {}' {}"

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -27,6 +27,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${RB_REPO_PATH:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
+
+# Guard: refuse to run when the script or REPO_ROOT resolves under /tmp/.
+# Bind-mount paths like ../migrations:/migrations:ro are resolved relative to the
+# compose project.working_dir label stored on each container. If that label points
+# into /tmp/ and the directory is later cleaned up, the bind fails at container
+# start with "migrations directory not found".
+if [[ "$SCRIPT_DIR" == /tmp/* || "$REPO_ROOT" == /tmp/* ]]; then
+  echo "[dev-stack-auto-rebuild] FATAL: refusing to run from a /tmp/ path" >&2
+  echo "[dev-stack-auto-rebuild]   SCRIPT_DIR=$SCRIPT_DIR" >&2
+  echo "[dev-stack-auto-rebuild]   REPO_ROOT=$REPO_ROOT" >&2
+  echo "[dev-stack-auto-rebuild]   Invoke from the canonical repo: ~/projects/rustacean/scripts/dev-stack-auto-rebuild.sh" >&2
+  exit 1
+fi
+
 LOG_DIR="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}"
 LOG_FILE="$LOG_DIR/dev-stack-rebuilds.ndjson"
 BYPASS_FILE="$REPO_ROOT/compose/.no-auto-rebuild"

--- a/scripts/dev-stack-watch.sh
+++ b/scripts/dev-stack-watch.sh
@@ -23,6 +23,29 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${1:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
+
+# Guard: refuse to start when the script or REPO_ROOT resolves under /tmp/.
+# Running the watcher from a /tmp/ working directory brands every container with
+# a stale project.working_dir label; bind-mounts like ../migrations:/migrations:ro
+# break the moment that directory is cleaned up.
+if [[ "$SCRIPT_DIR" == /tmp/* || "$REPO_ROOT" == /tmp/* ]]; then
+  echo "[dev-stack-watch] FATAL: refusing to run from a /tmp/ path" >&2
+  echo "[dev-stack-watch]   SCRIPT_DIR=$SCRIPT_DIR" >&2
+  echo "[dev-stack-watch]   REPO_ROOT=$REPO_ROOT" >&2
+  echo "[dev-stack-watch]   Run from the canonical repo: ~/projects/rustacean/scripts/dev-stack-watch.sh" >&2
+  exit 1
+fi
+
+# Guard: compose/active-env must exist and be non-empty. Systemd's ConditionPathNotEmpty
+# enforces the same check at unit-start time, but an in-script check ensures the watcher
+# also fails fast when launched manually without the systemd precondition.
+ACTIVE_ENV_FILE="$REPO_ROOT/compose/active-env"
+if [[ ! -f "$ACTIVE_ENV_FILE" || ! -s "$ACTIVE_ENV_FILE" ]]; then
+  echo "[dev-stack-watch] FATAL: $ACTIVE_ENV_FILE is missing or empty — refusing to start" >&2
+  echo "[dev-stack-watch]   Create it before starting. Example: echo tailscale > compose/active-env" >&2
+  exit 1
+fi
+
 POLL_INTERVAL="${POLL_INTERVAL:-60}"
 REMOTE="${REMOTE:-origin}"
 BRANCH="${BRANCH:-main}"


### PR DESCRIPTION
## Summary

Hardens the auto-rebuild watcher so the `/tmp/phase2-deploy` regression cannot recur. Root-cause: the watcher could be started from a transient `/tmp/` directory, stamping all containers with a `com.docker.compose.project.working_dir` label that resolves bind-mounts (e.g. `../migrations:/migrations:ro`) relative to that path. When `/tmp/phase2-deploy/` was cleaned up, the bind failed at container start.

- **`/tmp/` guard in `dev-stack-auto-rebuild.sh`**: fails fast with a fatal stderr message if `SCRIPT_DIR` or `REPO_ROOT` resolves under `/tmp/`, preventing containers from ever being labeled with a transient working directory.
- **`/tmp/` guard + `active-env` check in `dev-stack-watch.sh`**: same `/tmp/` guard; also verifies `compose/active-env` exists and is non-empty before entering the poll loop.
- **`ConditionPathNotEmpty` in `infra/systemd/rustbrain-dev-watch.service`**: systemd refuses to start the unit if `compose/active-env` is missing or empty, preventing a failed-start restart loop.
- **New `scripts/check-compose-working-dir.sh`**: reconcile script that inspects `com.docker.compose.project.working_dir` on every `rustbrain-dev-*` container and reports (`exit 1`) or fixes (`--fix` → `docker compose up -d --force-recreate`) any drift from the canonical `<repo>/compose` path.
- **`docs/dev-stack-auto-rebuild.md`**: "Reconciling working_dir drift" section documents the check and fix commands.

## GitHub Issue

Closes #571

## Migration type

Not applicable — no schema changes.

## Checklist

- [x] Guard fires correctly for `/tmp/` paths (validated with bash logic test)
- [x] Guard fires correctly for missing `active-env` (validated with bash logic test)
- [x] All scripts pass `bash -n` syntax check
- [x] `scripts/check-compose-working-dir.sh` is executable (`chmod +x`)
- [x] Docs updated (`docs/dev-stack-auto-rebuild.md`)
- [x] No `RUSAA-` outside the title bracket prefix