### PR TITLE
[RUSAA-587] fix(frontend): declare VITE_TEMPO_URL in ImportMetaEnv

### DIFF
--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_TEMPO_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Adds `readonly VITE_TEMPO_URL?: string` to the `ImportMetaEnv` interface in `frontend/src/env.d.ts`
- `VITE_TEMPO_URL` is used in `TraceViewerPage.tsx` (REQ-FE-08) but was absent from the type declaration, leaving it as implicit `any`

## GitHub Issue

Closes #599

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR