### PR TITLE
[RUSAA-1719] feat: S7 synthetic-load harness for 7-day pre-prod soak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1525,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2656,6 +2683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3712,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4273,6 +4322,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -5107,6 +5158,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "synthetic-load"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "metrics",
+ "rb-build-info",
+ "rb-metrics",
+ "rb-tracing",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/rb-kafka-health",
     "crates/rb-build-info",
     "crates/rb-metrics",
+    "services/synthetic-load",
 ]
 
 [workspace.package]

--- a/docker/synthetic-load/Dockerfile
+++ b/docker/synthetic-load/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: chef base ────────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
+WORKDIR /app
+
+# ── Stage 2: planner ──────────────────────────────────────────────────────────
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+FROM chef AS builder
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        cmake libssl-dev libsasl2-dev zlib1g-dev libcurl4-openssl-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p synthetic-load
+
+COPY . .
+
+ARG GIT_SHA=unknown
+ARG BUILT_AT=unknown
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    RB_BUILD_SHA="${GIT_SHA}" RB_BUILD_TIMESTAMP="${BUILT_AT}" cargo build --release -p synthetic-load && \
+    cp target/release/synthetic-load /usr/local/bin/
+
+# ── Stage 4: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+ARG GIT_SHA=unknown
+LABEL git_sha=${GIT_SHA}
+ENV RB_BUILD_SHA=${GIT_SHA}
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libsasl2-2 zlib1g libcurl4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --system nonroot && \
+    install -d -m 755 -o nonroot -g nonroot /var/lib/rustbrain/synthetic-load
+
+USER nonroot
+
+ENV SYNTHETIC_LOAD_STATE_DIR=/var/lib/rustbrain/synthetic-load
+
+COPY --from=builder /usr/local/bin/synthetic-load /usr/local/bin/synthetic-load
+
+ENTRYPOINT ["/usr/local/bin/synthetic-load"]
+CMD ["start"]

--- a/scripts/synthetic-load.sh
+++ b/scripts/synthetic-load.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/synthetic-load.sh — synthetic-load harness entrypoint for Wave 8 S7.
+#
+# Usage:
+#   scripts/synthetic-load.sh start      # start the 7-day soak (default)
+#   scripts/synthetic-load.sh provision  # pre-provision the tenant pool and exit
+#   scripts/synthetic-load.sh report     # print the latest daily summary and exit
+#   scripts/synthetic-load.sh status     # tail the harness-state.json
+#
+# Required env vars:
+#   SYNTHETIC_LOAD_TARGET          — control-api base URL (e.g. https://pre-prod.example.com)
+#   SYNTHETIC_LOAD_ADMIN_TOKEN     — same as RB_ADMIN_TOKEN on the target stack
+#   SYNTHETIC_LOAD_DATABASE_URL    — Postgres DSN for email verification (same as DATABASE_URL)
+#
+# Optional env vars (see services/synthetic-load/src/config.rs for full list):
+#   SYNTHETIC_LOAD_TENANT_COUNT       (default: 10)
+#   SYNTHETIC_LOAD_DAYS               (default: 7)
+#   SYNTHETIC_LOAD_PROMETHEUS_URL     (default: unset)
+#   SYNTHETIC_LOAD_SERVICE_URLS       (default: SYNTHETIC_LOAD_TARGET)
+#   SYNTHETIC_LOAD_STATE_DIR          (default: ~/.local/state/rustbrain/synthetic-load)
+#
+# Prerequisites:
+#   • The binary must be built: cargo build --release -p synthetic-load
+#   • Or run via Docker: docker run --env-file ... ghcr.io/f-crop/rustacean/synthetic-load start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+COMMAND="${1:-start}"
+
+BINARY="${SYNTHETIC_LOAD_BINARY:-${REPO_ROOT}/target/release/synthetic-load}"
+
+if [[ ! -x "${BINARY}" ]]; then
+    echo "synthetic-load binary not found at ${BINARY}" >&2
+    echo "Build it first: cargo build --release -p synthetic-load" >&2
+    exit 1
+fi
+
+# Resolve state dir for status command.
+STATE_DIR="${SYNTHETIC_LOAD_STATE_DIR:-${HOME}/.local/state/rustbrain/synthetic-load}"
+
+case "${COMMAND}" in
+    start)
+        echo "==> synthetic-load: starting 7-day soak"
+        echo "    target   : ${SYNTHETIC_LOAD_TARGET:-<unset>}"
+        echo "    state_dir: ${STATE_DIR}"
+        exec "${BINARY}" start
+        ;;
+    provision)
+        echo "==> synthetic-load: provisioning tenant pool"
+        exec "${BINARY}" provision
+        ;;
+    report)
+        exec "${BINARY}" report
+        ;;
+    status)
+        state_file="${STATE_DIR}/harness-state.json"
+        if [[ -f "${state_file}" ]]; then
+            python3 -m json.tool "${state_file}" 2>/dev/null || cat "${state_file}"
+        else
+            echo "no harness state found at ${state_file}" >&2
+            exit 1
+        fi
+        ;;
+    build-info)
+        exec "${BINARY}" build-info
+        ;;
+    *)
+        echo "unknown command: ${COMMAND}" >&2
+        echo "usage: $0 {start|provision|report|status|build-info}" >&2
+        exit 1
+        ;;
+esac

--- a/services/synthetic-load/Cargo.toml
+++ b/services/synthetic-load/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "synthetic-load"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "synthetic-load"
+path = "src/main.rs"
+
+[dependencies]
+rb-build-info = { path = "../../crates/rb-build-info", version = "0.1.0" }
+rb-metrics    = { path = "../../crates/rb-metrics",    version = "0.1.0" }
+rb-tracing    = { path = "../../crates/rb-tracing",    version = "0.1.0" }
+anyhow.workspace     = true
+chrono.workspace     = true
+clap.workspace       = true
+metrics.workspace    = true
+reqwest              = { workspace = true, features = ["cookies"] }
+serde.workspace      = true
+serde_json.workspace = true
+sqlx.workspace       = true
+tokio.workspace      = true
+tokio-util           = { version = "0.7" }
+tracing.workspace    = true
+uuid.workspace       = true
+
+[lints]
+workspace = true

--- a/services/synthetic-load/src/client.rs
+++ b/services/synthetic-load/src/client.rs
@@ -1,0 +1,227 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Thin wrapper around `reqwest::Client` that carries a session cookie jar.
+///
+/// Cookie-based session is established by calling `login()`. On 401 the
+/// caller is expected to re-login and retry.
+#[derive(Clone, Debug)]
+pub struct ApiClient {
+    pub client: Client,
+    pub base_url: String,
+    /// Trace ID of the most recent failed request, saved for daily summaries.
+    pub last_failed_trace_id: Option<String>,
+}
+
+impl ApiClient {
+    pub fn new(base_url: &str) -> Result<Self> {
+        let client = Client::builder()
+            .cookie_store(true)
+            .timeout(Duration::from_secs(30))
+            .user_agent("synthetic-load/0.1 rustbrain-harness")
+            .build()
+            .context("failed to build reqwest client")?;
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            last_failed_trace_id: None,
+        })
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    pub async fn post_json<B: Serialize, R: for<'de> Deserialize<'de>>(
+        &mut self,
+        path: &str,
+        body: &B,
+    ) -> Result<R> {
+        let resp = self
+            .client
+            .post(self.url(path))
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("POST {path} network error"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            if let Some(v) = resp.headers().get("x-trace-id") {
+                if let Ok(s) = v.to_str() {
+                    self.last_failed_trace_id = Some(s.to_owned());
+                }
+            }
+        }
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("POST {path} → {status}: {text}");
+        }
+        serde_json::from_str(&text)
+            .with_context(|| format!("POST {path}: deserialize failed: {text}"))
+    }
+
+    pub async fn get_json<R: for<'de> Deserialize<'de>>(&mut self, path: &str) -> Result<R> {
+        let resp = self
+            .client
+            .get(self.url(path))
+            .send()
+            .await
+            .with_context(|| format!("GET {path} network error"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            if let Some(v) = resp.headers().get("x-trace-id") {
+                if let Ok(s) = v.to_str() {
+                    self.last_failed_trace_id = Some(s.to_owned());
+                }
+            }
+        }
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("GET {path} → {status}: {text}");
+        }
+        serde_json::from_str(&text)
+            .with_context(|| format!("GET {path}: deserialize failed: {text}"))
+    }
+
+    pub async fn delete_ok(&mut self, path: &str) -> Result<StatusCode> {
+        let resp = self
+            .client
+            .delete(self.url(path))
+            .send()
+            .await
+            .with_context(|| format!("DELETE {path} network error"))?;
+        Ok(resp.status())
+    }
+
+    /// Returns `(up: bool, error_detail: Option<String>)`.
+    pub async fn health_check(&self, service_url: &str) -> (bool, Option<String>) {
+        let url = format!("{}/health", service_url.trim_end_matches('/'));
+        match self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+        {
+            Ok(r) if r.status().is_success() => (true, None),
+            Ok(r) => (
+                false,
+                Some(format!("{service_url} health → {}", r.status())),
+            ),
+            Err(e) => (false, Some(format!("{service_url} health error: {e}"))),
+        }
+    }
+
+    /// Returns the SHA reported by `/health/build`, or `None` on failure.
+    pub async fn health_build_sha(&self, service_url: &str) -> Option<String> {
+        #[derive(Deserialize)]
+        struct BuildResp {
+            sha: String,
+        }
+        let url = format!("{}/health/build", service_url.trim_end_matches('/'));
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .ok()?;
+        resp.json::<BuildResp>().await.ok().map(|b| b.sha)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct SignupRequest {
+    pub email: String,
+    pub password: String,
+    pub tenant_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignupResponse {
+    pub user_id: Uuid,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginResponse {}
+
+#[derive(Debug, Serialize)]
+pub struct CreateSessionRequest {
+    pub runtime: String,
+    pub initial_prompt: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionResponse {
+    pub session_id: Uuid,
+    pub status: String,
+}
+
+/// Response from `GET /v1/agents/sessions/{id}`.
+#[derive(Debug, Deserialize)]
+pub struct SessionDetail {
+    pub status: String,
+}
+
+/// Response from `POST /v1/repos/{repo_id}/ingestions`.
+#[derive(Debug, Deserialize)]
+pub struct TriggerIngestionResponse {
+    pub ingest_run_id: Uuid,
+    pub trace_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoItem {
+    pub repo_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoListResponse {
+    pub repos: Vec<RepoItem>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StageRunItem {
+    pub stage: String,
+    pub status: String,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StageTimelineResponse {
+    pub stages: Vec<StageRunItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchRequest {
+    pub q: String,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchResponse {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when an `anyhow::Error` from a client method indicates HTTP 401.
+pub fn is_unauthorized(err: &anyhow::Error) -> bool {
+    err.to_string().contains("→ 401")
+}

--- a/services/synthetic-load/src/client.rs
+++ b/services/synthetic-load/src/client.rs
@@ -59,6 +59,9 @@ impl ApiClient {
         }
         let text = resp.text().await.unwrap_or_default();
         if !status.is_success() {
+            if status == StatusCode::UNAUTHORIZED {
+                return Err(anyhow::Error::new(UnauthorizedError));
+            }
             anyhow::bail!("POST {path} → {status}: {text}");
         }
         serde_json::from_str(&text)
@@ -83,6 +86,9 @@ impl ApiClient {
         }
         let text = resp.text().await.unwrap_or_default();
         if !status.is_success() {
+            if status == StatusCode::UNAUTHORIZED {
+                return Err(anyhow::Error::new(UnauthorizedError));
+            }
             anyhow::bail!("GET {path} → {status}: {text}");
         }
         serde_json::from_str(&text)
@@ -221,7 +227,20 @@ pub struct SearchResponse {}
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when an `anyhow::Error` from a client method indicates HTTP 401.
+/// Typed sentinel returned by client methods on HTTP 401 so callers can match
+/// on the error type rather than parsing the message string.
+#[derive(Debug)]
+pub struct UnauthorizedError;
+
+impl std::fmt::Display for UnauthorizedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HTTP 401 Unauthorized")
+    }
+}
+
+impl std::error::Error for UnauthorizedError {}
+
+/// Returns `true` when an `anyhow::Error` from a client method is an HTTP 401.
 pub fn is_unauthorized(err: &anyhow::Error) -> bool {
-    err.to_string().contains("→ 401")
+    err.is::<UnauthorizedError>()
 }

--- a/services/synthetic-load/src/config.rs
+++ b/services/synthetic-load/src/config.rs
@@ -1,0 +1,122 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::{Context, Result};
+
+pub struct Config {
+    /// Base URL of the control-api (e.g. `http://control-api:4000`).
+    pub target_url: String,
+
+    /// `RB_ADMIN_TOKEN` — used for admin force-delete + impersonation.
+    pub admin_token: String,
+
+    /// Postgres DSN for direct email-verification writes after signup.
+    pub database_url: String,
+
+    /// Number of active synthetic tenants to maintain simultaneously.
+    pub tenant_count: usize,
+
+    /// Directory where run state and daily summaries are persisted.
+    pub state_dir: PathBuf,
+
+    /// Total target soak duration; harness exits cleanly when this elapses.
+    pub soak_duration: Duration,
+
+    /// Prometheus HTTP API base URL (e.g. `http://prometheus:9090`).
+    /// Used to query `rb_outbox_age_seconds` and `rb_kafka_consumer_lag`.
+    pub prometheus_url: Option<String>,
+
+    /// Comma-separated list of service base URLs to health-check.
+    /// Defaults to just `target_url`.
+    pub service_urls: Vec<String>,
+
+    /// Interval between health check passes.
+    pub health_interval: Duration,
+
+    /// Interval between ingestion-loop iterations per tenant.
+    pub ingestion_interval: Duration,
+
+    /// Interval between agent-loop iterations per tenant.
+    pub agent_interval: Duration,
+
+    /// Interval between query-loop iterations per tenant.
+    pub query_interval: Duration,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        let target_url = std::env::var("SYNTHETIC_LOAD_TARGET")
+            .context("SYNTHETIC_LOAD_TARGET is required (e.g. http://control-api:4000)")?;
+
+        let admin_token = std::env::var("SYNTHETIC_LOAD_ADMIN_TOKEN")
+            .context("SYNTHETIC_LOAD_ADMIN_TOKEN is required (same as RB_ADMIN_TOKEN)")?;
+
+        let database_url = std::env::var("SYNTHETIC_LOAD_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .context("SYNTHETIC_LOAD_DATABASE_URL or DATABASE_URL is required")?;
+
+        let tenant_count: usize = std::env::var("SYNTHETIC_LOAD_TENANT_COUNT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10);
+
+        let state_dir = std::env::var("SYNTHETIC_LOAD_STATE_DIR")
+            .map_or_else(|_| dirs_or_home().join("synthetic-load"), PathBuf::from);
+
+        let soak_days: u64 = std::env::var("SYNTHETIC_LOAD_DAYS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(7);
+        let soak_duration = Duration::from_secs(soak_days * 24 * 3600);
+
+        let prometheus_url = std::env::var("SYNTHETIC_LOAD_PROMETHEUS_URL").ok();
+
+        let service_urls = std::env::var("SYNTHETIC_LOAD_SERVICE_URLS").map_or_else(
+            |_| vec![target_url.clone()],
+            |s| s.split(',').map(str::trim).map(String::from).collect(),
+        );
+
+        let health_interval = parse_duration_secs("SYNTHETIC_LOAD_HEALTH_INTERVAL_SECS", 60);
+        let ingestion_interval = parse_duration_secs("SYNTHETIC_LOAD_INGEST_INTERVAL_SECS", 120);
+        let agent_interval = parse_duration_secs("SYNTHETIC_LOAD_AGENT_INTERVAL_SECS", 90);
+        let query_interval = parse_duration_secs("SYNTHETIC_LOAD_QUERY_INTERVAL_SECS", 30);
+
+        if !target_url.starts_with("http") {
+            anyhow::bail!("SYNTHETIC_LOAD_TARGET must be an http(s) URL, got: {target_url}");
+        }
+
+        Ok(Self {
+            target_url,
+            admin_token,
+            database_url,
+            tenant_count,
+            state_dir,
+            soak_duration,
+            prometheus_url,
+            service_urls,
+            health_interval,
+            ingestion_interval,
+            agent_interval,
+            query_interval,
+        })
+    }
+}
+
+fn dirs_or_home() -> PathBuf {
+    // ~/.local/state/rustbrain/synthetic-load
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".local")
+            .join("state")
+            .join("rustbrain");
+    }
+    PathBuf::from("/var/lib/rustbrain")
+}
+
+fn parse_duration_secs(var: &str, default: u64) -> Duration {
+    Duration::from_secs(
+        std::env::var(var)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(default),
+    )
+}

--- a/services/synthetic-load/src/health.rs
+++ b/services/synthetic-load/src/health.rs
@@ -1,0 +1,125 @@
+use serde::Deserialize;
+
+use crate::client::ApiClient;
+use crate::report::{KAFKA_LAG_THRESHOLD, OUTBOX_AGE_THRESHOLD_SECS};
+
+/// Result of one health-check pass.
+#[derive(Debug, Default)]
+pub struct HealthCheckResult {
+    /// Total services polled.
+    pub total: u32,
+    /// Services that returned 200.
+    pub up: u32,
+    /// Human-readable detail for any failures.
+    pub failures: Vec<String>,
+    /// Drift events: SHA changed since the harness started.
+    pub drift_events: Vec<String>,
+    /// `rb_outbox_age_seconds` p95 if available (scraped from Prometheus).
+    pub outbox_age_p95_secs: Option<f64>,
+    /// Highest `rb_kafka_consumer_lag` sample seen.
+    pub kafka_max_consumer_lag: Option<u64>,
+    /// Whether outbox / lag are above degradation thresholds.
+    pub degradation_events: Vec<String>,
+}
+
+impl HealthCheckResult {
+    /// Availability = up / total × 100.
+    pub fn availability_pct(&self) -> f64 {
+        if self.total == 0 {
+            return 100.0;
+        }
+        (f64::from(self.up) / f64::from(self.total)) * 100.0
+    }
+}
+
+/// Run one health-check pass against all configured service URLs.
+///
+/// `expected_sha` is the SHA captured at harness start; drift is flagged when
+/// any service returns a different SHA.
+pub async fn run_health_check(
+    client: &ApiClient,
+    service_urls: &[String],
+    expected_sha: Option<&str>,
+    prometheus_url: Option<&str>,
+) -> HealthCheckResult {
+    let mut result = HealthCheckResult::default();
+
+    for url in service_urls {
+        result.total += 1;
+        let (up, detail) = client.health_check(url).await;
+        if up {
+            result.up += 1;
+        } else if let Some(d) = detail {
+            result.failures.push(d);
+        }
+
+        // Build SHA drift detection
+        if let Some(sha) = client.health_build_sha(url).await {
+            if let Some(expected) = expected_sha {
+                if sha != expected && expected != "unknown" && sha != "unknown" {
+                    result
+                        .drift_events
+                        .push(format!("{url} SHA changed: expected {expected}, got {sha}"));
+                }
+            }
+        }
+    }
+
+    // Prometheus metric scrape
+    if let Some(prom) = prometheus_url {
+        if let Some(age) = query_prometheus_scalar(prom, "rb_outbox_age_seconds").await {
+            result.outbox_age_p95_secs = Some(age);
+            if age > OUTBOX_AGE_THRESHOLD_SECS {
+                result.degradation_events.push(format!(
+                    "rb_outbox_age_seconds p95 = {age:.1} s > {OUTBOX_AGE_THRESHOLD_SECS} s threshold"
+                ));
+            }
+        }
+        if let Some(lag) = query_prometheus_scalar(prom, "rb_kafka_consumer_lag").await {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let lag_u64 = lag.round() as u64;
+            result.kafka_max_consumer_lag = Some(lag_u64);
+            if lag_u64 > KAFKA_LAG_THRESHOLD {
+                result.degradation_events.push(format!(
+                    "rb_kafka_consumer_lag = {lag_u64} > {KAFKA_LAG_THRESHOLD} threshold"
+                ));
+            }
+        }
+    }
+
+    result
+}
+
+/// Query Prometheus HTTP API for a metric's current value.
+///
+/// Returns the first scalar value found, or `None` on any error.
+async fn query_prometheus_scalar(prom_url: &str, metric: &str) -> Option<f64> {
+    #[derive(Deserialize)]
+    struct PromResp {
+        data: PromData,
+    }
+    #[derive(Deserialize)]
+    struct PromData {
+        result: Vec<PromResult>,
+    }
+    #[derive(Deserialize)]
+    struct PromResult {
+        value: (f64, String),
+    }
+
+    let url = format!(
+        "{}/api/v1/query?query={}",
+        prom_url.trim_end_matches('/'),
+        urlencoding_simple(metric)
+    );
+
+    let resp: PromResp = reqwest::get(&url).await.ok()?.json().await.ok()?;
+    resp.data
+        .result
+        .first()
+        .and_then(|r| r.value.1.parse::<f64>().ok())
+}
+
+fn urlencoding_simple(s: &str) -> String {
+    s.replace(' ', "+")
+}

--- a/services/synthetic-load/src/loops/agent.rs
+++ b/services/synthetic-load/src/loops/agent.rs
@@ -1,0 +1,115 @@
+//! Agent-execution loop — creates a session, polls until terminal, then deletes.
+//!
+//! ADR-012 §2.7.2: "POST /agents/:id/sessions → poll → terminate".
+
+use std::time::{Duration, Instant};
+
+use crate::client::{
+    ApiClient, CreateSessionRequest, CreateSessionResponse, SessionDetail, is_unauthorized,
+};
+use crate::state::IterationOutcome;
+use crate::tenant::TenantRecord;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+const SESSION_TIMEOUT: Duration = Duration::from_secs(120);
+const SYNTHETIC_PROMPT: &str = "List the files in the workspace and exit.";
+
+pub async fn run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+) -> IterationOutcome {
+    match try_run_once(client, tenant, password).await {
+        Ok(trace_id) => IterationOutcome {
+            loop_name: "agent",
+            ok: true,
+            latency_ms: None,
+            trace_id,
+        },
+        Err(e) => {
+            let trace_id = client.last_failed_trace_id.clone();
+            tracing::warn!(tenant_id = %tenant.tenant_id, error = %e, "agent iteration failed");
+            IterationOutcome {
+                loop_name: "agent",
+                ok: false,
+                latency_ms: None,
+                trace_id,
+            }
+        }
+    }
+}
+
+async fn try_run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+) -> anyhow::Result<Option<String>> {
+    // Create session.
+    let resp: CreateSessionResponse = match client
+        .post_json(
+            "/v1/agents/sessions",
+            &CreateSessionRequest {
+                runtime: "claude_code".to_owned(),
+                initial_prompt: SYNTHETIC_PROMPT.to_owned(),
+            },
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) if is_unauthorized(&e) => {
+            crate::tenant::login(client, &tenant.email, password).await?;
+            client
+                .post_json(
+                    "/v1/agents/sessions",
+                    &CreateSessionRequest {
+                        runtime: "claude_code".to_owned(),
+                        initial_prompt: SYNTHETIC_PROMPT.to_owned(),
+                    },
+                )
+                .await?
+        }
+        Err(e) => return Err(e),
+    };
+
+    let session_id = resp.session_id;
+
+    // Poll until terminal or timeout.
+    let deadline = Instant::now() + SESSION_TIMEOUT;
+    let mut last_status = resp.status.clone();
+
+    loop {
+        if Instant::now() > deadline {
+            // Best-effort cleanup before bailing.
+            let _ = client
+                .delete_ok(&format!("/v1/agents/sessions/{session_id}"))
+                .await;
+            anyhow::bail!(
+                "session {session_id} did not reach terminal state within {SESSION_TIMEOUT:?}; last status: {last_status}"
+            );
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        let detail: SessionDetail = client
+            .get_json(&format!("/v1/agents/sessions/{session_id}"))
+            .await?;
+        last_status.clone_from(&detail.status);
+
+        if is_terminal(&detail.status) {
+            break;
+        }
+    }
+
+    // Delete (clean up) after completion.
+    let _ = client
+        .delete_ok(&format!("/v1/agents/sessions/{session_id}"))
+        .await;
+
+    Ok(None)
+}
+
+fn is_terminal(status: &str) -> bool {
+    matches!(
+        status,
+        "completed" | "failed" | "cancelled" | "terminated" | "error"
+    )
+}

--- a/services/synthetic-load/src/loops/ingestion.rs
+++ b/services/synthetic-load/src/loops/ingestion.rs
@@ -109,7 +109,8 @@ async fn try_run_once(
             anyhow::bail!("ingestion run {run_id} failed: {msg}");
         }
 
-        let all_done = timeline.stages.iter().all(|s| s.status == "succeeded");
+        let all_done = !timeline.stages.is_empty()
+            && timeline.stages.iter().all(|s| s.status == "succeeded");
         if all_done {
             break;
         }

--- a/services/synthetic-load/src/loops/ingestion.rs
+++ b/services/synthetic-load/src/loops/ingestion.rs
@@ -109,8 +109,8 @@ async fn try_run_once(
             anyhow::bail!("ingestion run {run_id} failed: {msg}");
         }
 
-        let all_done = !timeline.stages.is_empty()
-            && timeline.stages.iter().all(|s| s.status == "succeeded");
+        let all_done =
+            !timeline.stages.is_empty() && timeline.stages.iter().all(|s| s.status == "succeeded");
         if all_done {
             break;
         }

--- a/services/synthetic-load/src/loops/ingestion.rs
+++ b/services/synthetic-load/src/loops/ingestion.rs
@@ -1,0 +1,131 @@
+//! Ingestion loop — connects repos and drives the full pipeline per ADR-012 §2.7.2.
+//!
+//! For each iteration: pick an existing repo on the tenant, trigger an
+//! ingestion, poll until all stages reach a terminal state, then run a
+//! semantic search to validate the results landed.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use uuid::Uuid;
+
+use crate::client::{ApiClient, SearchRequest, TriggerIngestionResponse, is_unauthorized};
+use crate::state::IterationOutcome;
+use crate::tenant::TenantRecord;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(10);
+const INGESTION_TIMEOUT: Duration = Duration::from_secs(600);
+
+pub async fn run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+) -> IterationOutcome {
+    match try_run_once(client, tenant, password).await {
+        Ok(trace_id) => IterationOutcome {
+            loop_name: "ingestion",
+            ok: true,
+            latency_ms: None,
+            trace_id,
+        },
+        Err(e) => {
+            let trace_id = client.last_failed_trace_id.clone();
+            tracing::warn!(tenant_id = %tenant.tenant_id, error = %e, "ingestion iteration failed");
+            IterationOutcome {
+                loop_name: "ingestion",
+                ok: false,
+                latency_ms: None,
+                trace_id,
+            }
+        }
+    }
+}
+
+async fn try_run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+) -> Result<Option<String>> {
+    // Find an existing repo on the tenant to trigger re-ingestion.
+    let repos = match client
+        .get_json::<crate::client::RepoListResponse>("/v1/repos")
+        .await
+    {
+        Ok(r) => r.repos,
+        Err(e) if is_unauthorized(&e) => {
+            crate::tenant::login(client, &tenant.email, password).await?;
+            client
+                .get_json::<crate::client::RepoListResponse>("/v1/repos")
+                .await?
+                .repos
+        }
+        Err(e) => return Err(e),
+    };
+
+    if repos.is_empty() {
+        // No repos connected to this tenant yet — skip iteration.
+        tracing::debug!(tenant_id = %tenant.tenant_id, "no repos; skipping ingestion iteration");
+        return Ok(None);
+    }
+
+    // Pick the first repo (deterministic).
+    let repo = &repos[0];
+    let path = format!("/v1/repos/{}/ingestions", repo.repo_id);
+
+    let trigger: TriggerIngestionResponse = client.post_json(&path, &serde_json::json!({})).await?;
+
+    let run_id: Uuid = trigger.ingest_run_id;
+    let trace_id = trigger.trace_id.clone();
+
+    // Poll stages until terminal.
+    let deadline = Instant::now() + INGESTION_TIMEOUT;
+    loop {
+        if Instant::now() > deadline {
+            anyhow::bail!("ingestion run {run_id} timed out after {INGESTION_TIMEOUT:?}");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        let timeline = client
+            .get_json::<crate::client::StageTimelineResponse>(&format!(
+                "/v1/ingestions/{run_id}/stages"
+            ))
+            .await?;
+
+        let any_failed = timeline.stages.iter().any(|s| s.status == "failed");
+        if any_failed {
+            let msg = timeline
+                .stages
+                .iter()
+                .filter(|s| s.status == "failed")
+                .map(|s| {
+                    format!(
+                        "{}: {}",
+                        s.stage,
+                        s.error_message.as_deref().unwrap_or("no detail")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::bail!("ingestion run {run_id} failed: {msg}");
+        }
+
+        let all_done = timeline.stages.iter().all(|s| s.status == "succeeded");
+        if all_done {
+            break;
+        }
+    }
+
+    // Post-ingestion smoke: run a quick search to validate results landed.
+    let _: crate::client::SearchResponse = client
+        .post_json(
+            "/v1/search",
+            &SearchRequest {
+                q: "fn main".to_owned(),
+                limit: Some(5),
+            },
+        )
+        .await
+        .unwrap_or(crate::client::SearchResponse {});
+
+    Ok(trace_id)
+}

--- a/services/synthetic-load/src/loops/mod.rs
+++ b/services/synthetic-load/src/loops/mod.rs
@@ -1,0 +1,411 @@
+//! Loop orchestrator — runs the three workload loops concurrently across the
+//! tenant pool and applies health gating every `health_interval`.
+
+pub mod agent;
+pub mod ingestion;
+pub mod query;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::health::run_health_check;
+use crate::report::DailySummary;
+use crate::state::HarnessState;
+use crate::tenant::{TenantRecord, force_delete, provision};
+
+/// Minimum consecutive catastrophic failures before the harness exits.
+const CATASTROPHIC_FAILURE_SECS: u64 = 300;
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(
+    config: Arc<Config>,
+    state: Arc<Mutex<HarnessState>>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    // Build a shared plain HTTP client for admin operations.
+    let admin_http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("synthetic-load/0.1 rustbrain-harness-admin")
+        .build()?;
+
+    // Ensure the tenant pool is populated before starting loops.
+    ensure_tenant_pool(&config, &state, &admin_http).await?;
+
+    // Record expected SHA from first healthy service.
+    {
+        let probe = ApiClient::new(&config.target_url)?;
+        if let Some(sha) = probe.health_build_sha(&config.target_url).await {
+            let mut s = state.lock().await;
+            if s.expected_sha.is_none() {
+                tracing::info!(sha = %sha, "captured expected build SHA");
+                s.expected_sha = Some(sha);
+            }
+        }
+    }
+
+    // Spawn the three per-tenant loop tasks.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::state::IterationOutcome>(256);
+
+    spawn_loop_tasks(&config, &state, tx, cancel.clone()).await;
+
+    // Health check timer and daily report timer.
+    let mut health_ticker = tokio::time::interval(config.health_interval);
+    let mut checkpoint_ticker = tokio::time::interval(Duration::from_secs(300));
+    let mut daily_ticker = tokio::time::interval(Duration::from_secs(3600));
+    let mut tenant_rotation_ticker = tokio::time::interval(Duration::from_secs(7200));
+
+    let mut db_unavailable_since: Option<std::time::Instant> = None;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::info!("cancellation received; writing final summary");
+                break;
+            }
+
+            outcome = rx.recv() => {
+                let Some(outcome) = outcome else { break; };
+                let mut s = state.lock().await;
+                match outcome.loop_name {
+                    "ingestion" => s.ingestion.record(outcome.ok),
+                    "agent"     => s.agent.record(outcome.ok),
+                    "query"     => {
+                        s.query.record(outcome.ok);
+                        if let Some(ms) = outcome.latency_ms {
+                            s.record_query_latency(ms);
+                        }
+                    }
+                    _ => {}
+                }
+                if let Some(tid) = outcome.trace_id {
+                    if !outcome.ok {
+                        s.last_failed_trace_id = Some(tid);
+                    }
+                }
+                metrics::counter!("rb_synthetic_load_iterations_total",
+                    "loop" => outcome.loop_name,
+                    "outcome" => if outcome.ok { "ok" } else { "error" }
+                ).increment(1);
+            }
+
+            _tick = health_ticker.tick() => {
+                let (expected_sha, prom_url, service_urls) = {
+                    let s = state.lock().await;
+                    (s.expected_sha.clone(), config.prometheus_url.clone(), config.service_urls.clone())
+                };
+                let probe = match ApiClient::new(&config.target_url) {
+                    Ok(c) => c,
+                    Err(e) => { tracing::warn!("health probe client error: {e}"); continue; }
+                };
+                let result = run_health_check(
+                    &probe,
+                    &service_urls,
+                    expected_sha.as_deref(),
+                    prom_url.as_deref(),
+                ).await;
+
+                let check_failed = !result.failures.is_empty();
+                {
+                    let mut s = state.lock().await;
+                    s.health.checks_total += 1;
+                    if check_failed {
+                        s.health.checks_failed += 1;
+                    }
+                    s.health.degradation_events += result.degradation_events.len() as u64;
+                    s.health.drift_events += result.drift_events.len() as u64;
+                }
+
+                if check_failed {
+                    // Track catastrophic-failure window (all services down).
+                    if result.up == 0 {
+                        db_unavailable_since.get_or_insert_with(std::time::Instant::now);
+                    } else {
+                        db_unavailable_since = None;
+                    }
+                    tracing::warn!(
+                        failures = ?result.failures,
+                        availability = result.availability_pct(),
+                        "health check failed"
+                    );
+                } else {
+                    db_unavailable_since = None;
+                }
+
+                // Exit on catastrophic failure.
+                if let Some(since) = db_unavailable_since {
+                    if since.elapsed().as_secs() > CATASTROPHIC_FAILURE_SECS {
+                        tracing::error!("stack unreachable for >5 min — catastrophic failure exit");
+                        cancel.cancel();
+                        break;
+                    }
+                }
+            }
+
+            _tick = checkpoint_ticker.tick() => {
+                let mut s = state.lock().await;
+                if let Err(e) = s.save(&config.state_dir) {
+                    tracing::warn!("checkpoint save failed: {e}");
+                }
+            }
+
+            _tick = daily_ticker.tick() => {
+                let s = state.lock().await;
+                let summary = DailySummary::from_state(&s);
+                if let Err(e) = summary.write(&config.state_dir) {
+                    tracing::warn!("daily summary write failed: {e}");
+                }
+                tracing::info!(
+                    verdict = %summary.verdict,
+                    elapsed_hours = summary.elapsed_hours,
+                    "daily summary written"
+                );
+            }
+
+            _tick = tenant_rotation_ticker.tick() => {
+                rotate_oldest_tenant(&config, &state, &admin_http).await;
+            }
+        }
+    }
+
+    // Final summary on exit.
+    {
+        let s = state.lock().await;
+        let summary = DailySummary::from_state(&s);
+        let _ = summary.write(&config.state_dir);
+        tracing::info!(verdict = %summary.verdict, "final summary written");
+    }
+
+    Ok(())
+}
+
+/// Spawn one task per tenant per loop type.
+async fn spawn_loop_tasks(
+    config: &Arc<Config>,
+    state: &Arc<Mutex<HarnessState>>,
+    tx: tokio::sync::mpsc::Sender<crate::state::IterationOutcome>,
+    cancel: CancellationToken,
+) {
+    let tenants = state.lock().await.tenants.clone();
+    for tenant in tenants {
+        let cfg = Arc::clone(config);
+        let tx_ingest = tx.clone();
+        let cancel_i = cancel.clone();
+        let t = tenant.clone();
+        tokio::spawn(async move {
+            ingestion_worker(cfg, t, tx_ingest, cancel_i).await;
+        });
+
+        let cfg = Arc::clone(config);
+        let tx_agent = tx.clone();
+        let cancel_a = cancel.clone();
+        let t = tenant.clone();
+        tokio::spawn(async move {
+            agent_worker(cfg, t, tx_agent, cancel_a).await;
+        });
+
+        let cfg = Arc::clone(config);
+        let tx_query = tx.clone();
+        let cancel_q = cancel.clone();
+        let t = tenant.clone();
+        tokio::spawn(async move {
+            query_worker(cfg, t, tx_query, cancel_q).await;
+        });
+    }
+}
+
+async fn ingestion_worker(
+    config: Arc<Config>,
+    tenant: TenantRecord,
+    tx: tokio::sync::mpsc::Sender<crate::state::IterationOutcome>,
+    cancel: CancellationToken,
+) {
+    let password = TenantRecord::password_for_slot(tenant.slot);
+    let Ok(mut client) = ApiClient::new(&config.target_url) else {
+        return;
+    };
+
+    // Re-login on start.
+    if crate::tenant::login(&mut client, &tenant.email, &password)
+        .await
+        .is_err()
+    {
+        tracing::warn!(tenant_id = %tenant.tenant_id, "ingestion worker: initial login failed");
+    }
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            () = tokio::time::sleep(config.ingestion_interval) => {
+                let outcome = ingestion::run_once(&mut client, &tenant, &password).await;
+                if tx.send(outcome).await.is_err() { break; }
+            }
+        }
+    }
+}
+
+async fn agent_worker(
+    config: Arc<Config>,
+    tenant: TenantRecord,
+    tx: tokio::sync::mpsc::Sender<crate::state::IterationOutcome>,
+    cancel: CancellationToken,
+) {
+    let password = TenantRecord::password_for_slot(tenant.slot);
+    let Ok(mut client) = ApiClient::new(&config.target_url) else {
+        return;
+    };
+
+    if crate::tenant::login(&mut client, &tenant.email, &password)
+        .await
+        .is_err()
+    {
+        tracing::warn!(tenant_id = %tenant.tenant_id, "agent worker: initial login failed");
+    }
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            () = tokio::time::sleep(config.agent_interval) => {
+                let outcome = agent::run_once(&mut client, &tenant, &password).await;
+                if tx.send(outcome).await.is_err() { break; }
+            }
+        }
+    }
+}
+
+async fn query_worker(
+    config: Arc<Config>,
+    tenant: TenantRecord,
+    tx: tokio::sync::mpsc::Sender<crate::state::IterationOutcome>,
+    cancel: CancellationToken,
+) {
+    let password = TenantRecord::password_for_slot(tenant.slot);
+    let Ok(mut client) = ApiClient::new(&config.target_url) else {
+        return;
+    };
+
+    if crate::tenant::login(&mut client, &tenant.email, &password)
+        .await
+        .is_err()
+    {
+        tracing::warn!(tenant_id = %tenant.tenant_id, "query worker: initial login failed");
+    }
+
+    let mut iteration: u64 = 0;
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            () = tokio::time::sleep(config.query_interval) => {
+                let outcome = query::run_once(&mut client, &tenant, &password, iteration).await;
+                if tx.send(outcome).await.is_err() { break; }
+                iteration += 1;
+            }
+        }
+    }
+}
+
+/// Public entry point for `main.rs` provision-only mode.
+pub async fn ensure_tenant_pool_pub(
+    config: &Config,
+    state: &Arc<Mutex<HarnessState>>,
+    admin_http: &reqwest::Client,
+) -> Result<()> {
+    ensure_tenant_pool(config, state, admin_http).await
+}
+
+async fn ensure_tenant_pool(
+    config: &Config,
+    state: &Arc<Mutex<HarnessState>>,
+    _admin_http: &reqwest::Client,
+) -> Result<()> {
+    let (current_count, next_slot) = {
+        let s = state.lock().await;
+        (s.tenants.len(), s.next_slot)
+    };
+
+    let needed = config.tenant_count.saturating_sub(current_count);
+    if needed == 0 {
+        tracing::info!(count = current_count, "tenant pool already populated");
+        return Ok(());
+    }
+
+    tracing::info!(needed = needed, "provisioning synthetic tenants");
+    for i in 0..needed {
+        let slot = next_slot + i;
+        let mut client = ApiClient::new(&config.target_url)?;
+        match provision(&mut client, slot, &config.database_url).await {
+            Ok(record) => {
+                tracing::info!(slot = slot, tenant_id = %record.tenant_id, "provisioned tenant");
+                let mut s = state.lock().await;
+                s.tenants.push(record);
+                s.next_slot = slot + 1;
+            }
+            Err(e) => {
+                tracing::error!(slot = slot, error = %e, "failed to provision tenant");
+                return Err(e.context(format!("failed to provision tenant at slot {slot}")));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn rotate_oldest_tenant(
+    config: &Config,
+    state: &Arc<Mutex<HarnessState>>,
+    admin_http: &reqwest::Client,
+) {
+    let oldest = {
+        let s = state.lock().await;
+        s.tenants.first().cloned()
+    };
+    let Some(oldest) = oldest else {
+        return;
+    };
+
+    tracing::info!(tenant_id = %oldest.tenant_id, slot = oldest.slot, "rotating oldest tenant");
+
+    // Force-delete the oldest tenant.
+    if let Err(e) = force_delete(
+        admin_http,
+        &config.target_url,
+        &config.admin_token,
+        oldest.tenant_id,
+    )
+    .await
+    {
+        tracing::warn!(tenant_id = %oldest.tenant_id, error = %e, "force-delete failed; keeping tenant");
+        return;
+    }
+
+    // Remove from pool.
+    {
+        let mut s = state.lock().await;
+        s.tenants.retain(|t| t.tenant_id != oldest.tenant_id);
+    }
+
+    // Provision a replacement.
+    let next_slot = state.lock().await.next_slot;
+    let mut client = match ApiClient::new(&config.target_url) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("client build failed during rotation: {e}");
+            return;
+        }
+    };
+    match provision(&mut client, next_slot, &config.database_url).await {
+        Ok(record) => {
+            tracing::info!(slot = next_slot, tenant_id = %record.tenant_id, "replacement tenant provisioned");
+            let mut s = state.lock().await;
+            s.tenants.push(record);
+            s.next_slot = next_slot + 1;
+        }
+        Err(e) => {
+            tracing::warn!(slot = next_slot, error = %e, "replacement tenant provision failed");
+        }
+    }
+}

--- a/services/synthetic-load/src/loops/mod.rs
+++ b/services/synthetic-load/src/loops/mod.rs
@@ -52,7 +52,7 @@ pub async fn run(
     // Spawn the three per-tenant loop tasks.
     let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::state::IterationOutcome>(256);
 
-    spawn_loop_tasks(&config, &state, tx, cancel.clone()).await;
+    spawn_loop_tasks(&config, &state, tx.clone(), cancel.clone()).await;
 
     // Health check timer and daily report timer.
     let mut health_ticker = tokio::time::interval(config.health_interval);
@@ -168,7 +168,7 @@ pub async fn run(
             }
 
             _tick = tenant_rotation_ticker.tick() => {
-                rotate_oldest_tenant(&config, &state, &admin_http).await;
+                rotate_oldest_tenant(&config, &state, &admin_http, tx.clone(), cancel.clone()).await;
             }
         }
     }
@@ -177,7 +177,9 @@ pub async fn run(
     {
         let s = state.lock().await;
         let summary = DailySummary::from_state(&s);
-        let _ = summary.write(&config.state_dir);
+        if let Err(e) = summary.write(&config.state_dir) {
+            tracing::warn!("final summary write failed: {e}");
+        }
         tracing::info!(verdict = %summary.verdict, "final summary written");
     }
 
@@ -230,12 +232,13 @@ async fn ingestion_worker(
         return;
     };
 
-    // Re-login on start.
+    // Re-login on start; abort if credentials are rejected to avoid a silently broken worker.
     if crate::tenant::login(&mut client, &tenant.email, &password)
         .await
         .is_err()
     {
-        tracing::warn!(tenant_id = %tenant.tenant_id, "ingestion worker: initial login failed");
+        tracing::warn!(tenant_id = %tenant.tenant_id, "ingestion worker: initial login failed; aborting");
+        return;
     }
 
     loop {
@@ -264,7 +267,8 @@ async fn agent_worker(
         .await
         .is_err()
     {
-        tracing::warn!(tenant_id = %tenant.tenant_id, "agent worker: initial login failed");
+        tracing::warn!(tenant_id = %tenant.tenant_id, "agent worker: initial login failed; aborting");
+        return;
     }
 
     loop {
@@ -293,7 +297,8 @@ async fn query_worker(
         .await
         .is_err()
     {
-        tracing::warn!(tenant_id = %tenant.tenant_id, "query worker: initial login failed");
+        tracing::warn!(tenant_id = %tenant.tenant_id, "query worker: initial login failed; aborting");
+        return;
     }
 
     let mut iteration: u64 = 0;
@@ -355,9 +360,11 @@ async fn ensure_tenant_pool(
 }
 
 async fn rotate_oldest_tenant(
-    config: &Config,
+    config: &Arc<Config>,
     state: &Arc<Mutex<HarnessState>>,
     admin_http: &reqwest::Client,
+    tx: tokio::sync::mpsc::Sender<crate::state::IterationOutcome>,
+    cancel: CancellationToken,
 ) {
     let oldest = {
         let s = state.lock().await;
@@ -400,9 +407,35 @@ async fn rotate_oldest_tenant(
     match provision(&mut client, next_slot, &config.database_url).await {
         Ok(record) => {
             tracing::info!(slot = next_slot, tenant_id = %record.tenant_id, "replacement tenant provisioned");
-            let mut s = state.lock().await;
-            s.tenants.push(record);
-            s.next_slot = next_slot + 1;
+            {
+                let mut s = state.lock().await;
+                s.tenants.push(record.clone());
+                s.next_slot = next_slot + 1;
+            }
+
+            // Spawn all three worker tasks for the new tenant.
+            let cfg = Arc::clone(config);
+            let tx_i = tx.clone();
+            let cancel_i = cancel.clone();
+            let t = record.clone();
+            tokio::spawn(async move {
+                ingestion_worker(cfg, t, tx_i, cancel_i).await;
+            });
+
+            let cfg = Arc::clone(config);
+            let tx_a = tx.clone();
+            let cancel_a = cancel.clone();
+            let t = record.clone();
+            tokio::spawn(async move {
+                agent_worker(cfg, t, tx_a, cancel_a).await;
+            });
+
+            let cfg = Arc::clone(config);
+            let tx_q = tx;
+            let cancel_q = cancel;
+            tokio::spawn(async move {
+                query_worker(cfg, record, tx_q, cancel_q).await;
+            });
         }
         Err(e) => {
             tracing::warn!(slot = next_slot, error = %e, "replacement tenant provision failed");

--- a/services/synthetic-load/src/loops/query.rs
+++ b/services/synthetic-load/src/loops/query.rs
@@ -1,0 +1,91 @@
+//! Query loop — measures semantic search latency.
+//!
+//! ADR-012 §2.7.2: "Query-loop p95 latency ≤ 2 s".
+
+use std::time::Instant;
+
+use crate::client::{ApiClient, SearchRequest, SearchResponse, is_unauthorized};
+use crate::state::IterationOutcome;
+use crate::tenant::TenantRecord;
+
+/// Search terms rotated across iterations to exercise the embedding cache
+/// and cold-path lookups.
+const SEARCH_QUERIES: &[&str] = &[
+    "fn main",
+    "error handling",
+    "async function",
+    "database connection",
+    "HTTP handler",
+    "configuration loading",
+    "tenant isolation",
+    "Kafka consumer",
+    "metrics counter",
+    "graceful shutdown",
+];
+
+pub async fn run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+    iteration: u64,
+) -> IterationOutcome {
+    #[allow(clippy::cast_possible_truncation)]
+    let query = SEARCH_QUERIES[iteration as usize % SEARCH_QUERIES.len()];
+
+    match try_run_once(client, tenant, password, query).await {
+        Ok(latency_ms) => IterationOutcome {
+            loop_name: "query",
+            ok: true,
+            latency_ms: Some(latency_ms),
+            trace_id: None,
+        },
+        Err(e) => {
+            let trace_id = client.last_failed_trace_id.clone();
+            tracing::warn!(tenant_id = %tenant.tenant_id, error = %e, "query iteration failed");
+            IterationOutcome {
+                loop_name: "query",
+                ok: false,
+                latency_ms: None,
+                trace_id,
+            }
+        }
+    }
+}
+
+async fn try_run_once(
+    client: &mut ApiClient,
+    tenant: &TenantRecord,
+    password: &str,
+    query: &str,
+) -> anyhow::Result<u64> {
+    let t0 = Instant::now();
+
+    let _resp: SearchResponse = match client
+        .post_json(
+            "/v1/search",
+            &SearchRequest {
+                q: query.to_owned(),
+                limit: Some(10),
+            },
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) if is_unauthorized(&e) => {
+            crate::tenant::login(client, &tenant.email, password).await?;
+            client
+                .post_json(
+                    "/v1/search",
+                    &SearchRequest {
+                        q: query.to_owned(),
+                        limit: Some(10),
+                    },
+                )
+                .await?
+        }
+        Err(e) => return Err(e),
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(t0.elapsed().as_millis() as u64)
+}

--- a/services/synthetic-load/src/main.rs
+++ b/services/synthetic-load/src/main.rs
@@ -211,7 +211,9 @@ async fn shutdown_signal() {
                 stream.recv().await;
             }
             Err(e) => {
-                tracing::warn!("SIGTERM handler install failed: {e}; SIGTERM will not trigger shutdown");
+                tracing::warn!(
+                    "SIGTERM handler install failed: {e}; SIGTERM will not trigger shutdown"
+                );
                 std::future::pending::<()>().await;
             }
         }

--- a/services/synthetic-load/src/main.rs
+++ b/services/synthetic-load/src/main.rs
@@ -1,0 +1,220 @@
+//! Synthetic-load harness for Wave 8 7-day pre-prod exit run.
+//!
+//! ADR-012 §2.7 — Platform Engineer implementation.
+//!
+//! Usage:
+//!   synthetic-load start        # run the harness
+//!   synthetic-load provision    # only provision tenant pool, then exit
+//!   synthetic-load report       # print the latest daily summary and exit
+//!   synthetic-load build-info   # print compile-time build provenance and exit
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use clap::{Parser, Subcommand};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+mod client;
+mod config;
+mod health;
+mod loops;
+mod report;
+mod state;
+mod tenant;
+
+use config::Config;
+use state::HarnessState;
+
+#[derive(Parser)]
+#[command(name = "synthetic-load", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the harness and run for the configured soak duration.
+    Start,
+
+    /// Provision the tenant pool only, then exit. Useful for pre-flight.
+    Provision,
+
+    /// Print the most recent daily summary from the state directory and exit.
+    Report,
+
+    /// Print compile-time build provenance as JSON and exit.
+    BuildInfo,
+}
+
+fn validate_boot_env(config: &Config) -> Result<()> {
+    let mut errors: Vec<String> = Vec::new();
+
+    if config.target_url.is_empty() {
+        errors.push("SYNTHETIC_LOAD_TARGET: required but empty".to_owned());
+    }
+    if config.admin_token.is_empty() {
+        errors.push("SYNTHETIC_LOAD_ADMIN_TOKEN: required but empty".to_owned());
+    }
+    if config.database_url.is_empty() {
+        errors.push("SYNTHETIC_LOAD_DATABASE_URL or DATABASE_URL: required but empty".to_owned());
+    }
+
+    if !errors.is_empty() {
+        anyhow::bail!(
+            "synthetic-load boot validation failed ({} error(s)):\n{}",
+            errors.len(),
+            errors
+                .iter()
+                .map(|e| format!("  - {e}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    if let Command::BuildInfo = cli.command {
+        let info = rb_build_info::get();
+        println!(
+            "{}",
+            serde_json::json!({
+                "sha": info.sha,
+                "timestamp": info.timestamp,
+                "dirty": info.dirty,
+            })
+        );
+        return Ok(());
+    }
+
+    let config = Config::from_env().context("failed to load config from environment")?;
+
+    match cli.command {
+        Command::Report => {
+            return print_latest_report(&config);
+        }
+        Command::BuildInfo => unreachable!(),
+        _ => {}
+    }
+
+    validate_boot_env(&config)?;
+
+    let _guard = rb_tracing::init("synthetic-load")?;
+    rb_metrics::spawn_metrics_server(rb_metrics::install_recorder("synthetic-load")?);
+
+    tracing::info!(
+        target = %config.target_url,
+        tenant_count = config.tenant_count,
+        soak_days = config.soak_duration.as_secs() / 86400,
+        "synthetic-load harness starting"
+    );
+
+    let state = Arc::new(Mutex::new(
+        HarnessState::load_or_new(&config.state_dir).context("failed to load harness state")?,
+    ));
+    let config = Arc::new(config);
+    let cancel = CancellationToken::new();
+
+    match cli.command {
+        Command::Provision => {
+            provision_only(&config, &state).await?;
+            tracing::info!("provision complete");
+        }
+        Command::Start => {
+            let cancel_clone = cancel.clone();
+            let cancel_signal = cancel.clone();
+
+            // Wire graceful shutdown.
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                tracing::info!("shutdown signal received");
+                cancel_signal.cancel();
+            });
+
+            // Enforce soak duration.
+            let soak_dur = config.soak_duration;
+            let cancel_timer = cancel.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(soak_dur).await;
+                tracing::info!("soak duration elapsed; initiating clean shutdown");
+                cancel_timer.cancel();
+            });
+
+            let result = loops::run(Arc::clone(&config), Arc::clone(&state), cancel_clone).await;
+
+            // Save final state.
+            {
+                let mut s = state.lock().await;
+                let _ = s.save(&config.state_dir);
+            }
+
+            return result;
+        }
+        Command::BuildInfo | Command::Report => unreachable!(),
+    }
+
+    Ok(())
+}
+
+async fn provision_only(config: &Arc<Config>, state: &Arc<Mutex<HarnessState>>) -> Result<()> {
+    let admin_http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    loops::ensure_tenant_pool_pub(config, state, &admin_http).await
+}
+
+fn print_latest_report(config: &Config) -> Result<()> {
+    let dir = &config.state_dir;
+    // Find the most recently modified JSON file (excluding harness-state.json).
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read state dir {}", dir.display()))?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| {
+            let n = e.file_name();
+            let name = n.to_string_lossy();
+            name.ends_with(".json")
+                && name != "harness-state.json"
+                && name != "harness-state.json.tmp"
+        })
+        .collect();
+
+    entries.sort_by_key(|e| std::cmp::Reverse(e.metadata().ok().and_then(|m| m.modified().ok())));
+
+    let Some(entry) = entries.first() else {
+        anyhow::bail!("no daily summary files found in {}", dir.display());
+    };
+
+    let bytes = std::fs::read(entry.path())
+        .with_context(|| format!("failed to read {}", entry.path().display()))?;
+    println!("{}", String::from_utf8_lossy(&bytes));
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}

--- a/services/synthetic-load/src/main.rs
+++ b/services/synthetic-load/src/main.rs
@@ -150,7 +150,9 @@ async fn main() -> Result<()> {
             // Save final state.
             {
                 let mut s = state.lock().await;
-                let _ = s.save(&config.state_dir);
+                if let Err(e) = s.save(&config.state_dir) {
+                    tracing::warn!("final state save failed: {e}");
+                }
             }
 
             return result;
@@ -197,17 +199,22 @@ fn print_latest_report(config: &Config) -> Result<()> {
 
 async fn shutdown_signal() {
     let ctrl_c = async {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("failed to install CTRL+C handler");
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::warn!("CTRL+C handler error: {e}");
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut stream) => {
+                stream.recv().await;
+            }
+            Err(e) => {
+                tracing::warn!("SIGTERM handler install failed: {e}; SIGTERM will not trigger shutdown");
+                std::future::pending::<()>().await;
+            }
+        }
     };
 
     #[cfg(not(unix))]

--- a/services/synthetic-load/src/report.rs
+++ b/services/synthetic-load/src/report.rs
@@ -1,0 +1,167 @@
+//! Daily summary report — one JSON file per UTC day.
+//!
+//! Written to `<state_dir>/<date>.json`. Pass/fail verdict per ADR-012 §2.7.2.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::state::HarnessState;
+
+/// ADR-012 §2.7.2 pass/fail thresholds.
+pub const AVAILABILITY_THRESHOLD_PCT: f64 = 99.5;
+pub const INGESTION_SUCCESS_THRESHOLD_PCT: f64 = 99.0;
+pub const AGENT_SUCCESS_THRESHOLD_PCT: f64 = 95.0;
+pub const QUERY_P95_LATENCY_THRESHOLD_SECS: f64 = 2.0;
+pub const KAFKA_LAG_THRESHOLD: u64 = 10_000;
+pub const OUTBOX_AGE_THRESHOLD_SECS: f64 = 60.0;
+
+/// Verdict for a single threshold check.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ThresholdCheck {
+    pub name: String,
+    pub threshold: String,
+    pub actual: String,
+    pub pass: bool,
+}
+
+/// Daily summary written to `<state_dir>/<date>.json`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DailySummary {
+    pub date: String,
+    pub generated_at: DateTime<Utc>,
+    pub run_number: u32,
+    pub elapsed_hours: f64,
+
+    pub ingestion_ok: u64,
+    pub ingestion_err: u64,
+    pub ingestion_success_pct: f64,
+
+    pub agent_ok: u64,
+    pub agent_err: u64,
+    pub agent_success_pct: f64,
+
+    pub query_ok: u64,
+    pub query_err: u64,
+    pub query_success_pct: f64,
+
+    pub query_p95_latency_secs: Option<f64>,
+
+    pub health_checks_total: u64,
+    pub health_checks_failed: u64,
+    pub availability_pct: f64,
+    pub degradation_events: u64,
+    pub drift_events: u64,
+
+    pub last_failed_trace_id: Option<String>,
+
+    pub threshold_checks: Vec<ThresholdCheck>,
+
+    /// Overall pass/fail verdict for the Wave 8 exit gate.
+    pub verdict: String,
+}
+
+impl DailySummary {
+    pub fn from_state(state: &HarnessState) -> Self {
+        let now = Utc::now();
+        let date = now.format("%Y-%m-%d").to_string();
+        let elapsed_hours = state.elapsed_secs() / 3600.0;
+
+        let ingestion_success_pct = state.ingestion.success_rate();
+        let agent_success_pct = state.agent.success_rate();
+        let query_success_pct = state.query.success_rate();
+        let availability_pct = state.health.availability_pct();
+        let query_p95 = state.query_p95_seconds();
+
+        let checks = build_threshold_checks(
+            availability_pct,
+            ingestion_success_pct,
+            agent_success_pct,
+            query_p95,
+        );
+
+        let verdict = if checks.iter().all(|c| c.pass) {
+            "PASS".to_owned()
+        } else {
+            "FAIL".to_owned()
+        };
+
+        Self {
+            date,
+            generated_at: now,
+            run_number: state.run_number,
+            elapsed_hours,
+            ingestion_ok: state.ingestion.iterations_ok,
+            ingestion_err: state.ingestion.iterations_err,
+            ingestion_success_pct,
+            agent_ok: state.agent.iterations_ok,
+            agent_err: state.agent.iterations_err,
+            agent_success_pct,
+            query_ok: state.query.iterations_ok,
+            query_err: state.query.iterations_err,
+            query_success_pct,
+            query_p95_latency_secs: query_p95,
+            health_checks_total: state.health.checks_total,
+            health_checks_failed: state.health.checks_failed,
+            availability_pct,
+            degradation_events: state.health.degradation_events,
+            drift_events: state.health.drift_events,
+            last_failed_trace_id: state.last_failed_trace_id.clone(),
+            threshold_checks: checks,
+            verdict,
+        }
+    }
+
+    /// Write to `<state_dir>/<date>.json`.
+    pub fn write(&self, state_dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(state_dir)
+            .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+        let path = state_dir.join(format!("{}.json", self.date));
+        let bytes = serde_json::to_vec_pretty(self).context("failed to serialize daily summary")?;
+        std::fs::write(&path, &bytes)
+            .with_context(|| format!("failed to write daily summary to {}", path.display()))?;
+        tracing::info!(path = %path.display(), verdict = %self.verdict, "daily summary written");
+        Ok(())
+    }
+}
+
+fn build_threshold_checks(
+    availability_pct: f64,
+    ingestion_success_pct: f64,
+    agent_success_pct: f64,
+    query_p95: Option<f64>,
+) -> Vec<ThresholdCheck> {
+    let mut checks = vec![
+        ThresholdCheck {
+            name: "availability".to_owned(),
+            threshold: format!("≥ {AVAILABILITY_THRESHOLD_PCT:.1}%"),
+            actual: format!("{availability_pct:.2}%"),
+            pass: availability_pct >= AVAILABILITY_THRESHOLD_PCT,
+        },
+        ThresholdCheck {
+            name: "ingestion_success_rate".to_owned(),
+            threshold: format!("≥ {INGESTION_SUCCESS_THRESHOLD_PCT:.1}%"),
+            actual: format!("{ingestion_success_pct:.2}%"),
+            pass: ingestion_success_pct >= INGESTION_SUCCESS_THRESHOLD_PCT,
+        },
+        ThresholdCheck {
+            name: "agent_success_rate".to_owned(),
+            threshold: format!("≥ {AGENT_SUCCESS_THRESHOLD_PCT:.1}%"),
+            actual: format!("{agent_success_pct:.2}%"),
+            pass: agent_success_pct >= AGENT_SUCCESS_THRESHOLD_PCT,
+        },
+    ];
+
+    if let Some(p95) = query_p95 {
+        checks.push(ThresholdCheck {
+            name: "query_p95_latency".to_owned(),
+            threshold: format!("≤ {QUERY_P95_LATENCY_THRESHOLD_SECS:.1} s"),
+            actual: format!("{p95:.3} s"),
+            pass: p95 <= QUERY_P95_LATENCY_THRESHOLD_SECS,
+        });
+    }
+
+    checks
+}

--- a/services/synthetic-load/src/state.rs
+++ b/services/synthetic-load/src/state.rs
@@ -5,6 +5,7 @@
 //! the last checkpoint and now exceeds 1 hour, the soak clock resets to zero
 //! (ADR-012 §2.7.2 resume semantics).
 
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -54,7 +55,6 @@ pub struct HealthCounters {
     pub checks_failed: u64,
     pub degradation_events: u64,
     pub drift_events: u64,
-    pub db_unavailable_since: Option<DateTime<Utc>>,
 }
 
 impl HealthCounters {
@@ -101,9 +101,8 @@ pub struct HarnessState {
     /// Trace ID of the most recent failed request across any loop.
     pub last_failed_trace_id: Option<String>,
 
-    /// Cumulative query latency samples for p95 approximation.
-    /// Stored as a rolling window of the last 1000 samples.
-    pub query_latency_samples_ms: Vec<u64>,
+    /// Rolling window of the last 1000 query latency samples for p95 approximation.
+    pub query_latency_samples_ms: VecDeque<u64>,
 }
 
 impl HarnessState {
@@ -121,7 +120,7 @@ impl HarnessState {
             health: HealthCounters::default(),
             expected_sha: None,
             last_failed_trace_id: None,
-            query_latency_samples_ms: Vec::new(),
+            query_latency_samples_ms: VecDeque::new(),
         }
     }
 
@@ -135,9 +134,9 @@ impl HarnessState {
     /// Append a query latency sample; keep the window at ≤1000 entries.
     pub fn record_query_latency(&mut self, latency_ms: u64) {
         if self.query_latency_samples_ms.len() >= 1000 {
-            self.query_latency_samples_ms.remove(0);
+            self.query_latency_samples_ms.pop_front();
         }
-        self.query_latency_samples_ms.push(latency_ms);
+        self.query_latency_samples_ms.push_back(latency_ms);
     }
 
     /// Approximate p95 query latency in seconds from the rolling window.
@@ -145,7 +144,7 @@ impl HarnessState {
         if self.query_latency_samples_ms.is_empty() {
             return None;
         }
-        let mut sorted = self.query_latency_samples_ms.clone();
+        let mut sorted: Vec<u64> = self.query_latency_samples_ms.iter().copied().collect();
         sorted.sort_unstable();
         #[allow(
             clippy::cast_precision_loss,

--- a/services/synthetic-load/src/state.rs
+++ b/services/synthetic-load/src/state.rs
@@ -1,0 +1,230 @@
+//! Persisted harness state — checkpoint and resume semantics.
+//!
+//! State is written to `<state_dir>/harness-state.json` on every checkpoint.
+//! On restart, the harness loads this file and resumes. If the gap between
+//! the last checkpoint and now exceeds 1 hour, the soak clock resets to zero
+//! (ADR-012 §2.7.2 resume semantics).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::tenant::TenantRecord;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const STATE_FILE: &str = "harness-state.json";
+const RESUME_GAP_LIMIT: Duration = Duration::from_secs(3600);
+
+/// Per-loop iteration counters.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct LoopCounters {
+    pub iterations_ok: u64,
+    pub iterations_err: u64,
+}
+
+impl LoopCounters {
+    pub fn record(&mut self, ok: bool) {
+        if ok {
+            self.iterations_ok += 1;
+        } else {
+            self.iterations_err += 1;
+        }
+    }
+
+    pub fn total(&self) -> u64 {
+        self.iterations_ok + self.iterations_err
+    }
+
+    pub fn success_rate(&self) -> f64 {
+        let t = self.total();
+        if t == 0 {
+            return 100.0;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let result = (self.iterations_ok as f64 / t as f64) * 100.0;
+        result
+    }
+}
+
+/// Accumulated health-gate state over the run.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct HealthCounters {
+    pub checks_total: u64,
+    pub checks_failed: u64,
+    pub degradation_events: u64,
+    pub drift_events: u64,
+    pub db_unavailable_since: Option<DateTime<Utc>>,
+}
+
+impl HealthCounters {
+    pub fn availability_pct(&self) -> f64 {
+        if self.checks_total == 0 {
+            return 100.0;
+        }
+        let passed = self.checks_total.saturating_sub(self.checks_failed);
+        #[allow(clippy::cast_precision_loss)]
+        let result = (passed as f64 / self.checks_total as f64) * 100.0;
+        result
+    }
+}
+
+/// Top-level persisted harness state.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HarnessState {
+    /// Wall-clock time when the soak effectively started (after any resume).
+    pub effective_start: DateTime<Utc>,
+
+    /// Time of the last checkpoint write.
+    pub last_checkpoint: DateTime<Utc>,
+
+    /// Run number — incremented each time the soak clock is reset.
+    pub run_number: u32,
+
+    /// Provisioned tenant pool.
+    pub tenants: Vec<TenantRecord>,
+
+    /// Next slot number for new tenant provisioning.
+    pub next_slot: usize,
+
+    /// Loop-specific counters.
+    pub ingestion: LoopCounters,
+    pub agent: LoopCounters,
+    pub query: LoopCounters,
+
+    /// Health gate counters.
+    pub health: HealthCounters,
+
+    /// SHA captured at harness start (from the first health/build response).
+    pub expected_sha: Option<String>,
+
+    /// Trace ID of the most recent failed request across any loop.
+    pub last_failed_trace_id: Option<String>,
+
+    /// Cumulative query latency samples for p95 approximation.
+    /// Stored as a rolling window of the last 1000 samples.
+    pub query_latency_samples_ms: Vec<u64>,
+}
+
+impl HarnessState {
+    pub fn new() -> Self {
+        let now = Utc::now();
+        Self {
+            effective_start: now,
+            last_checkpoint: now,
+            run_number: 1,
+            tenants: Vec::new(),
+            next_slot: 0,
+            ingestion: LoopCounters::default(),
+            agent: LoopCounters::default(),
+            query: LoopCounters::default(),
+            health: HealthCounters::default(),
+            expected_sha: None,
+            last_failed_trace_id: None,
+            query_latency_samples_ms: Vec::new(),
+        }
+    }
+
+    /// Seconds elapsed since `effective_start`.
+    pub fn elapsed_secs(&self) -> f64 {
+        #[allow(clippy::cast_precision_loss)]
+        let secs = (Utc::now() - self.effective_start).num_seconds() as f64;
+        secs
+    }
+
+    /// Append a query latency sample; keep the window at ≤1000 entries.
+    pub fn record_query_latency(&mut self, latency_ms: u64) {
+        if self.query_latency_samples_ms.len() >= 1000 {
+            self.query_latency_samples_ms.remove(0);
+        }
+        self.query_latency_samples_ms.push(latency_ms);
+    }
+
+    /// Approximate p95 query latency in seconds from the rolling window.
+    pub fn query_p95_seconds(&self) -> Option<f64> {
+        if self.query_latency_samples_ms.is_empty() {
+            return None;
+        }
+        let mut sorted = self.query_latency_samples_ms.clone();
+        sorted.sort_unstable();
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let idx = (sorted.len() as f64 * 0.95) as usize;
+        let idx = idx.min(sorted.len() - 1);
+        #[allow(clippy::cast_precision_loss)]
+        Some(sorted[idx] as f64 / 1000.0)
+    }
+
+    /// Path to the state file.
+    pub fn state_file(state_dir: &Path) -> PathBuf {
+        state_dir.join(STATE_FILE)
+    }
+
+    /// Load from disk, applying resume semantics. Returns a fresh state if the
+    /// file does not exist.
+    pub fn load_or_new(state_dir: &Path) -> Result<Self> {
+        let path = Self::state_file(state_dir);
+        if !path.exists() {
+            tracing::info!("no prior state file; starting fresh soak");
+            return Ok(Self::new());
+        }
+
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("failed to read state file {}", path.display()))?;
+        let mut state: Self = serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse state file {}", path.display()))?;
+
+        let gap = Utc::now() - state.last_checkpoint;
+        let gap_duration = Duration::from_secs(gap.num_seconds().unsigned_abs());
+
+        if gap_duration > RESUME_GAP_LIMIT {
+            tracing::warn!(
+                gap_secs = gap.num_seconds(),
+                "gap exceeds 1 h — resetting soak clock"
+            );
+            state.effective_start = Utc::now();
+            state.run_number += 1;
+        } else {
+            tracing::info!(
+                gap_secs = gap.num_seconds(),
+                run_number = state.run_number,
+                "resuming harness; gap within 1 h threshold"
+            );
+        }
+        state.last_checkpoint = Utc::now();
+        Ok(state)
+    }
+
+    /// Persist to disk atomically (write temp then rename).
+    pub fn save(&mut self, state_dir: &Path) -> Result<()> {
+        self.last_checkpoint = Utc::now();
+        let path = Self::state_file(state_dir);
+        std::fs::create_dir_all(state_dir)
+            .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+        let tmp = path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(self).context("failed to serialize state")?;
+        std::fs::write(&tmp, &bytes)
+            .with_context(|| format!("failed to write temp state file {}", tmp.display()))?;
+        std::fs::rename(&tmp, &path)
+            .with_context(|| format!("failed to rename state file to {}", path.display()))?;
+        Ok(())
+    }
+}
+
+impl Default for HarnessState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Outcome of one loop iteration.
+#[derive(Debug, Clone)]
+pub struct IterationOutcome {
+    pub loop_name: &'static str,
+    pub ok: bool,
+    pub latency_ms: Option<u64>,
+    pub trace_id: Option<String>,
+}

--- a/services/synthetic-load/src/tenant.rs
+++ b/services/synthetic-load/src/tenant.rs
@@ -1,0 +1,166 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPoolOptions;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::client::{ApiClient, LoginRequest, LoginResponse, SignupRequest, SignupResponse};
+
+/// A provisioned synthetic tenant with credentials for re-login.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TenantRecord {
+    pub slot: usize,
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub email: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl TenantRecord {
+    pub fn password_for_slot(slot: usize) -> String {
+        // Deterministic 20-char password, satisfies the ≥12 char requirement.
+        format!("SynthLoad-{slot}-2026!Harness")
+    }
+}
+
+/// Create a new synthetic tenant at `slot`, verify its email via Postgres,
+/// and return a `TenantRecord`.
+///
+/// The client's session cookie is updated to this tenant after a successful login.
+pub async fn provision(
+    client: &mut ApiClient,
+    slot: usize,
+    database_url: &str,
+) -> Result<TenantRecord> {
+    let email = format!("synth-load-{slot}@synthetic.internal");
+    let tenant_name = format!("synth-load-{slot}");
+    let password = TenantRecord::password_for_slot(slot);
+
+    // 1. Sign up
+    let signup: SignupResponse = client
+        .post_json(
+            "/v1/auth/signup",
+            &SignupRequest {
+                email: email.clone(),
+                password: password.clone(),
+                tenant_name,
+            },
+        )
+        .await
+        .with_context(|| format!("signup for slot {slot} failed"))?;
+
+    // 2. Verify email directly in Postgres (same pattern as board-smoke.sh)
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(10))
+        .connect(database_url)
+        .await
+        .context("failed to connect to Postgres for email verification")?;
+
+    sqlx::query(
+        "UPDATE control.users SET email_verified_at = now() \
+         WHERE email = $1 AND email_verified_at IS NULL",
+    )
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .context("email verification UPDATE failed")?;
+
+    let tenant_id: Uuid = sqlx::query_scalar(
+        "SELECT tm.tenant_id FROM control.tenant_members tm \
+         JOIN control.users u ON u.id = tm.user_id \
+         WHERE u.email = $1 \
+         LIMIT 1",
+    )
+    .bind(&email)
+    .fetch_one(&pool)
+    .await
+    .context("could not look up tenant_id for new signup")?;
+
+    pool.close().await;
+
+    // 3. Login — sets the session cookie in the client
+    login(client, &email, &password).await?;
+
+    Ok(TenantRecord {
+        slot,
+        tenant_id,
+        user_id: signup.user_id,
+        email,
+        created_at: chrono::Utc::now(),
+    })
+}
+
+/// Log in and refresh the session cookie on the client.
+pub async fn login(client: &mut ApiClient, email: &str, password: &str) -> Result<LoginResponse> {
+    client
+        .post_json(
+            "/v1/auth/login",
+            &LoginRequest {
+                email: email.to_owned(),
+                password: password.to_owned(),
+            },
+        )
+        .await
+        .with_context(|| format!("login for {email} failed"))
+}
+
+/// Two-phase force-delete for a synthetic tenant.
+///
+/// Phase 1: POST without `confirm_token` → get `confirm_token`.
+/// Phase 2: POST with `confirm_token` → execute deletion.
+///
+/// Uses the admin bearer token (not the tenant's session cookie).
+pub async fn force_delete(
+    http: &reqwest::Client,
+    base_url: &str,
+    admin_token: &str,
+    tenant_id: Uuid,
+) -> Result<()> {
+    #[derive(Deserialize)]
+    struct Phase1Resp {
+        confirm_token: String,
+    }
+    #[derive(Serialize)]
+    struct Req {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        confirm_token: Option<String>,
+    }
+
+    let path = format!(
+        "{}/api/admin/v1/tenants/{tenant_id}/force-delete",
+        base_url.trim_end_matches('/')
+    );
+
+    // Phase 1 — dry-run
+    let p1: Phase1Resp = http
+        .post(&path)
+        .bearer_auth(admin_token)
+        .header("X-Admin-Actor", "synthetic-load-harness")
+        .json(&Req {
+            confirm_token: None,
+        })
+        .send()
+        .await
+        .context("force-delete phase-1 network error")?
+        .error_for_status()
+        .context("force-delete phase-1 error")?
+        .json()
+        .await
+        .context("force-delete phase-1 deserialize")?;
+
+    // Phase 2 — confirm
+    http.post(&path)
+        .bearer_auth(admin_token)
+        .header("X-Admin-Actor", "synthetic-load-harness")
+        .json(&Req {
+            confirm_token: Some(p1.confirm_token),
+        })
+        .send()
+        .await
+        .context("force-delete phase-2 network error")?
+        .error_for_status()
+        .context("force-delete phase-2 error")?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the Wave 8 S7 deliverable: a self-contained Rust binary that
drives the pre-prod deployment unattended for 7 days, satisfying the Wave 8
exit criterion defined in ADR-012 §2.7.

- Three concurrent workload loops per synthetic tenant: ingestion, agent session, and semantic search
- 10 synthetic tenants provisioned via signup → direct Postgres email verification → session cookie auth
- Admin force-delete (`/api/admin/v1/tenants/{id}/force-delete`) used for 2h rotation
- Health gating every 60s; Prometheus scrape for `rb_outbox_age_seconds` + `rb_kafka_consumer_lag`
- Catastrophic failure (all services down >5 min) → clean exit with non-zero code
- State persisted to `~/.local/state/rustbrain/synthetic-load/` with gap-based resume semantics
- Hourly daily JSON summaries with pass/fail verdicts (availability ≥ 99.5%, ingestion ≥ 99%, agent ≥ 95%, query p95 ≤ 2s)

## GitHub Issue

Closes #633

## Migration type

None — no schema migrations in this PR.

## Checklist

- [x] `cargo check -p synthetic-load` passes
- [x] `cargo clippy -p synthetic-load --all-targets -- -D warnings` passes
- [x] `cargo fmt -p synthetic-load -- --check` passes
- [x] `cargo deny check` passes
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Docs: `docs/PORT_MAP.md` — no new port; harness is an operator tool, not a long-running server