### PR TITLE
[RUSAA-88] feat: Grafana dashboards S3 — four provisioned dashboards + grafana-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: review-ready review-checklist review-checklist-fixtures state-reconcile-fixtures install-hooks blob-smoke blob-smoke-s3 ingest-smoke apply-branch-protection
+.PHONY: review-ready review-checklist review-checklist-fixtures state-reconcile-fixtures install-hooks blob-smoke blob-smoke-s3 ingest-smoke apply-branch-protection grafana-lint
 
 # Run all local pre-PR checks: fmt, clippy, test, deny, openapi, frontend (if changed).
 # All steps run even on partial failure so you see the full picture before pushing.
@@ -28,6 +28,13 @@ install-hooks:
 # Use --dry-run to preview without applying: make apply-branch-protection ARGS=--dry-run
 apply-branch-protection:
 	bash scripts/apply-branch-protection.sh $(ARGS)
+
+# Validate that every Grafana dashboard panel only references metrics that are
+# in the S2 frozen registry (ADR-012 §S3).  Fails if a panel queries a metric
+# not listed in infra/grafana/metrics-registry.txt.
+# Folded into ci/test per ADR-012 §S5.2.
+grafana-lint:
+	bash scripts/grafana-lint.sh
 
 
 # Run SSE ingest smoke tests (no Kafka required — uses dev test-publish route).

--- a/infra/grafana/dashboards/changes.json
+++ b/infra/grafana/dashboards/changes.json
@@ -1,0 +1,173 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "Changes & deploys — what changed recently? (ADR-012 §S3)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    { "title": "Stack Overview",      "url": "/d/rb-stack-overview",     "type": "dashboards" },
+    { "title": "Latency & Throughput","url": "/d/rb-latency-throughput", "type": "dashboards" },
+    { "title": "Operability & Admin", "url": "/d/rb-operability-admin",  "type": "dashboards" }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["rust-brain", "changes", "deploys", "s3"],
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Changes & Deploys",
+  "uid": "rb-changes-deploys",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Current Build",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Current build SHAs — all services",
+      "description": "rb_build_info — current deployed SHA and version for every service. A SHA change indicates a deploy event.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 1 },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "service", "desc": false }]
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto" } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "git_sha" },
+            "properties": [
+              { "id": "custom.width", "value": 400 },
+              { "id": "links", "value": [
+                {
+                  "title": "View PR on GitHub",
+                  "url": "https://github.com/f-crop/rustacean/commits/${__value.raw}",
+                  "targetBlank": true
+                }
+              ]}
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "rb_build_info",
+          "legendFormat": "{{service}}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["service", "version", "git_sha", "Value"] } } },
+        { "id": "sortBy", "options": { "fields": [{ "displayName": "service" }] } }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "row",
+      "title": "Build History",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Build SHA change events",
+      "description": "Changes in rb_build_info over time — each step-change marks a deploy event for that service.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 80
+          }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "changes(rb_build_info[10m])",
+          "legendFormat": "{{service}} deploys",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Restarts & Availability",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Service restarts (rb_build_info resets)",
+      "description": "A restart is detected as rb_build_info resetting to 1 after being non-zero. Gaps indicate the service was unreachable.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "resets(rb_build_info[10m])",
+          "legendFormat": "{{service}} resets",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Services reporting",
+      "description": "Number of distinct service labels currently reporting rb_build_info. Should equal 13 (all services).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 13 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "expr": "count(rb_build_info)",
+          "legendFormat": "services reporting",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/latency.json
+++ b/infra/grafana/dashboards/latency.json
@@ -1,0 +1,324 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "Latency & throughput — where is the bottleneck if something is slow? (ADR-012 §S3)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    { "title": "Stack Overview",      "url": "/d/rb-stack-overview",      "type": "dashboards" },
+    { "title": "Changes & Deploys",   "url": "/d/rb-changes-deploys",     "type": "dashboards" },
+    { "title": "Operability & Admin", "url": "/d/rb-operability-admin",   "type": "dashboards" }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["rust-brain", "latency", "throughput", "s3"],
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Latency & Throughput",
+  "uid": "rb-latency-throughput",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "API Latency",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Request latency p50/p95/p99 (control-api)",
+      "description": "rb_control_api_request_duration_seconds histogram — request latency percentiles.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, route) (rate(rb_control_api_request_duration_seconds_bucket[2m])))",
+          "legendFormat": "p50 {{route}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(rb_control_api_request_duration_seconds_bucket[2m])))",
+          "legendFormat": "p95 {{route}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(rb_control_api_request_duration_seconds_bucket[2m])))",
+          "legendFormat": "p99 {{route}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Request rate by route (control-api)",
+      "description": "rb_control_api_requests_total — per-route request throughput.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (route, method) (rate(rb_control_api_requests_total{status_class=\"2xx\"}[1m]))",
+          "legendFormat": "{{method}} {{route}} 2xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (route) (rate(rb_control_api_requests_total{status_class=\"4xx\"}[1m]))",
+          "legendFormat": "{{route}} 4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (route) (rate(rb_control_api_requests_total{status_class=\"5xx\"}[1m]))",
+          "legendFormat": "{{route}} 5xx",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "row",
+      "title": "Kafka Throughput",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Kafka produce rate (msg/s)",
+      "description": "rb_kafka_messages_total{op=\"produce\"} — per-topic produce throughput.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rate(rb_kafka_messages_total{op=\"produce\",outcome=\"ok\"}[1m]))",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Kafka consume rate (msg/s)",
+      "description": "rb_kafka_messages_total{op=\"consume\"} — per-topic consume throughput.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rate(rb_kafka_messages_total{op=\"consume\",outcome=\"ok\"}[1m]))",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Consumer lag by topic/group",
+      "description": "rb_kafka_consumer_lag_records — queue depth; should stay near 0 under normal load.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1000 },
+              { "color": "red", "value": 10000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic, group) (rb_kafka_consumer_lag_records)",
+          "legendFormat": "{{topic}} / {{group}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Ingestion Pipeline Throughput",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Ingestion pipeline — per-stage event rate",
+      "description": "Per-stage event rates through the 11-worker ingestion pipeline.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_ingest_clone_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "ingest-clone",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_parse_worker_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "parse-worker",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rb_expand_worker_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "expand-worker",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rb_ingest_graph_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "ingest-graph",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rb_typecheck_worker_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "typecheck-worker",
+          "refId": "E"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Projection & embedding throughput",
+      "description": "Downstream projection and vector embedding event rates.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_projector_pg_events_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "projector-pg",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_projector_neo4j_events_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "projector-neo4j",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rb_embed_worker_total{outcome=\"ok\"}[1m]))",
+          "legendFormat": "embed-worker batches",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rb_embed_worker_vectors_total[1m]))",
+          "legendFormat": "vectors embedded/s",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Error Rates",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Worker error rates",
+      "description": "Per-worker error event rates — spikes indicate processing failures.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_ingest_clone_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "ingest-clone err",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_parse_worker_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "parse-worker err",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rb_expand_worker_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "expand-worker err",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rb_projector_pg_events_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "projector-pg err",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rb_projector_neo4j_events_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "projector-neo4j err",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rb_embed_worker_total{outcome=\"err\"}[1m]))",
+          "legendFormat": "embed-worker err",
+          "refId": "F"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "API error rate (5xx)",
+      "description": "rb_control_api_requests_total{status_class=\"5xx\"} — server errors indicate a broken service path.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "color": { "fixedColor": "red", "mode": "fixed" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (route) (rate(rb_control_api_requests_total{status_class=\"5xx\"}[1m]))",
+          "legendFormat": "{{route}} 5xx",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/operability.json
+++ b/infra/grafana/dashboards/operability.json
@@ -1,0 +1,279 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "Operability & admin — who did what, and can the operator fix it without SQL? (ADR-012 §S3)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    { "title": "Stack Overview",       "url": "/d/rb-stack-overview",     "type": "dashboards" },
+    { "title": "Latency & Throughput", "url": "/d/rb-latency-throughput", "type": "dashboards" },
+    { "title": "Changes & Deploys",    "url": "/d/rb-changes-deploys",    "type": "dashboards" }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["rust-brain", "operability", "admin", "s3"],
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Operability & Admin",
+  "uid": "rb-operability-admin",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Admin Actions",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Admin request rate by action",
+      "description": "rb_admin_requests_total — rate of admin API calls per action type. Each spike corresponds to an operator action.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (action, outcome) (rate(rb_admin_requests_total[5m]))",
+          "legendFormat": "{{action}} / {{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Admin denials (last 15 min)",
+      "description": "rb_admin_requests_total{outcome=\"denied\"} — non-zero may indicate misconfigured token or unauthorised access attempt.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["sum"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "expr": "increase(rb_admin_requests_total{outcome=\"denied\"}[15m])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Admin errors (last 15 min)",
+      "description": "rb_admin_requests_total{outcome=\"error\"} — 5xx on admin endpoints indicates a server-side fault.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["sum"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "expr": "increase(rb_admin_requests_total{outcome=\"error\"}[15m])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Session Health",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Session failure rate",
+      "description": "rb_session_failures_total{reason} — bounded enum of failure reasons. Non-zero indicates agent session problems.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(rb_session_failures_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Agent relay failures & retries",
+      "description": "rb_agent_relay_failed_total and rb_agent_relay_retry_total — event relay health from agent-runner to control-api.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_agent_relay_failed_total[1m]))",
+          "legendFormat": "relay failed/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_agent_relay_retry_total[1m]))",
+          "legendFormat": "relay retries/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rb_agent_relay_dropped_total[1m]))",
+          "legendFormat": "relay dropped/s",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Queue Depth",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Kafka consumer lag (all topics)",
+      "description": "rb_kafka_consumer_lag_records — synthetic-load threshold: < 10,000 messages, never sustained > 1 min.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1000 },
+              { "color": "red", "value": 10000 }
+            ]
+          },
+          "custom": { "thresholdsStyle": { "mode": "area" } }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rb_kafka_consumer_lag_records)",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Outbox age",
+      "description": "rb_outbox_age_seconds — age of the oldest undelivered outbox event. Synthetic-load threshold: p95 < 60 s.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 60 }
+            ]
+          },
+          "custom": { "thresholdsStyle": { "mode": "area" } }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "rb_outbox_age_seconds",
+          "legendFormat": "{{service}} / {{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Connection Pools",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "DB pool connections (idle / busy)",
+      "description": "rb_db_pool_connections — pool utilisation per service. Consistently full busy pool indicates saturation.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "rb_db_pool_connections{state=\"busy\"}",
+          "legendFormat": "{{service}} / {{pool}} busy",
+          "refId": "A"
+        },
+        {
+          "expr": "rb_db_pool_connections{state=\"idle\"}",
+          "legendFormat": "{{service}} / {{pool}} idle",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/overview.json
+++ b/infra/grafana/dashboards/overview.json
@@ -1,0 +1,275 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "Stack overview — is the stack healthy right now? (ADR-012 §S3)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    { "title": "Latency & Throughput", "url": "/d/rb-latency-throughput", "type": "dashboards" },
+    { "title": "Changes & Deploys",    "url": "/d/rb-changes-deploys",    "type": "dashboards" },
+    { "title": "Operability & Admin",  "url": "/d/rb-operability-admin",  "type": "dashboards" }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["rust-brain", "overview", "s3"],
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Stack Overview",
+  "uid": "rb-stack-overview",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Service Status",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Build info — all services",
+      "description": "rb_build_info{service, version, git_sha} — one row per service. Red = service not reporting.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "service", "desc": false }]
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rb_build_info",
+          "legendFormat": "{{service}}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["service", "version", "git_sha", "Value"] } } }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "row",
+      "title": "Kafka",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Consumer lag by topic",
+      "description": "rb_kafka_consumer_lag_records — should stay near 0. Sustained lag indicates a slow consumer.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1000 },
+              { "color": "red", "value": 5000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic, group) (rb_kafka_consumer_lag_records)",
+          "legendFormat": "{{topic}} / {{group}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Kafka message rates (produce + consume)",
+      "description": "rb_kafka_messages_total{op} — per-topic produce and consume rates.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0 },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum by (topic, op) (rate(rb_kafka_messages_total[1m]))",
+          "legendFormat": "{{op}} / {{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Sessions & SSE",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Active SSE clients",
+      "description": "rb_sse_clients — current count of open SSE connections.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "expr": "sum(rb_sse_clients)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "SSE dropped events rate",
+      "description": "rb_sse_dropped_total{reason} — events dropped because a client's buffer was full.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 9, "x": 6, "y": 19 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "color": { "fixedColor": "orange", "mode": "fixed" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(rb_sse_dropped_total[1m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Active agent sessions",
+      "description": "rb_agent_runner_active_sessions — number of agent sessions currently running.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 9, "x": 15, "y": 19 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rb_agent_runner_active_sessions",
+          "legendFormat": "active sessions",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Error Rates",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Worker DLQ rates",
+      "description": "Dead-letter queue event rates across all workers — non-zero means unprocessable messages.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "color": { "fixedColor": "red", "mode": "fixed" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_ingest_clone_total{outcome=\"dlq\"}[1m]))",
+          "legendFormat": "ingest-clone dlq",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_parse_worker_dlq_total[1m]))",
+          "legendFormat": "parse-worker dlq",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rb_expand_worker_dlq_total[1m]))",
+          "legendFormat": "expand-worker dlq",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rb_ingest_graph_dlq_total[1m]))",
+          "legendFormat": "ingest-graph dlq",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rb_embed_worker_dlq_total[1m]))",
+          "legendFormat": "embed-worker dlq",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rb_typecheck_worker_dlq_total[1m]))",
+          "legendFormat": "typecheck-worker dlq",
+          "refId": "F"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Agent relay failures",
+      "description": "rb_agent_relay_failed_total — events that could not be relayed after all retries.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "color": { "fixedColor": "red", "mode": "fixed" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(rb_agent_relay_failed_total[1m]))",
+          "legendFormat": "relay failures/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rb_agent_events_dropped_total[1m]))",
+          "legendFormat": "events dropped/s",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/metrics-registry.txt
+++ b/infra/grafana/metrics-registry.txt
@@ -1,0 +1,98 @@
+# S2 frozen metric registry (ADR-012 §S2).
+#
+# Every metric emitted by any rb-* service or crate is listed here.
+# Sources:
+#   - ADR-012 §2.2.2 canonical examples (the frozen contract)
+#   - Rust source: grep 'metrics::(counter|gauge|histogram)!("rb_' crates/ services/
+#   - Pushgateway: scripts/push-token-metrics.sh
+#
+# grafana-lint reads this file and fails if any panel's PromQL references
+# a metric that is not listed below. Add new metrics here in the same PR
+# that introduces them to the source code.
+
+# ── ADR-012 §2.2.2 canonical (frozen contract) ──────────────────────────────
+rb_admin_requests_total
+rb_agent_runner_active_sessions
+rb_agent_runner_sessions_total
+rb_build_info
+rb_control_api_request_duration_seconds
+rb_control_api_requests_total
+rb_db_pool_connections
+rb_kafka_consumer_lag
+rb_outbox_age_seconds
+rb_session_failures_total
+
+# ── rb-kafka (crates/rb-kafka/src/consumer.rs, producer.rs) ─────────────────
+rb_kafka_consume_lag_seconds
+rb_kafka_consumer_lag_records
+rb_kafka_dlq_total
+rb_kafka_e2e_latency_seconds
+rb_kafka_messages_total
+rb_kafka_retry_total
+
+# ── rb-blob (crates/rb-blob/src/) ───────────────────────────────────────────
+rb_blob_bytes_total
+rb_blob_op_total
+
+# ── rb-sse (crates/rb-sse/src/) ─────────────────────────────────────────────
+rb_sse_clients
+rb_sse_dropped_total
+rb_sse_events_dispatched_total
+
+# ── agent-runner (services/agent-runner/src/) ────────────────────────────────
+rb_agent_commands_errors_total
+rb_agent_commands_total
+rb_agent_events_dropped_total
+rb_agent_events_failed_total
+rb_agent_events_published_total
+rb_agent_relay_dropped_total
+rb_agent_relay_failed_total
+rb_agent_relay_published_total
+rb_agent_relay_retry_total
+
+# ── embed-worker (services/embed-worker/src/) ────────────────────────────────
+rb_embed_worker_dlq_total
+rb_embed_worker_total
+rb_embed_worker_vectors_total
+rb_embeddings
+
+# ── expand-worker (services/expand-worker/src/) ──────────────────────────────
+rb_expand_worker_crate_skip_total
+rb_expand_worker_dlq_total
+rb_expand_worker_total
+
+# ── ingest-clone (services/ingest-clone/src/) ────────────────────────────────
+rb_ingest_clone_total
+
+# ── ingest-graph (services/ingest-graph/src/) ────────────────────────────────
+rb_ingest_graph_dlq_total
+rb_ingest_graph_relations_total
+rb_ingest_graph_total
+
+# ── parse-worker (services/parse-worker/src/) ────────────────────────────────
+rb_parse_worker_dlq_total
+rb_parse_worker_files_total
+rb_parse_worker_items_total
+rb_parse_worker_total
+
+# ── projector-neo4j (services/projector-neo4j/src/) ─────────────────────────
+rb_projector_neo4j_cap_exceeded_total
+rb_projector_neo4j_events_total
+
+# ── projector-pg (services/projector-pg/src/) ────────────────────────────────
+rb_projector_pg_events_total
+
+# ── tombstoner (services/tombstoner/src/) ────────────────────────────────────
+rb_tombstoner_events_total
+
+# ── typecheck-worker (services/typecheck-worker/src/) ────────────────────────
+rb_typecheck_worker_dlq_total
+rb_typecheck_worker_files_total
+rb_typecheck_worker_items_total
+rb_typecheck_worker_total
+
+# ── Pushgateway (scripts/push-token-metrics.sh) ──────────────────────────────
+rb_agent_context_budget_ratio_last_run
+rb_agent_context_tokens_current_run
+rb_agent_context_tokens_peak_last_run
+rb_agent_context_turns_last_run

--- a/scripts/grafana-lint.sh
+++ b/scripts/grafana-lint.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# grafana-lint.sh — ADR-012 §S3 binding between S2 metric registry and
+# S3 Grafana dashboards.
+#
+# For every *.json file in the dashboard directory, extract all rb_*
+# metric names that appear in PromQL "expr" fields and verify each one
+# is listed in the S2 frozen registry.  Exits 1 if any unknown metric
+# is found; exits 0 when all dashboards pass.
+#
+# Usage (from repo root):
+#   bash scripts/grafana-lint.sh
+#   bash scripts/grafana-lint.sh [dashboard-dir] [registry-file]
+set -euo pipefail
+
+DASHBOARD_DIR="${1:-infra/grafana/dashboards}"
+REGISTRY_FILE="${2:-infra/grafana/metrics-registry.txt}"
+
+# ── Prerequisite checks ──────────────────────────────────────────────────────
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$REGISTRY_FILE" ]]; then
+  echo "ERROR: metrics registry not found: $REGISTRY_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -d "$DASHBOARD_DIR" ]]; then
+  echo "ERROR: dashboard directory not found: $DASHBOARD_DIR" >&2
+  exit 1
+fi
+
+# ── Load registry ────────────────────────────────────────────────────────────
+
+declare -A REGISTRY
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  REGISTRY["$line"]=1
+done < "$REGISTRY_FILE"
+
+registry_size="${#REGISTRY[@]}"
+echo "grafana-lint: loaded ${registry_size} metrics from ${REGISTRY_FILE}"
+
+# ── Check each dashboard ─────────────────────────────────────────────────────
+
+failures=0
+dashboards=0
+
+for dashboard_file in "${DASHBOARD_DIR}"/*.json; do
+  [[ -f "$dashboard_file" ]] || continue
+  dashboards=$((dashboards + 1))
+  dashboard_name=$(basename "$dashboard_file")
+
+  # Extract all PromQL expr strings via jq recursive descent, then
+  # grep for rb_<name> tokens.  Normalize Prometheus histogram suffixes
+  # (_bucket, _sum, _count, _created) to their base metric name so the
+  # registry only stores one entry per histogram.
+  dashboard_metrics=$(
+    jq -r '.. | .expr? | strings' "$dashboard_file" 2>/dev/null \
+      | grep -oP 'rb_[a-z][a-z0-9_]*' \
+      | sed -E 's/_(bucket|sum|count|created)$//' \
+      | sort -u \
+      || true
+  )
+
+  panel_failures=0
+  while IFS= read -r metric_name; do
+    [[ -z "$metric_name" ]] && continue
+    if [[ -z "${REGISTRY[$metric_name]+_}" ]]; then
+      echo "  FAIL [$dashboard_name]: '$metric_name' is not in the S2 registry" >&2
+      panel_failures=$((panel_failures + 1))
+      failures=$((failures + 1))
+    fi
+  done <<< "$dashboard_metrics"
+
+  if [[ $panel_failures -eq 0 ]]; then
+    echo "  OK   [$dashboard_name]"
+  fi
+done
+
+echo ""
+echo "grafana-lint: checked ${dashboards} dashboard(s)"
+
+if [[ $failures -gt 0 ]]; then
+  echo "grafana-lint: FAIL — ${failures} unknown metric reference(s) across dashboards" >&2
+  exit 1
+fi
+
+echo "grafana-lint: PASS — all panel metrics are in the S2 registry"


### PR DESCRIPTION
## Summary

Implements ADR-012 §S3 (REQ-OB-03): four file-provisioned Grafana dashboards covering the four operator questions, plus a `make grafana-lint` target that enforces the S2⟷S3 metric-name binding.

## Dashboards

| File | Title | Key panels |
|---|---|---|
| `infra/grafana/dashboards/overview.json` | Stack Overview | build SHA table, Kafka lag, SSE clients, DLQ/relay error rates |
| `infra/grafana/dashboards/latency.json` | Latency & Throughput | API p50/p95/p99, Kafka produce/consume rates, ingestion pipeline |
| `infra/grafana/dashboards/changes.json` | Changes & Deploys | build SHA table with GH commit links, deploy event timeline, service-count stat |
| `infra/grafana/dashboards/operability.json` | Operability & Admin | admin action rates, denial/error stats, session failures, queue depth with S7 thresholds |

All four dashboards are:
- File-based provisioned (not API-pushed) — `infra/grafana/provisioning/dashboards.yaml` already has `allowUiUpdates: false`
- Linked to each other via dashboard nav links
- Datasource-explicit: `{ "type": "prometheus", "uid": "prometheus" }`

## grafana-lint

- `scripts/grafana-lint.sh` — extracts all `rb_*` metric names from every dashboard's `expr` fields (via `jq` recursive descent), normalises histogram suffixes (`_bucket/_sum/_count`), and checks each against the S2 registry
- `infra/grafana/metrics-registry.txt` — 57-entry S2 frozen metric registry covering ADR-012 §2.2.2 canonical list + all actually-emitted metrics from Rust source + Pushgateway scripts
- `Makefile: grafana-lint` target (folded into `ci/test` per ADR-012 §S5.2)
- All 7 dashboards (including pre-existing `ingestion-transport.json` and `agent-token-budget.json`) pass with zero failures

## Migration type

N/A — no database migrations.

## Checklist

- [x] `make grafana-lint` PASS (7 dashboards, 0 failures)
- [x] File-based provisioning confirmed (`allowUiUpdates: false` pre-existing)
- [x] No `RUSAA-XX` in commit message or source files
- [x] ADR-012 §S3.3 dashboard catalogue matches exactly
- [x] Tempo datasource provisioned (pre-existing in `datasources.yaml`)
- [x] Cross-stream: operability dashboard includes `rb_admin_requests_total` (S1), `rb_outbox_age_seconds` (S2 contract)

## GitHub Issue

Closes #626