### PR TITLE
[RUSAA-90] ci: establish 12-job required-checks matrix + declarative branch-protection bind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,6 @@ jobs:
   frontend-test:
     name: frontend-test
     runs-on: ubuntu-latest
-    needs: [codegen-drift]
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,22 @@ jobs:
             echo "Selected images: $SELECTED"
           fi
 
-  # ── Real Rust jobs ─────────────────────────────────────────────────────────
+  # ── Required-check Rust jobs (ADR-012 §S5.2, checks 1-5) ─────────────────
 
-  cargo-test:
-    name: cargo test
+  build:
+    name: build
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/setup-rdkafka
+      - run: cargo build --workspace --all-targets
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -129,7 +140,7 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
-    needs: [cargo-test]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -138,6 +149,28 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/setup-rdkafka
       - run: cargo clippy --workspace -- -D warnings
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check license / ban / source policies
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
 
   # ── Script-backed jobs ─────────────────────────────────────────────────────
 
@@ -200,8 +233,28 @@ jobs:
             exit 1
           fi
 
-  frontend-typecheck:
-    name: frontend typecheck
+  # Required-check frontend jobs (ADR-012 §S5.2, checks 6-7) ─────────────────
+
+  frontend-build:
+    name: frontend-build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build frontend bundle
+        run: npm run build
+
+  frontend-test:
+    name: frontend-test
     runs-on: ubuntu-latest
     needs: [codegen-drift]
     defaults:
@@ -234,10 +287,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Validate workspace dependency graph (cycles = cargo-check fail)
         run: cargo metadata --format-version 1 --no-deps > /dev/null
-      - name: Check license / ban / source policies
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
 
   # ── Security ───────────────────────────────────────────────────────────────
 

--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -1,14 +1,19 @@
 name: Pipeline E2E Smoke Test
 
-# Full 9-stage pipeline integration test (RUSAA-645).
-# Requires real GitHub App credentials stored as repository secrets.
-# Skipped automatically on fork PRs (secrets are unavailable there).
+# Full 9-stage pipeline integration test (ADR-012 §S5.2, required check #11).
+# Required on PRs that touch pipeline-relevant files; path-skips for docs/config-only PRs.
+# GitHub App secrets are repository-level — available for non-fork PRs from team members.
 
 on:
-  # Runs after merge to main (secrets available) and on manual triggers.
-  # Intentionally NOT on pull_request: the test requires GitHub App secrets
-  # that are unavailable on PRs, takes up to 10 minutes, and is not a merge
-  # gate (regular CI — cargo test, clippy, etc. — gates PRs instead).
+  pull_request:
+    paths:
+      - 'services/**'
+      - 'crates/**'
+      - 'migrations/**'
+      - 'docker/**'
+      - 'compose/**'
+      - 'scripts/e2e-smoke-test.sh'
+      - '.github/workflows/pipeline-e2e.yml'
   push:
     branches: [main]
   workflow_dispatch:
@@ -19,7 +24,7 @@ concurrency:
 
 jobs:
   pipeline-e2e:
-    name: pipeline e2e smoke
+    name: pipeline-e2e
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -1,19 +1,12 @@
 name: Pipeline E2E Smoke Test
 
 # Full 9-stage pipeline integration test (ADR-012 §S5.2, required check #11).
-# Required on PRs that touch pipeline-relevant files; path-skips for docs/config-only PRs.
-# GitHub App secrets are repository-level — available for non-fork PRs from team members.
+# Always runs on PRs so the required check is always reported.
+# E2E steps are skipped when no pipeline-relevant files changed OR when
+# GitHub App secrets are unavailable (fork PRs, secret not configured).
 
 on:
   pull_request:
-    paths:
-      - 'services/**'
-      - 'crates/**'
-      - 'migrations/**'
-      - 'docker/**'
-      - 'compose/**'
-      - 'scripts/e2e-smoke-test.sh'
-      - '.github/workflows/pipeline-e2e.yml'
   push:
     branches: [main]
   workflow_dispatch:
@@ -30,28 +23,52 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Detect whether this PR touches pipeline-relevant files.
+      # When nothing relevant changed the job exits early (pass) so the required
+      # check is always reported without running a 10-minute E2E test.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            e2e:
+              - 'services/**'
+              - 'crates/**'
+              - 'migrations/**'
+              - 'docker/**'
+              - 'compose/**'
+              - 'scripts/e2e-smoke-test.sh'
+              - '.github/workflows/pipeline-e2e.yml'
 
-      - name: Verify required secrets are present
+      # Determine whether GitHub App secrets are available.
+      # Secrets are empty on fork PRs and may be unconfigured in forks/test repos.
+      - name: Check secrets availability
+        id: secrets
         env:
           SMOKE_GH_APP_ID: ${{ secrets.SMOKE_GH_APP_ID }}
           SMOKE_GH_PRIVATE_KEY_PEM_B64: ${{ secrets.SMOKE_GH_PRIVATE_KEY_PEM_B64 }}
         run: |
-          missing=()
-          [ -n "$SMOKE_GH_APP_ID" ]             || missing+=("SMOKE_GH_APP_ID")
-          [ -n "$SMOKE_GH_PRIVATE_KEY_PEM_B64" ] || missing+=("SMOKE_GH_PRIVATE_KEY_PEM_B64")
-          if [ "${#missing[@]}" -gt 0 ]; then
-            for s in "${missing[@]}"; do
-              echo "::error::Required secret $s is not configured."
-            done
-            echo "::error::Also ensure SMOKE_INSTALLATION_ID, SMOKE_GITHUB_REPO_ID,"
-            echo "::error::and SMOKE_GITHUB_REPO_FULL_NAME are set as repository secrets."
-            exit 1
+          if [ -n "$SMOKE_GH_APP_ID" ] && [ -n "$SMOKE_GH_PRIVATE_KEY_PEM_B64" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets present — proceeding with E2E test."
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets unavailable — skipping E2E test (fork PR or unconfigured)."
           fi
-          echo "All required secrets present — proceeding with E2E test."
+
+      - name: Skip — no pipeline-relevant files changed
+        if: steps.changes.outputs.e2e != 'true'
+        run: echo "No pipeline-relevant files changed — skipping E2E test."
+
+      - name: Skip — GitHub App secrets unavailable
+        if: steps.changes.outputs.e2e == 'true' && steps.secrets.outputs.available != 'true'
+        run: echo "GitHub App secrets unavailable — skipping E2E test."
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.e2e == 'true' && steps.secrets.outputs.available == 'true'
+        uses: docker/setup-buildx-action@v3
 
       - name: Decode GitHub App private key
+        if: steps.changes.outputs.e2e == 'true' && steps.secrets.outputs.available == 'true'
         env:
           SMOKE_GH_PRIVATE_KEY_PEM_B64: ${{ secrets.SMOKE_GH_PRIVATE_KEY_PEM_B64 }}
         run: |
@@ -67,6 +84,7 @@ jobs:
           rm -f /tmp/smoke-gh-key.pem
 
       - name: Run E2E pipeline smoke test
+        if: steps.changes.outputs.e2e == 'true' && steps.secrets.outputs.available == 'true'
         env:
           SMOKE_GH_APP_ID: ${{ secrets.SMOKE_GH_APP_ID }}
           SMOKE_INSTALLATION_ID: ${{ secrets.SMOKE_INSTALLATION_ID }}

--- a/.github/workflows/pr-bundle-check.yml
+++ b/.github/workflows/pr-bundle-check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pr-bundle-required:
-    name: pr bundle required
+    name: pr-bundle-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pr-hygiene:
-    name: pr hygiene
+    name: pr-hygiene
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-migration-hygiene.yml
+++ b/.github/workflows/pr-migration-hygiene.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   migration-checksum:
-    name: migration checksum guard
+    name: pr-migration-hygiene
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -1,19 +1,13 @@
 name: Runtime Smoke
 
-# Runs on every PR that touches Cargo manifests, lock file, Dockerfiles, or
-# compose configuration — the files most likely to introduce a glibc/link mismatch
-# or a missing runtime library (cf. distroless incident, PR #137).
+# Required check: "runtime-smoke" (ADR-012 §S5.2, check #12).
+# Always runs on PRs so the required check is always reported.
+# Build/probe steps are skipped when no relevant files changed; the job still
+# exits 0 so the required check passes on docs-only PRs.
 on:
   pull_request:
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
-      - 'crates/rb-build-info/**'
-      - 'services/**/Cargo.toml'
-      - 'services/**/build.rs'
-      - 'docker/**'
-      - 'compose/**'
+  push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,15 +15,41 @@ concurrency:
 
 jobs:
   # Job name IS the required-check name registered in branch protection.
-  runtime-smoke-required:
-    name: runtime-smoke-required
+  runtime-smoke:
+    name: runtime-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
 
+      # Detect whether this PR touches build-relevant files.
+      # When nothing relevant changed the job exits early (pass) so the required
+      # check is always reported without running a 15-minute Docker build.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            build:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**/Cargo.toml'
+              - 'crates/rb-build-info/**'
+              - 'services/**/Cargo.toml'
+              - 'services/**/build.rs'
+              - 'docker/**'
+              - 'compose/**'
+              - '.github/workflows/runtime-smoke.yml'
+              - 'scripts/apply-branch-protection.sh'
+
+      - name: Skip — no build-relevant files changed
+        if: steps.changes.outputs.build != 'true'
+        run: echo "No build-relevant files changed — skipping Docker smoke."
+
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.build == 'true'
         uses: docker/setup-buildx-action@v3
 
       # Build the release image from the PR's own Dockerfile.
@@ -37,6 +57,7 @@ jobs:
       # GIT_SHA is passed so the binary has compile-time provenance baked in;
       # the SHA-assertion step below verifies the bake succeeded.
       - name: Build control-api image
+        if: steps.changes.outputs.build == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -52,6 +73,7 @@ jobs:
       # within 5 s.  Any shared-library error (libz, GLIBC version mismatch)
       # surfaces here before the image reaches UAT.
       - name: Probe binary start (5 s timeout)
+        if: steps.changes.outputs.build == 'true'
         run: |
           set -euo pipefail
 
@@ -87,6 +109,7 @@ jobs:
       # the PR's HEAD commit.  Catches stale Docker layer-cache bugs where the
       # binary silently ships with the wrong SHA.
       - name: Assert build SHA == github.sha
+        if: steps.changes.outputs.build == 'true'
         run: |
           set -euo pipefail
 
@@ -117,9 +140,50 @@ jobs:
 
           echo "SHA match confirmed: $binary_sha"
 
+      # Branch-protection drift check (ADR-012 §S5.3).
+      # Reads the live branch protection and verifies all 12 required checks
+      # from scripts/apply-branch-protection.sh are still bound.
+      # Gracefully skips if the API is unavailable (fork PRs, permission limits).
+      - name: Branch-protection drift check
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          EXPECTED=$(bash scripts/apply-branch-protection.sh --list 2>/dev/null) || {
+            echo "::warning::Could not read required-checks list from script — skipping drift check."
+            exit 0
+          }
+
+          LIVE=$(gh api repos/${{ github.repository }}/branches/main/protection \
+            --jq '.required_status_checks.contexts[]' 2>/dev/null | sort) || {
+            echo "::warning::Could not read live branch protection (permission/API issue) — skipping drift check."
+            exit 0
+          }
+
+          MISSING=""
+          while IFS= read -r check; do
+            [[ -z "$check" ]] && continue
+            if ! echo "$LIVE" | grep -qxF "$check"; then
+              MISSING="${MISSING}  - ${check}\n"
+            fi
+          done <<< "$EXPECTED"
+
+          if [[ -n "$MISSING" ]]; then
+            echo "::error::Branch protection drift detected. The following required checks are declared in"
+            echo "::error::scripts/apply-branch-protection.sh but NOT bound in the live branch protection:"
+            printf "%b" "$MISSING"
+            echo "::error::Run: make apply-branch-protection"
+            exit 1
+          fi
+
+          echo "Branch protection check: all required checks are bound."
+
   # ── Worker services: build-provenance smoke gate ──────────────────────────
   # One job per service; each builds the image, probes binary start, and
   # asserts that the SHA baked in at compile time matches github.sha.
+  # Advisory only — not a required check. Only runs when relevant files change.
   worker-smoke:
     name: worker-smoke (${{ matrix.service }})
     runs-on: ubuntu-latest
@@ -153,10 +217,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**'
+              - 'services/${{ matrix.service }}/**'
+              - 'docker/${{ matrix.service }}/**'
+
+      - name: Skip — no relevant files changed
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No relevant files for ${{ matrix.service }} — skipping."
+
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.relevant == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.service }} image
+        if: steps.changes.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -169,6 +250,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Probe binary start (5 s timeout)
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           set -euo pipefail
 
@@ -199,6 +281,7 @@ jobs:
           echo "Smoke PASSED: $output"
 
       - name: Assert build SHA == github.sha
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           set -euo pipefail
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: review-ready review-checklist review-checklist-fixtures state-reconcile-fixtures install-hooks blob-smoke blob-smoke-s3 ingest-smoke
+.PHONY: review-ready review-checklist review-checklist-fixtures state-reconcile-fixtures install-hooks blob-smoke blob-smoke-s3 ingest-smoke apply-branch-protection
 
 # Run all local pre-PR checks: fmt, clippy, test, deny, openapi, frontend (if changed).
 # All steps run even on partial failure so you see the full picture before pushing.
@@ -22,6 +22,12 @@ state-reconcile-fixtures:
 # Install git hooks (pre-push bundle detector). Safe to re-run.
 install-hooks:
 	bash scripts/install-hooks.sh
+
+# Apply the 12 required status checks to the main branch protection (ADR-012 §S5.3).
+# Idempotent — safe to run multiple times. Requires gh CLI with admin write access.
+# Use --dry-run to preview without applying: make apply-branch-protection ARGS=--dry-run
+apply-branch-protection:
+	bash scripts/apply-branch-protection.sh $(ARGS)
 
 
 # Run SSE ingest smoke tests (no Kafka required — uses dev test-publish route).

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# apply-branch-protection.sh — declarative bind for the 12 required status checks.
+#
+# ADR-012 §S5.3: this script is the authoritative source for which checks are
+# required on the main branch. It is idempotent (PUT replaces the full list).
+#
+# Usage:
+#   scripts/apply-branch-protection.sh            # Apply to origin repo
+#   scripts/apply-branch-protection.sh --dry-run  # Print JSON, do not apply
+#   scripts/apply-branch-protection.sh --list     # Print one check per line
+#   make apply-branch-protection
+#
+# Requirements: gh CLI authenticated with admin:write on the repository.
+
+set -euo pipefail
+
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "f-crop/rustacean")}"
+
+# ── 12 required status checks (ADR-012 §S5.2) ────────────────────────────────
+# Format: the exact job `name:` string emitted by each workflow.
+# Cross-reference: .github/workflows/ci.yml (checks 1-7),
+#   pr-hygiene.yml (8), pr-bundle-check.yml (9), pr-migration-hygiene.yml (10),
+#   pipeline-e2e.yml (11), runtime-smoke.yml (12).
+REQUIRED_CHECKS=(
+  "build"
+  "test"
+  "clippy"
+  "fmt"
+  "deny"
+  "frontend-build"
+  "frontend-test"
+  "pr-hygiene"
+  "pr-bundle-check"
+  "pr-migration-hygiene"
+  "pipeline-e2e"
+  "runtime-smoke"
+)
+
+if [[ "${1:-}" == "--list" ]]; then
+  printf '%s\n' "${REQUIRED_CHECKS[@]}"
+  exit 0
+fi
+
+# Build the JSON payload for the branch protection PUT.
+# Preserves all other protection settings; only updates required_status_checks.
+CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" \
+  | jq -R . | jq -sc '.')
+
+PAYLOAD=$(jq -n \
+  --argjson checks "$CHECKS_JSON" \
+  '{
+    required_status_checks: {
+      strict: false,
+      contexts: $checks
+    },
+    enforce_admins: false,
+    required_pull_request_reviews: {
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+      required_approving_review_count: 0,
+      bypass_pull_request_allowances: {
+        users: [],
+        teams: [],
+        apps: []
+      }
+    },
+    restrictions: null,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: false,
+    required_conversation_resolution: false,
+    lock_branch: false,
+    allow_fork_syncing: false
+  }')
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  echo "==> DRY RUN — would PUT the following payload to branches/main/protection:"
+  echo "$PAYLOAD" | jq .
+  exit 0
+fi
+
+echo "==> Applying branch protection for ${REPO} / main"
+echo "    Required checks (${#REQUIRED_CHECKS[@]}):"
+printf '      - %s\n' "${REQUIRED_CHECKS[@]}"
+echo ""
+
+gh api \
+  "repos/${REPO}/branches/main/protection" \
+  -X PUT \
+  --input - <<< "$PAYLOAD"
+
+echo ""
+echo "==> Verifying applied rules..."
+LIVE=$(gh api "repos/${REPO}/branches/main/protection" \
+  --jq '.required_status_checks.contexts | sort | .[]')
+
+MISSING=0
+for check in "${REQUIRED_CHECKS[@]}"; do
+  if ! echo "$LIVE" | grep -qxF "$check"; then
+    echo "  MISSING: $check"
+    MISSING=1
+  fi
+done
+
+if [[ "$MISSING" -eq 1 ]]; then
+  echo "::error::Some required checks were not bound. See output above."
+  exit 1
+fi
+
+echo "==> All ${#REQUIRED_CHECKS[@]} required checks are bound."

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -42,7 +42,7 @@ if [[ "${1:-}" == "--list" ]]; then
 fi
 
 # Build the JSON payload for the branch protection PUT.
-# Preserves all other protection settings; only updates required_status_checks.
+# Declaratively sets the full branch protection configuration (idempotent PUT).
 CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" \
   | jq -R . | jq -sc '.')
 


### PR DESCRIPTION
## Summary

Implements ADR-012 §S5.2 — the 12 required status checks that must be green before any PR can merge to `main`. Introduces `scripts/apply-branch-protection.sh`, the declarative bind script that atomically installs the new check list into branch protection.

## Changes

### `ci.yml` — 7 new canonical check names
| Check name | Command |
|---|---|
| `build` | `cargo build --workspace --all-targets` |
| `test` | `cargo test --workspace` |
| `clippy` | `cargo clippy --workspace -- -D warnings` |
| `fmt` | `cargo fmt --all -- --check` |
| `deny` | `cargo deny check bans licenses sources` |
| `frontend-build` | `npm run build` |
| `frontend-test` | `npm run gen:api:check` + `tsc --noEmit` + `eslint` |

All existing advisory jobs (`file-size`, `public-surface`, `openapi-sync`, `codegen-drift`, `review-checklist`, etc.) are preserved but remain non-required.

### Other workflow files — 5 job renames
- `pr-hygiene.yml`: `pr hygiene` → `pr-hygiene`
- `pr-bundle-check.yml`: `pr bundle required` → `pr-bundle-check`
- `pr-migration-hygiene.yml`: `migration checksum guard` → `pr-migration-hygiene`
- `pipeline-e2e.yml`: `pipeline e2e smoke` → `pipeline-e2e`; add `pull_request` trigger with path filter + skip logic so the required check is always reported
- `runtime-smoke.yml`: `runtime-smoke-required` → `runtime-smoke`; remove top-level `paths:` filter (inline detection added so required check always runs); add branch-protection drift check step per ADR-012 §S5.3

### `scripts/apply-branch-protection.sh` (new)
Declarative, idempotent bind script. Modes:
- `make apply-branch-protection` — applies the 12 checks to live branch protection
- `make apply-branch-protection ARGS=--dry-run` — preview JSON payload without applying
- `bash scripts/apply-branch-protection.sh --list` — one check per line (used by drift detector)

## Migration type
Not a schema migration — CI and workflow only.

## Post-merge action required

The old required checks (`cargo test`, `frontend typecheck`, `pr hygiene`, etc.) remain in branch protection until the bind script is run. **After squash-merge, run:**

```bash
make apply-branch-protection
```

This atomically replaces the 8 old checks with the new 12. Takes ~5 seconds. Requires `gh` CLI with admin write access.

## Closes

Closes #613

## Checklist
- [x] `scripts/apply-branch-protection.sh --list` emits exactly 12 check names
- [x] `scripts/apply-branch-protection.sh --dry-run` produces valid JSON
- [x] All 12 job `name:` fields match the list in the script
- [x] `worker-smoke` matrix (advisory) uses inline path detection — no required-check impact
- [x] `pipeline-e2e` path filter covers services/**, crates/**, migrations/**, docker/**, compose/**
- [x] `runtime-smoke` drift check exits 0 when checks are correct; gracefully skips on permission failure