### PR TITLE
[RUSAA-1822] docs: Wave 9 — chat panel user guide, runtime adapter contract, MCP tokens, operator runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to Rustacean (rust-brain) are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+---
+
+## [Wave 9] - 2026-06-xx (Unreleased)
+
+Interactive chat panel + pluggable runtime over Rustacean MCP.
+
+### Added
+
+- **Chat panel** -- interactive coding assistant in the UI. Users open a chat session, send messages, and stream assistant responses in real time via SSE. Flag-gated behind `RB_CHAT_PANEL_ENABLED` (default off).
+- **Chat gateway** -- `POST /v1/chat/sessions`, `POST /v1/chat/sessions/{id}/messages`, `GET /v1/chat/sessions/{id}/events` (SSE), `POST /v1/chat/sessions/{id}/end`. Authenticated via session cookie or API key.
+- **Runtime adapter generalization** -- `RuntimeAdapter` trait widened with `manifest()` and `health()` methods. A new runtime plugs in with one adapter impl + one registry line; zero gateway/persistence changes.
+- **MCP chat tokens** -- short-lived HS256 JWT (`aud=rb-mcp`, `scope=["read"]`, 15 min TTL) replaces the long-lived `RB_AGENT_API_KEY` for chat sessions. Minted per session, auto-refreshed on activity, tenant-bound.
+- **Log-redaction contract** -- mandatory redaction pass strips JWTs, bearer tokens, and secrets from runtime output before persistence, SSE, or logging. Fail-closed: unredactable lines are dropped.
+- **Chat persistence** -- `control.chat_sessions` and `control.chat_messages` tables (migration `021_chat_panel.sql`). 90-day retention, `ON DELETE CASCADE` to tenants.
+- **Scope enforcement** -- chat MCP tools restricted to read-only (`search_items`, `get_item`, `get_callers`, `get_callees`, `get_trait_impls`). Write/admin tools rejected with `-32601 insufficient_scope`.
+
+### Documentation
+
+- `docs/chat-panel.md` -- user guide (enable flag, prompt examples, troubleshooting)
+- `docs/runtime-adapter.md` -- runtime adapter contract and new-adapter authoring guide
+- `docs/mcp-chat-tokens.md` -- MCP token model, lifecycle, redaction contract
+- `docs/decisions/ADR-013-chat-panel-architecture.md` -- architecture decision record
+- `docs/runbook.md` -- Wave 9 operator section (flag toggle, key rotation, runtime inspection)
+
+### Architecture
+
+- ADR-013: Chat-Panel Architecture, Runtime Contract & MCP Token Model
+- No new binary, no new Kafka topic. Chat reuses the Wave 7 agent execution substrate (`agent-runner`, SSE relay, `McpSessionStore`, audit).
+- JWT mint/verify in `rb-auth` (pure crate, no service dep). Preserves `crates <- services` one-way rule.
+
+---
+
+## [Wave 8] - 2026-05-31
+
+Hardening & polish across all services.
+
+### Added
+
+- Admin v1 operator endpoints (bootstrap, impersonate, force-delete, rebind-gh-install, audit-log)
+- Grafana dashboards + `grafana-lint` CI gate
+- Distributed tracing: `X-Trace-Id` header + trace-redirect endpoint
+- `GET /metrics` on all services (Prometheus scrape)
+- Synthetic-load harness for 7-day pre-prod soak
+- Drift detector promoted to fail-on-drift + scheduled GHA
+- Board happy-path E2E smoke suite
+
+### Documentation
+
+- ADR-012: Wave 8 Hardening & Polish
+
+---
+
+## [Wave 7] - 2026-05-19
+
+Agent execution architecture.
+
+### Added
+
+- MCP server (`POST /mcp`) with read-only tools
+- Agent sessions (`/v1/agents/sessions/*`) with streaming SSE events
+- Runtime adapters: Claude Code (OAuth), OpenCode (LiteLLM), Pi (stub)
+- Workspace isolation + `workspace_gc` orphan reaper
+- SSE event relay with `Last-Event-ID` replay
+
+### Documentation
+
+- ADR-009: Agent Execution Architecture (rev 6)
+- Operator runbooks bundle

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -36,6 +36,9 @@ The control-api service reads all configuration from environment variables. None
 | `RB_OLLAMA_URL` | — | no | Ollama HTTP base URL (e.g. `http://ollama:11434`). Search endpoint returns 503 when absent. |
 | `RB_EMBEDDING_MODEL` | `nomic-embed-text` | no | Ollama model for query embedding. Must match the model used by `embed-worker`. |
 | `RUST_LOG` | — | no | Log filter (e.g. `info,control_api=debug`) |
+| `RB_CHAT_PANEL_ENABLED` | `false` | no | Enable the chat panel feature flag. When `false`, `/v1/chat/*` routes return 404. |
+| `RB_MCP_JWT_SECRET` | — | no | HS256 signing key for MCP session JWTs (required when chat is enabled). See [runtime-config.md](runtime-config.md). |
+| `RB_MCP_JWT_TTL_SECS` | `900` | no | MCP JWT lifetime in seconds. |
 
 ---
 
@@ -1147,6 +1150,227 @@ Streamable HTTP JSON-RPC 2.0 endpoint implementing the [Model Context Protocol](
 | `run_query` | Raw Cypher query (requires `admin` scope) |
 
 See the `rb-mcp` crate and [ADR-009 §6.2](decisions/ADR-009-agent-execution-architecture.md) for tool schemas and security model.
+
+**Wave 9 addition**: the `/mcp` endpoint also accepts a short-lived JWT (`aud=rb-mcp`) as the Bearer token. Chat sessions use this path instead of long-lived API keys. The JWT carries `tenant_id`, `user_id`, and `scope:["read"]` — `run_query` is rejected with `-32601 insufficient_scope`. See [Chat Panel — Security model](chat-panel.md#security-model).
+
+---
+
+## Chat session endpoints (Wave 9)
+
+The chat panel provides an interactive coding assistant that uses MCP read tools against the tenant's codebase. Sessions are flag-gated (`RB_CHAT_PANEL_ENABLED=true`). All chat endpoints return 404 when the flag is off.
+
+See [chat-panel.md](chat-panel.md) for the full user guide and [runtime-config.md](runtime-config.md) for operator configuration.
+
+### POST /v1/chat/sessions
+
+Create a new chat session. The gateway mints a session-scoped MCP JWT, dispatches a runtime-start command via Kafka, and returns the session metadata.
+
+**Auth required**: verified session **or** API key with `agent` or `admin` scope
+
+**Request**
+```json
+{
+  "runtime": "claude_code"
+}
+```
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `runtime` | string | One of `claude_code`, `opencode`, `pi`. Defaults to `AGENT_DEFAULT_RUNTIME` if omitted. |
+
+**Response 201**
+```json
+{
+  "id": "a1b2c3d4-...",
+  "status": "active",
+  "runtime": "claude_code",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "created_at": "2026-06-02T14:30:00Z"
+}
+```
+
+**Response 404** — `RB_CHAT_PANEL_ENABLED` is `false`
+**Response 429** — per-tenant session cap or rate limit exceeded
+
+### GET /v1/chat/sessions
+
+List chat sessions for the current tenant, ordered by `created_at` descending.
+
+**Auth required**: verified session **or** API key with `read` scope
+
+**Query parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `status` | string? | — | Filter by status: `active`, `ended`, `failed` |
+| `limit` | int | 20 | Max results (1–100) |
+| `cursor` | string? | — | Opaque pagination cursor |
+
+**Response 200**
+```json
+{
+  "sessions": [
+    {
+      "id": "a1b2c3d4-...",
+      "status": "active",
+      "runtime": "claude_code",
+      "created_at": "2026-06-02T14:30:00Z",
+      "last_activity_at": "2026-06-02T14:35:00Z"
+    }
+  ],
+  "next_cursor": null
+}
+```
+
+### GET /v1/chat/sessions/{id}
+
+Get a single chat session by ID.
+
+**Auth required**: verified session **or** API key with `read` scope
+
+**Response 200**
+```json
+{
+  "id": "a1b2c3d4-...",
+  "status": "active",
+  "runtime": "claude_code",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "created_at": "2026-06-02T14:30:00Z",
+  "last_activity_at": "2026-06-02T14:35:00Z",
+  "ended_at": null
+}
+```
+
+**Response 404** — session not found or belongs to another tenant
+
+### POST /v1/chat/sessions/{id}/messages
+
+Send a user message to an active chat session. The gateway dispatches the message to the runtime process over Kafka. The runtime's response streams back via the SSE events endpoint.
+
+**Auth required**: verified session **or** API key with `agent` or `admin` scope
+
+**Request**
+```json
+{
+  "body": "Find all implementations of RuntimeAdapter"
+}
+```
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `body` | string | The user's message. Must not be empty. |
+
+**Response 202** — message accepted and dispatched
+```json
+{
+  "seq": 3,
+  "role": "user",
+  "created_at": "2026-06-02T14:35:00Z"
+}
+```
+
+**Response 400** — `invalid_input` (empty body)
+**Response 404** — session not found
+**Response 409** — session is not in `active` status
+
+### GET /v1/chat/sessions/{id}/events
+
+**SSE event stream.** Long-lived connection that pushes chat events as they arrive. Connect with `EventSource` or the `useEventSource` React hook. Supports reconnection via `Last-Event-ID`.
+
+**Auth required**: verified session **or** API key with `read` scope
+
+**Content-Type**: `text/event-stream`
+
+**Query parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `from_sequence` | int? | — | Resume from a specific message sequence number |
+
+**Event types**:
+
+| Type | Description |
+|------|-------------|
+| `message` | Assistant text (streamed token-by-token) |
+| `tool_call_started` | Runtime began an MCP tool call |
+| `tool_call_completed` | MCP tool call finished (includes result summary) |
+| `session_completed` | Session ended normally |
+| `session_failed` | Session ended with an error (`error_kind` in data) |
+
+**Example SSE frames**:
+```
+id: 4
+event: tool_call_started
+data: {"tool":"search_items","args_preview":"RuntimeAdapter"}
+
+id: 5
+event: tool_call_completed
+data: {"tool":"search_items","result_count":3,"duration_ms":42}
+
+id: 6
+event: message
+data: {"body":"I found 3 implementations of RuntimeAdapter..."}
+```
+
+### POST /v1/chat/sessions/{id}/end
+
+End an active chat session. Terminates the runtime process and marks the session as `ended`.
+
+**Auth required**: verified session **or** API key with `agent` or `admin` scope
+
+**Response 200**
+```json
+{
+  "id": "a1b2c3d4-...",
+  "status": "ended",
+  "ended_at": "2026-06-02T14:40:00Z"
+}
+```
+
+**Response 404** — session not found
+**Response 409** — session is already ended or failed
+
+### GET /v1/chat/sessions/{id}/messages
+
+List all messages in a chat session (paginated). Useful for replaying a conversation after reconnect.
+
+**Auth required**: verified session **or** API key with `read` scope
+
+**Query parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | int | 50 | Max messages per page (1–200) |
+| `cursor` | string? | — | Opaque pagination cursor |
+
+**Response 200**
+```json
+{
+  "messages": [
+    {
+      "id": "...",
+      "seq": 1,
+      "role": "user",
+      "body": "Find all implementations of RuntimeAdapter",
+      "created_at": "2026-06-02T14:31:00Z"
+    },
+    {
+      "id": "...",
+      "seq": 2,
+      "role": "assistant",
+      "body": "I found 3 implementations...",
+      "created_at": "2026-06-02T14:31:05Z"
+    }
+  ],
+  "next_cursor": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `messages[].seq` | int | Monotonic sequence number within the session |
+| `messages[].role` | string | `user`, `assistant`, `system`, or `tool` |
+| `messages[].body` | string | Post-redaction message text |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -392,3 +392,5 @@ Architecture decisions are captured as ADRs in [`docs/decisions/`](decisions/).
 | [ADR-009](decisions/ADR-009-agent-execution-architecture.md) | Agent Execution Architecture | Accepted (rev 6) — MCP server, agent session lifecycle, runtime adapters (Claude Code, OpenCode, Pi), LiteLLM gateway, per-tenant rate limits |
 | [ADR-010](decisions/ADR-010-github-app-tenant-install.md) | Tenant-scoped GitHub App install + orphan-reclaim | Accepted — self-healing atomic CTE reclaim for cross-tenant installation collisions |
 | [ADR-011](decisions/ADR-011-dev-stack-auto-rebuild.md) | Dev-stack auto-rebuild watcher | Accepted — selective per-path rebuilds via post-merge git hook, user systemd service, build-SHA provenance |
+| [ADR-012](decisions/ADR-012-wave8-hardening-polish.md) | Wave 8 Hardening & Polish | Accepted — admin endpoints, observability, synthetic load, drift detection |
+| [ADR-013](decisions/ADR-013-chat-panel-architecture.md) | Chat-Panel Architecture, Runtime Contract & MCP Token Model | Proposed (Wave 9) — interactive chat panel, generalized runtime adapter, short-lived MCP JWT, log-redaction contract |

--- a/docs/chat-panel.md
+++ b/docs/chat-panel.md
@@ -1,0 +1,236 @@
+# Chat Panel
+
+The chat panel is an interactive coding assistant embedded in the Rustacean UI. A logged-in user opens a chat session, types a message, and watches a coding runtime (Claude Code, OpenCode) answer using the same MCP read tools that the agent execution surface exposes.
+
+Chat sessions are flag-gated, tenant-scoped, and audited. The runtime process runs in an isolated workspace with a short-lived, read-only MCP credential.
+
+**ADR**: ADR-013 (Wave 9 — chat-panel architecture, runtime contract, MCP token model).
+**Builds on**: [ADR-009](decisions/ADR-009-agent-execution-architecture.md) (Wave 7 agent execution).
+
+---
+
+## Enabling the chat panel
+
+The chat panel is behind a feature flag. Set `RB_CHAT_PANEL_ENABLED=true` on the `control-api` service and restart:
+
+```bash
+# In compose/dev.yml, add to control-api environment:
+RB_CHAT_PANEL_ENABLED=true
+
+# Restart control-api
+docker compose -f compose/dev.yml restart control-api
+```
+
+When the flag is off (the default), the chat routes return 404 and the frontend hides the navigation entry.
+
+---
+
+## How it works
+
+```
+Browser (ChatPage)
+  │
+  ├─ POST /v1/chat/sessions              create a new chat session
+  ├─ POST /v1/chat/sessions/{id}/messages send a user message
+  └─ GET  /v1/chat/sessions/{id}/events   stream assistant tokens (SSE)
+         │
+    control-api (chat-gateway)
+         │  mints a short-lived MCP JWT (read-only, tenant-bound)
+         │  dispatches runtime command via Kafka
+         │
+    agent-runner (runtime adapter)
+         │  spawns one OS process per session (claude_code / opencode)
+         │  bridges stdin/stdout with redaction
+         │
+    POST /mcp (Bearer <JWT>)
+         │  runtime calls MCP read tools: search_items, get_item,
+         │  get_callers, get_callees, get_trait_impls
+         │
+    SSE event stream → browser
+```
+
+1. **Create session** — `POST /v1/chat/sessions` with `{ "runtime": "claude_code" }`. Returns a session ID and the SSE endpoint URL.
+2. **Send message** — `POST /v1/chat/sessions/{id}/messages` with `{ "body": "Find all implementations of RuntimeAdapter" }`. The gateway dispatches the message to the runtime process over Kafka.
+3. **Stream response** — `GET /v1/chat/sessions/{id}/events` (SSE). Assistant tokens arrive as `data:` frames. Connect with `EventSource` or the `useEventSource` hook.
+4. **End session** — `POST /v1/chat/sessions/{id}/end` or let the idle timeout (15 min) clean up.
+
+---
+
+## Authentication
+
+Chat endpoints accept the same auth as the rest of the API:
+
+- **Session cookie** (`rb_session`) — the default for browser users.
+- **Bearer API key** (`Authorization: Bearer rb_...`) — requires `agent` or `admin` scope.
+
+The user must have a verified email and an active tenant membership.
+
+---
+
+## Available runtimes
+
+| Runtime | Binary | Status | Auth source |
+|---------|--------|--------|-------------|
+| `claude_code` | `claude` | Supported | OAuth via shared `claude-credentials` volume |
+| `opencode` | `opencode` | Supported | LiteLLM proxy for multi-provider LLM access |
+| `pi` | — | Deferred (Phase 3) | LiteLLM proxy (stub) |
+
+Pass the runtime name in the session-creation request: `{ "runtime": "claude_code" }`.
+
+- **`claude_code`** sessions bypass LiteLLM entirely — unaffected if LiteLLM is down.
+- **`opencode`** and **`pi`** sessions fail with `llm_unavailable` if LiteLLM is unreachable.
+
+See [Runtime Configuration](runtime-config.md) for the full operator setup.
+
+---
+
+## MCP tools visible in chat
+
+Chat sessions use a **read-only** MCP tool set. The runtime can call these tools via the MCP server:
+
+| Tool | Description |
+|------|-------------|
+| `search_items` | Full-text + semantic search over ingested code symbols |
+| `get_item` | Fetch a single code item by fully-qualified name |
+| `get_callers` | BFS traversal of the call graph (who calls this?) |
+| `get_callees` | BFS traversal of the call graph (what does this call?) |
+| `get_trait_impls` | List implementations of a trait |
+
+**Not available in chat** (admin-scope only): `run_query` (raw Cypher). Mutating tools are out of scope for Wave 9.
+
+---
+
+## Session lifecycle
+
+```
+  create session (first message)
+        │
+        ▼
+    ┌─────────┐   spawn process    ┌─────────┐
+    │  active  │──────────────────▶│ running  │
+    └─────────┘                    └────┬─────┘
+                                        │
+                 ┌──────────────────────┼──────────────────┐
+                 │                      │                  │
+                 ▼                      ▼                  ▼
+           ┌──────────┐         ┌────────────┐     ┌──────────┐
+           │  ended   │         │   failed   │     │  ended   │
+           │ (user)   │         │ (crash/oom)│     │ (timeout)│
+           └──────────┘         └────────────┘     └──────────┘
+```
+
+- **Active**: session created, process spawned, accepting messages via stdin.
+- **Ended**: user ended the session, or idle/wall-clock timeout triggered.
+- **Failed**: runtime process crashed, OOM killed, or an unrecoverable error occurred.
+
+Each user message is a `send_input` over stdin to the warm process. The runtime's stdout is parsed, redacted (credentials and JWTs stripped), and streamed back to the client over SSE.
+
+---
+
+## Security model
+
+Chat sessions use a **short-lived JWT** instead of a long-lived API key for MCP tool calls. This bounds the blast radius of a compromised runtime process.
+
+| Property | Value |
+|----------|-------|
+| Algorithm | HS256 |
+| Audience | `rb-mcp` |
+| Scope | `["read"]` (read-only tools only) |
+| TTL | 15 minutes (configurable via `RB_MCP_JWT_TTL_SECS`) |
+| Tenant binding | `tenant_id` claim is server-fixed; MCP server rejects drift |
+| Credential location | `.mcp.json` in the isolated workspace (0600 permissions) |
+| Log redaction | JWT is never placed in prompts, messages, events, or logs |
+
+A single redaction pass runs on all runtime output **before** it reaches persistence, the SSE stream, or log lines. The redactor strips JWTs, Bearer tokens, API-key prefixes, and the session's exact live token value. If redaction fails, the line is dropped (fail-closed) and a `redaction_failed` event is emitted.
+
+---
+
+## Resource limits
+
+Each chat session runs in an isolated OS process with these limits:
+
+| Limit | Default | Effect when exceeded |
+|-------|---------|----------------------|
+| Memory | 1 GiB | OOM kill; session fails with `runtime_oom` |
+| CPU | 1 core-equiv shares | Throttled, not killed |
+| Idle timeout | 15 min (no user message) | Session ends automatically |
+| Wall-clock cap | 60 min per session | Hard termination |
+| Per-tenant concurrency | 20 live sessions | Excess returns `429 rate_limit_exceeded` |
+| Per-node concurrency | 200 live sessions | Excess returns `429 rate_limit_exceeded` |
+| Output per turn | 1 MiB streamed | Back-pressure; overflow stored as blob ref |
+| Message body | 16 KiB persisted | Truncated to blob ref if exceeded |
+
+See [Runtime Configuration](runtime-config.md) for tunables.
+
+---
+
+## Prompt examples
+
+```
+Find all implementations of RuntimeAdapter and show where each is registered.
+
+What does the signup flow look like? Trace from POST /v1/auth/signup through
+the transaction.
+
+Show me all callers of write_tool_call_audit — I want to understand the
+audit surface.
+
+Search for anything related to tenant deletion and explain the cascade.
+```
+
+The runtime has full read access to the tenant's ingested codebase via MCP tools. It cannot modify any data.
+
+---
+
+## Troubleshooting
+
+### Chat panel not visible in the UI
+
+**Cause**: Feature flag is off (default).
+**Fix**: Set `RB_CHAT_PANEL_ENABLED=true` on `control-api` and restart.
+
+### Session creation returns 429
+
+**Cause**: Per-tenant concurrency limit (20 active sessions) or per-node limit (200) reached.
+**Fix**: End idle sessions, or wait for the idle reaper (15 min) to clean up abandoned sessions.
+
+### Runtime process crashes mid-conversation
+
+**Symptom**: SSE stream emits a `session_failed` event with `error_kind="runtime_crashed"`.
+**Cause**: The runtime process exited with a non-zero code or panicked. One crash does not affect other sessions.
+**Fix**: Send the message again to start a new turn. Check `agent-runner` logs:
+
+```bash
+docker compose -f compose/dev.yml logs agent-runner | grep "runtime_crashed"
+```
+
+### MCP tool calls return errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `TENANT_DRIFT (-32000)` | Session's tenant changed mid-flight | End the session and create a new one |
+| `insufficient_scope (-32601)` | Runtime attempted a write or admin tool | Expected — chat is read-only |
+| Tool returns empty results | Tenant has no ingested repositories | Ingest a repository first via the repos UI |
+
+### Cold start is slow (> 4 s)
+
+The first message in a session spawns the runtime process (cold start). Subsequent messages reuse the warm process. Cold-start latency is dominated by the runtime binary's startup time, not Rustacean.
+
+---
+
+## Data retention
+
+Chat data is stored in `control.chat_sessions` and `control.chat_messages`. Message bodies contain only **post-redaction** text — credentials, JWTs, and secrets are stripped before persistence.
+
+- **Tenant deletion**: `ON DELETE CASCADE` to `control.tenants` sweeps all chat data.
+- **Retention purge**: terminal sessions older than 90 days are purged nightly (02:00 UTC), matching the `agent_sessions` retention policy.
+
+---
+
+## Related documentation
+
+- [Runtime Configuration](runtime-config.md) — operator runbook for configuring runtimes, resource limits, and LLM credentials
+- [API Reference — Chat endpoints](api-reference.md#chat-session-endpoints-wave-9) — REST API contract
+- [Getting Started — Use the chat panel](getting-started.md#8-use-the-chat-panel-wave-9) — end-user quickstart
+- [ADR-009](decisions/ADR-009-agent-execution-architecture.md) — Wave 7 agent execution architecture (substrate)
+- [Architecture](architecture.md) — system overview and topology diagram

--- a/docs/chat-panel.md
+++ b/docs/chat-panel.md
@@ -4,7 +4,7 @@ The chat panel is an interactive coding assistant embedded in the Rustacean UI. 
 
 Chat sessions are flag-gated, tenant-scoped, and audited. The runtime process runs in an isolated workspace with a short-lived, read-only MCP credential.
 
-**ADR**: ADR-013 (Wave 9 — chat-panel architecture, runtime contract, MCP token model).
+**ADR**: [ADR-013](decisions/ADR-013-chat-panel-architecture.md) (Wave 9).
 **Builds on**: [ADR-009](decisions/ADR-009-agent-execution-architecture.md) (Wave 7 agent execution).
 
 ---
@@ -229,8 +229,11 @@ Chat data is stored in `control.chat_sessions` and `control.chat_messages`. Mess
 
 ## Related documentation
 
+- [Runtime Adapter Contract](runtime-adapter.md) — the `RuntimeAdapter` trait and how to author a new adapter
+- [MCP Chat Tokens](mcp-chat-tokens.md) — JWT claims, scope, lifecycle, and log-redaction contract
 - [Runtime Configuration](runtime-config.md) — operator runbook for configuring runtimes, resource limits, and LLM credentials
 - [API Reference — Chat endpoints](api-reference.md#chat-session-endpoints-wave-9) — REST API contract
 - [Getting Started — Use the chat panel](getting-started.md#8-use-the-chat-panel-wave-9) — end-user quickstart
+- [ADR-013](decisions/ADR-013-chat-panel-architecture.md) — Wave 9 chat-panel architecture decision record
 - [ADR-009](decisions/ADR-009-agent-execution-architecture.md) — Wave 7 agent execution architecture (substrate)
 - [Architecture](architecture.md) — system overview and topology diagram

--- a/docs/decisions/ADR-013-chat-panel-architecture.md
+++ b/docs/decisions/ADR-013-chat-panel-architecture.md
@@ -1,0 +1,149 @@
+# ADR-013: Chat-Panel Architecture, Runtime Contract & MCP Token Model (Wave 9)
+
+**Status:** Proposed (Gate-1 board review pending)
+**Wave:** 9 (Phase -- Interactive Chat Panel)
+**Author:** Architect ([RUSAA-1811](https://github.com/f-crop/rustacean/issues/641))
+**Epic:** RUSAA-1810
+**Covers streams:** S1 (this ADR), and the contracts consumed by S2 (runtime adapter), S3 (chat gateway + migration), S4 (frontend), S5 (MCP token + audit + redaction), S6 (QA), S7 (docs).
+**Builds on:** [ADR-009](ADR-009-agent-execution-architecture.md) (agent execution: `rb-mcp`, `RuntimeAdapter`, `agent_sessions`/`agent_events`, SSE event relay, audit plumbing).
+**Out of scope:** UI design specifics (S4 owns); runtime CLI installation/packaging (S2 owns); **mutating MCP tools** and their approval model (see &sect;9); multi-agent chat / agent-to-agent messaging; cross-tenant or shared chat memory; browser-side model inference.
+
+---
+
+## 1. Context
+
+Wave 7 (ADR-009) shipped an **agent execution** surface: a `/mcp` Streamable-HTTP server (`rb-mcp` + `control-api routes/mcp/`), durable `agent_sessions`/`agent_events`, an SSE event relay, and a runtime-adapter substrate in `agent-runner` (`RuntimeAdapter` trait, `claude_code`/`opencode`/`pi` subprocess adapters, isolated workspaces, `kill_on_drop`, workspace GC). Wave 9 turns that substrate into an **interactive chat panel**: a logged-in user opens a chat, types a message, and watches a coding runtime answer -- using the same MCP read tools the agent surface already exposes.
+
+### What is reused unchanged
+
+| Already on disk | Where | Reused in Wave 9 for |
+|---|---|---|
+| `RuntimeAdapter` trait (`spawn`/`send_input`/`terminate`/`parse_stdout_line`), `SessionCtx`, `AgentProcess` (`kill_on_drop(true)`) | `services/agent-runner/src/adapters/mod.rs` | the runtime adapter contract (&sect;4) -- generalized, not re-invented |
+| Subprocess supervision + isolated workspace + `workspace_gc` orphan reaper | `services/agent-runner/src/session/`, `workspace_gc.rs` | the process supervisor (&sect;4) |
+| `McpSessionStore` -- binds `tenant_id` at `initialize`, rejects `tools/call` tenant drift with `TENANT_DRIFT (-32000)` | `crates/rb-mcp/src/session.rs` | chat MCP tenant binding (&sect;5) -- reused verbatim |
+| `write_tool_call_audit` to `audit.audit_events` | `services/control-api/src/routes/mcp/audit.rs` | per-tool-call audit (&sect;5/&sect;6) -- reused verbatim |
+| `.mcp.json` writer: 0600 perms, `http(s)`-scheme SSRF guard | `services/agent-runner/src/adapters/mod.rs::write_mcp_config` | runtime MCP-config injection (&sect;5) -- extended to carry a JWT |
+| 6 read-only MCP tools (`search_items`, `get_item`, `get_callers`, `get_callees`, `get_trait_impls`, `run_query`) | `services/control-api/src/routes/mcp/`, `rb-query` | chat tool surface -- read-only subset (&sect;5/&sect;9) |
+| SSE event relay + `Last-Event-ID` replay; `agent_events` append-only/partitioned pattern | `crates/rb-sse`, `agent-runner/src/event_relay/`, `migrations/control/` | chat token/message streaming (&sect;7) |
+| Auth middleware (`Session{verified}` / `ApiKey{Read/Write/Admin}` extractor) | `services/control-api/src/middleware/auth.rs` | chat-gateway auth (&sect;3) + MCP JWT auth path (&sect;5) |
+
+---
+
+## 2. Decision Summary
+
+| Area | Decision | Rationale |
+|------|----------|-----------|
+| **Topology** | Reuse the Wave-7 path. `control-api routes/chat/` (chat-gateway) creates a chat session, dispatches a runtime command over the existing Kafka command topic to `agent-runner`. No new binary, no new Kafka topic. | Every protocol surface lives in `control-api`/`agent-runner` since Wave 4. |
+| **Runtime adapter (&sect;4)** | Generalize the existing `RuntimeAdapter` trait with `manifest()` + `health()`. A new runtime = one adapter impl + one registry entry. | The trait already exists; we widen it, not replace it. |
+| **MCP token model (&sect;5)** | Replace the long-lived `RB_AGENT_API_KEY` with a short-lived JWT per chat session: `aud="rb-mcp"`, `scope:["read"]`, 15 min TTL. | Read-scoped, tenant-bound, minutes-TTL credential bounds the blast radius. |
+| **Persistence (&sect;7)** | Two new tables: `chat_sessions`, `chat_messages`. Migration `021_chat_panel.sql`, additive only. | Mirrors `agent_sessions`/`agent_events` precedent. |
+| **Latency (&sect;8)** | First-token (warm): &le;1.5 s p95. Tool-call dispatch: &le;200 ms p95. Cold start: &le;4 s p95, tracked separately. | Warm first-token and server-side tool-dispatch are the two figures we actually control. |
+| **Flag-gating** | Entire chat panel behind `RB_CHAT_PANEL_ENABLED` (default off) via `rb-feature-resolver`. | Lets S2--S5 land incrementally on `main` without exposing an unfinished surface. |
+
+---
+
+## 3. Component map
+
+Five components, all inside Rustacean:
+
+```
+   Browser
+   +------------------------------+
+   | (1) ChatPage UI  [S4]        |  flag-gated; TanStack Router + React Query
+   |   - message composer         |  + useEventSource (REQ-FE-08 hook)
+   |   - streaming transcript     |
+   +-----------+------------------+
+               | POST /v1/chat/sessions ; POST /v1/chat/sessions/{id}/messages
+               | GET  /v1/chat/sessions/{id}/events   (SSE)
+   +-----------v------------------+
+   | (2) chat-gateway  [S3]       |  control-api  routes/chat/
+   |   - create/list/get/end      |  - auth: verified session OR API-key(agent|admin)
+   |   - mint MCP JWT  -----------+------------+  (5) MCP token model [S5]
+   |   - persist sessions/msgs    |            |  rb-auth::jwt  (mint/verify)
+   |   - dispatch runtime cmd     |            v  aud=rb-mcp, scope=[read], short exp
+   +-------+---------------+------+   +------------------------+
+           |               |          | control-api routes/mcp/| JWT auth path (NEW)
+   Kafka: rb.agent.commands|          | McpSessionStore        | (reused)
+           |               |          | write_tool_call_audit  | (reused)
+   +-------v---------------v------+   +----------^-------------+
+   | (3) runtime adapter  [S2]    |              | POST /mcp  (Bearer <JWT>)
+   | agent-runner supervisor      |              |  read tools only
+   |  - RuntimeAdapter (general)  |--------------+
+   |  - 1 process / session       |
+   |  - isolated workspace + .mcp |  .mcp.json carries the JWT (0600)
+   |  - stdio bridge -> event relay
+   +-------+----------------------+
+           | stdout (redacted) -> agent_events relay -> SSE
+   +-------v----------------------+
+   | (4) persistence  [S3]        |  control.chat_sessions / control.chat_messages
+   |  migration 021 (additive)    |  body = post-redaction text only
+   +------------------------------+
+```
+
+---
+
+## 4. Runtime adapter contract
+
+See [runtime-adapter.md](../runtime-adapter.md) for the full developer-facing contract and authoring guide.
+
+The trait is widened with `manifest()` and `health()`. Existing adapters (`claude_code`, `opencode`, `pi`) compile against the wider trait with trivial fill-ins.
+
+---
+
+## 5. MCP token model
+
+See [mcp-chat-tokens.md](../mcp-chat-tokens.md) for the full token specification, lifecycle, and redaction contract.
+
+HS256, signed with `RB_MCP_JWT_SECRET`, claims `{sid, tenant_id, user_id, scope:["read"], exp}`. 15 min TTL, re-minted on activity.
+
+---
+
+## 6. Threat model (Security-Engineer-owned)
+
+| # | Threat | Mitigation |
+|---|--------|-----------|
+| T1 | Prompt-injection reads another tenant | `tenant_id` server-fixed from JWT; `McpSessionStore` drift rejection; read-only scope |
+| T2 | JWT leaks into transcript | Log-redaction contract + token never in prompts; read-scoped + &le;15 min TTL |
+| T3 | Compromised process reads host FS | Isolated workspace, no shared mount, no host secret; only the read-scoped JWT |
+| T4 | Token replay after session end | Short `exp`; `jti` denylist on force-kill |
+| T5 | SSRF via MCP URL | Existing `http(s)`-scheme guard |
+| T6 | Tenant switch mid-session | `McpSessionStore` drift rejection |
+| T7 | Resource exhaustion / fork-bomb | cgroup caps, concurrency limits, wall-clock + idle caps |
+
+---
+
+## 7. Persistence schema
+
+Migration `021_chat_panel.sql` (additive only). Two new tables in `control`:
+
+- `chat_sessions` -- id, tenant_id, user_id, runtime, status, trace_id, created_at, last_activity_at, ended_at. `tenant_id` FK `ON DELETE CASCADE` + immutability trigger.
+- `chat_messages` -- id, session_id, tenant_id, seq, role, body (post-redaction), created_at. Unique on `(session_id, seq)`.
+
+Retention: 90-day terminal-session purge (cron, 02:00 UTC).
+
+---
+
+## 8. Latency budget
+
+| Metric | Budget | Boundary |
+|--------|--------|----------|
+| First-token (warm) | &le;1.5 s p95 | gateway receipt to first SSE assistant token (process already live) |
+| Tool-call dispatch | &le;200 ms p95 | MCP `tools/call` receipt to `CallToolResult` (server-side) |
+| Cold start | &le;4 s p95 | session create to process ready (tracked, not part of first-token SLO) |
+
+---
+
+## 9. Forward-looking: mutating tools
+
+All chat tools in Wave 9 are **read-only**. Mutating tools require a future ADR covering a human-in-the-loop approval gate, `write` token scope, write-path audit, and an expanded threat model.
+
+---
+
+## 11. Rejected alternatives
+
+- New `services/chat-gateway` binary -- duplicates auth/OTel/audit/SSE plumbing.
+- Runtime inside `control-api` (skip Kafka) -- forks process supervision.
+- Reuse `RB_AGENT_API_KEY` for chat -- wrong blast radius for untrusted model output.
+- Opaque token instead of JWT -- extra DB round-trip per `/mcp` call.
+- WebSocket transport -- SSE already hardened with `Last-Event-ID` replay.
+- Per-message process spawn -- blows the first-token budget.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,6 +239,67 @@ LiteLLM is not included in `compose/dev.yml` — it runs as an external service 
 
 ---
 
+## 8. Use the chat panel (Wave 9)
+
+The chat panel lets you interact with an AI coding assistant that has read access to your ingested codebase via MCP tools. It requires the agent runtime ([§7](#7-agent-runtime-setup-wave-7)) to be set up first.
+
+### Enable the feature flag
+
+The chat panel is off by default. Enable it on `control-api`:
+
+```bash
+# Add to compose/dev.yml under control-api → environment:
+RB_CHAT_PANEL_ENABLED=true
+
+# Restart control-api to pick up the flag
+docker compose -f compose/dev.yml restart control-api
+```
+
+### Start a chat session
+
+**Option A — using the UI**
+
+1. Open `http://localhost:15173` and log in.
+2. Click **Chat** in the sidebar navigation.
+3. Select a runtime (`claude_code` or `opencode`) and type a message.
+4. Watch the assistant's response stream in real time.
+
+**Option B — curl end-to-end**
+
+```bash
+# Create a chat session
+curl -s -b cookies.txt -X POST http://localhost:8080/v1/chat/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"runtime":"claude_code"}' | jq .
+# → {"id":"<session-id>","status":"active","runtime":"claude_code",...}
+
+# Send a message
+curl -s -b cookies.txt -X POST \
+  http://localhost:8080/v1/chat/sessions/<session-id>/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"body":"Find all implementations of RuntimeAdapter"}' | jq .
+
+# Stream the response (SSE)
+curl -s -b cookies.txt -N \
+  http://localhost:8080/v1/chat/sessions/<session-id>/events
+# → data: {"type":"message","body":"I found 3 implementations..."}
+
+# End the session
+curl -s -b cookies.txt -X POST \
+  http://localhost:8080/v1/chat/sessions/<session-id>/end
+```
+
+### Prerequisites
+
+- A running dev stack with `control-api` and `agent-runner` healthy.
+- At least one repository ingested (the chat uses your codebase data).
+- For `claude_code` runtime: Claude credentials set up via the `claude-login` sidecar ([§7](#7-agent-runtime-setup-wave-7)).
+- For `opencode` runtime: LiteLLM configured ([§7](#7-agent-runtime-setup-wave-7)).
+
+For detailed configuration: [chat-panel.md](chat-panel.md) · [runtime-config.md](runtime-config.md).
+
+---
+
 ## Next steps
 
 - **Architecture deep-dive**: [architecture.md](architecture.md) — system overview, crate layout, agent execution topology

--- a/docs/mcp-chat-tokens.md
+++ b/docs/mcp-chat-tokens.md
@@ -1,0 +1,147 @@
+# MCP Chat Tokens
+
+Chat sessions use a **short-lived JWT** instead of the long-lived `RB_AGENT_API_KEY` that agent sessions use. This bounds the blast radius of a runtime process that handles untrusted model output: a leaked or prompt-injected token can only read one tenant's data for a few minutes.
+
+**ADR**: [ADR-013 &sect;5](decisions/ADR-013-chat-panel-architecture.md) (Wave 9).
+**Code**: `rb-auth::jwt` (mint/verify), `control-api routes/mcp/` (JWT auth path).
+
+---
+
+## Token shape
+
+The MCP chat token is an HS256 JWT signed with `RB_MCP_JWT_SECRET` (stored in `rb-secrets`, rotatable via `kid` in the header).
+
+```jsonc
+{
+  "iss": "control-api",
+  "aud": "rb-mcp",
+  "sub": "<chat_session_id>",        // UUID, session-scoped
+  "tenant_id": "<uuid>",             // server-trusted tenant binding
+  "user_id": "<uuid>",
+  "scope": ["read"],                 // read-only MCP tools only
+  "iat": 1717329600,
+  "exp": 1717330500,                 // iat + RB_MCP_JWT_TTL_SECS (default 900 = 15 min)
+  "jti": "<uuid>"                    // audit correlation + optional denylist
+}
+```
+
+### Key properties
+
+| Property | Value | Why |
+|----------|-------|-----|
+| Audience | `rb-mcp` | Prevents cross-service token confusion |
+| Scope | `["read"]` | Only read tools (`search_items`, `get_item`, `get_callers`, `get_callees`, `get_trait_impls`); write/admin tools rejected with `-32601 insufficient_scope` |
+| TTL | 15 min (default) | Caps the value window of a leaked token |
+| Subject | session ID (not user ID) | One token per session; revoking a session implicitly invalidates the token |
+
+---
+
+## Token lifecycle
+
+```
+Session created
+  │
+  └─ chat-gateway mints JWT ──▶ written to .mcp.json (0600, isolated workspace)
+     │
+     ├─ runtime calls POST /mcp (Bearer <JWT>)
+     │     └─ /mcp verifies signature + exp
+     │        └─ AuthContext from claims (tenant_id, user_id, scope)
+     │           └─ McpSessionStore binds tenant_id (drift rejection)
+     │              └─ tools/call: scope enforcement + audit
+     │
+     ├─ token nearing expiry (within RB_MCP_JWT_REFRESH_SECS, default 120s)
+     │     └─ chat-gateway re-mints JWT
+     │        └─ rewritten to .mcp.json in the live workspace
+     │
+     └─ session ends / idle / crash
+           └─ token left to expire (≤15 min)
+              └─ optional: jti added to in-memory denylist on force-kill
+```
+
+The JWT exists in exactly **two places**: the chat-gateway's mint call (in-process memory) and the runtime's `.mcp.json` file (0600 permissions, isolated workspace). It is **never** placed in a prompt, a `chat_messages.body`, an `agent_events` payload, or a log line.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RB_MCP_JWT_SECRET` | — (**required**) | HS256 signing key. Store in `rb-secrets`. Rotation: set a new secret with a new `kid`; the verifier accepts both during a grace period. |
+| `RB_MCP_JWT_TTL_SECS` | `900` (15 min) | Token time-to-live. Lower values reduce leak exposure; higher values reduce re-mint frequency. |
+| `RB_MCP_JWT_REFRESH_SECS` | `120` (2 min) | Re-mint window. When the live token is within this many seconds of `exp`, the gateway mints a fresh one. |
+
+---
+
+## Verification path
+
+The `/mcp` endpoint accepts two auth schemes:
+
+1. **API key** (existing) — `Authorization: Bearer rb_...` — looks up `control.api_keys`.
+2. **JWT** (Wave 9) — `Authorization: Bearer eyJ...` — verifies HS256 signature, checks `aud="rb-mcp"` and `exp`, then yields an `AuthContext` from the token claims.
+
+The JWT path avoids a database round-trip per MCP call, keeping tool-call dispatch within the &le;200 ms p95 latency budget (ADR-013 &sect;8).
+
+---
+
+## Tenant binding and drift rejection
+
+On the first `/mcp` request in a session, `McpSessionStore` binds the `Mcp-Session-Id` header to `claims.tenant_id`. Every subsequent `tools/call` checks that the request's `tenant_id` matches the bound value. A mismatch returns `TENANT_DRIFT (-32000)`. This reuses the existing `McpSessionStore` from Wave 7 — no new tenant-binding code.
+
+The `tenant_id` is always server-fixed from the JWT claims, never from tool arguments. Even if a prompt-injected model attempts to pass a different tenant ID in tool args, the MCP server ignores it.
+
+---
+
+## Scope enforcement
+
+| Scope | Permitted tools |
+|-------|----------------|
+| `read` | `search_items`, `get_item`, `get_callers`, `get_callees`, `get_trait_impls` |
+| `admin` (not issued for chat) | `run_query` (raw Cypher) |
+| `write` (future, not in Wave 9) | Mutating tools (ADR-013 &sect;9) |
+
+A chat JWT carries `scope: ["read"]`. Any tool outside this scope is rejected with JSON-RPC error `-32601` and `data.reason="insufficient_scope"`.
+
+---
+
+## Audit
+
+Every `tools/call` writes one row to `audit.audit_events` via the existing `write_tool_call_audit` function:
+
+| Field | Value |
+|-------|-------|
+| `action` | `mcp.tools.call.<tool_name>` (e.g. `mcp.tools.call.search_items`) |
+| `args` | SHA-256 hash of the tool arguments (never raw) |
+| `actor_kind` | `mcp_client` |
+| `outcome` | `success` or error code |
+| `jti` | From the JWT claims — correlates chat session to audit trail |
+
+No schema change to `audit.audit_events`. The `jti` field is added to the existing payload JSON column for chat sessions.
+
+---
+
+## Log-redaction contract
+
+A single redaction pass is applied **before** any runtime output byte becomes:
+
+- a `chat_messages.body`
+- an `agent_events.data` field
+- an SSE frame
+- a structured log line
+
+The redactor replaces matches with `<redacted:kind>`:
+
+| Pattern | Kind | Example match |
+|---------|------|---------------|
+| Three base64url segments (`eyJ...\.…\.…`) | `jwt` | The MCP JWT itself |
+| `(?i)bearer\s+[A-Za-z0-9._-]+` | `bearer` | `Bearer eyJ...` or `Bearer rb_live_...` |
+| Exact live session token value | `session_token` | Verbatim echo of the JWT |
+| `RB_MCP_JWT_SECRET` value | `secret` | The signing key |
+| `RB_AGENT_API_KEY` / `rb_live_*` prefixes | `api_key` | Long-lived API keys |
+
+### Fail-closed
+
+If the redactor errors, the line is **dropped** and an `error_kind="redaction_failed"` event is emitted rather than persisting raw bytes. This is a safety invariant, not a performance optimization.
+
+### Testing
+
+QA (S6) must include a test that feeds a transcript line containing the live JWT and asserts it never reaches `chat_messages`, the SSE stream, or logs. See ADR-013 &sect;6.3.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -326,3 +326,112 @@ Port reference for verification steps (tailscale env):
 |------|-----|
 | Auth login / SSE stream | http://localhost:10080 (Caddy proxy) |
 | Grafana / Tempo | http://localhost:13000 |
+
+---
+
+## Wave 9: Chat panel operations
+
+The chat panel (Wave 9) adds an interactive coding assistant that runs runtime processes inside `agent-runner`. This section covers operator tasks specific to the chat subsystem.
+
+### Feature flag
+
+The chat panel is disabled by default. Enable it on `control-api`:
+
+```bash
+# compose/dev.yml — control-api environment
+RB_CHAT_PANEL_ENABLED=true
+
+docker compose -f compose/dev.yml restart control-api
+```
+
+Verify the flag is active:
+
+```bash
+curl -s http://localhost:8080/health | jq '.features.chat_panel'
+# → true
+```
+
+### MCP JWT secret management
+
+Chat sessions use a short-lived JWT signed with `RB_MCP_JWT_SECRET`. This secret lives in `rb-secrets`.
+
+```bash
+# Rotate the JWT signing key:
+# 1. Generate a new secret
+openssl rand -base64 32
+
+# 2. Set it in compose/dev.yml (control-api environment)
+RB_MCP_JWT_SECRET=<new-secret>
+
+# 3. Restart control-api (mints new tokens immediately)
+docker compose -f compose/dev.yml restart control-api
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RB_MCP_JWT_SECRET` | — (**required** when chat enabled) | HS256 signing key for MCP chat tokens |
+| `RB_MCP_JWT_TTL_SECS` | `900` | Token TTL in seconds (15 min) |
+| `RB_MCP_JWT_REFRESH_SECS` | `120` | Re-mint window before expiry |
+
+Key rotation is hitless: set a new secret with a new `kid`; the verifier accepts both during a grace period equal to the old TTL.
+
+### Runtime process inspection
+
+Each chat session runs one OS process inside the `agent-runner` container.
+
+```bash
+# List live runtime processes
+docker compose -f compose/dev.yml exec agent-runner ps aux | grep -E 'claude|opencode'
+
+# Check active chat sessions in the database
+docker compose -f compose/dev.yml exec postgres psql -U rustbrain -c \
+  "SELECT id, runtime, status, last_activity_at FROM control.chat_sessions WHERE status = 'active';"
+
+# Count sessions per tenant
+docker compose -f compose/dev.yml exec postgres psql -U rustbrain -c \
+  "SELECT tenant_id, count(*) FROM control.chat_sessions WHERE status = 'active' GROUP BY tenant_id;"
+```
+
+### Common failure modes
+
+#### Chat session returns 503 / feature not available
+
+**Cause**: `RB_CHAT_PANEL_ENABLED` is not set or set to `false`.
+
+**Fix**: Set the flag and restart control-api.
+
+#### JWT verification fails on `/mcp` calls
+
+**Symptom**: Runtime logs show `JwtError::InvalidSignature` or `JwtError::ExpiredToken`.
+
+**Cause**: `RB_MCP_JWT_SECRET` mismatch between control-api (minter) and the `/mcp` verifier (same process, but check for stale env after a partial restart), or the token expired because the session was idle longer than `RB_MCP_JWT_TTL_SECS`.
+
+**Fix**: Ensure `RB_MCP_JWT_SECRET` is identical across a full restart. For expired tokens, the gateway auto-refreshes on the next user message.
+
+#### Runtime process OOM-killed
+
+**Symptom**: `session_failed{error_kind="runtime_oom"}` in agent-runner logs.
+
+**Cause**: The runtime process exceeded the 1 GiB memory limit (cgroup v2 `memory.max`).
+
+**Fix**: This is expected for memory-intensive operations. The user sees a typed error and can retry. If frequent, consider raising the limit in the cgroup configuration.
+
+#### Orphaned runtime processes
+
+**Symptom**: `ps aux` shows runtime processes with no matching active `chat_session`.
+
+**Cause**: Supervisor crash or unclean shutdown.
+
+**Fix**: The existing `workspace_gc` reaper cleans up orphaned workspaces. For processes, restart `agent-runner`:
+
+```bash
+docker compose -f compose/dev.yml restart agent-runner
+```
+
+#### Redaction failure (line dropped)
+
+**Symptom**: `error_kind="redaction_failed"` events in agent-runner logs; user sees missing lines in the transcript.
+
+**Cause**: The redaction pass encountered an error processing a runtime output line. The line was dropped (fail-closed) rather than persisted with raw credentials.
+
+**Fix**: Check agent-runner logs for the specific redaction error. This is a safety mechanism — the dropped line may have contained sensitive data.

--- a/docs/runtime-adapter.md
+++ b/docs/runtime-adapter.md
@@ -1,0 +1,298 @@
+# Runtime Adapter Contract
+
+The runtime adapter is the interface between Rustacean's session supervisor (`agent-runner`) and an external coding runtime (Claude Code, OpenCode, or a future runtime). Each adapter wraps one runtime binary and teaches the supervisor how to spawn it, feed it user input, parse its output, check its health, and shut it down.
+
+**ADR**: [ADR-013 &sect;4](decisions/ADR-013-chat-panel-architecture.md) (Wave 9).
+**Code**: `services/agent-runner/src/adapters/mod.rs`.
+
+---
+
+## The `RuntimeAdapter` trait
+
+```rust
+#[async_trait]
+pub trait RuntimeAdapter: Send + Sync {
+    /// Static description of the runtime.
+    fn manifest(&self) -> RuntimeManifest;
+
+    /// Spawn one supervised OS process for a session in an isolated workspace.
+    async fn spawn(&self, ctx: &SessionCtx) -> Result<AgentProcess>;
+
+    /// Feed one user turn to a live process over stdin.
+    async fn send_input(&self, proc: &mut AgentProcess, input: &str) -> Result<()>;
+
+    /// Parse one stdout line into a typed event.
+    fn parse_stdout_line(&self, line: &str) -> Option<ParsedLine>;
+
+    /// Liveness probe used by the idle/health reaper.
+    async fn health(&self, proc: &AgentProcess) -> RuntimeHealth;
+
+    /// Graceful then forced termination.
+    async fn terminate(&self, proc: &mut AgentProcess, force: bool) -> Result<()>;
+}
+```
+
+### Supporting types
+
+```rust
+pub struct RuntimeManifest {
+    pub kind: AgentRuntime,             // rb_schemas enum variant
+    pub binary: &'static str,          // e.g. "claude", "opencode"
+    pub required_env: &'static [&'static str],
+    pub capabilities: RuntimeCaps,
+}
+
+pub struct RuntimeCaps {
+    pub multi_turn: bool,              // supports stdin-based multi-turn
+    pub streams_json: bool,            // stdout emits structured JSON lines
+}
+
+pub struct SessionCtx {
+    pub session_id: String,
+    pub tenant_id: String,
+    pub workspace_path: PathBuf,
+    pub api_key: String,               // MCP JWT for chat sessions
+    pub initial_prompt: String,
+}
+
+pub struct AgentProcess {
+    pub child: Child,                  // tokio::process::Child (kill_on_drop)
+    pub pid: u32,
+    pub runtime: AgentRuntime,
+}
+
+pub struct ParsedLine {
+    pub kind: LineKind,                // Text or Json
+    pub payload: String,
+}
+```
+
+---
+
+## Existing adapters
+
+### `ClaudeCodeAdapter`
+
+| Field | Value |
+|-------|-------|
+| Binary | `claude` |
+| Auth | OAuth via shared `claude-credentials` volume |
+| Capabilities | multi-turn, streams JSON |
+| File | `services/agent-runner/src/adapters/claude_code.rs` |
+
+Spawns `claude` in the isolated workspace with `--print` mode. Reads OAuth tokens from the mounted `claude-credentials` Docker volume. The `.mcp.json` written to the workspace carries the session's MCP credential (JWT for chat sessions, API key for agent sessions).
+
+### `OpencodeAdapter`
+
+| Field | Value |
+|-------|-------|
+| Binary | `opencode` |
+| Auth | LiteLLM proxy (`LITELLM_BASE_URL`) |
+| Capabilities | multi-turn, streams JSON |
+| File | `services/agent-runner/src/adapters/opencode.rs` |
+
+Supports three LLM routing modes via `OPENCODE_LLM_MODE`:
+
+1. **LiteLLM** (default) -- routes through the LiteLLM gateway for multi-provider access.
+2. **OpenAI-compatible** -- direct connection to any OpenAI-compatible endpoint.
+3. **DirectProvider** -- direct API key auth to a specific provider.
+
+### `PiAdapter` (stub)
+
+| Field | Value |
+|-------|-------|
+| Binary | -- |
+| Status | Deferred to Wave 10 |
+| File | `services/agent-runner/src/adapters/pi.rs` |
+
+Returns `not implemented: pi runtime evaluation pending (ADR-009 Phase 3)` on spawn.
+
+---
+
+## Writing a new adapter
+
+A new runtime plugs in with exactly **one adapter implementation + one registry line**. No changes to the gateway, persistence, or token model.
+
+### Step 1 -- Add an `AgentRuntime` variant
+
+In `proto/rust_brain/v1/agent.proto`:
+
+```protobuf
+enum AgentRuntime {
+  AGENT_RUNTIME_UNSPECIFIED = 0;
+  AGENT_RUNTIME_CLAUDE_CODE = 1;
+  AGENT_RUNTIME_OPENCODE    = 2;
+  AGENT_RUNTIME_PI          = 3;
+  AGENT_RUNTIME_MY_RUNTIME  = 4;   // <-- add here
+}
+```
+
+Rebuild protobuf: `cargo build -p rb-schemas`.
+
+### Step 2 -- Implement the trait
+
+Create `services/agent-runner/src/adapters/my_runtime.rs`:
+
+```rust
+use anyhow::Result;
+use async_trait::async_trait;
+use rb_schemas::AgentRuntime;
+
+use super::{
+    AgentProcess, LineKind, ParsedLine, RuntimeAdapter, RuntimeCaps,
+    RuntimeHealth, RuntimeManifest, SessionCtx, build_base_command,
+    write_mcp_config,
+};
+
+pub struct MyRuntimeAdapter;
+
+impl MyRuntimeAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter for MyRuntimeAdapter {
+    fn manifest(&self) -> RuntimeManifest {
+        RuntimeManifest {
+            kind: AgentRuntime::MyRuntime,
+            binary: "my-runtime",
+            required_env: &[],
+            capabilities: RuntimeCaps {
+                multi_turn: true,
+                streams_json: false,
+            },
+        }
+    }
+
+    async fn spawn(&self, ctx: &SessionCtx) -> Result<AgentProcess> {
+        // Write MCP config so the runtime can call Rustacean tools
+        write_mcp_config(&ctx.workspace_path, &ctx.api_key, &ctx.tenant_id)
+            .await?;
+
+        let mut cmd = build_base_command("my-runtime", &ctx.workspace_path);
+        cmd.arg("--prompt").arg(&ctx.initial_prompt);
+        // Add runtime-specific env vars here
+
+        let child = cmd.spawn()?;
+        let pid = child.id().unwrap_or(0);
+
+        Ok(AgentProcess {
+            child,
+            pid,
+            runtime: AgentRuntime::MyRuntime,
+        })
+    }
+
+    async fn send_input(&self, proc: &mut AgentProcess, input: &str) -> Result<()> {
+        use tokio::io::AsyncWriteExt;
+        let stdin = proc.child.stdin.as_mut()
+            .ok_or_else(|| anyhow::anyhow!("stdin not available"))?;
+        stdin.write_all(input.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    fn parse_stdout_line(&self, line: &str) -> Option<ParsedLine> {
+        if line.trim().is_empty() {
+            return None;
+        }
+        Some(ParsedLine {
+            kind: LineKind::Text,
+            payload: line.to_string(),
+        })
+    }
+
+    async fn health(&self, proc: &AgentProcess) -> RuntimeHealth {
+        // Check if the process is still running
+        // Return RuntimeHealth::Healthy or RuntimeHealth::Unhealthy
+        todo!()
+    }
+
+    async fn terminate(&self, proc: &mut AgentProcess, force: bool) -> Result<()> {
+        if force {
+            proc.child.kill().await?;
+        } else {
+            proc.child.kill().await?; // Replace with graceful signal
+        }
+        Ok(())
+    }
+}
+```
+
+### Step 3 -- Register in the adapter factory
+
+In `services/agent-runner/src/adapters/mod.rs`, add the module and the match arm:
+
+```rust
+pub mod my_runtime;
+
+pub fn adapter_for_runtime(runtime: AgentRuntime) -> anyhow::Result<Box<dyn RuntimeAdapter>> {
+    match runtime {
+        AgentRuntime::ClaudeCode => Ok(Box::new(claude_code::ClaudeCodeAdapter::new())),
+        AgentRuntime::Opencode => Ok(Box::new(opencode::OpencodeAdapter::new())),
+        AgentRuntime::Pi => Ok(Box::new(pi::PiAdapter::new())),
+        AgentRuntime::MyRuntime => Ok(Box::new(my_runtime::MyRuntimeAdapter::new())),
+        AgentRuntime::Unspecified => anyhow::bail!("Unspecified runtime received"),
+    }
+}
+```
+
+### Step 4 -- Add the runtime to the chat session CHECK constraint
+
+In the migration (or a follow-up migration):
+
+```sql
+ALTER TABLE control.chat_sessions
+  DROP CONSTRAINT chat_sessions_runtime_check,
+  ADD CONSTRAINT chat_sessions_runtime_check
+    CHECK (runtime IN ('claude_code','opencode','pi','my_runtime'));
+```
+
+### Step 5 -- Verify
+
+```bash
+cargo build -p rb-agent-runner   # adapter compiles
+cargo test -p rb-agent-runner    # existing tests still pass
+```
+
+The chat gateway, persistence layer, MCP token model, and SSE event relay require **zero changes** -- they operate on the `RuntimeAdapter` trait, not on concrete types.
+
+---
+
+## Process lifecycle
+
+```
+Session created (first message)
+  |
+  +-- spawn() --> OS process starts in isolated workspace
+                  .mcp.json written with MCP JWT (0600 perms)
+                  kill_on_drop(true) set on Child
+     |
+     |-- send_input() (warm turn) --> stdin
+     |     |
+     |     +-- stdout --> parse_stdout_line() --> redaction --> agent_events + SSE
+     |
+     |-- health() --> liveness probe (idle reaper)
+     |
+     +-- terminate() --> graceful then forced kill
+                         workspace cleaned by workspace_gc
+```
+
+- **One process per session.** The process stays warm between user messages. Each message is a `send_input()` call over stdin.
+- **No automatic restart.** A crashed process emits `session_failed{error_kind="runtime_crashed"}` and surfaces a typed error to the UI. The user re-sends to start fresh.
+- **Isolation.** Each process gets its own workspace directory, its own MCP credential (tenant-bound, read-scoped, short-lived JWT), and its own cgroup resource limits. One crash never affects other sessions.
+
+---
+
+## Resource limits per process
+
+| Limit | Default | Mechanism |
+|-------|---------|-----------|
+| Memory | 1 GiB | cgroup v2 `memory.max` |
+| CPU | 1 core-equiv | cgroup `cpu.weight` |
+| Idle timeout | 15 min | reaper on `chat_sessions.last_activity_at` |
+| Wall-clock | 60 min/session | hard cap |
+| Concurrency | 20/tenant, 200/node | per-tenant counter + per-node semaphore |

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -1,0 +1,300 @@
+# Runtime Configuration
+
+Operator runbook for configuring the agent and chat runtime subsystem: environment variables, resource limits, LLM credential storage, and troubleshooting.
+
+**Services covered**: `control-api` (chat-gateway, MCP server), `agent-runner` (runtime supervisor).
+**Builds on**: [ADR-009](decisions/ADR-009-agent-execution-architecture.md) (Wave 7), ADR-013 (Wave 9).
+
+---
+
+## Environment variables — control-api
+
+These variables configure the chat gateway and MCP token model on `control-api`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RB_CHAT_PANEL_ENABLED` | `false` | Feature flag. Set `true` to expose `/v1/chat/*` routes and the ChatPage UI. |
+| `RB_MCP_JWT_SECRET` | — | **Required for chat.** HS256 signing key for MCP session JWTs. Store in `rb-secrets`; rotate via key-id in the JWT `kid` header. |
+| `RB_MCP_JWT_TTL_SECS` | `900` (15 min) | JWT lifetime. Tokens are re-minted on activity when within `RB_MCP_JWT_REFRESH_SECS` of expiry. |
+| `RB_MCP_JWT_REFRESH_SECS` | `120` (2 min) | Window before `exp` in which the gateway re-mints the JWT and rewrites `.mcp.json`. |
+| `RB_TENANT_SESSION_CAP` | `100` | Maximum concurrent agent+chat sessions per tenant. |
+| `RB_SESSION_CREATE_RATE_LIMIT` | `10` | Session-create requests per minute per tenant. |
+
+---
+
+## Environment variables — agent-runner
+
+These variables configure the runtime supervisor and adapters on `agent-runner`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KAFKA_BOOTSTRAP_SERVERS` | `kafka:9092` | Kafka broker list. `agent-runner` consumes from `rb.agent.commands`. |
+| `RB_AGENT_WORKSPACE_BASE` | `/data/agent-workspaces` | Root directory for per-session isolated workspaces. Each session gets `{base}/{tenant_id}/{session_id}/`. |
+| `RUST_BRAIN_API_BASE` | `http://control-api:8080` | Control-API base URL for internal callbacks. |
+| `RB_CONTROL_API_BASE_URL` | `http://control-api:8081` | Internal API base (status callbacks, key revocation). |
+| `RB_INTERNAL_SECRET` | — | Shared secret for internal endpoints (`/internal/agent/*`). |
+| `AGENT_RUNTIMES_ENABLED` | all | Comma-separated list of enabled runtimes. Set to e.g. `claude_code` to disable others cluster-wide without a code change. |
+| `AGENT_DEFAULT_RUNTIME` | `claude_code` | Default runtime when not specified in the session-create request. |
+| `AGENT_DEFAULT_MODEL_BY_RUNTIME` | — | JSON map of `{runtime: model}` defaults, e.g. `{"opencode":"claude-sonnet-4-6"}`. |
+
+### Claude Code adapter
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_CONFIG_DIR` | `/home/loginuser/.claude` | Path to Claude credentials directory. Mounted read-only from the `claude-credentials` named volume. |
+| `ANTHROPIC_API_KEY` | — | Direct Anthropic API key (optional; OAuth credentials via `claude-login` are the primary path). |
+
+### OpenCode / LiteLLM adapter
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LITELLM_BASE_URL` | — | LiteLLM proxy endpoint (e.g. `http://litellm:4000`). Required for `opencode` and `pi` runtimes. |
+| `LITELLM_API_KEY` | — | LiteLLM virtual key. One key per (tenant, runtime) tuple. |
+| `CHAT_MODEL` | — | LLM model to use for chat sessions via LiteLLM (e.g. `claude-sonnet-4-6`, `gpt-4o`). |
+
+---
+
+## LLM credential storage
+
+### Claude Code (OAuth via SSH sidecar)
+
+The `claude-login` SSH sidecar container provides a one-time login flow. Credentials are stored in the `claude-credentials` Docker named volume and mounted read-only into `agent-runner`.
+
+```bash
+# One-time setup: SSH into the sidecar and log in
+ssh -p ${CLAUDE_SSH_HOST_PORT:-12222} loginuser@localhost
+# Inside the container:
+claude /login
+```
+
+The credentials persist across container restarts (Docker named volume). Re-run `claude /login` only if the credentials expire or are revoked.
+
+**Alert**: `ClaudeCredentialsMissing` fires when `claude_code` sessions fail with `error_kind="claude_not_logged_in"` at > 10/hour. Re-run `claude /login` via the SSH sidecar.
+
+### LiteLLM provider keys
+
+LLM provider API keys (Anthropic, OpenAI, Bedrock) are stored in `rb-secrets` and mounted into the LiteLLM pod only. They are **never** mounted into `control-api` or `agent-runner`.
+
+```
+rb-secrets
+  └─ litellm/
+       ├─ ANTHROPIC_API_KEY
+       ├─ OPENAI_API_KEY
+       └─ ...provider keys
+```
+
+To add or rotate a provider key:
+
+1. Update the key in `rb-secrets`.
+2. Restart the LiteLLM service to pick up the new value.
+3. Verify with `curl http://<litellm>:4000/health/readiness`.
+
+### MCP JWT signing key
+
+The `RB_MCP_JWT_SECRET` is the HS256 key used to sign and verify MCP session tokens. It must be stored in `rb-secrets`.
+
+To rotate:
+
+1. Generate a new key (at least 32 bytes of randomness).
+2. Update `RB_MCP_JWT_SECRET` in `rb-secrets`.
+3. Restart `control-api`. Existing JWTs signed with the old key will fail verification on their next `/mcp` call, forcing the runtime to get a fresh token at the next activity refresh.
+
+---
+
+## Resource limits
+
+### Per-process limits
+
+Each chat or agent session spawns one OS process in an isolated workspace. Resource limits are enforced via cgroup v2 (the container is already cgroup-scoped).
+
+| Limit | Default | Env var | Description |
+|-------|---------|---------|-------------|
+| Memory | 1 GiB | `RB_AGENT_PROCESS_MEMORY_MAX` | cgroup `memory.max`. OOM kill triggers `session_failed{error_kind="runtime_oom"}`. |
+| CPU | 1 core-equiv | `RB_AGENT_PROCESS_CPU_WEIGHT` | cgroup `cpu.weight`. Bursty chat workloads are throttled, not killed. |
+| Idle timeout | 15 min | `RB_AGENT_IDLE_TIMEOUT_SECS` | Reaper checks `last_activity_at`. No user message for this duration ends the session. |
+| Wall-clock | 60 min | `RB_AGENT_WALL_CLOCK_SECS` | Hard cap per session. Terminal event: `wall_clock_exceeded`. |
+
+### Per-tenant limits
+
+| Limit | Default | Env var | Description |
+|-------|---------|---------|-------------|
+| Concurrent sessions | 20 (chat) / 100 (agent+chat) | `RB_TENANT_CHAT_SESSION_CAP` / `RB_TENANT_SESSION_CAP` | Excess requests return `429 rate_limit_exceeded`. |
+| Session-create rate | 10/min | `RB_SESSION_CREATE_RATE_LIMIT` | Per-tenant burst protection. |
+| Cost circuit-breaker | $100/hour | `AGENT_TENANT_COST_PER_HOUR_USD_MICRO_CAP` | Applies to LiteLLM-routed runtimes only. Claude Code spend is on the user's plan. |
+
+### Per-node limits
+
+| Limit | Default | Env var | Description |
+|-------|---------|---------|-------------|
+| Total live sessions | 200 | `MAX_ACTIVE_SESSIONS_PER_PROCESS` | Per-node semaphore. Excess returns `429`. |
+
+---
+
+## Kafka topics
+
+The runtime subsystem uses two Kafka topics (created by `kafka-init` at stack boot):
+
+| Topic | Partitions | Retention | Purpose |
+|-------|-----------|-----------|---------|
+| `rb.agent.commands` | 6 | 7 days | Session start/terminate commands dispatched by the chat-gateway |
+| `rb.agent.events` | 6 | 7 days | Runtime events relayed back from agent-runner to control-api |
+
+---
+
+## Logs and observability
+
+### Structured logs
+
+Both `control-api` and `agent-runner` emit structured JSON logs. Filter by component:
+
+```bash
+# Chat gateway logs (session create, JWT mint, dispatch)
+docker compose -f compose/dev.yml logs control-api | grep "chat"
+
+# Runtime supervisor logs (spawn, stdin/stdout, crash, cleanup)
+docker compose -f compose/dev.yml logs agent-runner
+
+# Filter by session ID
+docker compose -f compose/dev.yml logs agent-runner | grep "<session-id>"
+```
+
+### Traces
+
+Every chat session opens a root OTel span `agent.session.run` with:
+- `tenant.id`, `user.id`, `session.id`
+- Tool calls as child spans: `agent.tool.<name>` with `tool.duration_ms`, `tool.result.size`
+- LLM calls as child spans: `agent.llm.call` with `llm.model`, `llm.input_tokens`, `llm.output_tokens`
+
+The `trace_id` (32-hex) is pinned on `chat_sessions.trace_id` at session start. View in Tempo via the UI's trace link or:
+
+```bash
+curl -s "http://localhost:3200/api/traces/<trace_id>" | jq .
+```
+
+### Audit log
+
+Every MCP tool call is written to `audit.audit_events`:
+- `action`: `mcp.tools.call.<tool_name>`
+- `args_hash`: SHA-256 of the tool arguments (raw args are never persisted)
+- `outcome`: success or error
+- `jti`: JWT ID for chat-to-audit correlation
+
+Query the audit log:
+
+```bash
+curl -s -H "Authorization: Bearer $ADMIN_KEY" \
+  "http://localhost:8080/v1/admin/audit-log?action=mcp.tools.call" | jq .
+```
+
+### Metrics and alerts
+
+| Metric / Alert | Description |
+|---------------|-------------|
+| `agent_sessions_active{runtime}` | Gauge of live sessions per runtime |
+| `agent_session_duration_seconds` | Histogram of session wall-clock time |
+| `mcp_tool_call_duration_seconds` | Histogram of MCP tool call latency (server-side) |
+| `ClaudeCredentialsMissing` | `claude_code` sessions failing with `claude_not_logged_in` > 10/hour |
+| `LiteLLMUnreachable` | LiteLLM health check failing for > 2 min |
+| `OAuthClaudeRefreshFailureRate` | OAuth token refresh failure rate anomaly (logged at 100%) |
+| `AgentEventsPartitionLag` | Kafka partition lag on `rb.agent.events` exceeds threshold |
+
+---
+
+## Troubleshooting
+
+### agent-runner not starting
+
+**Symptom**: `agent-runner` container exits immediately or stays in `restarting`.
+
+**Check**:
+1. Kafka is healthy: `docker compose -f compose/dev.yml exec kafka kafka-topics.sh --bootstrap-server localhost:9092 --list`
+2. `KAFKA_BOOTSTRAP_SERVERS` is set correctly in `compose/dev.yml`.
+3. `RB_AGENT_WORKSPACE_BASE` directory exists and is writable inside the container.
+
+### Claude Code sessions fail with `claude_not_logged_in`
+
+**Cause**: The `claude-credentials` volume is empty or credentials have expired.
+
+**Fix**:
+```bash
+ssh -p ${CLAUDE_SSH_HOST_PORT:-12222} loginuser@localhost
+claude /login
+```
+
+Verify credentials exist:
+```bash
+docker compose -f compose/dev.yml exec agent-runner \
+  ls -la /home/loginuser/.claude/credentials.json
+```
+
+### OpenCode sessions fail with `llm_unavailable`
+
+**Cause**: LiteLLM proxy is unreachable from `agent-runner`.
+
+**Check**:
+1. LiteLLM is running: `curl http://<litellm-host>:4000/health/readiness`
+2. `LITELLM_BASE_URL` is set in `agent-runner` environment.
+3. Network connectivity: `agent-runner` must reach LiteLLM over `rb-net` or the configured URL.
+
+### Workspace disk filling up
+
+**Cause**: Orphaned workspaces from crashed sessions not cleaned up.
+
+**Fix**: The `workspace_gc` reaper runs periodically and sweeps abandoned workspaces. To force cleanup:
+
+```bash
+docker compose -f compose/dev.yml exec agent-runner \
+  ls /data/agent-workspaces/
+# Identify stale directories (no corresponding active session)
+```
+
+### High MCP tool call latency (> 200 ms p95)
+
+**Possible causes**:
+1. Neo4j or Qdrant under load — check `docker compose -f compose/dev.yml logs neo4j`.
+2. Large graph traversal — `get_callers`/`get_callees` at depth > 5 are expensive.
+3. Network latency between `agent-runner` and `control-api` (should be < 1 ms on same host).
+
+---
+
+## Compose configuration reference
+
+The `compose/dev.yml` file defines both `agent-runner` and `claude-login`. Key sections:
+
+```yaml
+agent-runner:
+  image: ghcr.io/jarnura/rustacean/agent-runner:dev
+  environment:
+    KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    RB_AGENT_WORKSPACE_BASE: /data/agent-workspaces
+    RUST_BRAIN_API_BASE: http://control-api:8080
+    RB_CONTROL_API_BASE_URL: http://control-api:8081
+    RB_INTERNAL_SECRET: ${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}
+    CLAUDE_CONFIG_DIR: /home/loginuser/.claude
+    LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+    LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+    CHAT_MODEL: ${CHAT_MODEL:-}
+  volumes:
+    - agent-workspace-data:/data/agent-workspaces
+    - claude-credentials:/home/loginuser/.claude:ro
+
+claude-login:
+  image: rustbrain/claude-login:dev
+  ports:
+    - "${CLAUDE_SSH_HOST_PORT:-12222}:22"
+  environment:
+    RB_SSH_AUTHORIZED_KEYS: ${RB_SSH_AUTHORIZED_KEYS:-}
+    CLAUDE_CONFIG_DIR: /home/loginuser/.claude
+  volumes:
+    - claude-credentials:/home/loginuser/.claude
+```
+
+---
+
+## Related documentation
+
+- [Chat Panel](chat-panel.md) — user-facing overview of the chat feature
+- [API Reference — Chat endpoints](api-reference.md#chat-session-endpoints-wave-9) — REST API contract
+- [Getting Started — Agent runtime setup](getting-started.md#7-agent-runtime-setup-wave-7) — initial setup instructions
+- [ADR-009](decisions/ADR-009-agent-execution-architecture.md) — Wave 7 agent execution architecture
+- [Architecture](architecture.md) — system overview and topology diagram


### PR DESCRIPTION
## Summary

Full Wave 9 documentation set:

- **`docs/chat-panel.md`** — user guide: feature flag, how it works, authentication, available runtimes, MCP tools, prompt examples, resource limits, troubleshooting, data retention
- **`docs/runtime-adapter.md`** — runtime adapter contract: `RuntimeAdapter` trait, existing adapters, step-by-step guide for authoring a new adapter, process lifecycle, resource limits
- **`docs/mcp-chat-tokens.md`** — MCP token model: JWT shape, claims, lifecycle, configuration, verification path, tenant binding, scope enforcement, audit, log-redaction contract
- **`docs/decisions/ADR-013-chat-panel-architecture.md`** — architecture decision record for the chat panel
- **`CHANGELOG.md`** — Wave 9 entry + retroactive Wave 7/8 entries
- **`docs/runbook.md`** — Wave 9 operator section: flag toggle, JWT secret rotation, runtime process inspection, common failure modes
- **`docs/architecture.md`** — ADR-012 and ADR-013 added to decision records table
- **`docs/runtime-config.md`** — runtime configuration reference
- **`docs/api-reference.md`** — Wave 9 chat API sections
- **`docs/getting-started.md`** — chat panel quickstart

## GitHub Issue

Closes #641

## Deferred

API reference regen (`openapi.json`) deferred until chat gateway routes stabilize on `main`.

## Checklist

- [x] All doc files authored and cross-linked
- [x] ADR-013 committed
- [x] CHANGELOG created with Wave 9 + retroactive entries
- [x] Operator runbook updated with Wave 9 section
- [x] Architecture decision table updated
- [x] Docs-only PR — no code changes