### PR TITLE
[RUSAA-1716] fix: qualify kafka-get-offsets.sh with full path in uat-fingerprint.sh

### DIFF
--- a/scripts/uat-fingerprint.sh
+++ b/scripts/uat-fingerprint.sh
@@ -57,7 +57,7 @@ neo4j_q() {
 # Returns the log-end offset for topic:partition from the live Kafka broker.
 kafka_end_offset() {
   local topic="$1"
-  ${DC} exec -T kafka kafka-get-offsets.sh \
+  ${DC} exec -T kafka /opt/kafka/bin/kafka-get-offsets.sh \
     --bootstrap-server localhost:9092 \
     --topic-partitions "${topic}:0" \
     --time latest 2>/dev/null \


### PR DESCRIPTION
## Summary

`scripts/uat-fingerprint.sh::kafka_end_offset()` called `kafka-get-offsets.sh` without a full path. The Kafka image (Apache Kafka) only installs this binary at `/opt/kafka/bin/kafka-get-offsets.sh` — it is not on `$PATH` inside the container. Because the call is wrapped with `2>/dev/null`, the failure was silent; the `awk -F: '{print $NF}' | tr -d '[:space:]'` pipeline then normalised the empty output to `"0"`, so every `sse_offsets` entry came back as zero regardless of actual broker state, failing the fingerprint gate with `sse_nonzero=0`.

One-line fix: fully qualify the path to `/opt/kafka/bin/kafka-get-offsets.sh`.

## Change

```diff
-  ${DC} exec -T kafka kafka-get-offsets.sh \
+  ${DC} exec -T kafka /opt/kafka/bin/kafka-get-offsets.sh \
```

## GitHub Issue

Closes #606

## Checklist

- [x] One-line script fix, no Rust code changed — `cargo` suite unchanged
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] No migration needed
- [x] Docs unchanged (no architecture change)

## Migration type

N/A — scripts only.

## Verification

After fix, run:
```bash
bash scripts/uat-fingerprint.sh compose/dev.yml /tmp/fp.json
```
against a live ingested stack. `sse_offsets` must contain non-zero values matching direct queries via `/opt/kafka/bin/kafka-get-offsets.sh --topic-partitions <topic>:0 --time latest`.