### PR TITLE
[RUSAA-1345] fix(agent-runner): EventRelay retry_total metric overcounts attempt-0 failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "chrono",
  "clap",
  "metrics",
+ "metrics-util 0.18.0",
  "nix",
  "rb-build-info",
  "rb-kafka",

--- a/services/agent-runner/Cargo.toml
+++ b/services/agent-runner/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+metrics-util.workspace = true
 tempfile = "3"
 wiremock.workspace = true
 

--- a/services/agent-runner/src/event_relay.rs
+++ b/services/agent-runner/src/event_relay.rs
@@ -264,6 +264,7 @@ async fn post_with_retry(
         if attempt > 0 {
             let delay_ms = BASE_RETRY_DELAY_MS * (1u64 << (attempt - 1));
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            counter!("rb_agent_relay_retry_total").increment(1);
         }
 
         match client.post(url).json(body).send().await {
@@ -284,9 +285,6 @@ async fn post_with_retry(
                     event_count = event_count,
                     "EventRelay: POST 5xx — will retry"
                 );
-                if attempt > 0 {
-                    counter!("rb_agent_relay_retry_total").increment(1);
-                }
             }
             Ok(resp) => {
                 // 4xx and other non-retryable responses
@@ -307,9 +305,6 @@ async fn post_with_retry(
                     event_count = event_count,
                     "EventRelay: connection error — will retry"
                 );
-                if attempt > 0 {
-                    counter!("rb_agent_relay_retry_total").increment(1);
-                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -537,9 +532,9 @@ mod tests {
 
     // ── Metric correctness ─────────────────────────────────────────────────
 
-    /// Regression: attempt-0 failures must NOT increment retry_total.
+    /// Regression: attempt-0 failures must NOT increment `retry_total`.
     /// A single 5xx on attempt=0 followed by a 2xx success on attempt=1
-    /// must produce retry_total == 1 (not 2).
+    /// must produce `retry_total` == 1 (not 2).
     #[tokio::test]
     async fn retry_total_not_incremented_on_attempt_zero() {
         use metrics_util::debugging::{DebugValue, DebuggingRecorder};

--- a/services/agent-runner/src/event_relay.rs
+++ b/services/agent-runner/src/event_relay.rs
@@ -284,7 +284,9 @@ async fn post_with_retry(
                     event_count = event_count,
                     "EventRelay: POST 5xx — will retry"
                 );
-                counter!("rb_agent_relay_retry_total").increment(1);
+                if attempt > 0 {
+                    counter!("rb_agent_relay_retry_total").increment(1);
+                }
             }
             Ok(resp) => {
                 // 4xx and other non-retryable responses
@@ -305,7 +307,9 @@ async fn post_with_retry(
                     event_count = event_count,
                     "EventRelay: connection error — will retry"
                 );
-                counter!("rb_agent_relay_retry_total").increment(1);
+                if attempt > 0 {
+                    counter!("rb_agent_relay_retry_total").increment(1);
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -529,5 +533,62 @@ mod tests {
 
         let n = server.received_requests().await.unwrap().len();
         assert_eq!(n, 1, "success on first attempt — no retries");
+    }
+
+    // ── Metric correctness ─────────────────────────────────────────────────
+
+    /// Regression: attempt-0 failures must NOT increment retry_total.
+    /// A single 5xx on attempt=0 followed by a 2xx success on attempt=1
+    /// must produce retry_total == 1 (not 2).
+    #[tokio::test]
+    async fn retry_total_not_incremented_on_attempt_zero() {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        // A fresh recorder per test; ignore errors if another test already
+        // installed a global recorder (the assertion below is what matters).
+        let _ = recorder.install();
+
+        let server = MockServer::start().await;
+        // attempt 0 → 500, attempt 1 → 200
+        Mock::given(method("POST"))
+            .and(path("/internal/agent/sessions/s5/events"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/internal/agent/sessions/s5/events"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let body = serde_json::json!({ "tenant_id": "t1", "events": [] });
+        let url = format!("{}/internal/agent/sessions/s5/events", server.uri());
+
+        post_with_retry(&client, &url, &body, "s5", 1).await;
+
+        let entries = snapshotter.snapshot().into_vec();
+        let retry_count: u64 = entries
+            .iter()
+            .filter(|(key, _, _, _)| key.key().name() == "rb_agent_relay_retry_total")
+            .filter_map(|(_, _, _, v)| {
+                if let DebugValue::Counter(n) = v {
+                    Some(*n)
+                } else {
+                    None
+                }
+            })
+            .sum();
+
+        // Only attempt=1 (the real retry) must be counted.
+        assert_eq!(
+            retry_count, 1,
+            "retry_total must be 1 (attempt=1 only); attempt=0 failure must not count"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `rb_agent_relay_retry_total` was incremented on every failed attempt including `attempt=0` (the first request), inflating retry dashboards.
- A batch exhausting all 5 attempts incorrectly reported `retry_total += 5`; the correct value is `+4` (only the re-attempts after the initial try count as retries).
- Fix: guard both the 5xx and connection-error counter increments with `if attempt > 0`.

## Changes

- `services/agent-runner/src/event_relay.rs` — two `counter!("rb_agent_relay_retry_total")` sites wrapped in `if attempt > 0`.
- `services/agent-runner/Cargo.toml` — add `metrics-util` to `[dev-dependencies]` (workspace version, `debugging` feature already enabled).
- Regression test `retry_total_not_incremented_on_attempt_zero` — uses `DebuggingRecorder` to assert `retry_total == 1` for a single-5xx-then-success sequence.

## GitHub Issue

Closes #426

## Checklist

- [ ] `cargo-locked test --workspace` passes (CI)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes (CI)
- [ ] `cargo fmt --all -- --check` passes (verified locally)
- [ ] No tracker IDs outside this title bracket prefix