### PR TITLE
[RUSAA-1672] feat(infra): promote drift detector from warn-only to fail-on-drift

### DIFF
--- a/.github/workflows/dev-stack-drift-check.yml
+++ b/.github/workflows/dev-stack-drift-check.yml
@@ -1,0 +1,176 @@
+name: Dev-stack Drift Check
+
+# Runs every 15 minutes against mars.  On detected drift the job fails
+# (honoring check-dev-stack-drift.sh exit 1) and opens / updates a GitHub
+# issue tagged dev-stack-drift to page Platform.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      no_fetch:
+        description: 'Pass --no-fetch to skip git fetch on mars'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dev-stack-drift-check
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    name: drift-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # ── SSH to mars, run the drift detector ───────────────────────────────
+      - name: Run drift check on mars
+        id: drift
+        env:
+          MARS_SSH_KEY:  ${{ secrets.MARS_SSH_KEY }}
+          MARS_SSH_HOST: ${{ secrets.MARS_SSH_HOST }}
+          MARS_SSH_USER: ${{ secrets.MARS_SSH_USER }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MARS_SSH_KEY:-}" || -z "${MARS_SSH_HOST:-}" || -z "${MARS_SSH_USER:-}" ]]; then
+            echo "::error::Required secrets not configured: MARS_SSH_KEY, MARS_SSH_HOST, MARS_SSH_USER"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$MARS_SSH_KEY" > ~/.ssh/mars_key
+          chmod 600 ~/.ssh/mars_key
+
+          # StrictHostKeyChecking=no — acceptable for a dev-stack monitor.
+          # Rotate MARS_SSH_KEY if the mars host key changes.
+          SSH_OPTS="-i ~/.ssh/mars_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes"
+
+          FETCH_FLAG=""
+          [[ "${{ inputs.no_fetch }}" == "true" ]] && FETCH_FLAG="--no-fetch"
+
+          set +e
+          RAW_OUTPUT=$(ssh $SSH_OPTS "${MARS_SSH_USER}@${MARS_SSH_HOST}" \
+            "~/projects/rustacean/scripts/check-dev-stack-drift.sh $FETCH_FLAG" 2>&1)
+          DRIFT_EXIT=$?
+          set -e
+
+          {
+            echo "exit_code=$DRIFT_EXIT"
+            echo "drift_report<<EOF"
+            echo "$RAW_OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Drift check exited: $DRIFT_EXIT"
+          echo "$RAW_OUTPUT"
+
+      # ── On drift: ensure the alert label exists ────────────────────────────
+      - name: Ensure dev-stack-drift label exists
+        if: steps.drift.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create dev-stack-drift \
+            --repo f-crop/rustacean \
+            --description "Automated alert: dev-stack behind origin/main on mars" \
+            --color "d93f0b" \
+            --force
+
+      # ── On drift: open or update the drift alert issue ─────────────────────
+      - name: Open or update drift alert issue
+        if: steps.drift.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          DETECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          BODY="## Dev-stack drift detected on mars
+
+The scheduled drift check at **${DETECTED_AT}** found one or more containers running behind \`origin/main\`.
+
+**Workflow run:** ${RUN_URL}
+
+### Drift report
+
+\`\`\`
+${{ steps.drift.outputs.drift_report }}
+\`\`\`
+
+### Remediation
+
+On mars, trigger a full rebuild:
+\`\`\`bash
+cd ~/projects/rustacean
+scripts/dev-stack-auto-rebuild.sh --cold-start
+\`\`\`
+
+Or restart the auto-rebuild watcher (it will detect drift and rebuild on next main commit):
+\`\`\`bash
+systemctl --user restart rustbrain-dev-watch
+\`\`\`
+
+See [docs/dev-stack-auto-rebuild.md](https://github.com/f-crop/rustacean/blob/main/docs/dev-stack-auto-rebuild.md#scheduled-drift-detection) for full remediation steps."
+
+          # Check for an existing open drift alert so we update rather than spam
+          EXISTING=$(gh issue list \
+            --repo f-crop/rustacean \
+            --label dev-stack-drift \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          if [[ -n "$EXISTING" ]]; then
+            gh issue comment "$EXISTING" \
+              --repo f-crop/rustacean \
+              --body "$BODY"
+            echo "::warning::Drift still present — updated alert issue #$EXISTING"
+          else
+            gh issue create \
+              --repo f-crop/rustacean \
+              --title "[ALERT] Dev-stack drift on mars — ${DETECTED_AT}" \
+              --label dev-stack-drift \
+              --body "$BODY"
+            echo "::warning::New drift alert issue created"
+          fi
+
+      # ── On recovery: close any open drift alert issues ─────────────────────
+      - name: Close resolved drift alert issues
+        if: steps.drift.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          OPEN_ALERTS=$(gh issue list \
+            --repo f-crop/rustacean \
+            --label dev-stack-drift \
+            --state open \
+            --json number \
+            --jq '.[].number' 2>/dev/null || echo "")
+
+          for n in $OPEN_ALERTS; do
+            gh issue close "$n" \
+              --repo f-crop/rustacean \
+              --comment "Dev-stack is now current with \`origin/main\`. Auto-closing drift alert." \
+              2>/dev/null || true
+            echo "Closed drift alert #$n"
+          done
+
+      # ── Fail the job so GHA marks the run red on any non-zero exit ─────────
+      - name: Fail on drift or error
+        if: steps.drift.outputs.exit_code != '0'
+        run: |
+          EXIT="${{ steps.drift.outputs.exit_code }}"
+          if [[ "$EXIT" == "1" ]]; then
+            echo "::error::Dev-stack drift detected on mars. See the dev-stack-drift issue."
+          else
+            echo "::error::Drift check returned exit $EXIT — SSH error or Docker unavailable on mars."
+          fi
+          exit 1

--- a/docs/dev-stack-auto-rebuild.md
+++ b/docs/dev-stack-auto-rebuild.md
@@ -265,6 +265,69 @@ non-zero code and a fatal journal entry, which triggers the `Restart=on-failure`
 systemd. The systemd unit also carries `ConditionPathNotEmpty=…/compose/active-env` so it will
 not start at all if that sentinel file is missing or empty.
 
+## Scheduled drift detection
+
+`check-dev-stack-drift.sh` inspects every running container's `git_sha` Docker label and
+compares it against `origin/main` HEAD.  Exit codes:
+
+| Exit | Meaning |
+|------|---------|
+| `0`  | All running containers match HEAD — no drift. |
+| `1`  | One or more containers are behind HEAD — drift detected. |
+| `2`  | Fatal error (git fetch failed, Docker unavailable, etc.). |
+
+The GitHub Actions workflow `.github/workflows/dev-stack-drift-check.yml` runs this check
+every **15 minutes** by SSHing to mars.  When exit 1 is returned:
+
+1. The GHA job **fails** (red check).
+2. A GitHub issue tagged `dev-stack-drift` is opened (or an existing one is updated).
+3. When the stack catches up, the next passing run auto-closes any open drift alert.
+
+### Required GitHub secrets
+
+| Secret | Value |
+|--------|-------|
+| `MARS_SSH_KEY`  | Private SSH key that can reach mars. |
+| `MARS_SSH_HOST` | Hostname or IP of mars. |
+| `MARS_SSH_USER` | SSH username on mars (e.g. `jarnura`). |
+
+Add these via **GitHub → Settings → Secrets → Actions** before the first scheduled run.
+
+### Manual trigger
+
+```bash
+# From the GitHub Actions UI:
+#   Actions → Dev-stack Drift Check → Run workflow
+# or via CLI:
+gh workflow run dev-stack-drift-check.yml --repo f-crop/rustacean
+```
+
+### Remediation
+
+When a drift alert fires:
+
+```bash
+# On mars — force a full rebuild to catch up with origin/main
+cd ~/projects/rustacean
+scripts/dev-stack-auto-rebuild.sh --cold-start
+```
+
+Or restart the auto-rebuild watcher (it will rebuild on the next commit):
+
+```bash
+systemctl --user restart rustbrain-dev-watch
+```
+
+### Testing exit-code contract
+
+```bash
+# Run the shell unit tests (no Docker or live git required):
+scripts/test-drift-exit-codes.sh
+```
+
+Covers: stack fully down (exit 0), all current (exit 0), one drifted (exit 1),
+no-label image (exit 1), mixed absent+drifted (exit 1).
+
 ## Troubleshooting
 
 **Rebuild never triggers**

--- a/scripts/test-drift-exit-codes.sh
+++ b/scripts/test-drift-exit-codes.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Unit tests for check-dev-stack-drift.sh exit-code contract.
+#
+# Injects mock git/docker executables via PATH — no real Docker daemon or git
+# state required.  Each test case controls which containers "exist" and what
+# SHA label they carry via files in a per-test MOCK_DIR.
+#
+# Mock git reads $MOCK_DIR/head_sha for rev-parse responses.
+# Mock docker reads $MOCK_DIR/sha_<svc_key> (e.g. sha_control_api) for label
+# responses; a missing file means the container is absent/not-running.
+#
+# Exit: 0 all tests passed, 1 one or more failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIFT_SCRIPT="$SCRIPT_DIR/check-dev-stack-drift.sh"
+
+PASS=0
+FAIL=0
+
+# ── Mock binary directory (written once; read $MOCK_DIR at runtime) ─────────
+
+MOCK_BIN_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$MOCK_BIN_DIR"; }
+trap cleanup EXIT
+
+cat > "$MOCK_BIN_DIR/git" <<'GITMOCK'
+#!/usr/bin/env bash
+if   [[ "$1" == "fetch" ]];                                   then exit 0; fi
+if   [[ "$1 $2" == "rev-parse origin/main" ]];                then cat "$MOCK_DIR/head_sha"; exit 0; fi
+if   [[ "$1" == "show" ]];                                    then echo "1000000000"; exit 0; fi
+if   [[ "$1 $2 $3" == "merge-base --is-ancestor" ]];          then exit 1; fi
+exit 128
+GITMOCK
+chmod +x "$MOCK_BIN_DIR/git"
+
+cat > "$MOCK_BIN_DIR/docker" <<'DOCKMOCK'
+#!/usr/bin/env bash
+# Handles: docker inspect --format FORMAT CONTAINER
+[[ "$1" == "inspect" ]] || exit 0
+
+format="$3"
+container="$4"
+
+# Derive service key: rustbrain-dev-control-api-1 → control_api
+svc="${container#rustbrain-dev-}"
+svc="${svc%-1}"
+svc_key="${svc//-/_}"
+sha_file="$MOCK_DIR/sha_${svc_key}"
+
+if [[ "$format" == *State.Running* ]]; then
+  [[ -f "$sha_file" ]] && echo "true" && exit 0
+  exit 1
+fi
+
+if [[ "$format" == *git_sha* ]]; then
+  [[ -f "$sha_file" ]] || exit 1
+  cat "$sha_file"
+  exit 0
+fi
+
+exit 1
+DOCKMOCK
+chmod +x "$MOCK_BIN_DIR/docker"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# setup_mock HEAD_SHA [svc=value ...]
+#   value="HEAD"    → container is running at HEAD sha (current)
+#   value="<sha>"   → container is running at that sha (drifted)
+#   value=""        → container is running but has no git_sha label
+#   value="absent"  → container is not running (skipped by drift script)
+setup_mock() {
+  local mock_dir
+  mock_dir="$(mktemp -d)"
+  local head_sha="$1"; shift
+  echo "$head_sha" > "$mock_dir/head_sha"
+
+  for pair in "$@"; do
+    local svc="${pair%%=*}"
+    local sha="${pair#*=}"
+    local key="${svc//-/_}"
+    if [[ "$sha" == "absent" ]]; then
+      : # no file → container absent
+    elif [[ "$sha" == "HEAD" ]]; then
+      echo "$head_sha" > "$mock_dir/sha_${key}"
+    else
+      echo "$sha" > "$mock_dir/sha_${key}"  # includes empty-string case
+    fi
+  done
+
+  echo "$mock_dir"
+}
+
+# assert_exit NAME EXPECTED_EXIT MOCK_DIR
+assert_exit() {
+  local name="$1" expected="$2" mock_dir="$3"
+  local repo_dir
+  repo_dir="$(mktemp -d)"
+
+  set +e
+  RB_REPO_PATH="$repo_dir" MOCK_DIR="$mock_dir" \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    "$DRIFT_SCRIPT" --no-fetch > /dev/null 2>&1
+  local actual=$?
+  set -e
+
+  rm -rf "$repo_dir" "$mock_dir"
+
+  if [[ "$actual" -eq "$expected" ]]; then
+    printf "  PASS  %s (exit %s)\n" "$name" "$actual"
+    PASS=$(( PASS + 1 ))
+  else
+    printf "  FAIL  %s — expected exit %s, got %s\n" "$name" "$expected" "$actual"
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# ── Test cases ────────────────────────────────────────────────────────────────
+
+HEAD_SHA="aaaa1234bbbb5678cccc9012dddd3456eeee7890aaaa1234"
+OLD_SHA="ffff1234aaaa5678bbbb9012cccc3456dddd7890ffff1234"
+
+echo "=== check-dev-stack-drift.sh exit-code tests ==="
+echo ""
+
+# Stack fully stopped: all containers absent → nothing drifted → exit 0
+assert_exit "stack fully down (all absent)" 0 \
+  "$(setup_mock "$HEAD_SHA" control-api=absent agent-runner=absent frontend=absent)"
+
+# All running containers match HEAD → exit 0
+assert_exit "all containers current" 0 \
+  "$(setup_mock "$HEAD_SHA" control-api=HEAD agent-runner=HEAD frontend=HEAD)"
+
+# Mixed: some current, one behind → exit 1
+assert_exit "one container behind HEAD" 1 \
+  "$(setup_mock "$HEAD_SHA" control-api=HEAD agent-runner="$OLD_SHA" frontend=HEAD)"
+
+# All containers behind HEAD → exit 1
+assert_exit "all containers behind HEAD" 1 \
+  "$(setup_mock "$HEAD_SHA" control-api="$OLD_SHA" agent-runner="$OLD_SHA")"
+
+# Container with no git_sha label (pre-label image) → counted as drifted → exit 1
+assert_exit "container with no git_sha label" 1 \
+  "$(setup_mock "$HEAD_SHA" control-api=HEAD agent-runner="")"
+
+# One absent (skipped), one current, one drifted → exit 1
+assert_exit "absent + current + drifted mix" 1 \
+  "$(setup_mock "$HEAD_SHA" control-api=absent agent-runner=HEAD frontend="$OLD_SHA")"
+
+# One absent (skipped), one current → exit 0 (absent is not drift)
+assert_exit "absent + current (no drift)" 0 \
+  "$(setup_mock "$HEAD_SHA" control-api=absent agent-runner=HEAD)"
+
+echo ""
+printf "Results: %s passed, %s failed\n" "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Promotes `scripts/check-dev-stack-drift.sh` from an unused tool to an enforced scheduled gate:

- **Scheduled GHA** (`.github/workflows/dev-stack-drift-check.yml`): runs every 15 minutes, SSHes to mars, fails the job on exit 1, opens/updates a `dev-stack-drift` GitHub issue to page Platform, auto-closes the alert on recovery.
- **Shell unit test** (`scripts/test-drift-exit-codes.sh`): 7 test cases covering exit 0 (current, stack fully down), exit 1 (drifted, pre-label image, mixed), via PATH-injected mock git/docker. All pass.
- **Docs**: new `## Scheduled drift detection` section in `docs/dev-stack-auto-rebuild.md` — failure mode, required secrets, remediation steps, test invocation.

## GitHub Issue
Closes #585

## Required setup (one-time)

Add three secrets under **GitHub → Settings → Secrets → Actions**:

| Secret | Value |
|--------|-------|
| `MARS_SSH_KEY`  | Private key that can SSH to mars |
| `MARS_SSH_HOST` | Mars hostname or IP |
| `MARS_SSH_USER` | SSH user on mars |

## Done-gate

- [x] `check-dev-stack-drift.sh` exit code is honored — GHA fails on exit 1
- [x] Failure mode documented in `docs/dev-stack-auto-rebuild.md#scheduled-drift-detection`
- [x] `scripts/test-drift-exit-codes.sh` — 7/7 tests pass

## Checklist

- [x] No `RUSAA-XX` in commits or branch name
- [x] No Rust changes — no cargo test / clippy needed
- [x] Docs updated