### PR TITLE
[RUSAA-1737] fix: harden apply-branch-protection.sh defaults to match live policy

### DIFF
--- a/docs/decisions/ADR-012-wave8-hardening-polish.md
+++ b/docs/decisions/ADR-012-wave8-hardening-polish.md
@@ -330,12 +330,25 @@ Three more workflows (`dev-stack-drift-check`, `frontend-axe-dispatch`, `board-s
 
 #### 2.5.3 Branch-protection bind procedure
 
-Branch protection is **declarative** via a checked-in `.github/branch-protection.yml`-equivalent (or a documented `gh api` script under `scripts/` if GitHub does not support declarative yet — Wave 8 picks whichever is reliable). The bind procedure:
+Branch protection is **declarative** via `scripts/apply-branch-protection.sh` under source control. The bind procedure:
 
-1. Update the bind script / declarative file with the new required-checks list.
+1. Update `scripts/apply-branch-protection.sh` with the new required-checks list (and any policy field changes).
 2. PR review pings PR Reviewer (who is allowed to merge with the new check passing).
-3. Once merged, PR Reviewer runs `scripts/apply-branch-protection.sh` (idempotent) which calls `gh api repos/:owner/:repo/branches/main/protection -X PUT` with the new list.
+3. Once merged, PR Reviewer runs `scripts/apply-branch-protection.sh` (idempotent) which calls `gh api repos/:owner/:repo/branches/main/protection -X PUT` with the full payload.
 4. A read-back verification (`gh api .../branches/main/protection`) runs in `runtime-smoke` to detect drift between the file and the live protection rules.
+
+**Full-payload scope.** GitHub's branch-protection PUT endpoint is **replace-semantics** — every field in the payload replaces the live value, including fields not related to required-checks. `scripts/apply-branch-protection.sh` therefore owns the complete protection policy for `main`, not just the check-name list. The canonical values for the non-check fields are:
+
+| Field | Value | Rationale |
+|---|---|---|
+| `enforce_admins` | `true` | Admins must not bypass required checks; CTO uses `--admin` merge only when the branch-protection check itself is what blocks (e.g. the initial bind). |
+| `required_approving_review_count` | `1` | Gate-3 reviewer approval required before merge. |
+| `dismiss_stale_reviews` | `true` | A force-push after approval must re-trigger review; stale approvals must not re-attach. |
+| `allow_force_pushes` | `false` | History rewrite on `main` is prohibited. |
+| `allow_deletions` | `false` | `main` cannot be deleted. |
+| `bypass_pull_request_allowances` | (omitted) | No documented allow-list exists; omitting the field preserves GitHub's default (empty). Adding entries here requires an ADR amendment. |
+
+**Regression prevention.** The script contains inline assertions that verify the three security-critical values (`enforce_admins`, `dismiss_stale_reviews`, `required_approving_review_count`) are present in the generated PAYLOAD before the PUT executes. Any regression in these values causes the script to exit non-zero before writing to the live branch.
 
 #### 2.5.4 Cross-stream dependencies
 

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # apply-branch-protection.sh — declarative bind for the 12 required status checks.
 #
-# ADR-012 §S5.3: this script is the authoritative source for which checks are
-# required on the main branch. It is idempotent (PUT replaces the full list).
+# ADR-012 §S5.3: this script is the authoritative source for the FULL branch
+# protection payload for main.  GitHub's PUT endpoint is replace-semantics —
+# every field in the payload overwrites the live policy, so the defaults here
+# must match the intended production policy exactly.
+#
+# Canonical non-check settings (do not weaken without board approval):
+#   enforce_admins:                  true   (admins cannot bypass required checks)
+#   required_approving_review_count: 1      (Gate-3 reviewer approval required)
+#   dismiss_stale_reviews:           true   (stale approvals cleared on new push)
 #
 # Usage:
 #   scripts/apply-branch-protection.sh            # Apply to origin repo
@@ -42,7 +49,8 @@ if [[ "${1:-}" == "--list" ]]; then
 fi
 
 # Build the JSON payload for the branch protection PUT.
-# Declaratively sets the full branch protection configuration (idempotent PUT).
+# GitHub PUT is replace-semantics: every field here replaces the live value.
+# Keep all three security settings in sync with the canonical values above.
 CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" \
   | jq -R . | jq -sc '.')
 
@@ -53,16 +61,11 @@ PAYLOAD=$(jq -n \
       strict: false,
       contexts: $checks
     },
-    enforce_admins: false,
+    enforce_admins: true,
     required_pull_request_reviews: {
-      dismiss_stale_reviews: false,
+      dismiss_stale_reviews: true,
       require_code_owner_reviews: false,
-      required_approving_review_count: 0,
-      bypass_pull_request_allowances: {
-        users: [],
-        teams: [],
-        apps: []
-      }
+      required_approving_review_count: 1
     },
     restrictions: null,
     allow_force_pushes: false,
@@ -72,6 +75,22 @@ PAYLOAD=$(jq -n \
     lock_branch: false,
     allow_fork_syncing: false
   }')
+
+# ── Pre-flight assertions: verify the three security-critical values ──────────
+# Catches regressions if the jq template is edited accidentally.
+_assert_payload() {
+  local field="$1" expected="$2"
+  local actual
+  actual=$(echo "$PAYLOAD" | jq -r "$field")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "::error::PAYLOAD assertion failed: $field = $actual (expected $expected)" >&2
+    exit 1
+  fi
+}
+
+_assert_payload '.enforce_admins'                                          'true'
+_assert_payload '.required_pull_request_reviews.dismiss_stale_reviews'    'true'
+_assert_payload '.required_pull_request_reviews.required_approving_review_count' '1'
 
 if [[ "${1:-}" == "--dry-run" ]]; then
   echo "==> DRY RUN — would PUT the following payload to branches/main/protection:"


### PR DESCRIPTION
## Summary

`scripts/apply-branch-protection.sh` shipped with three security-critical fields weaker than the live production policy. Because GitHub's branch-protection PUT is **replace-semantics**, running the script as-shipped would silently regress main branch security on the next operator run.

Three regressions fixed:

| Field | Was | Now | Severity |
|---|---|---|---|
| `enforce_admins` | `false` | `true` | HIGH — admins could bypass required checks |
| `required_approving_review_count` | `0` | `1` | HIGH — Gate-3 reviewer approval no longer required |
| `dismiss_stale_reviews` | `false` | `true` | MEDIUM — stale approvals could re-attach after force-push |

Additionally:
- Removed `bypass_pull_request_allowances` with empty lists (no documented allow-list; omitting preserves GitHub's default).
- Added pre-flight `_assert_payload` function that verifies all three values are present before the PUT executes — future edits to the jq template that accidentally regress a value will exit non-zero immediately.
- Updated ADR-012 §S5.3 to document that the script owns the **full** protection payload (not just the check-name list), lists canonical values for each non-check field, and explains the regression-prevention assertions.

## Verification

```bash
bash scripts/apply-branch-protection.sh --dry-run
```

Output shows `enforce_admins: true`, `dismiss_stale_reviews: true`, `required_approving_review_count: 1`, and the assertions pass (exit 0).

## Note on PR #616 (RUSAA-90)

This script will also be introduced by PR #616. Whichever PR merges second will see a simple conflict on `scripts/apply-branch-protection.sh`; the resolution is to keep the hardened values from this PR. The conflict is intentional — this PR must win on those three fields regardless of merge order.

## Migration type

N/A — no database migrations.

## Checklist
- [x] `bash scripts/apply-branch-protection.sh --dry-run` exits 0 with correct values
- [x] Pre-flight assertions guard all three security-critical fields
- [x] ADR-012 §S5.3 updated to document full-payload scope and canonical values
- [x] No tracker IDs in source or commits

Closes #619