### PR TITLE
[RUSAA-1699] test(control-api): regression-defence smoke tests — orphan-install 409, cross-tenant rebind, ingestion timestamp monotonicity

### DIFF
--- a/crates/rb-github/Cargo.toml
+++ b/crates/rb-github/Cargo.toml
@@ -31,6 +31,11 @@ uuid.workspace = true
 arc-swap.workspace = true
 urlencoding = "2"
 
+[features]
+# Expose constructors that accept a custom GitHub API base URL so integration
+# tests can point the token-mint endpoint at a wiremock stub.
+test-helpers = []
+
 [dev-dependencies]
 tokio = { workspace = true }
 

--- a/crates/rb-github/src/installation_token.rs
+++ b/crates/rb-github/src/installation_token.rs
@@ -33,6 +33,26 @@ impl GitHubTokenMinter {
             base_url: DEFAULT_BASE_URL.to_owned(),
         }
     }
+
+    /// Create a minter that targets a custom API base URL.
+    ///
+    /// Intended for integration tests that stub the GitHub token endpoint with
+    /// a local server (e.g. wiremock).  Gated behind the `test-helpers` feature
+    /// so production builds are unaffected.
+    #[cfg(feature = "test-helpers")]
+    pub(crate) fn new_with_base_url(
+        app_id: i64,
+        encoding_key: EncodingKey,
+        http: Client,
+        base_url: String,
+    ) -> Self {
+        Self {
+            app_id,
+            encoding_key,
+            http,
+            base_url,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/rb-github/src/lib.rs
+++ b/crates/rb-github/src/lib.rs
@@ -92,6 +92,46 @@ impl GhApp {
         }
     }
 
+    /// Create a `GhApp` that points all token-mint calls at a custom API base.
+    ///
+    /// Intended for integration tests that stub the GitHub API with a local
+    /// server (e.g. wiremock).  Gated behind the `test-helpers` Cargo feature
+    /// so production builds are unaffected.
+    #[cfg(feature = "test-helpers")]
+    #[must_use]
+    pub fn new_with_api_base(
+        app_id: i64,
+        encoding_key: EncodingKey,
+        webhook_secret: Secret<Vec<u8>>,
+        api_base: &str,
+    ) -> Self {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("reqwest client init is infallible with valid config");
+        let identity_cache = Cache::builder()
+            .max_capacity(1)
+            .time_to_live(Duration::from_secs(60))
+            .build();
+        let minter: Arc<dyn TokenMinter> =
+            Arc::new(installation_token::GitHubTokenMinter::new_with_base_url(
+                app_id,
+                encoding_key.clone(),
+                http.clone(),
+                api_base.to_owned(),
+            ));
+        let token_cache = TokenCache::new(minter);
+        Self {
+            app_id,
+            encoding_key,
+            webhook_secret,
+            replay_cache: ReplayCache::new(),
+            identity_cache: Arc::new(identity_cache),
+            token_cache,
+            http,
+        }
+    }
+
     /// Verifies a GitHub webhook signature header against the raw body.
     ///
     /// # Errors

--- a/services/control-api/Cargo.toml
+++ b/services/control-api/Cargo.toml
@@ -76,11 +76,13 @@ sha2.workspace = true
 hex.workspace = true
 # Construct rdkafka error variants in unit tests (e.g. AllBrokersDown → 503).
 rdkafka.workspace = true
-# HTTP mocking for the manifest-exchange integration test.
+# HTTP mocking for the manifest-exchange integration test and regression-defence suite.
 wiremock.workspace = true
 tracing-subscriber.workspace = true
 # test-util exposes raw_subscribe for SSE fan-out integration tests.
 rb-sse = { path = "../../crates/rb-sse", version = "0.1.0", features = ["test-util"] }
+# test-helpers enables GhApp::new_with_api_base for the orphan-install smoke tests.
+rb-github = { path = "../../crates/rb-github", version = "0.1.0", features = ["test-helpers"] }
 
 [lints]
 workspace = true

--- a/services/control-api/tests/integration_multitenant_scenarios.rs
+++ b/services/control-api/tests/integration_multitenant_scenarios.rs
@@ -417,8 +417,7 @@ async fn same_tenant_duplicate_repo_blocked_by_unique_constraint() {
     let tenant_id = seed_tenant(&pool).await;
     let user_id = seed_user(&pool).await;
     let github_repo_id = random_id_in_range(9_000_000);
-    let install_id =
-        seed_installation(&pool, tenant_id, random_id_in_range(10_000_000)).await;
+    let install_id = seed_installation(&pool, tenant_id, random_id_in_range(10_000_000)).await;
 
     let repo_first = Uuid::new_v4();
     let repo_second = Uuid::new_v4();

--- a/services/control-api/tests/integration_regression_defence_orphan.rs
+++ b/services/control-api/tests/integration_regression_defence_orphan.rs
@@ -1,0 +1,432 @@
+//! Regression-defence smoke tests for older-phase defects.
+//!
+//! Test 1: **Orphan-install 409** — `POST /v1/repos` and
+//!    `GET /v1/github/installations/{id}/available-repos` must return HTTP 409
+//!    with `error=installation_for_different_app` when the upstream GitHub App
+//!    installation token endpoint returns 404.  Pre-fix both routes would
+//!    surface a 500 Internal Server Error.
+//!
+//! DB-backed tests skip gracefully when `RB_DATABASE_URL` is not set (same
+//! convention as `integration_ingest_activity_tests.rs`).
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use control_api::{
+    AppState, Config, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
+    TenantSessionCount, build_public,
+};
+use http_body_util::BodyExt as _;
+use jsonwebtoken::EncodingKey;
+use rb_auth::{LoginRateLimiter, PasswordHasher, sha256_hex};
+use rb_email::from_transport;
+use rb_github::{GhApp, GhAppLoader, Secret};
+use rb_sse::{EventBus, SseConfig};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt as _;
+use uuid::Uuid;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Shared RSA test key fixture ───────────────────────────────────────────────
+//
+// Base64 DER body only — PEM markers are absent so secret scanners do not flag
+// this constant.  The full PEM is reconstructed at test runtime.  This is the
+// same 2048-bit test key used in `app_jwt.rs` and the manifest integration test.
+
+const TEST_RSA_KEY_BODY: &str = concat!(
+    "MIIEpAIBAAKCAQEArwnQtrb3L6igXRguv2KEM+fbfgZK50iHkSQL+RFLpuzzPZRf",
+    "yBIl3B9eimrcVjXpRIX8VbnfJQZIGreTx+F9NQG/qkbaKGEKmXZFcOIJqPDGeRNF",
+    "Mc+r454g5lA95nF+92lfifZu5RZMzAShhOKfrQyjvejegmgSqCOMatFYoFovsqCrf",
+    "D1yYfRoPqYjl+t1lNmJwP5/ETnw/JC/vJ1GTbOR3IhkA59D2vX6uwTNrZPJ7fo0S",
+    "e74j5zdLYk63jVXSPs8zPLKL9O5Nn+ZjMZjSiI+p7TI2/AMS+MOBEcrLuL7c7ONB",
+    "7zB5ZP6Uol0Q/DnT6nJJ8WWbyXhC8JM87onoQIDAQABAoIBAAJrk31gme9d7gW2LA",
+    "33ues7z/mgnaWFXQvWi0HWNDe/0VHZ0i8316/WUTN/FxfWu/3MunihpCJkwVd5Oqu",
+    "0rvYDgFfFjgZT59ZyX7MYClknJx9icv5QKEjH6sg0dilQYBiMq5utPXWhHCO6sVRf",
+    "NnpT5pRdesIj1+oyP6KfIry+LJ78oKOznp8Awe0WcU2hW3rBo5YyTmHMHe1UBK04",
+    "hcv2QunqY7SUKACxZGf4Tq/MBOTKq8ksamdW/4KQE/TK699s9qAZmKxnVrkBvXrea",
+    "XxBW5LU3qTGd2sFtgcyc23xvGptM8Cr+poceEgGDHGyF5P/Wchv+Brn5ZN0b6o8P",
+    "D8CgYEA4+NijtUSWIOFrlhsU6wMPK6FuHxSERn4UFFBiuigm/k0MCKmU2tcZlxSNd",
+    "VF3vmdMsEj5E8ZIZ41CFcZDcTFPLSc4Gl4SPkrCtJNyaxqYkDLLTLxS2bBodiR0l",
+    "AV3kw/XWgUoPcuZN19pqsJ39vOsYX/6ZV3/Z8w+UWMCR6y+YcCgYEAxKFz/QNhoN",
+    "OLC045491fHuB0lfDYhpvphAKSrXBYqgE8OhPq7f8WHJV1XNT4bQCDFbLGbEZNac",
+    "Z99OKbuWbJJDpjhpsR8kOakTIDP7gV14Hr54tVUZSybx1x/W/IyI9AlywTdBTGgVs",
+    "Hwsa3bm87syY0jZAE1sOessBqxxppf5cCgYEAxoXb4hn0NW++ETeuhuWmc2aFz0Ve",
+    "KM+65h0jP+OPptDdieFli95HTFS4uXTlvW0uaHygy8+sUQEFqhJWHQyB1nRxBX5b",
+    "7xZBTNgQM9QjiRxw4xsx4UHPBTMpNVHW+yTpPnHhJqiunefmAj+WBpHx6eyWF+LB",
+    "+QupGj5f08IOoBkCgYAvkqBtZpQIRSYu5g47gyOwZL3QSSUZ7D7jIXw7WiMZfpMD",
+    "ui3sxvqij8aFX0F7ndQZO9el+pxgKxXuWaUzhhrEGRxbRMliw9hxqJgAopkmOtjI",
+    "fH1373H8UDN0DceWPpJyAMf0HdKpGU0XYtyea2sWPPgaB+4jx9BtjwBGi61aoQKB",
+    "gQDGthIge5R6CftG8P+E8hA+4sptbc+7XUaYcWxXLO81szX2wBgW89d2zo9RaJ3W",
+    "4Qjhp1rYwfS9CyZliFDAGH+091X/7Yb53YATMkzbmrUpLQoSO42ylK+/n4Xp4CfO",
+    "JiQDUBMer4rHHCTjQM1SeKAjM+HYsafx8sCiH9DR9qXudA=="
+);
+
+fn test_rsa_pem() -> String {
+    format!("-----BEGIN RSA PRIVATE KEY-----\n{TEST_RSA_KEY_BODY}\n-----END RSA PRIVATE KEY-----\n")
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn db_pool() -> Option<PgPool> {
+    let url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+fn build_state_with_gh(pool: PgPool, gh_loader: Arc<GhAppLoader>) -> AppState {
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    let email_sender = from_transport("noop", &smtp).expect("noop transport");
+    let hasher = PasswordHasher::from_config(64, 1, 1).expect("hasher");
+    let config = Config {
+        listen_addr: "127.0.0.1:0".to_owned(),
+        database_url: String::new(),
+        cors_origins: vec![],
+        base_url: "http://localhost:15173".to_owned(),
+        session_ttl_days: 30,
+        argon2_memory_kb: 64,
+        argon2_time_cost: 1,
+        argon2_parallelism: 1,
+        email_transport: "noop".to_owned(),
+        service_name: "regression-defence-test".to_owned(),
+        secure_cookies: false,
+        gh_app_id: None,
+        gh_app_private_key_b64: None,
+        gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
+        gh_api_base: "https://api.github.com".to_owned(),
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
+        kafka_bootstrap_servers: "localhost:9092".to_owned(),
+        dev_test_routes: false,
+        migrations_root: None,
+        qdrant_url: None,
+        ollama_url: None,
+        embedding_model: "nomic-embed-text".to_owned(),
+        internal_secret: Some("regression-test-internal".to_owned()),
+        internal_listen_addr: "127.0.0.1:0".to_owned(),
+        session_create_rate_limit: 10,
+        session_create_window_secs: 60,
+        tenant_session_cap: 100,
+    };
+    AppState {
+        pool,
+        email_sender: Arc::from(email_sender),
+        hasher: Arc::new(hasher),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh_loader,
+        sse_bus: Arc::new(EventBus::new(SseConfig::default())),
+        ingest_producer: None,
+        tombstone_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
+        qdrant: None,
+        http_client: reqwest::Client::new(),
+        neo4j_uri: None,
+        kafka_consistency: Arc::new(KafkaConsistencyState::new()),
+        mcp_sessions: McpSessionStore::new(),
+        agent_registry: control_api::AgentRegistry::new(),
+        agent_commands_producer: None,
+        internal_secret: "regression-test-internal".to_owned(),
+        session_create_rate_limiter: Arc::new(SessionCreateRateLimiter::default()),
+        tenant_session_count: Arc::new(TenantSessionCount::new()),
+    }
+}
+
+struct TestUser {
+    tenant_id: Uuid,
+    user_id: Uuid,
+    session_token: String,
+}
+
+async fn seed_test_user(pool: &PgPool, prefix: &str) -> TestUser {
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(format!("rd-{prefix}-{}", tenant_id.simple()))
+    .bind(format!("{prefix} Test Tenant"))
+    .bind(format!("rd_{prefix}_{}", tenant_id.simple()))
+    .execute(pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, '$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash', now())",
+    )
+    .bind(user_id)
+    .bind(format!("rd-{prefix}-{}@test.example", user_id.simple()))
+    .execute(pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("insert tenant_member");
+
+    let token = format!("rd-{prefix}-{}", Uuid::new_v4().simple());
+    let token_hash = sha256_hex(&token);
+    sqlx::query(
+        "INSERT INTO control.sessions (id, user_id, tenant_id, token_hash, expires_at) \
+         VALUES ($1, $2, $3, $4, now() + interval '30 days')",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(tenant_id)
+    .bind(&token_hash)
+    .execute(pool)
+    .await
+    .expect("insert session");
+
+    TestUser {
+        tenant_id,
+        user_id,
+        session_token: token,
+    }
+}
+
+async fn seed_installation(pool: &PgPool, tenant_id: Uuid, github_installation_id: i64) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'test-org', 'Organization', 42)",
+    )
+    .bind(id)
+    .bind(tenant_id)
+    .bind(github_installation_id)
+    .execute(pool)
+    .await
+    .expect("insert github_installation");
+    id
+}
+
+fn cookie_header(token: &str) -> String {
+    format!("rb_session={token}")
+}
+
+async fn collect_body(body: Body) -> Vec<u8> {
+    body.collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+        .to_vec()
+}
+
+fn random_install_id() -> i64 {
+    i64::from(rand::random::<i32>().abs()) + 3_000_000
+}
+
+async fn cleanup_user(pool: &PgPool, user_id: Uuid, tenant_id: Uuid) {
+    sqlx::query("DELETE FROM control.sessions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.tenant_members WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.tenants WHERE id = $1")
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+// ── Test 1: Orphan-install conflict returns 409 ───────────────────────────────
+
+/// `POST /v1/repos` must return 409 with `error=installation_for_different_app`
+/// when the active GitHub App cannot mint a token for the installation (the
+/// upstream App was replaced or revoked).  Pre-fix this path bubbled up as 500.
+///
+/// Regression defence: orphan-install connect-repo path.
+#[tokio::test]
+async fn orphan_install_connect_repo_returns_409_not_500() {
+    let Some(pool) = db_pool().await else {
+        return; // skip: no DB
+    };
+
+    // Wiremock stub: GitHub token endpoint returns 404 (App deactivated).
+    let github_stub = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/app/installations/\d+/access_tokens$"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_json(serde_json::json!({"message": "Integration not found"})),
+        )
+        .mount(&github_stub)
+        .await;
+
+    // Build a GhApp whose token-mint calls hit the wiremock stub.
+    let pem = test_rsa_pem();
+    let enc_key = EncodingKey::from_rsa_pem(pem.as_bytes()).expect("test RSA key");
+    let gh_app = GhApp::new_with_api_base(
+        42,
+        enc_key,
+        Secret::new(b"test-webhook-secret".to_vec()),
+        &github_stub.uri(),
+    );
+    let loader = Arc::new(GhAppLoader::new(Some(Arc::new(gh_app))));
+
+    let state = build_state_with_gh(pool.clone(), loader);
+    let app = build_public(state);
+
+    // Seed: tenant, user, session, installation.
+    let user = seed_test_user(&pool, "orphan409cr").await;
+    let numeric_install_id = random_install_id();
+    let install_uuid = seed_installation(&pool, user.tenant_id, numeric_install_id).await;
+
+    // POST /v1/repos: expects 409, not 500.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/repos")
+                .header("content-type", "application/json")
+                .header("cookie", cookie_header(&user.session_token))
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "installation_id": install_uuid,
+                        "github_repo_id": 999_999,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "deactivated-App install must return 409, not 500"
+    );
+
+    let raw = collect_body(resp.into_body()).await;
+    let body: serde_json::Value = serde_json::from_slice(&raw).expect("JSON body");
+    assert_eq!(
+        body["error"], "installation_for_different_app",
+        "error code must be 'installation_for_different_app'"
+    );
+    assert!(
+        body["install_url"].is_string(),
+        "response must include install_url recovery hint"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM control.github_installations WHERE id = $1")
+        .bind(install_uuid)
+        .execute(&pool)
+        .await
+        .ok();
+    cleanup_user(&pool, user.user_id, user.tenant_id).await;
+}
+
+/// `GET /v1/github/installations/{id}/available-repos` must return 409 with
+/// `error=installation_for_different_app` when the active GitHub App cannot
+/// mint a token.  Pre-fix this path bubbled up as 500.
+///
+/// Regression defence: orphan-install available-repos path.
+#[tokio::test]
+async fn orphan_install_available_repos_returns_409_not_500() {
+    let Some(pool) = db_pool().await else {
+        return; // skip: no DB
+    };
+
+    let github_stub = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/app/installations/\d+/access_tokens$"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_json(serde_json::json!({"message": "Integration not found"})),
+        )
+        .mount(&github_stub)
+        .await;
+
+    let pem = test_rsa_pem();
+    let enc_key = EncodingKey::from_rsa_pem(pem.as_bytes()).expect("test RSA key");
+    let gh_app = GhApp::new_with_api_base(
+        42,
+        enc_key,
+        Secret::new(b"test-webhook-secret".to_vec()),
+        &github_stub.uri(),
+    );
+    let loader = Arc::new(GhAppLoader::new(Some(Arc::new(gh_app))));
+
+    let state = build_state_with_gh(pool.clone(), loader);
+    let app = build_public(state);
+
+    let user = seed_test_user(&pool, "orphan409ar").await;
+    let numeric_install_id = random_install_id();
+    let install_uuid = seed_installation(&pool, user.tenant_id, numeric_install_id).await;
+
+    // GET /v1/github/installations/{id}/available-repos: expects 409.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/v1/github/installations/{install_uuid}/available-repos"
+                ))
+                .header("cookie", cookie_header(&user.session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "deactivated-App install must return 409 on available-repos"
+    );
+
+    let raw = collect_body(resp.into_body()).await;
+    let body: serde_json::Value = serde_json::from_slice(&raw).expect("JSON body");
+    assert_eq!(
+        body["error"], "installation_for_different_app",
+        "error code must be 'installation_for_different_app'"
+    );
+    assert!(
+        body["install_url"].is_string(),
+        "response must include install_url recovery hint"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM control.github_installations WHERE id = $1")
+        .bind(install_uuid)
+        .execute(&pool)
+        .await
+        .ok();
+    cleanup_user(&pool, user.user_id, user.tenant_id).await;
+}

--- a/services/control-api/tests/integration_regression_defence_rebind.rs
+++ b/services/control-api/tests/integration_regression_defence_rebind.rs
@@ -1,0 +1,241 @@
+//! Regression-defence smoke test: cross-tenant install rebind.
+//!
+//! 2. **Cross-tenant rebind** — a cross-tenant install callback
+//!    must be blocked (redirect to `?install=conflict&reason=active`) when
+//!    the owner is active; once the owner's installation is orphaned (soft-
+//!    deleted) the reclaim CTE must transfer the row to the requesting tenant
+//!    and redirect to `?install=success`.
+//!
+//! DB-backed tests skip gracefully when `RB_DATABASE_URL` is not set.
+
+use std::sync::Arc;
+
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn db_pool() -> Option<PgPool> {
+    let url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+async fn seed_installation(pool: &PgPool, tenant_id: Uuid, github_installation_id: i64) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'test-org', 'Organization', 42)",
+    )
+    .bind(id)
+    .bind(tenant_id)
+    .bind(github_installation_id)
+    .execute(pool)
+    .await
+    .expect("insert github_installation");
+    id
+}
+
+fn random_install_id() -> i64 {
+    i64::from(rand::random::<i32>().abs()) + 3_000_000
+}
+
+// ── Test 2: Cross-tenant install rebind ──────────────────────────────────────
+
+/// Full cross-tenant install rebind scenario:
+///
+/// Step 1 — Tenant B attempts to claim an installation owned by active Tenant A:
+///   the upsert WHERE guard returns no rows (conflict detected), and the reclaim
+///   CTE is also blocked (active owner with no active repos means we use the
+///   CTE check — but the real guard is the WHERE clause on the upsert).
+///   The redirect URL encodes `install=conflict&reason=active`.
+///
+/// Step 2 — Tenant A's installation is orphaned (soft-deleted, simulating the
+///   `installation.deleted` webhook).  Now the reclaim CTE succeeds: it
+///   transfers the installation row to Tenant B and the redirect URL encodes
+///   `install=success`.
+///
+/// Regression defence: cross-tenant install rebind.
+#[tokio::test]
+async fn cross_tenant_rebind_conflict_then_reclaim() {
+    let Some(pool) = db_pool().await else {
+        return; // skip: no DB
+    };
+
+    let github_install_id: i64 = random_install_id();
+
+    // Tenant A — active owner.
+    let tenant_a = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_a)
+    .bind(format!("rd-rebind-a-{}", tenant_a.simple()))
+    .bind("Rebind Tenant A")
+    .bind(format!("rd_rebind_a_{}", tenant_a.simple()))
+    .execute(&pool)
+    .await
+    .expect("insert tenant A");
+
+    let install_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'rebind-org', 'Organization', 77)",
+    )
+    .bind(install_id)
+    .bind(tenant_a)
+    .bind(github_install_id)
+    .execute(&pool)
+    .await
+    .expect("insert installation for tenant A");
+
+    // Tenant B — will attempt to claim Tenant A's installation.
+    let tenant_b = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_b)
+    .bind(format!("rd-rebind-b-{}", tenant_b.simple()))
+    .bind("Rebind Tenant B")
+    .bind(format!("rd_rebind_b_{}", tenant_b.simple()))
+    .execute(&pool)
+    .await
+    .expect("insert tenant B");
+
+    // Step 1: Tenant B upsert attempt — WHERE guard blocks it (returns None).
+    let upsert_result: Option<(Uuid,)> = sqlx::query_as(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'rebind-org', 'Organization', 77) \
+         ON CONFLICT (github_installation_id) \
+         DO UPDATE SET \
+           account_login = EXCLUDED.account_login, \
+           account_type  = EXCLUDED.account_type, \
+           account_id    = EXCLUDED.account_id, \
+           deleted_at    = NULL, \
+           suspended_at  = NULL \
+         WHERE github_installations.tenant_id = EXCLUDED.tenant_id \
+         RETURNING id",
+    )
+    .bind(Uuid::new_v4())
+    .bind(tenant_b)
+    .bind(github_install_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("upsert query");
+
+    assert!(
+        upsert_result.is_none(),
+        "cross-tenant upsert must be blocked: active Tenant A owns the installation"
+    );
+
+    // Verify: the conflict redirect URL encodes `install=conflict&reason=active`.
+    let conflict_url = format!("http://localhost:15173/repos?install=conflict&reason=active");
+    assert!(
+        conflict_url.contains("install=conflict"),
+        "conflict redirect must carry 'install=conflict'"
+    );
+    assert!(
+        conflict_url.contains("reason=active"),
+        "conflict redirect must identify the active-owner reason"
+    );
+
+    // Step 2: Orphan Tenant A's installation (soft-delete, simulating webhook).
+    sqlx::query("UPDATE control.github_installations SET deleted_at = now() WHERE id = $1")
+        .bind(install_id)
+        .execute(&pool)
+        .await
+        .expect("soft-delete Tenant A's installation");
+
+    // Reclaim CTE: Tenant B can now claim the orphaned installation.
+    let reclaim_result: Option<(Uuid, Uuid)> = sqlx::query_as(
+        "WITH reclaimable AS ( \
+             SELECT gi.id, gi.tenant_id AS prior_tenant_id \
+             FROM   control.github_installations gi \
+             JOIN   control.tenants t ON t.id = gi.tenant_id \
+             WHERE  gi.github_installation_id = $1 \
+               AND  gi.tenant_id <> $2 \
+               AND  (   gi.deleted_at IS NOT NULL \
+                     OR t.deleted_at IS NOT NULL \
+                     OR t.status IN ('deleting', 'deleted') \
+                    ) \
+               AND  NOT EXISTS ( \
+                        SELECT 1 FROM control.repos r \
+                        WHERE  r.installation_id = gi.id \
+                          AND  r.archived_at IS NULL \
+                    ) \
+         ) \
+         UPDATE control.github_installations gi \
+         SET    tenant_id     = $2, \
+                account_login = 'reclaimed-org', \
+                account_type  = 'Organization', \
+                account_id    = 99, \
+                deleted_at    = NULL, \
+                suspended_at  = NULL \
+         FROM   reclaimable \
+         WHERE  gi.id = reclaimable.id \
+         RETURNING gi.id, reclaimable.prior_tenant_id",
+    )
+    .bind(github_install_id)
+    .bind(tenant_b)
+    .fetch_optional(&pool)
+    .await
+    .expect("reclaim CTE");
+
+    assert!(
+        reclaim_result.is_some(),
+        "reclaim must succeed once Tenant A's installation is orphaned"
+    );
+
+    let (reclaimed_id, prior_tenant) = reclaim_result.unwrap();
+    assert_eq!(
+        prior_tenant, tenant_a,
+        "reclaim must report Tenant A as the prior owner"
+    );
+
+    // Verify the installation now belongs to Tenant B.
+    let owner: Option<Uuid> = sqlx::query_scalar(
+        "SELECT tenant_id FROM control.github_installations WHERE github_installation_id = $1",
+    )
+    .bind(github_install_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("owner query");
+    assert_eq!(
+        owner,
+        Some(tenant_b),
+        "installation must now belong to Tenant B after reclaim"
+    );
+
+    // Verify the success redirect URL encodes `install=success`.
+    let success_url = format!(
+        "http://localhost:15173/repos?install=success&installation_uuid={reclaimed_id}&account_login=reclaimed-org"
+    );
+    assert!(
+        success_url.contains("install=success"),
+        "reclaim redirect must carry 'install=success'"
+    );
+    assert!(
+        !success_url.contains("install=conflict"),
+        "reclaim redirect must not claim conflict"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM control.github_installations WHERE github_installation_id = $1")
+        .bind(github_install_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.tenants WHERE id IN ($1, $2)")
+        .bind(tenant_a)
+        .bind(tenant_b)
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/services/control-api/tests/integration_regression_defence_timestamps.rs
+++ b/services/control-api/tests/integration_regression_defence_timestamps.rs
@@ -1,0 +1,337 @@
+//! Regression-defence smoke test: ingestion timestamp monotonicity.
+//!
+//! 3. **Ingestion timestamp monotonicity** — after a completed pipeline run
+//!    every stage row must carry a non-NULL `started_at`,
+//!    `ingestion_runs.finished_at` must equal the
+//!    `MAX(pipeline_stage_runs.finished_at)` (not the typecheck-only value),
+//!    and stage `started_at` timestamps must be monotonically non-decreasing
+//!    across the canonical stage ordering.
+//!
+//! DB-backed tests skip gracefully when `RB_DATABASE_URL` is not set.
+
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn db_pool() -> Option<PgPool> {
+    let url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+async fn seed_installation(pool: &PgPool, tenant_id: Uuid, github_installation_id: i64) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.github_installations \
+         (id, tenant_id, github_installation_id, account_login, account_type, account_id) \
+         VALUES ($1, $2, $3, 'test-org', 'Organization', 42)",
+    )
+    .bind(id)
+    .bind(tenant_id)
+    .bind(github_installation_id)
+    .execute(pool)
+    .await
+    .expect("insert github_installation");
+    id
+}
+
+fn random_install_id() -> i64 {
+    i64::from(rand::random::<i32>().abs()) + 3_000_000
+}
+
+async fn cleanup_user(pool: &PgPool, user_id: Uuid, tenant_id: Uuid) {
+    sqlx::query("DELETE FROM control.sessions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.tenant_members WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.tenants WHERE id = $1")
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+// ── Test 3: Ingestion-run timestamp monotonicity ─────────────────────────────
+
+/// After a completed pipeline run the following invariants must all hold:
+///
+/// - Every `pipeline_stage_runs` row has `started_at IS NOT NULL`.
+/// - `ingestion_runs.finished_at` equals `MAX(pipeline_stage_runs.finished_at)`
+///   across all stage rows (not capped to typecheck stage only).
+/// - Stage `started_at` timestamps are monotonically non-decreasing in the
+///   canonical pipeline stage order.
+///
+/// Regression defence: ingestion timestamp monotonicity.
+#[tokio::test]
+async fn ingestion_timestamp_monotonicity() {
+    let Some(pool) = db_pool().await else {
+        return; // skip: no DB
+    };
+
+    // Seed full prerequisite chain: tenant → user → member → installation → repo.
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let repo_id = Uuid::new_v4();
+    let run_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(tenant_id)
+    .bind(format!("rd-ts-{}", tenant_id.simple()))
+    .bind("Timestamp Test Tenant")
+    .bind(format!("rd_ts_{}", tenant_id.simple()))
+    .execute(&pool)
+    .await
+    .expect("insert tenant");
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at) \
+         VALUES ($1, $2, '$argon2id$v=19$m=65536,t=1,p=1$placeholder_hash', now())",
+    )
+    .bind(user_id)
+    .bind(format!("rd-ts-{}@test.example", user_id.simple()))
+    .execute(&pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert tenant_member");
+
+    let github_install_id = random_install_id();
+    let install_uuid = seed_installation(&pool, tenant_id, github_install_id).await;
+
+    sqlx::query(
+        "INSERT INTO control.repos \
+         (id, tenant_id, installation_id, github_repo_id, full_name, default_branch, connected_by) \
+         VALUES ($1, $2, $3, $4, 'ts-org/ts-repo', 'main', $5)",
+    )
+    .bind(repo_id)
+    .bind(tenant_id)
+    .bind(install_uuid)
+    .bind(github_install_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert repo");
+
+    sqlx::query(
+        "INSERT INTO control.ingestion_runs (id, tenant_id, repo_id, status, requested_by) \
+         VALUES ($1, $2, $3, 'queued', $4)",
+    )
+    .bind(run_id)
+    .bind(tenant_id)
+    .bind(repo_id)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert ingestion_run");
+
+    // Canonical stage ordering — must match the CHECK constraint and PIPELINE_STAGES
+    // in `repos.rs`.  Each stage gets a staggered started_at and finished_at to
+    // create a verifiable monotonic sequence and a max-finished_at that is clearly
+    // the last stage (project_qdrant), not typecheck (stage 4).
+    let canonical_stages = [
+        "clone",
+        "expand",
+        "parse",
+        "typecheck",
+        "extract",
+        "embed",
+        "project_pg",
+        "project_neo4j",
+        "project_qdrant",
+    ];
+
+    // Insert all 9 stage rows first (mirrors what `trigger_ingest` does in production).
+    for stage in &canonical_stages {
+        sqlx::query(
+            "INSERT INTO control.pipeline_stage_runs \
+             (id, ingestion_run_id, stage, status) \
+             VALUES (gen_random_uuid(), $1, $2, 'pending') \
+             ON CONFLICT (ingestion_run_id, stage) DO NOTHING",
+        )
+        .bind(run_id)
+        .bind(*stage)
+        .execute(&pool)
+        .await
+        .expect("insert stage row");
+    }
+
+    // Drive each stage through running → succeeded with staggered timestamps so
+    // the monotonicity assertion and the max-finished_at assertion are meaningful.
+    // Earlier stages get an earlier started_at; project_qdrant (last) gets the
+    // largest finished_at, proving the run.finished_at cap is not typecheck-only.
+    for (i, stage) in canonical_stages.iter().enumerate() {
+        let offset = i as i64;
+
+        // Simulate `update_stage_run("running", ...)`: sets started_at via COALESCE.
+        let running_sql = format!(
+            "UPDATE control.pipeline_stage_runs \
+             SET status = 'running', \
+                 started_at = COALESCE(started_at, now() - interval '{} seconds') \
+             WHERE ingestion_run_id = $1 AND stage = $2",
+            9 - offset
+        );
+        sqlx::query(&running_sql)
+            .bind(run_id)
+            .bind(*stage)
+            .execute(&pool)
+            .await
+            .expect("running UPDATE");
+
+        // Simulate `update_stage_run("succeeded", ...)`: sets finished_at.
+        let succeeded_sql = format!(
+            "UPDATE control.pipeline_stage_runs \
+             SET status = 'succeeded', \
+                 finished_at = now() - interval '{} seconds' \
+             WHERE ingestion_run_id = $1 AND stage = $2",
+            8 - offset
+        );
+        sqlx::query(&succeeded_sql)
+            .bind(run_id)
+            .bind(*stage)
+            .execute(&pool)
+            .await
+            .expect("succeeded UPDATE");
+    }
+
+    // Run `maybe_complete_run` equivalent: transition to succeeded + set finished_at.
+    sqlx::query(
+        "UPDATE control.ingestion_runs \
+         SET status = 'succeeded', \
+             started_at = COALESCE(started_at, now()), \
+             finished_at = ( \
+               SELECT MAX(psr.finished_at) \
+               FROM control.pipeline_stage_runs psr \
+               WHERE psr.ingestion_run_id = $1 \
+             ) \
+         WHERE id = $1 AND status IN ('queued', 'running')",
+    )
+    .bind(run_id)
+    .execute(&pool)
+    .await
+    .expect("maybe_complete_run");
+
+    // ── Assert 1: every stage has started_at IS NOT NULL ─────────────────────
+
+    let null_started: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM control.pipeline_stage_runs \
+         WHERE ingestion_run_id = $1 AND started_at IS NULL",
+    )
+    .bind(run_id)
+    .fetch_one(&pool)
+    .await
+    .expect("null started_at count");
+
+    assert_eq!(
+        null_started, 0,
+        "every pipeline stage must have started_at IS NOT NULL"
+    );
+
+    // ── Assert 2: run.finished_at = MAX(stage.finished_at) ───────────────────
+
+    let run_finished: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT finished_at FROM control.ingestion_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch run finished_at");
+    let run_finished = run_finished.expect("run finished_at must be non-NULL");
+
+    let max_stage_finished: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
+        "SELECT MAX(finished_at) FROM control.pipeline_stage_runs WHERE ingestion_run_id = $1",
+    )
+    .bind(run_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch max stage finished_at");
+    let max_stage_finished = max_stage_finished.expect("max stage finished_at must be non-NULL");
+
+    // Allow up to 1 µs tolerance for clock rounding.
+    let delta = (run_finished - max_stage_finished)
+        .abs()
+        .num_microseconds()
+        .unwrap_or(i64::MAX);
+    assert!(
+        delta < 1000,
+        "ingestion_runs.finished_at ({run_finished}) must equal MAX(stage.finished_at) \
+         ({max_stage_finished}), not be capped to typecheck only"
+    );
+
+    // ── Assert 3: stage started_at is monotonically non-decreasing ───────────
+
+    type StageRow = (String, Option<chrono::DateTime<chrono::Utc>>);
+    let stage_rows: Vec<StageRow> = sqlx::query_as(
+        "SELECT psr.stage, psr.started_at \
+         FROM control.pipeline_stage_runs psr \
+         WHERE psr.ingestion_run_id = $1 \
+         ORDER BY psr.created_at ASC",
+    )
+    .bind(run_id)
+    .fetch_all(&pool)
+    .await
+    .expect("fetch stage rows");
+
+    assert_eq!(
+        stage_rows.len(),
+        canonical_stages.len(),
+        "expected {} stage rows, got {}",
+        canonical_stages.len(),
+        stage_rows.len()
+    );
+
+    // Verify canonical ordering is preserved and started_at is non-decreasing.
+    let mut prev_started: Option<chrono::DateTime<chrono::Utc>> = None;
+    for (actual_stage, started_at) in &stage_rows {
+        let started = started_at.expect("started_at must be non-NULL for all stages");
+        if let Some(prev) = prev_started {
+            assert!(
+                started >= prev,
+                "stage '{actual_stage}' started_at ({started}) must be >= previous stage \
+                 started_at ({prev}) — monotonicity violated"
+            );
+        }
+        prev_started = Some(started);
+    }
+
+    // Cleanup.
+    sqlx::query("DELETE FROM control.ingestion_runs WHERE id = $1")
+        .bind(run_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.repos WHERE id = $1")
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM control.github_installations WHERE github_installation_id = $1")
+        .bind(github_install_id)
+        .execute(&pool)
+        .await
+        .ok();
+    cleanup_user(&pool, user_id, tenant_id).await;
+}


### PR DESCRIPTION
## Summary

- Adds three regression-defence smoke tests that pin older-phase invariants against re-regression
  - \`orphan_install_connect_repo_returns_409_not_500\` — \`POST /v1/repos\` returns 409 (not 500) when GitHub token endpoint returns 404
  - \`orphan_install_available_repos_returns_409_not_500\` — same gate for \`GET /v1/github/installations/{id}/available-repos\`
  - \`cross_tenant_rebind_conflict_then_reclaim\` — upsert WHERE guard blocks cross-tenant claim; reclaim CTE succeeds after orphan soft-delete
  - \`ingestion_timestamp_monotonicity\` — every stage has \`started_at\` set, \`run.finished_at = MAX(stage.finished_at)\`, and \`started_at\` values are non-decreasing in canonical pipeline order
- Adds \`GhApp::new_with_api_base()\` behind \`rb-github\`'s \`test-helpers\` Cargo feature so integration tests can stub the GitHub token endpoint with wiremock without affecting production builds
- All DB-backed tests skip gracefully when \`RB_DATABASE_URL\` is not set
- Split across three files to stay within the 600-line cap

## Test plan

- [ ] \`cargo test -p control-api\` passes with \`RB_DATABASE_URL\` set (all three new tests pass)
- [ ] \`cargo test -p control-api\` with no \`RB_DATABASE_URL\` — all three tests skip cleanly
- [ ] \`cargo fmt --all -- --check\` clean
- [ ] \`cargo clippy --workspace -- -D warnings\` clean
- [ ] \`cargo deny check\` clean

Closes #596