### PR TITLE
[RUSAA-1678] fix(infra): effective-SHA state file fixes squash-merge drift gate false-positive

### DIFF
--- a/docs/decisions/ADR-011-dev-stack-auto-rebuild.md
+++ b/docs/decisions/ADR-011-dev-stack-auto-rebuild.md
@@ -20,6 +20,7 @@ Every claim in this ADR is traceable to a merged PR on `main`.
 | 4b | — | #568 | `6025e907` | `rb-build-info` fleet rollout to all 11 services (Phase 2). |
 | 4c | RUSAA-1644 | #570 | `af9624c5` | Agent-runner / MCP SHA pairing — warn-only mismatch detection (Phase 3). |
 | 5 | RUSAA-1653 | #572 | `eff8ed51` | Watcher pinned to **canonical** repo compose dir; refuses to run under `/tmp/`; `ConditionPathNotEmpty=…/compose/active-env` sentinel on the unit. |
+| 6 | RUSAA-1678 | #583 | TBD | Effective-SHA state file fixes squash-merge false-positive BLOCK; `dev-stack-auto-rebuild.sh` writes `service-effective-shas.json` on every successful exit (including "no paths changed"); drift gate reads it to certify label-divergent-but-code-current services. |
 
 ---
 
@@ -87,6 +88,7 @@ Selective rebuild plus user systemd gave us *automated* deployment but not *veri
 
 ### 2.5 Stage 5 — Canonical compose-dir invariant (RUSAA-1653, PR #572, `eff8ed51`)
 
+
 `docker compose` stamps each container with `com.docker.compose.project.working_dir`. Bind-mount paths like `../migrations:/migrations:ro` resolve **relative to that label**, not relative to the running watcher's CWD. A second clone of the repo (e.g. `/tmp/phase2-deploy/rustacean`) that ran `docker compose up` would silently rewrite the label, and when that scratch dir was cleaned up the next container restart would fail on a missing bind source.
 
 The fix is layered defense:
@@ -96,6 +98,38 @@ The fix is layered defense:
 3. **Drift detector.** `scripts/check-compose-working-dir.sh` reports `OK` / `DRIFT` per container and exits non-zero on any divergence; `--fix` runs `docker compose up -d --force-recreate` to re-stamp the label.
 
 The invariant: **one canonical clone per host, and the watcher refuses to operate on any other.** Operators may keep additional clones for hotfix work; they may not point the dev-stack at them.
+
+### 2.6 Stage 6 — Effective-SHA state file (RUSAA-1678, PR #583)
+
+The drift gate (`scripts/check-dev-stack-drift.sh`) compares each running container's `git_sha` label against `origin/main` HEAD using a git ancestry check: a label SHA that is an ancestor of HEAD is considered current. This breaks after a squash-merge: the squash commit is a new SHA with no parent relationship to the branch commits it absorbed, so worker services whose code did not change retain their pre-squash branch SHA as their label, and `git merge-base --is-ancestor` returns `false` even though the running code is bit-for-bit identical to HEAD.
+
+Forensic baseline (see [RUSAA-1678](/RUSAA/issues/RUSAA-1678)): PR #568 was squash-merged as `6025e907`, leaving 9 worker images labelled `b046bbac` (the pre-squash branch SHA). Every subsequent docs-only PR (#569–#577) hit the false-positive BLOCK because no worker paths changed, so those workers were never rebuilt to a HEAD-ancestral label.
+
+**Fix:** `scripts/dev-stack-auto-rebuild.sh` now writes `~/.local/state/rustbrain/service-effective-shas.json` on every successful exit (including the "no paths changed" skip path). The file records `{ "updated_at": "<iso8601>", "services": { "<name>": "<sha>", … } }` for all 12 managed services (11 Rust + frontend). The drift gate loads this file and, for each container whose label SHA does not match HEAD, checks whether `services[name] == HEAD_SHA`; if so, the service is marked **OK (certified)** and omitted from the `drifted` array.
+
+**Invariant:** the file is updated to `NEW_SHA` only on successful exit. On error exits (build failure, health failure, rollback) the file retains the last known-good SHA, so the drift gate still BLOCKs until the next successful run — the conservative, correct behaviour.
+
+**Graceful absent-file fallback:** when the file does not exist (fresh mars clone, or the file was manually deleted to reset to label-only mode), the drift gate operates exactly as before Stage 6: ancestry-check only.
+
+**JSON report field:** the drift report gains a top-level `ok_certified` array alongside `ok`. Entries in `ok_certified` passed via the state file, not via label match. This lets operators distinguish the two acceptance modes:
+
+```json
+{
+  "head_sha": "6025e907…",
+  "head_commit_age_seconds": 120,
+  "drifted": [],
+  "ok": ["control-api"],
+  "ok_certified": ["projector-pg", "tombstoner", "ingest-clone", "expand-worker",
+                   "parse-worker", "typecheck-worker", "ingest-graph",
+                   "projector-neo4j", "embed-worker", "agent-runner", "frontend"]
+}
+```
+
+The exit-0 console line includes a count when certified services are present:
+
+```
+[check-dev-stack-drift] all services current (head=6025e907); 11 certified via effective-SHA state file
+```
 
 ---
 
@@ -110,6 +144,8 @@ The invariant: **one canonical clone per host, and the watcher refuses to operat
 **One watcher per host is sufficient and intended.** Stage 5's canonical-dir invariant is structural: a second watcher cannot coexist on the same host without one of them violating either the script-level `/tmp/` guard or the unit-level `ConditionPathNotEmpty` sentinel. Operators wanting to test watcher changes do so in a non-mars environment.
 
 **Rebuild logs are the durable record.** `~/.local/state/rustbrain/dev-stack-rebuilds.ndjson` is append-only; the most recent N records are queryable via `scripts/dev-stack-auto-rebuild.sh --logs [N]`. The NDJSON schema (`timestamp`, `prev_sha`, `new_sha`, `rebuilt[]`, `result`, `health`, `elapsed_s`, `reason`) is the surface that Done-gate evidence reads from. Changes to the schema are breaking; additive fields only.
+
+**The effective-SHA state file is a secondary durable artifact.** `~/.local/state/rustbrain/service-effective-shas.json` records the last HEAD SHA that all services were certified against. It is overwritten (not appended) on every successful auto-rebuild exit; it is the drift gate's secondary acceptance mechanism (Stage 6). Deleting the file is safe — the drift gate falls back to label-only ancestry mode. Do not commit it; it is machine-local state. The drift report's `ok_certified` array is the user-visible signal that the state file influenced the result.
 
 **Operator runbook is a separate deliverable.** The recovery procedures (what to do when the watcher is wedged, how to force a cold-start, how to fix working_dir drift, how to read NDJSON logs to triage a stuck UAT round) belong to the C4 stack-rebuild-verify runbook under the Wave-7 docs umbrella ([RUSAA-1664](/RUSAA/issues/RUSAA-1664)), not this ADR. The `dev-deployment` skill covers the mars-specific recovery paths that an agent needs at runtime.
 

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -328,6 +328,27 @@ scripts/test-drift-exit-codes.sh
 Covers: stack fully down (exit 0), all current (exit 0), one drifted (exit 1),
 no-label image (exit 1), mixed absent+drifted (exit 1).
 
+## Effective-SHA state file (squash-merge false-positive fix)
+
+`dev-stack-auto-rebuild.sh` writes `~/.local/state/rustbrain/service-effective-shas.json` on every successful exit — including the "no paths changed" skip path. The file records the HEAD SHA that all managed services are certified against. The drift gate (`check-dev-stack-drift.sh`) reads this file so that services whose container label carries a pre-squash branch SHA (not an ancestor of `main`) are correctly reported as current rather than BLOCKed.
+
+**Normal operation:** the file is maintained automatically. No operator action is needed.
+
+**If the file ever gets corrupt or contains a wrong SHA** (e.g. after a manual partial rebuild), delete it to reset to label-only mode:
+
+```bash
+rm ~/.local/state/rustbrain/service-effective-shas.json
+```
+
+The drift gate falls back to the git ancestry check when the file is absent. Run a full `--cold-start` or wait for the next `main` commit to trigger a rebuild, which will rewrite the file with the correct HEAD SHA.
+
+**Inspect the current file:**
+
+```bash
+cat ~/.local/state/rustbrain/service-effective-shas.json | python3 -m json.tool
+```
+
+
 ## Troubleshooting
 
 **Rebuild never triggers**

--- a/scripts/check-dev-stack-drift.sh
+++ b/scripts/check-dev-stack-drift.sh
@@ -85,6 +85,28 @@ HEAD_TS="$(git show -s --format=%ct "$HEAD_SHA" 2>/dev/null || echo "0")"
 NOW_TS="$(date +%s)"
 HEAD_COMMIT_AGE=$(( NOW_TS - HEAD_TS ))
 
+# -- Load effective-SHA state file --------------------------------------------
+# Written by dev-stack-auto-rebuild.sh on every successful exit (including the
+# "no paths changed" skipped path) so that services whose label SHA is a
+# pre-squash branch commit — not an ancestor of main — are not false-positive
+# BLOCKed by the ancestry check.  Falls back gracefully to label-only mode when
+# the file is absent (e.g. on a fresh mars clone).
+EFFECTIVE_SHA_FILE="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}/service-effective-shas.json"
+declare -A EFFECTIVE_SHAS=()
+if [[ -f "$EFFECTIVE_SHA_FILE" ]]; then
+  while IFS="=" read -r svc sha; do
+    [[ -n "$svc" ]] && EFFECTIVE_SHAS["$svc"]="$sha"
+  done < <(python3 -c "
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+    for svc, sha in data.get('services', {}).items():
+        print(f'{svc}={sha}')
+except Exception:
+    pass
+" "$EFFECTIVE_SHA_FILE")
+fi
+
 # -- Services -----------------------------------------------------------------
 # All services in compose/dev.yml with a build: stanza.
 # Container names follow the compose project name 'rustbrain-dev'.
@@ -112,6 +134,7 @@ CUSTOM_SERVICES=(
 
 DRIFTED_ROWS=""
 OK_NAMES=""
+OK_CERTIFIED_NAMES=""
 
 for svc in "${CUSTOM_SERVICES[@]}"; do
   container="rustbrain-dev-${svc}-1"
@@ -132,12 +155,21 @@ for svc in "${CUSTOM_SERVICES[@]}"; do
     OK_NAMES="${OK_NAMES}${svc}
 "
   else
-    is_ancestor=false
-    if git merge-base --is-ancestor "$deployed_sha" "$HEAD_SHA" 2>/dev/null; then
-      is_ancestor=true
-    fi
-    DRIFTED_ROWS="${DRIFTED_ROWS}${svc}	${deployed_sha}	${is_ancestor}
+    # Check the effective-SHA state file before falling back to ancestry check.
+    # A service whose label is a pre-squash branch SHA (not an ancestor of main)
+    # is code-equivalent to HEAD when the state file was updated after that squash.
+    effective_sha="${EFFECTIVE_SHAS[$svc]:-}"
+    if [[ -n "$effective_sha" && "$effective_sha" == "$HEAD_SHA" ]]; then
+      OK_CERTIFIED_NAMES="${OK_CERTIFIED_NAMES}${svc}
 "
+    else
+      is_ancestor=false
+      if git merge-base --is-ancestor "$deployed_sha" "$HEAD_SHA" 2>/dev/null; then
+        is_ancestor=true
+      fi
+      DRIFTED_ROWS="${DRIFTED_ROWS}${svc}	${deployed_sha}	${is_ancestor}
+"
+    fi
   fi
 done
 
@@ -150,6 +182,7 @@ head_sha = sys.argv[1]
 head_age = int(sys.argv[2])
 drifted_raw = sys.argv[3]
 ok_raw = sys.argv[4]
+ok_certified_raw = sys.argv[5]
 
 drifted = []
 for line in drifted_raw.splitlines():
@@ -164,14 +197,16 @@ for line in drifted_raw.splitlines():
     })
 
 ok = [s.strip() for s in ok_raw.splitlines() if s.strip()]
+ok_certified = [s.strip() for s in ok_certified_raw.splitlines() if s.strip()]
 
 print(json.dumps({
     'head_sha': head_sha,
     'head_commit_age_seconds': head_age,
     'drifted': drifted,
     'ok': ok,
+    'ok_certified': ok_certified,
 }, indent=2))
-" "$HEAD_SHA" "$HEAD_COMMIT_AGE" "$DRIFTED_ROWS" "$OK_NAMES")"
+" "$HEAD_SHA" "$HEAD_COMMIT_AGE" "$DRIFTED_ROWS" "$OK_NAMES" "$OK_CERTIFIED_NAMES")"
 
 # -- Output & exit ------------------------------------------------------------
 
@@ -179,7 +214,13 @@ DRIFTED_COUNT=0
 [[ -n "$DRIFTED_ROWS" ]] && DRIFTED_COUNT="$(printf '%s' "$DRIFTED_ROWS" | grep -c $'\t' || true)"
 
 if [[ "$DRIFTED_COUNT" -eq 0 ]]; then
-  echo "[check-dev-stack-drift] all services current (head=${HEAD_SHA:0:8})"
+  CERTIFIED_COUNT=0
+  [[ -n "$OK_CERTIFIED_NAMES" ]] && CERTIFIED_COUNT="$(printf '%s' "$OK_CERTIFIED_NAMES" | grep -c '[^[:space:]]' || true)"
+  if [[ "$CERTIFIED_COUNT" -gt 0 ]]; then
+    echo "[check-dev-stack-drift] all services current (head=${HEAD_SHA:0:8}); ${CERTIFIED_COUNT} certified via effective-SHA state file"
+  else
+    echo "[check-dev-stack-drift] all services current (head=${HEAD_SHA:0:8})"
+  fi
   post_gh_status "success" "Dev-stack current against HEAD" "$HEAD_SHA"
   exit 0
 else

--- a/scripts/dev-stack-auto-rebuild.sh
+++ b/scripts/dev-stack-auto-rebuild.sh
@@ -43,6 +43,7 @@ fi
 
 LOG_DIR="${RB_LOG_DIR:-"$HOME/.local/state/rustbrain"}"
 LOG_FILE="$LOG_DIR/dev-stack-rebuilds.ndjson"
+EFFECTIVE_SHA_FILE="$LOG_DIR/service-effective-shas.json"
 BYPASS_FILE="$REPO_ROOT/compose/.no-auto-rebuild"
 
 # -- Helpers -----------------------------------------------------------------
@@ -66,6 +67,22 @@ print(json.dumps({
   'elapsed_s':  int(sys.argv[8]),
 }))
 " "$START_TS" "$PREV_SHA" "$NEW_SHA" "$result" "$health" "$rebuilt_json" "$reason" "$elapsed" >> "$LOG_FILE"
+}
+
+# Writes service-effective-shas.json, recording that all managed services are
+# code-equivalent to SHA.  Called on every successful exit (including "skipped —
+# no paths changed") so the drift gate can distinguish a label-divergent-but-
+# code-current service (squash-merge false-positive) from a genuinely stale one.
+# The file is NOT updated on error exits, keeping the last known-good SHA intact.
+write_effective_shas() {
+  local sha="$1"
+  python3 -c "
+import json, sys
+sha = sys.argv[1]
+ts  = sys.argv[2]
+services = sys.argv[3].split()
+print(json.dumps({'updated_at': ts, 'services': {svc: sha for svc in services}}, indent=2))
+" "$sha" "$(ts)" "${ALL_RUST_SERVICES[*]} frontend" > "$EFFECTIVE_SHA_FILE"
 }
 
 # -- Early init: must precede COMPOSE_ENV_FILE sourcing so the EXIT trap can
@@ -211,6 +228,7 @@ else
 
   if [[ -z "$CHANGED_FILES" ]]; then
     echo "[dev-stack-auto-rebuild] no changed files — nothing to do"
+    write_effective_shas "$NEW_SHA"
     log_record "skipped" "" "[]" "no changed files"
     exit 0
   fi
@@ -255,6 +273,7 @@ else
 
   if [[ "${#REBUILD_SERVICE[@]}" -eq 0 && "$REBUILD_FRONTEND" == "false" ]]; then
     echo "[dev-stack-auto-rebuild] no service paths changed — skipping"
+    write_effective_shas "$NEW_SHA"
     log_record "skipped" "" "[]" "no service paths changed"
     exit 0
   fi
@@ -429,6 +448,7 @@ HEALTH_DETAIL="${HEALTH_DETAIL% }"  # trim trailing space
 
 if [[ "$HEALTH_OK" == "true" ]]; then
   echo "[dev-stack-auto-rebuild] all healthy: $HEALTH_DETAIL"
+  write_effective_shas "$NEW_SHA"
   log_record "ok" "$HEALTH_DETAIL" "$REBUILT_JSON" ""
   post_gh_status "success" "Dev-stack healthy after rebuild: $HEALTH_DETAIL"
 else


### PR DESCRIPTION
## Summary

The drift gate (`scripts/check-dev-stack-drift.sh`) permanently emitted a false-positive BLOCK for worker services after a squash-merge: the pre-squash branch SHA is not an ancestor of the squash commit, so `git merge-base --is-ancestor` returned `false` even though the running code was bit-for-bit identical to HEAD.

This PR implements **Option 1 (effective-SHA state file)** from the approved plan (rev 1, `c14f3442`):

- `dev-stack-auto-rebuild.sh` writes `~/.local/state/rustbrain/service-effective-shas.json` on every successful exit, including the "no paths changed" skip path. The file maps every managed service to `NEW_SHA`. It is **not** written on error exits.
- `check-dev-stack-drift.sh` loads the state file at startup. For each service whose container label does not match HEAD, the file is checked before the ancestry test. If `effective_shas[service] == HEAD_SHA`, the service is marked **OK (certified)** and reported in a new `ok_certified` array (not `drifted`).
- Absent-file fallback: when the file does not exist the drift gate behaves exactly as before (ancestry-check only).
- ADR-011 amended: Stage 6 row added to the source-PR table; new §2.6 section; §3 Consequences updated with the `ok_certified` field.
- `docs/dev-stack-auto-rebuild.md`: new section explaining the state file and how to clear it.

## Migration type

Additive
- Tables touched: none (no schema changes)
- Operations: new local state file managed at runtime; no migrations

## GitHub Issue

Closes #583

## Checklist

- [x] Both scripts pass `bash -n` syntax check
- [x] `write_effective_shas()` references `ALL_RUST_SERVICES` only after it is defined (both skip paths are inside the `else` block that follows the array declaration)
- [x] Python round-trip verified (12 services, write → read → IFS-split)
- [x] Absent-file fallback: `declare -A EFFECTIVE_SHAS=()` remains empty, no false certifications
- [x] ADR-011 Stage 6 row + §2.6 + §3 amendment committed in same PR
- [x] No `RUSAA-XX` outside the title bracket prefix