### PR TITLE
[RUSAA-589] feat(frontend): add trace viewer + axe-dispatch coverage for /trace/$traceId

### DIFF
--- a/frontend/e2e/axe-dispatch.spec.ts
+++ b/frontend/e2e/axe-dispatch.spec.ts
@@ -7,6 +7,7 @@ import {
   REPOS_RESPONSE,
   MEMBERS_RESPONSE,
   API_KEYS_RESPONSE,
+  STAGE_TIMELINE_RESPONSE,
 } from "./fixtures/mock-api";
 
 const ALL_ROUTES = [
@@ -18,6 +19,7 @@ const ALL_ROUTES = [
   "/repos",
   "/members",
   "/api-keys",
+  "/trace/abc12345def67890abc12345def67890",
 ] as const;
 
 const scanRouteEnv = (process.env.SCAN_ROUTE ?? "").trim();
@@ -40,6 +42,12 @@ const ROUTE_MOCKS: Partial<Record<string, MockFn>> = {
     await page.route("**/v1/me", (r) => r.fulfill({ json: ME_RESPONSE }));
     await page.route("**/v1/api-keys", (r) =>
       r.fulfill({ json: API_KEYS_RESPONSE }),
+    );
+  },
+  "/trace/abc12345def67890abc12345def67890": async (page) => {
+    await page.route("**/v1/me", (r) => r.fulfill({ json: ME_RESPONSE }));
+    await page.route("**/v1/ingestions/*/stages", (r) =>
+      r.fulfill({ json: STAGE_TIMELINE_RESPONSE }),
     );
   },
 };

--- a/frontend/e2e/fixtures/mock-api.ts
+++ b/frontend/e2e/fixtures/mock-api.ts
@@ -39,6 +39,22 @@ export const REPOS_EMPTY_RESPONSE = { repos: [] };
 
 export const INGEST_RESPONSE = { run_id: "run-id-1" };
 
+export const STAGE_TIMELINE_RESPONSE = {
+  ingestion_run_id: "run-uuid-axe-1",
+  trace_id: "abc12345def67890abc12345def67890",
+  stages: [
+    { stage: "clone", status: "succeeded", started_at: "2024-01-01T00:00:00Z", finished_at: "2024-01-01T00:00:02Z", error_message: null },
+    { stage: "expand", status: "succeeded", started_at: "2024-01-01T00:00:02Z", finished_at: "2024-01-01T00:00:04Z", error_message: null },
+    { stage: "parse", status: "succeeded", started_at: "2024-01-01T00:00:04Z", finished_at: "2024-01-01T00:00:06Z", error_message: null },
+    { stage: "typecheck", status: "succeeded", started_at: "2024-01-01T00:00:06Z", finished_at: "2024-01-01T00:00:08Z", error_message: null },
+    { stage: "extract", status: "succeeded", started_at: "2024-01-01T00:00:08Z", finished_at: "2024-01-01T00:00:10Z", error_message: null },
+    { stage: "embed", status: "succeeded", started_at: "2024-01-01T00:00:10Z", finished_at: "2024-01-01T00:00:12Z", error_message: null },
+    { stage: "project_pg", status: "succeeded", started_at: "2024-01-01T00:00:12Z", finished_at: "2024-01-01T00:00:14Z", error_message: null },
+    { stage: "project_neo4j", status: "succeeded", started_at: "2024-01-01T00:00:14Z", finished_at: "2024-01-01T00:00:16Z", error_message: null },
+    { stage: "project_qdrant", status: "succeeded", started_at: "2024-01-01T00:00:16Z", finished_at: "2024-01-01T00:00:18Z", error_message: null },
+  ],
+};
+
 export const CONNECT_REPO_RESPONSE = {
   repo_id: "repo-2",
   full_name: "acme/api",

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -93,3 +93,7 @@ export {
   type EventItem,
   type HistoryResponse,
 } from "./useAgentSessions";
+export {
+  useStageTimeline,
+  stageTimelineQueryKey,
+} from "./useTraceViewer";

--- a/frontend/src/api/hooks/useTraceViewer.ts
+++ b/frontend/src/api/hooks/useTraceViewer.ts
@@ -1,0 +1,31 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { apiClient, toApiError, type ApiError } from "../client";
+import type { components } from "../generated/schema";
+
+export type StageTimelineResponse = components["schemas"]["StageTimelineResponse"];
+export type StageRunItem = components["schemas"]["StageRunItem"];
+
+export function stageTimelineQueryKey(ingestionRunId: string) {
+  return ["ingestions", ingestionRunId, "stages"] as const;
+}
+
+export function useStageTimeline(
+  ingestionRunId: string,
+  options?: Omit<UseQueryOptions<StageTimelineResponse, ApiError>, "queryKey" | "queryFn">,
+) {
+  return useQuery<StageTimelineResponse, ApiError>({
+    queryKey: stageTimelineQueryKey(ingestionRunId),
+    queryFn: async () => {
+      const { data, error, response } = await apiClient.GET(
+        "/v1/ingestions/{ingestion_run_id}/stages",
+        { params: { path: { ingestion_run_id: ingestionRunId } } },
+      );
+      if (error || !data) {
+        throw toApiError(response.status, error);
+      }
+      return data;
+    },
+    enabled: ingestionRunId.length > 0,
+    ...options,
+  });
+}

--- a/frontend/src/api/tempo.ts
+++ b/frontend/src/api/tempo.ts
@@ -1,0 +1,90 @@
+// Browser-direct client for the Grafana Tempo HTTP API.
+// Tempo is an external observability backend — not our control-api — so
+// it has no OpenAPI spec and cannot go through apiClient.
+// Raw fetch is intentionally allowed here (see eslint.config.js override for tempo.ts).
+
+export interface TempoTag {
+  readonly key: string;
+  readonly type: string;
+  readonly value: unknown;
+}
+
+export interface TempoLogField {
+  readonly key: string;
+  readonly value: unknown;
+}
+
+export interface TempoLog {
+  readonly timestamp: number;
+  readonly fields: readonly TempoLogField[];
+}
+
+export interface TempoRef {
+  readonly refType: string;
+  readonly traceID: string;
+  readonly spanID: string;
+}
+
+export interface TempoSpan {
+  readonly traceID: string;
+  readonly spanID: string;
+  readonly operationName: string;
+  readonly startTime: number;
+  readonly duration: number;
+  readonly tags?: readonly TempoTag[];
+  readonly logs?: readonly TempoLog[];
+  readonly references?: readonly TempoRef[];
+  readonly processID: string;
+}
+
+export interface TempoProcess {
+  readonly serviceName: string;
+}
+
+export interface TempoTrace {
+  readonly traceID: string;
+  readonly spans: readonly TempoSpan[];
+  readonly processes: Record<string, TempoProcess>;
+}
+
+interface TempoResponse {
+  readonly data: readonly TempoTrace[];
+}
+
+export type FetchTempoResult =
+  | { readonly ok: true; readonly trace: TempoTrace }
+  | { readonly ok: false; readonly reason: string };
+
+export async function fetchTempoTrace(
+  tempoUrl: string,
+  traceId: string,
+  signal?: AbortSignal,
+): Promise<FetchTempoResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${tempoUrl}/api/traces/${traceId}`, {
+      signal: signal ?? null,
+      headers: { Accept: "application/json" },
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    return { ok: false, reason: err instanceof Error ? err.message : "Network error" };
+  }
+
+  if (!response.ok) {
+    return { ok: false, reason: `Tempo returned HTTP ${response.status}` };
+  }
+
+  let body: TempoResponse;
+  try {
+    body = (await response.json()) as TempoResponse;
+  } catch {
+    return { ok: false, reason: "Invalid JSON from Tempo" };
+  }
+
+  const trace = body.data?.[0];
+  if (!trace) {
+    return { ok: false, reason: "Trace not found in Tempo response" };
+  }
+  return { ok: true, trace };
+}

--- a/frontend/src/components/activity/RecentIngestionsTable.tsx
+++ b/frontend/src/components/activity/RecentIngestionsTable.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import type { RecentIngestionRun } from "@/api";
 import { formatApiError } from "@/lib/errors/api";
 import { formatTimestamp } from "./utils";
@@ -124,7 +125,16 @@ export function RecentIngestionsTable({
                     : "—"}
                 </td>
                 <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-                  {run.trace_id ? `${run.trace_id.slice(0, 8)}…` : "—"}
+                  {run.trace_id ? (
+                    <Link
+                      to="/trace/$traceId"
+                      params={{ traceId: run.trace_id }}
+                      search={{ runId: run.id }}
+                      className="hover:underline"
+                    >
+                      {run.trace_id.slice(0, 8)}…
+                    </Link>
+                  ) : "—"}
                 </td>
               </tr>
             );

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_TEMPO_URL?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/pages/TraceViewerPage.tsx
+++ b/frontend/src/pages/TraceViewerPage.tsx
@@ -1,0 +1,394 @@
+import { useParams, useSearch } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { fetchTempoTrace, type TempoTrace, type TempoSpan, type TempoProcess } from "@/api/tempo";
+import { useStageTimeline } from "@/api/hooks/useTraceViewer";
+import { PageContainer } from "@/components/repos/PageContainer";
+import type { StageRunItem } from "@/api/hooks/useTraceViewer";
+
+// ---------------------------------------------------------------------------
+// Stage constants
+// ---------------------------------------------------------------------------
+
+const PIPELINE_STAGES = [
+  "clone",
+  "expand",
+  "parse",
+  "typecheck",
+  "extract",
+  "embed",
+  "project_pg",
+  "project_neo4j",
+  "project_qdrant",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Duration formatting
+// ---------------------------------------------------------------------------
+
+function formatDuration(startedAt: string | null, finishedAt: string | null): string {
+  if (!startedAt || !finishedAt) return "—";
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const s = (ms / 1000).toFixed(1);
+  return `${s}s`;
+}
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleTimeString();
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — Postgres stage timeline
+// ---------------------------------------------------------------------------
+
+const STAGE_STATUS_INDICATOR: Record<string, string> = {
+  pending: "h-3 w-3 rounded-full border-2 border-muted-foreground/40 bg-transparent",
+  running: "h-3 w-3 rounded-full bg-blue-500 animate-pulse",
+  succeeded: "h-3 w-3 rounded-full bg-green-500",
+  failed: "h-3 w-3 rounded-full bg-destructive",
+};
+
+const STAGE_STATUS_LABEL: Record<string, string> = {
+  pending: "Pending",
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+};
+
+const STAGE_STATUS_COLOR: Record<string, string> = {
+  pending: "text-muted-foreground",
+  running: "text-blue-600 dark:text-blue-400",
+  succeeded: "text-green-600 dark:text-green-400",
+  failed: "text-destructive",
+};
+
+interface StageRowProps {
+  readonly stage: string;
+  readonly stageData: StageRunItem | undefined;
+  readonly isLast: boolean;
+}
+
+function StageRow({ stage, stageData, isLast }: StageRowProps): JSX.Element {
+  const status = stageData?.status ?? "pending";
+  const indicator = STAGE_STATUS_INDICATOR[status] ?? STAGE_STATUS_INDICATOR.pending;
+  const label = STAGE_STATUS_LABEL[status] ?? status;
+  const color = STAGE_STATUS_COLOR[status] ?? STAGE_STATUS_COLOR.pending;
+
+  return (
+    <li className="flex items-start gap-4">
+      <div className="flex flex-col items-center">
+        <div
+          role="img"
+          aria-label={`${stage} stage: ${label}`}
+          className={indicator}
+        />
+        {!isLast && (
+          <div aria-hidden="true" className="mt-1 h-10 w-0.5 bg-border" />
+        )}
+      </div>
+      <div className="pb-10 last:pb-0 flex-1 min-w-0">
+        <p className="text-sm font-medium capitalize">{stage.replace("_", " ")}</p>
+        <p className={`text-xs ${color}`}>{label}</p>
+        {stageData && (stageData.started_at || stageData.finished_at) && (
+          <dl className="mt-1 grid grid-cols-3 gap-x-4 text-xs text-muted-foreground">
+            <div>
+              <dt className="sr-only">Start</dt>
+              <dd>{formatTimestamp(stageData.started_at ?? null)}</dd>
+            </div>
+            <div>
+              <dt className="sr-only">End</dt>
+              <dd>{formatTimestamp(stageData.finished_at ?? null)}</dd>
+            </div>
+            <div>
+              <dt className="sr-only">Duration</dt>
+              <dd>{formatDuration(stageData.started_at ?? null, stageData.finished_at ?? null)}</dd>
+            </div>
+          </dl>
+        )}
+        {stageData?.error_message && (
+          <p className="mt-1 text-xs text-destructive break-words">
+            {stageData.error_message}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+interface StageFallbackProps {
+  readonly ingestionRunId: string;
+  readonly traceId: string;
+}
+
+function StageFallback({ ingestionRunId, traceId }: StageFallbackProps): JSX.Element {
+  const { data, isLoading, isError } = useStageTimeline(ingestionRunId);
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-live="polite" className="text-sm text-muted-foreground">
+        Loading stage timeline…
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Stage timeline unavailable for this trace ID.
+      </p>
+    );
+  }
+
+  const stageMap = new Map<string, StageRunItem>();
+  for (const s of data.stages) {
+    stageMap.set(s.stage, s);
+  }
+
+  return (
+    <section aria-label="Stage timeline">
+      <header className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-medium">Pipeline stage timeline</h2>
+        <span className="text-xs text-muted-foreground font-mono">{traceId}</span>
+      </header>
+      <ol aria-label="Pipeline stages" className="list-none">
+        {PIPELINE_STAGES.map((stage, i) => (
+          <StageRow
+            key={stage}
+            stage={stage}
+            stageData={stageMap.get(stage)}
+            isLast={i === PIPELINE_STAGES.length - 1}
+          />
+        ))}
+      </ol>
+      <p className="mt-4 text-xs text-muted-foreground">
+        Ingestion run:{" "}
+        <span className="font-mono">{ingestionRunId}</span>
+      </p>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — Tempo span tree
+// ---------------------------------------------------------------------------
+
+interface SpanNodeProps {
+  readonly span: TempoSpan;
+  readonly minStart: number;
+  readonly totalDuration: number;
+  readonly processes: Record<string, TempoProcess>;
+  readonly depth: number;
+}
+
+function SpanNode({ span, minStart, totalDuration, processes, depth }: SpanNodeProps): JSX.Element {
+  const [expanded, setExpanded] = useState(true);
+  const offsetMs = span.startTime / 1000 - minStart;
+  const durationMs = span.duration / 1000;
+  const leftPct = totalDuration > 0 ? (offsetMs / totalDuration) * 100 : 0;
+  const widthPct = totalDuration > 0 ? Math.max((durationMs / totalDuration) * 100, 0.5) : 0.5;
+  const serviceName = processes[span.processID]?.serviceName ?? span.processID;
+
+  return (
+    <li>
+      <div
+        className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50 cursor-pointer text-sm"
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={() => setExpanded((v) => !v)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === "Enter" && setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className="w-4 text-muted-foreground text-xs">{expanded ? "▾" : "▸"}</span>
+        <span className="flex-1 min-w-0 truncate font-mono text-xs">
+          <span className="text-muted-foreground">{serviceName}/</span>
+          {span.operationName}
+        </span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {durationMs >= 1 ? `${durationMs.toFixed(0)}ms` : `<1ms`}
+        </span>
+      </div>
+      {expanded && (
+        <div className="relative h-2 mx-2 my-0.5 rounded bg-muted overflow-hidden">
+          <div
+            className="absolute h-full rounded bg-blue-500/70"
+            style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+          />
+        </div>
+      )}
+    </li>
+  );
+}
+
+interface TempoViewProps {
+  readonly trace: TempoTrace;
+}
+
+function TempoView({ trace }: TempoViewProps): JSX.Element {
+  if (trace.spans.length === 0) {
+    return <p className="text-sm text-muted-foreground">Trace contains no spans.</p>;
+  }
+
+  const minStart = Math.min(...trace.spans.map((s) => s.startTime / 1000));
+  const maxEnd = Math.max(...trace.spans.map((s) => s.startTime / 1000 + s.duration / 1000));
+  const totalDuration = maxEnd - minStart;
+
+  const spansByParent = new Map<string, TempoSpan[]>();
+  const rootSpans: TempoSpan[] = [];
+
+  for (const span of trace.spans) {
+    const parentRef = span.references?.find((r) => r.refType === "CHILD_OF");
+    if (parentRef) {
+      const siblings = spansByParent.get(parentRef.spanID) ?? [];
+      spansByParent.set(parentRef.spanID, [...siblings, span]);
+    } else {
+      rootSpans.push(span);
+    }
+  }
+
+  function renderSpan(span: TempoSpan, depth: number): JSX.Element {
+    const children = spansByParent.get(span.spanID) ?? [];
+    return (
+      <li key={span.spanID}>
+        <SpanNode
+          span={span}
+          minStart={minStart}
+          totalDuration={totalDuration}
+          processes={trace.processes}
+          depth={depth}
+        />
+        {children.length > 0 && (
+          <ol aria-label="Child spans" className="list-none">
+            {children.map((child) => renderSpan(child, depth + 1))}
+          </ol>
+        )}
+      </li>
+    );
+  }
+
+  return (
+    <section aria-label="Tempo span tree">
+      <header className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-medium">Distributed trace</h2>
+        <span className="text-xs text-muted-foreground">
+          {trace.spans.length} spans · {(totalDuration).toFixed(0)}ms total
+        </span>
+      </header>
+      <div className="rounded-lg border border-border bg-card overflow-auto max-h-[60vh]">
+        <ol aria-label="Trace spans" className="list-none py-1">
+          {rootSpans.map((span) => renderSpan(span, 0))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 loader — fetch from Tempo via api/tempo.ts
+// ---------------------------------------------------------------------------
+
+type TempoState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "success"; trace: TempoTrace }
+  | { kind: "error"; message: string };
+
+function useTempoTrace(traceId: string): TempoState {
+  const [state, setState] = useState<TempoState>({ kind: "idle" });
+  const tempoUrl = import.meta.env.VITE_TEMPO_URL as string | undefined;
+
+  useEffect(() => {
+    if (!tempoUrl) {
+      setState({ kind: "error", message: "VITE_TEMPO_URL not configured" });
+      return;
+    }
+
+    setState({ kind: "loading" });
+
+    const controller = new AbortController();
+
+    fetchTempoTrace(tempoUrl, traceId, controller.signal)
+      .then((result) => {
+        if (result.ok) {
+          setState({ kind: "success", trace: result.trace });
+        } else {
+          setState({ kind: "error", message: result.reason });
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name === "AbortError") return;
+        const message = err instanceof Error ? err.message : "Unknown Tempo error";
+        setState({ kind: "error", message });
+      });
+
+    return () => controller.abort();
+  }, [traceId, tempoUrl]);
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+interface TraceViewerInnerProps {
+  readonly traceId: string;
+  readonly ingestionRunId: string | undefined;
+}
+
+function TraceViewerInner({ traceId, ingestionRunId }: TraceViewerInnerProps): JSX.Element {
+  const tempo = useTempoTrace(traceId);
+
+  return (
+    <PageContainer>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Trace viewer</h1>
+        <p className="text-sm text-muted-foreground font-mono truncate">{traceId}</p>
+      </header>
+
+      {tempo.kind === "loading" && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mb-6 flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+          Loading trace from Tempo…
+        </div>
+      )}
+
+      {tempo.kind === "success" && (
+        <div className="mb-8">
+          <TempoView trace={tempo.trace} />
+        </div>
+      )}
+
+      {(tempo.kind === "error" || tempo.kind === "idle") && ingestionRunId && (
+        <div className="rounded-lg border border-border bg-card p-6">
+          {tempo.kind === "error" && (
+            <p className="mb-4 text-xs text-muted-foreground">
+              Tempo unavailable ({tempo.message}). Showing pipeline stage timeline.
+            </p>
+          )}
+          <StageFallback ingestionRunId={ingestionRunId} traceId={traceId} />
+        </div>
+      )}
+
+      {(tempo.kind === "error" || tempo.kind === "idle") && !ingestionRunId && (
+        <div className="rounded-lg border border-border bg-card p-6">
+          <p className="text-sm text-muted-foreground">
+            Tempo unavailable and no ingestion run linked to this trace ID.
+          </p>
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+export function TraceViewerPage(): JSX.Element {
+  const { traceId } = useParams({ from: '/trace/$traceId' });
+  const { runId: ingestionRunId } = useSearch({ from: '/trace/$traceId' });
+
+  return <TraceViewerInner traceId={traceId} ingestionRunId={ingestionRunId} />;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,6 +9,7 @@ import {
 import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
+import { TraceViewerPage } from "@/pages/TraceViewerPage";
 import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
 import { AgentSessionDetailPage } from "@/pages/AgentSessionDetailPage";
 import { SessionReplayPage } from "@/pages/SessionReplayPage";
@@ -171,6 +172,17 @@ const adminGithubRoute = createRoute({
   component: AdminGithubPage,
 });
 
+const traceSearchSchema = z.object({
+  runId: z.string().optional(),
+});
+
+const traceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.trace,
+  validateSearch: traceSearchSchema,
+  component: TraceViewerPage,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -198,6 +210,7 @@ const routeTree = rootRoute.addChildren([
   agentSessionDetailRoute,
   agentSessionReplayRoute,
   adminGithubRoute,
+  traceRoute,
   catchAllRoute,
 ]);
 


### PR DESCRIPTION
## Summary

- Ships `TraceViewerPage` to `main` — it was implemented in PR #218 but merged to `feature/activity-dashboard` after that branch had already been merged to `main`, leaving the trace viewer stranded
- Adds `/trace/$traceId` to `ALL_ROUTES` in `axe-dispatch.spec.ts` with mocked `GET /v1/ingestions/*/stages` responses so axe scans the page under realistic rendering conditions
- Adds `VITE_TEMPO_URL` to `ImportMetaEnv` in `env.d.ts` (TypeScript declaration required by `tempo.ts`)
- Wires `Link` from trace-ID column in `RecentIngestionsTable` to the viewer route

## New files

| File | Purpose |
|---|---|
| `src/pages/TraceViewerPage.tsx` | Two-tier viewer: Grafana Tempo span tree (tier 1) → Postgres stage timeline (tier 2 fallback) |
| `src/api/hooks/useTraceViewer.ts` | React Query hook for `GET /v1/ingestions/{id}/stages` |
| `src/api/tempo.ts` | Browser-direct Tempo HTTP API client |

## Axe scan mock

The `ALL_ROUTES` entry `/trace/abc12345def67890abc12345def67890` is backed by:
- `**/v1/me` → `ME_RESPONSE` (authenticated session)
- `**/v1/ingestions/*/stages` → `STAGE_TIMELINE_RESPONSE` (9 completed stages)

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes

## GitHub Issue
Closes #604