### PR TITLE
[RUSAA-1780] ci: add synthetic-load to docker build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
               - *workspace
               - 'services/typecheck-worker/**'
               - 'docker/typecheck-worker/**'
+            synthetic-load:
+              - *workspace
+              - 'services/synthetic-load/**'
+              - 'docker/synthetic-load/**'
       - id: compute
         env:
           EVENT: ${{ github.event_name }}
@@ -99,7 +103,7 @@ jobs:
           CHANGED: ${{ steps.filter.outputs.changes }}
         run: |
           set -euo pipefail
-          ALL='["agent-runner","control-api","embed-worker","expand-worker","frontend","ingest-clone","ingest-graph","parse-worker","projector-neo4j","projector-pg","tombstoner","typecheck-worker"]'
+          ALL='["agent-runner","control-api","embed-worker","expand-worker","frontend","ingest-clone","ingest-graph","parse-worker","projector-neo4j","projector-pg","tombstoner","typecheck-worker","synthetic-load"]'
           # On push-to-main, always build every image so :sha-<sha> tags exist
           # for every service. The path filter is only an optimisation for PRs.
           if [ "$EVENT" = "push" ] && [ "$REF" = "refs/heads/main" ]; then


### PR DESCRIPTION
## Summary

- Register `synthetic-load` in the `paths-filter` block so PR CI builds the image when `services/synthetic-load/**` or `docker/synthetic-load/**` change
- Add `"synthetic-load"` to the `ALL` JSON array so push-to-main always produces a `:sha-<sha>` tag in GHCR

## GitHub Issue

Closes #635

## Migration type

N/A — CI workflow YAML only, no schema or binary changes.

## Checklist

- [x] `ci.yml` paths-filter includes `synthetic-load:` entry
- [x] `ci.yml` ALL array includes `"synthetic-load"`
- [x] No source-code changes
- [x] No `RUSAA-XX` in body or commit messages