### PR TITLE
[RUSAA-1661] feat: self-heal cross-tenant GitHub install conflicts via orphan reclaim

### DIFF
--- a/frontend/src/pages/ReposPage.tsx
+++ b/frontend/src/pages/ReposPage.tsx
@@ -117,8 +117,11 @@ function ReposPageInner({ tenantId }: ReposPageInnerProps): JSX.Element {
     } else if (!installHandledRef.current && search.install === "conflict") {
       installHandledRef.current = true;
       toast.error(
-        "This GitHub account is already installed by another workspace. " +
-        "Please contact your administrator or re-install the GitHub App on a different account.",
+        search.reason === "active"
+          ? "This GitHub account is actively connected to another workspace. " +
+            "Contact your administrator to transfer it, or install the GitHub App on a different account."
+          : "This GitHub account is already connected to another workspace. " +
+            "Please contact your administrator or install the GitHub App on a different account.",
       );
       window.history.replaceState(null, "", routes.repos);
     }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -88,6 +88,7 @@ const reposSearchSchema = z.object({
   install: z.enum(["success", "conflict"]).optional(),
   installation_uuid: z.uuid().optional(),
   account_login: z.string().optional(),
+  reason: z.enum(["active"]).optional(),
 });
 
 const reposRoute = createRoute({

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -186,23 +186,72 @@ pub async fn github_callback(
     .await?;
 
     let Some((installation_uuid,)) = installation_uuid_opt else {
-        let owner: Option<Uuid> = sqlx::query_scalar(
-            "SELECT tenant_id FROM control.github_installations \
-             WHERE github_installation_id = $1",
+        // Upsert was a no-op: a different tenant owns this installation_id.
+        // Attempt an atomic orphan reclaim. Reclaim is safe only when:
+        //   • the existing installation is soft-deleted (gi.deleted_at IS NOT NULL), OR
+        //   • the owning tenant is in a terminal state (deleted/deleting),
+        //   AND no active repos are still linked to the installation.
+        let reclaim_opt: Option<(Uuid, Uuid)> = sqlx::query_as(
+            "WITH reclaimable AS ( \
+                 SELECT gi.id, gi.tenant_id AS prior_tenant_id \
+                 FROM   control.github_installations gi \
+                 JOIN   control.tenants t ON t.id = gi.tenant_id \
+                 WHERE  gi.github_installation_id = $1 \
+                   AND  gi.tenant_id <> $2 \
+                   AND  (   gi.deleted_at IS NOT NULL \
+                         OR t.deleted_at IS NOT NULL \
+                         OR t.status IN ('deleting', 'deleted') \
+                        ) \
+                   AND  NOT EXISTS ( \
+                            SELECT 1 \
+                            FROM   control.repos r \
+                            WHERE  r.installation_id = gi.id \
+                              AND  r.archived_at IS NULL \
+                        ) \
+             ) \
+             UPDATE control.github_installations gi \
+             SET    tenant_id     = $2, \
+                    account_login = $3, \
+                    account_type  = $4, \
+                    account_id    = $5, \
+                    deleted_at    = NULL, \
+                    suspended_at  = NULL \
+             FROM   reclaimable \
+             WHERE  gi.id = reclaimable.id \
+             RETURNING gi.id, reclaimable.prior_tenant_id",
         )
         .bind(params.installation_id)
+        .bind(tenant_id)
+        .bind(&info.account.login)
+        .bind(&info.account.kind)
+        .bind(info.account.id)
         .fetch_optional(&state.pool)
         .await?;
+
+        if let Some((installation_uuid, prior_tenant_id)) = reclaim_opt {
+            tracing::warn!(
+                requesting_tenant = %tenant_id,
+                prior_tenant = %prior_tenant_id,
+                installation_id = params.installation_id,
+                installation_uuid = %installation_uuid,
+                account = %info.account.login,
+                "github callback: orphaned installation reclaimed"
+            );
+            return Ok(Redirect::to(&format!(
+                "{}/repos?install=success&installation_uuid={}&account_login={}",
+                state.config.base_url,
+                installation_uuid,
+                urlencode(&info.account.login),
+            )));
+        }
+
         tracing::warn!(
             requesting_tenant = %tenant_id,
-            owner_tenant = ?owner,
             installation_id = params.installation_id,
-            "github callback: cross-tenant installation conflict rejected"
+            "github callback: cross-tenant installation conflict rejected (active owner)"
         );
-        // Redirect to the frontend with an error flag so the browser renders
-        // a friendly message rather than exposing the raw JSON 409 body.
         return Ok(Redirect::to(&format!(
-            "{}/repos?install=conflict",
+            "{}/repos?install=conflict&reason=active",
             state.config.base_url,
         )));
     };

--- a/services/control-api/src/routes/github/install.rs
+++ b/services/control-api/src/routes/github/install.rs
@@ -186,74 +186,7 @@ pub async fn github_callback(
     .await?;
 
     let Some((installation_uuid,)) = installation_uuid_opt else {
-        // Upsert was a no-op: a different tenant owns this installation_id.
-        // Attempt an atomic orphan reclaim. Reclaim is safe only when:
-        //   • the existing installation is soft-deleted (gi.deleted_at IS NOT NULL), OR
-        //   • the owning tenant is in a terminal state (deleted/deleting),
-        //   AND no active repos are still linked to the installation.
-        let reclaim_opt: Option<(Uuid, Uuid)> = sqlx::query_as(
-            "WITH reclaimable AS ( \
-                 SELECT gi.id, gi.tenant_id AS prior_tenant_id \
-                 FROM   control.github_installations gi \
-                 JOIN   control.tenants t ON t.id = gi.tenant_id \
-                 WHERE  gi.github_installation_id = $1 \
-                   AND  gi.tenant_id <> $2 \
-                   AND  (   gi.deleted_at IS NOT NULL \
-                         OR t.deleted_at IS NOT NULL \
-                         OR t.status IN ('deleting', 'deleted') \
-                        ) \
-                   AND  NOT EXISTS ( \
-                            SELECT 1 \
-                            FROM   control.repos r \
-                            WHERE  r.installation_id = gi.id \
-                              AND  r.archived_at IS NULL \
-                        ) \
-             ) \
-             UPDATE control.github_installations gi \
-             SET    tenant_id     = $2, \
-                    account_login = $3, \
-                    account_type  = $4, \
-                    account_id    = $5, \
-                    deleted_at    = NULL, \
-                    suspended_at  = NULL \
-             FROM   reclaimable \
-             WHERE  gi.id = reclaimable.id \
-             RETURNING gi.id, reclaimable.prior_tenant_id",
-        )
-        .bind(params.installation_id)
-        .bind(tenant_id)
-        .bind(&info.account.login)
-        .bind(&info.account.kind)
-        .bind(info.account.id)
-        .fetch_optional(&state.pool)
-        .await?;
-
-        if let Some((installation_uuid, prior_tenant_id)) = reclaim_opt {
-            tracing::warn!(
-                requesting_tenant = %tenant_id,
-                prior_tenant = %prior_tenant_id,
-                installation_id = params.installation_id,
-                installation_uuid = %installation_uuid,
-                account = %info.account.login,
-                "github callback: orphaned installation reclaimed"
-            );
-            return Ok(Redirect::to(&format!(
-                "{}/repos?install=success&installation_uuid={}&account_login={}",
-                state.config.base_url,
-                installation_uuid,
-                urlencode(&info.account.login),
-            )));
-        }
-
-        tracing::warn!(
-            requesting_tenant = %tenant_id,
-            installation_id = params.installation_id,
-            "github callback: cross-tenant installation conflict rejected (active owner)"
-        );
-        return Ok(Redirect::to(&format!(
-            "{}/repos?install=conflict&reason=active",
-            state.config.base_url,
-        )));
+        return attempt_orphan_reclaim(&state, params.installation_id, tenant_id, &info).await;
     };
 
     tracing::info!(
@@ -271,6 +204,85 @@ pub async fn github_callback(
         state.config.base_url,
         installation_uuid,
         urlencode(&info.account.login),
+    )))
+}
+
+/// Attempt to atomically reclaim a GitHub installation that belongs to another tenant.
+///
+/// Reclaim is permitted only when the existing row's tenant is in a terminal/deleted
+/// state and no active repos are linked. Returns a redirect to `/repos?install=…`.
+async fn attempt_orphan_reclaim(
+    state: &AppState,
+    installation_id: i64,
+    tenant_id: Uuid,
+    info: &rb_github::InstallationInfo,
+) -> Result<Redirect, AppError> {
+    // Reclaim is safe only when:
+    //   • the existing installation is soft-deleted (gi.deleted_at IS NOT NULL), OR
+    //   • the owning tenant is in a terminal state (deleted/deleting),
+    //   AND no active repos are still linked to the installation.
+    let reclaim_opt: Option<(Uuid, Uuid)> = sqlx::query_as(
+        "WITH reclaimable AS ( \
+             SELECT gi.id, gi.tenant_id AS prior_tenant_id \
+             FROM   control.github_installations gi \
+             JOIN   control.tenants t ON t.id = gi.tenant_id \
+             WHERE  gi.github_installation_id = $1 \
+               AND  gi.tenant_id <> $2 \
+               AND  (   gi.deleted_at IS NOT NULL \
+                     OR t.deleted_at IS NOT NULL \
+                     OR t.status IN ('deleting', 'deleted') \
+                    ) \
+               AND  NOT EXISTS ( \
+                        SELECT 1 \
+                        FROM   control.repos r \
+                        WHERE  r.installation_id = gi.id \
+                          AND  r.archived_at IS NULL \
+                    ) \
+         ) \
+         UPDATE control.github_installations gi \
+         SET    tenant_id     = $2, \
+                account_login = $3, \
+                account_type  = $4, \
+                account_id    = $5, \
+                deleted_at    = NULL, \
+                suspended_at  = NULL \
+         FROM   reclaimable \
+         WHERE  gi.id = reclaimable.id \
+         RETURNING gi.id, reclaimable.prior_tenant_id",
+    )
+    .bind(installation_id)
+    .bind(tenant_id)
+    .bind(&info.account.login)
+    .bind(&info.account.kind)
+    .bind(info.account.id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    if let Some((installation_uuid, prior_tenant_id)) = reclaim_opt {
+        tracing::warn!(
+            requesting_tenant = %tenant_id,
+            prior_tenant = %prior_tenant_id,
+            installation_id = installation_id,
+            installation_uuid = %installation_uuid,
+            account = %info.account.login,
+            "github callback: orphaned installation reclaimed"
+        );
+        return Ok(Redirect::to(&format!(
+            "{}/repos?install=success&installation_uuid={}&account_login={}",
+            state.config.base_url,
+            installation_uuid,
+            urlencode(&info.account.login),
+        )));
+    }
+
+    tracing::warn!(
+        requesting_tenant = %tenant_id,
+        installation_id = installation_id,
+        "github callback: cross-tenant installation conflict rejected (active owner)"
+    );
+    Ok(Redirect::to(&format!(
+        "{}/repos?install=conflict&reason=active",
+        state.config.base_url,
     )))
 }
 

--- a/services/control-api/tests/integration_github_install_conflict.rs
+++ b/services/control-api/tests/integration_github_install_conflict.rs
@@ -1,0 +1,297 @@
+//! Integration tests for the orphan-reclaim path in `GET /v1/github/callback`.
+//!
+//! These tests exercise the SQL reclaim CTE directly, mirroring the pattern
+//! used by `upsert_guard_rejects_cross_tenant_owner` in `install.rs`.
+//!
+//! Skipped automatically when `RB_DATABASE_URL` is not set.
+
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn connect() -> Option<sqlx::PgPool> {
+    let Ok(db_url) = std::env::var("RB_DATABASE_URL") else {
+        return None;
+    };
+    Some(
+        PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&db_url)
+            .await
+            .expect("connect to test database"),
+    )
+}
+
+fn random_install_id() -> i64 {
+    i64::from(rand::random::<i32>().abs()) + 2_000_000
+}
+
+async fn seed_tenant(pool: &sqlx::PgPool, id: Uuid, status: &str) {
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name, status) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(id)
+    .bind(format!("reclaim-test-{id}"))
+    .bind("Reclaim Test Tenant")
+    .bind(format!("reclaim_{}", id.simple()))
+    .bind(status)
+    .execute(pool)
+    .await
+    .expect("seed tenant");
+}
+
+async fn seed_installation(
+    pool: &sqlx::PgPool,
+    id: Uuid,
+    tenant_id: Uuid,
+    github_installation_id: i64,
+    deleted: bool,
+) {
+    let sql = if deleted {
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id, \
+          deleted_at) \
+         VALUES ($1, $2, $3, 'test-org', 'Organization', 42, now())"
+    } else {
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'test-org', 'Organization', 42)"
+    };
+    sqlx::query(sql)
+        .bind(id)
+        .bind(tenant_id)
+        .bind(github_installation_id)
+        .execute(pool)
+        .await
+        .expect("seed github_installation");
+}
+
+async fn cleanup(pool: &sqlx::PgPool, installation_id: i64, tenant_ids: &[Uuid]) {
+    sqlx::query("DELETE FROM control.github_installations WHERE github_installation_id = $1")
+        .bind(installation_id)
+        .execute(pool)
+        .await
+        .ok();
+    for tid in tenant_ids {
+        sqlx::query("DELETE FROM control.tenants WHERE id = $1")
+            .bind(tid)
+            .execute(pool)
+            .await
+            .ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reclaim CTE (mirrors the production SQL in install.rs)
+// ---------------------------------------------------------------------------
+
+async fn try_reclaim(
+    pool: &sqlx::PgPool,
+    github_installation_id: i64,
+    requesting_tenant: Uuid,
+) -> Option<(Uuid, Uuid)> {
+    sqlx::query_as(
+        "WITH reclaimable AS ( \
+             SELECT gi.id, gi.tenant_id AS prior_tenant_id \
+             FROM   control.github_installations gi \
+             JOIN   control.tenants t ON t.id = gi.tenant_id \
+             WHERE  gi.github_installation_id = $1 \
+               AND  gi.tenant_id <> $2 \
+               AND  (   gi.deleted_at IS NOT NULL \
+                     OR t.deleted_at IS NOT NULL \
+                     OR t.status IN ('deleting', 'deleted') \
+                    ) \
+               AND  NOT EXISTS ( \
+                        SELECT 1 \
+                        FROM   control.repos r \
+                        WHERE  r.installation_id = gi.id \
+                          AND  r.archived_at IS NULL \
+                    ) \
+         ) \
+         UPDATE control.github_installations gi \
+         SET    tenant_id     = $2, \
+                account_login = 'reclaimed-org', \
+                account_type  = 'Organization', \
+                account_id    = 99, \
+                deleted_at    = NULL, \
+                suspended_at  = NULL \
+         FROM   reclaimable \
+         WHERE  gi.id = reclaimable.id \
+         RETURNING gi.id, reclaimable.prior_tenant_id",
+    )
+    .bind(github_installation_id)
+    .bind(requesting_tenant)
+    .fetch_optional(pool)
+    .await
+    .expect("reclaim CTE query")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Reclaim succeeds when the prior owner's installation row has `deleted_at` set
+/// (GitHub sent an `installation.deleted` webhook that soft-deleted the row).
+#[tokio::test]
+async fn reclaim_succeeds_when_installation_soft_deleted() {
+    let Some(pool) = connect().await else { return };
+
+    let prior_tenant = Uuid::new_v4();
+    let new_tenant = Uuid::new_v4();
+    let install_row = Uuid::new_v4();
+    let github_id = random_install_id();
+
+    seed_tenant(&pool, prior_tenant, "active").await;
+    seed_tenant(&pool, new_tenant, "active").await;
+    seed_installation(
+        &pool,
+        install_row,
+        prior_tenant,
+        github_id,
+        /* deleted */ true,
+    )
+    .await;
+
+    let result = try_reclaim(&pool, github_id, new_tenant).await;
+
+    assert!(
+        result.is_some(),
+        "reclaim must succeed when installation is soft-deleted"
+    );
+    let (returned_id, prior_id) = result.unwrap();
+    assert_eq!(
+        returned_id, install_row,
+        "reclaim returns the installation UUID"
+    );
+    assert_eq!(
+        prior_id, prior_tenant,
+        "reclaim returns the prior tenant UUID"
+    );
+
+    // Verify the row now belongs to the new tenant.
+    let owner: Option<Uuid> = sqlx::query_scalar(
+        "SELECT tenant_id FROM control.github_installations WHERE github_installation_id = $1",
+    )
+    .bind(github_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("owner query");
+    assert_eq!(
+        owner,
+        Some(new_tenant),
+        "row must now belong to the new tenant"
+    );
+
+    cleanup(&pool, github_id, &[prior_tenant, new_tenant]).await;
+}
+
+/// Reclaim succeeds when the owning tenant is in 'deleted' status (tenant was
+/// torn down but the installation row was never soft-deleted via webhook).
+#[tokio::test]
+async fn reclaim_succeeds_when_owner_tenant_deleted() {
+    let Some(pool) = connect().await else { return };
+
+    let prior_tenant = Uuid::new_v4();
+    let new_tenant = Uuid::new_v4();
+    let install_row = Uuid::new_v4();
+    let github_id = random_install_id();
+
+    seed_tenant(&pool, prior_tenant, "deleted").await;
+    seed_tenant(&pool, new_tenant, "active").await;
+    seed_installation(
+        &pool,
+        install_row,
+        prior_tenant,
+        github_id,
+        /* deleted */ false,
+    )
+    .await;
+
+    let result = try_reclaim(&pool, github_id, new_tenant).await;
+
+    assert!(
+        result.is_some(),
+        "reclaim must succeed when owner tenant is in 'deleted' status"
+    );
+
+    cleanup(&pool, github_id, &[prior_tenant, new_tenant]).await;
+}
+
+/// Reclaim is blocked when the owner's installation has at least one active repo
+/// (archived_at IS NULL). The active owner must not lose their installation.
+#[tokio::test]
+async fn reclaim_blocked_when_owner_has_active_repos() {
+    let Some(pool) = connect().await else { return };
+
+    let prior_tenant = Uuid::new_v4();
+    let new_tenant = Uuid::new_v4();
+    let install_row = Uuid::new_v4();
+    let repo_id = Uuid::new_v4();
+    let github_id = random_install_id();
+
+    // prior_tenant has the installation soft-deleted BUT has an active repo —
+    // the repo check must override and block the reclaim.
+    seed_tenant(&pool, prior_tenant, "active").await;
+    seed_tenant(&pool, new_tenant, "active").await;
+
+    // Seed a user for the repo FK.
+    let user_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, '$argon2id$placeholder', now())",
+    )
+    .bind(user_id)
+    .bind(format!("reclaim-test-{}@example.com", user_id.simple()))
+    .execute(&pool)
+    .await
+    .expect("seed user");
+
+    seed_installation(
+        &pool,
+        install_row,
+        prior_tenant,
+        github_id,
+        /* deleted */ true,
+    )
+    .await;
+
+    // Active repo linked to the installation (archived_at IS NULL).
+    sqlx::query(
+        "INSERT INTO control.repos \
+         (id, tenant_id, installation_id, github_repo_id, full_name, default_branch, \
+          connected_by) \
+         VALUES ($1, $2, $3, $4, 'org/repo', 'main', $5)",
+    )
+    .bind(repo_id)
+    .bind(prior_tenant)
+    .bind(install_row)
+    .bind(github_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("seed active repo");
+
+    let result = try_reclaim(&pool, github_id, new_tenant).await;
+
+    assert!(
+        result.is_none(),
+        "reclaim must be blocked when active repos are linked to the installation"
+    );
+
+    // Cleanup: repos first (FK), then installations, then tenants + user.
+    sqlx::query("DELETE FROM control.repos WHERE id = $1")
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    cleanup(&pool, github_id, &[prior_tenant, new_tenant]).await;
+}


### PR DESCRIPTION
## Summary

- Adds an atomic orphan-reclaim path in `github_callback` (`install.rs:188`): when the upsert conflict belongs to an abandoned tenant (installation soft-deleted, or tenant deleted/deleting, with no active repos), ownership is transferred atomically to the requesting tenant.
- Active-owner collisions now produce a specific `?install=conflict&reason=active` redirect with a clearer toast message.
- Three integration tests cover reclaim-success (soft-deleted install), reclaim-success (deleted tenant), and reclaim-blocked (active repos).
- No schema migration — global `UNIQUE(github_installation_id)` is preserved. Webhook routing is unaffected.

## GitHub Issue

Closes #573

## Files Changed

| File | Change |
|---|---|
| `services/control-api/src/routes/github/install.rs` | Reclaim CTE path in conflict branch |
| `services/control-api/tests/integration_github_install_conflict.rs` | 3 new integration tests |
| `frontend/src/pages/ReposPage.tsx` | Differentiated conflict toast |
| `frontend/src/router.tsx` | Add `reason` to repos search schema |

## Migration type

**None** — additive code-only change.

## Checklist

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] No `RUSAA-XX` outside the title bracket prefix