### PR TITLE
[REQ-FE-12] feat(frontend): chat panel — ChatPage + hooks (flag-gated)

### DIFF
--- a/frontend/src/api/chat-client.ts
+++ b/frontend/src/api/chat-client.ts
@@ -1,0 +1,63 @@
+// Typed wrapper for /v1/chat/* API calls.
+// The chat paths are not yet in the generated openapi.json (S3 is a peer stream);
+// this module provides a typed surface until `npm run gen:api` is re-run after S3 ships.
+// At that point, delete this file and migrate to the main apiClient in ./client.ts.
+
+import createClient from "openapi-fetch";
+import type {
+  CreateChatSessionRequest,
+  CreateChatSessionResponse,
+  ListChatSessionsResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+} from "@/lib/chat-api";
+
+function resolveBaseUrl(): string {
+  const fromEnv = import.meta.env.VITE_API_BASE_URL as string | undefined;
+  return fromEnv?.replace(/\/$/, "") ?? "";
+}
+
+// We use `createClient` (not raw `fetch`) so the middleware stack (trace IDs,
+// credentials) is consistent with the main apiClient. The `as unknown as` cast
+// is unavoidable here: the /v1/chat/* path types are not in the generated
+// OpenAPI schema yet (S3 peer stream), so we define the contract locally and
+// cast once at the boundary rather than carrying `any` through the hooks.
+const _rawClient = createClient({
+  baseUrl: resolveBaseUrl(),
+  credentials: "include",
+  headers: { "Content-Type": "application/json" },
+});
+
+type FetchResponse<T> = {
+  data: T | undefined;
+  error: unknown;
+  response: Response;
+};
+
+export const chatApiClient = {
+  listSessions: (): Promise<FetchResponse<ListChatSessionsResponse>> =>
+    (_rawClient.GET as (path: string) => Promise<FetchResponse<ListChatSessionsResponse>>)(
+      "/v1/chat/sessions",
+    ),
+
+  createSession: (
+    body: CreateChatSessionRequest,
+  ): Promise<FetchResponse<CreateChatSessionResponse>> =>
+    (
+      _rawClient.POST as (
+        path: string,
+        opts: { body: CreateChatSessionRequest },
+      ) => Promise<FetchResponse<CreateChatSessionResponse>>
+    )("/v1/chat/sessions", { body }),
+
+  sendMessage: (
+    sessionId: string,
+    body: SendMessageRequest,
+  ): Promise<FetchResponse<SendMessageResponse>> =>
+    (
+      _rawClient.POST as (
+        path: string,
+        opts: { params: { path: { id: string } }; body: SendMessageRequest },
+      ) => Promise<FetchResponse<SendMessageResponse>>
+    )("/v1/chat/sessions/{id}/messages", { params: { path: { id: sessionId } }, body }),
+};

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -97,3 +97,13 @@ export {
   useStageTimeline,
   stageTimelineQueryKey,
 } from "./useTraceViewer";
+export {
+  useChatSessions,
+  useCreateChatSession,
+  useSendChatMessage,
+  chatSessionsQueryKey,
+  type ChatSession,
+  type ListChatSessionsResponse,
+  type CreateChatSessionRequest,
+  type CreateChatSessionResponse,
+} from "./useChatSessions";

--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -106,4 +106,5 @@ export {
   type ListChatSessionsResponse,
   type CreateChatSessionRequest,
   type CreateChatSessionResponse,
+  type SendMessageVariables,
 } from "./useChatSessions";

--- a/frontend/src/api/hooks/useChatSessions.ts
+++ b/frontend/src/api/hooks/useChatSessions.ts
@@ -57,9 +57,11 @@ export function useCreateChatSession(tenantId: string) {
   });
 }
 
-export function useSendChatMessage(sessionId: string) {
-  return useMutation<SendMessageResponse, ApiError, SendMessageRequest>({
-    mutationFn: async (body) => {
+export type SendMessageVariables = SendMessageRequest & { sessionId: string };
+
+export function useSendChatMessage() {
+  return useMutation<SendMessageResponse, ApiError, SendMessageVariables>({
+    mutationFn: async ({ sessionId, ...body }) => {
       const { data, error, response } = await chatApiClient.sendMessage(sessionId, body);
       if (error || !data) {
         throw toApiError(response.status, error, response);

--- a/frontend/src/api/hooks/useChatSessions.ts
+++ b/frontend/src/api/hooks/useChatSessions.ts
@@ -1,0 +1,79 @@
+// Chat session API hooks.
+// Uses chatApiClient (locally-typed wrapper) because /v1/chat/* paths are not yet
+// in the generated openapi.json (S3 is a peer stream). Once S3 ships and
+// `npm run gen:api` regenerates the schema, migrate to the main apiClient.
+
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from "@tanstack/react-query";
+import { toApiError, type ApiError } from "../client";
+import { chatApiClient } from "../chat-client";
+import type {
+  ListChatSessionsResponse,
+  CreateChatSessionRequest,
+  CreateChatSessionResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+  ChatSession,
+} from "@/lib/chat-api";
+
+export const chatSessionsQueryKey = (tenantId: string) =>
+  ["tenants", tenantId, "chat-sessions"] as const;
+
+export function useChatSessions(
+  tenantId: string,
+  options?: Omit<
+    UseQueryOptions<ListChatSessionsResponse, ApiError>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<ListChatSessionsResponse, ApiError>({
+    queryKey: chatSessionsQueryKey(tenantId),
+    queryFn: async () => {
+      const { data, error, response } = await chatApiClient.listSessions();
+      if (error || !data) {
+        throw toApiError(response.status, error, response);
+      }
+      return data;
+    },
+    enabled: tenantId.length > 0,
+    staleTime: 15_000,
+    refetchInterval: 10_000,
+    ...options,
+  });
+}
+
+export function useCreateChatSession(tenantId: string) {
+  const qc = useQueryClient();
+  return useMutation<CreateChatSessionResponse, ApiError, CreateChatSessionRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await chatApiClient.createSession(body);
+      if (error || !data) {
+        throw toApiError(response.status, error, response);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: chatSessionsQueryKey(tenantId) });
+    },
+  });
+}
+
+export function useSendChatMessage(sessionId: string) {
+  return useMutation<SendMessageResponse, ApiError, SendMessageRequest>({
+    mutationFn: async (body) => {
+      const { data, error, response } = await chatApiClient.sendMessage(sessionId, body);
+      if (error || !data) {
+        throw toApiError(response.status, error, response);
+      }
+      return data;
+    },
+  });
+}
+
+export type {
+  ChatSession,
+  ListChatSessionsResponse,
+  CreateChatSessionRequest,
+  CreateChatSessionResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+};

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import { routes } from "@/lib/routes";
+import { useChatFeatureEnabled } from "@/hooks/useChatFeatureEnabled";
 import type { ReactNode } from "react";
 
 interface AppShellProps {
@@ -8,6 +9,8 @@ interface AppShellProps {
 }
 
 export function AppShell({ children }: AppShellProps): JSX.Element {
+  const chatEnabled = useChatFeatureEnabled();
+
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <header className="border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -58,6 +61,14 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
             >
               Admin
             </Link>
+            {chatEnabled && (
+              <Link
+                to={routes.chat}
+                className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-[current=page]:bg-accent aria-[current=page]:text-foreground aria-[current=page]:font-medium"
+              >
+                Chat
+              </Link>
+            )}
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />

--- a/frontend/src/components/chat/MessageComposer.tsx
+++ b/frontend/src/components/chat/MessageComposer.tsx
@@ -1,0 +1,62 @@
+import { useRef, type FormEvent, type KeyboardEvent } from "react";
+
+interface MessageComposerProps {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly onSend: (content: string) => void;
+  readonly isDisabled: boolean;
+}
+
+export function MessageComposer({
+  value,
+  onChange,
+  onSend,
+  isDisabled,
+}: MessageComposerProps): JSX.Element {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed || isDisabled) return;
+    onSend(trimmed);
+    onChange("");
+    textareaRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      const trimmed = value.trim();
+      if (!trimmed || isDisabled) return;
+      onSend(trimmed);
+      onChange("");
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex gap-2 border-t border-border bg-background p-3"
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+        disabled={isDisabled}
+        rows={2}
+        aria-label="Chat message"
+        className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      <button
+        type="submit"
+        disabled={isDisabled || value.trim().length === 0}
+        className="self-end rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Send
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/chat/MessageThread.tsx
+++ b/frontend/src/components/chat/MessageThread.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef } from "react";
+import { ToolCallBlock } from "./ToolCallBlock";
+import type { TranscriptItem, AssistantItem } from "./transcript";
+
+interface MessageThreadProps {
+  readonly items: ReadonlyArray<TranscriptItem>;
+  readonly isStreaming: boolean;
+}
+
+export function MessageThread({ items, isStreaming }: MessageThreadProps): JSX.Element {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [items]);
+
+  if (items.length === 0 && !isStreaming) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-sm text-muted-foreground">Send a message to start the conversation.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+      {items.map((item) => {
+        if (item.kind === "user") {
+          return <UserBubble key={item.id} text={item.text} />;
+        }
+        if (item.kind === "assistant") {
+          return <AssistantBubble key={item.id} items={item.items} />;
+        }
+        if (item.kind === "error") {
+          return item.code !== undefined
+            ? <ErrorBanner key={item.id} message={item.message} code={item.code} />
+            : <ErrorBanner key={item.id} message={item.message} />;
+        }
+        return null;
+      })}
+      {isStreaming && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="Waiting for response"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        >
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/60" />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0.2s]" />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0.4s]" />
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+function UserBubble({ text }: { readonly text: string }): JSX.Element {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-primary px-4 py-2.5 text-primary-foreground">
+        <p className="whitespace-pre-wrap text-sm leading-relaxed">{text}</p>
+      </div>
+    </div>
+  );
+}
+
+function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantItem> }): JSX.Element {
+  if (items.length === 0) return <></>;
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[90%] space-y-2">
+        {items.map((item, i) => {
+          if (item.type === "text") {
+            return (
+              <p key={i} className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                {item.text}
+              </p>
+            );
+          }
+          if (item.type === "thinking") {
+            return <ThinkingBlock key={i} thinking={item.thinking} sequence={item.seq} />;
+          }
+          if (item.type === "tool_use") {
+            const result = findToolResult(items, item.id);
+            return (
+              <ToolCallBlock
+                key={item.id}
+                name={item.name}
+                input={item.input}
+                result={result?.content ?? null}
+                isError={result?.isError ?? false}
+                sequence={item.seq}
+              />
+            );
+          }
+          if (item.type === "error") {
+            return (
+              <p key={i} className="text-sm text-destructive">
+                {item.message}
+              </p>
+            );
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function findToolResult(
+  items: ReadonlyArray<AssistantItem>,
+  toolUseId: string,
+): { content: unknown; isError: boolean } | null {
+  for (const item of items) {
+    if (item.type === "tool_result" && item.toolUseId === toolUseId) {
+      return { content: item.content, isError: item.isError };
+    }
+  }
+  return null;
+}
+
+function ThinkingBlock({
+  thinking,
+  sequence,
+}: {
+  readonly thinking: string;
+  readonly sequence: number;
+}): JSX.Element {
+  const preview = thinking.slice(0, 80);
+  return (
+    <details className="rounded border border-border/40 bg-muted/10 px-3 py-2 text-xs">
+      <summary className="cursor-pointer text-muted-foreground">
+        #{sequence} Thinking: {preview}{thinking.length > 80 ? "…" : ""}
+      </summary>
+      <p className="mt-2 whitespace-pre-wrap text-muted-foreground">{thinking}</p>
+    </details>
+  );
+}
+
+function ErrorBanner({
+  message,
+  code,
+}: {
+  readonly message: string;
+  readonly code?: string;
+}): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="rounded border border-destructive/30 bg-destructive/5 px-4 py-3 text-center"
+    >
+      {code && <p className="text-xs font-medium uppercase text-muted-foreground">{code}</p>}
+      <p className="text-sm text-destructive">{message}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/SessionSidebar.tsx
+++ b/frontend/src/components/chat/SessionSidebar.tsx
@@ -1,0 +1,120 @@
+import type { ChatSession, ChatRuntime } from "@/lib/chat-api";
+import type { ApiError } from "@/api/client";
+import { formatApiError } from "@/lib/errors/api";
+import { formatTimestamp } from "@/components/activity/utils";
+
+interface SessionSidebarProps {
+  readonly sessions: ReadonlyArray<ChatSession>;
+  readonly activeSessionId: string | null;
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly error: ApiError | null;
+  readonly isCreating: boolean;
+  readonly onSelectSession: (id: string) => void;
+  readonly onNewSession: (runtime: ChatRuntime) => void;
+}
+
+const RUNTIME_LABELS: Record<ChatRuntime, string> = {
+  claude_code: "Claude Code",
+  opencode: "OpenCode",
+  pi: "Pi",
+};
+
+const STATUS_DOT: Record<string, string> = {
+  active: "bg-green-500",
+  ended: "bg-muted-foreground",
+  failed: "bg-destructive",
+};
+
+export function SessionSidebar({
+  sessions,
+  activeSessionId,
+  isLoading,
+  isError,
+  error,
+  isCreating,
+  onSelectSession,
+  onNewSession,
+}: SessionSidebarProps): JSX.Element {
+  return (
+    <aside
+      aria-label="Chat sessions"
+      className="flex w-64 shrink-0 flex-col border-r border-border bg-card"
+    >
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-sm font-semibold">Sessions</h2>
+        <button
+          type="button"
+          onClick={() => onNewSession("claude_code")}
+          disabled={isCreating}
+          aria-label="New chat session"
+          className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          {isCreating ? "Creating…" : "+ New"}
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <p className="px-4 py-3 text-xs text-muted-foreground">Loading…</p>
+        ) : isError ? (
+          <p className="px-4 py-3 text-xs text-destructive">
+            {formatApiError(error, "Could not load sessions.")}
+          </p>
+        ) : sessions.length === 0 ? (
+          <p className="px-4 py-4 text-xs text-muted-foreground">
+            No sessions yet. Click + New to start.
+          </p>
+        ) : (
+          <ul role="list" className="space-y-px py-1">
+            {sessions.map((session) => (
+              <SessionRow
+                key={session.id}
+                session={session}
+                isActive={session.id === activeSessionId}
+                onClick={() => onSelectSession(session.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+interface SessionRowProps {
+  readonly session: ChatSession;
+  readonly isActive: boolean;
+  readonly onClick: () => void;
+}
+
+function SessionRow({ session, isActive, onClick }: SessionRowProps): JSX.Element {
+  const statusDot = STATUS_DOT[session.status] ?? "bg-muted-foreground";
+  const runtimeLabel = RUNTIME_LABELS[session.runtime] ?? session.runtime;
+  const created = formatTimestamp(session.created_at);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={isActive}
+        className={`w-full px-4 py-2.5 text-left transition-colors hover:bg-accent ${
+          isActive ? "bg-accent text-foreground" : "text-muted-foreground"
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className={`h-1.5 w-1.5 rounded-full ${statusDot}`}
+          />
+          <span className="text-xs font-medium">{runtimeLabel}</span>
+        </div>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
+          {session.id.slice(0, 8)}…
+        </p>
+        <p className="mt-0.5 text-[10px] text-muted-foreground/60">{created}</p>
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+interface ToolCallBlockProps {
+  readonly name: string;
+  readonly input: unknown;
+  readonly result: unknown | null;
+  readonly isError: boolean;
+  readonly sequence: number;
+}
+
+export function ToolCallBlock({
+  name,
+  input,
+  result,
+  isError,
+  sequence,
+}: ToolCallBlockProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const hasResult = result !== null;
+
+  const containerClass = hasResult && isError
+    ? "rounded border border-destructive/30 bg-destructive/5 px-3 py-2"
+    : hasResult
+      ? "rounded border border-green-200 bg-green-50/60 px-3 py-2 dark:border-green-900/40 dark:bg-green-950/20"
+      : "rounded border border-blue-200 bg-blue-50/60 px-3 py-2 dark:border-blue-900/40 dark:bg-blue-950/20";
+
+  const statusBadgeClass = hasResult && isError
+    ? "rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive"
+    : hasResult
+      ? "rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/40 dark:text-green-300"
+      : "rounded bg-blue-100 px-1.5 py-0.5 font-mono text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300";
+
+  const statusLabel = hasResult && isError ? "Error" : hasResult ? "Done" : "Running…";
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-label={`${name} tool call — ${statusLabel}`}
+      >
+        <span className="font-mono text-[10px] text-muted-foreground/50 tabular-nums">
+          #{sequence}
+        </span>
+        <span className={statusBadgeClass}>{name}</span>
+        <span className="text-xs text-muted-foreground">{statusLabel}</span>
+        <span className="ml-auto text-xs text-muted-foreground" aria-hidden="true">
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+      {open && (
+        <div className="mt-2 space-y-2">
+          <div>
+            <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              Input
+            </p>
+            <pre className="overflow-x-auto whitespace-pre text-xs text-muted-foreground">
+              {JSON.stringify(input, null, 2)}
+            </pre>
+          </div>
+          {hasResult && (
+            <div>
+              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Result
+              </p>
+              <pre className="overflow-x-auto whitespace-pre text-xs text-muted-foreground">
+                {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -1,0 +1,192 @@
+// Transcript types and reducer for building a conversational view from SSE events.
+
+import type { StreamedEvent } from "@/hooks/useEventStream";
+import type { ChatSessionEventEnvelope, ChatRuntimePayload } from "@/lib/chat-api";
+
+export interface UserTranscriptItem {
+  kind: "user";
+  id: string;
+  text: string;
+  seq: number;
+}
+
+export interface AssistantTranscriptItem {
+  kind: "assistant";
+  id: string;
+  items: ReadonlyArray<AssistantItem>;
+}
+
+export interface ErrorTranscriptItem {
+  kind: "error";
+  id: string;
+  message: string;
+  code?: string;
+}
+
+export type TranscriptItem =
+  | UserTranscriptItem
+  | AssistantTranscriptItem
+  | ErrorTranscriptItem;
+
+export type AssistantItem =
+  | { type: "text"; text: string; seq: number }
+  | { type: "thinking"; thinking: string; seq: number }
+  | { type: "tool_use"; id: string; name: string; input: unknown; seq: number }
+  | { type: "tool_result"; toolUseId: string; content: unknown; isError: boolean; seq: number }
+  | { type: "error"; message: string; code?: string; seq: number };
+
+interface ReducerState {
+  readonly items: ReadonlyArray<TranscriptItem>;
+  readonly pendingAssistant: ReadonlyArray<AssistantItem> | null;
+  readonly counter: number;
+}
+
+function parseJson<T>(s: string): T | null {
+  try {
+    return JSON.parse(s) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isChatSessionEventEnvelope(v: unknown): v is ChatSessionEventEnvelope {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.sequence === "number" &&
+    typeof o.payload === "object" &&
+    o.payload !== null &&
+    typeof (o.payload as Record<string, unknown>).type === "string"
+  );
+}
+
+function appendAssistantItem(
+  pending: ReadonlyArray<AssistantItem>,
+  payload: ChatRuntimePayload,
+  sequence: number,
+): ReadonlyArray<AssistantItem> {
+  if (payload.type === "text") {
+    const last = pending[pending.length - 1];
+    if (last?.type === "text") {
+      // Merge consecutive text tokens into one entry (immutable update).
+      return [
+        ...pending.slice(0, -1),
+        { type: "text", text: last.text + payload.text, seq: last.seq },
+      ];
+    }
+    return [...pending, { type: "text", text: payload.text, seq: sequence }];
+  }
+  if (payload.type === "thinking") {
+    return [...pending, { type: "thinking", thinking: payload.thinking, seq: sequence }];
+  }
+  if (payload.type === "tool_use") {
+    return [
+      ...pending,
+      { type: "tool_use", id: payload.id, name: payload.name, input: payload.input, seq: sequence },
+    ];
+  }
+  if (payload.type === "tool_result") {
+    return [
+      ...pending,
+      {
+        type: "tool_result",
+        toolUseId: payload.tool_use_id,
+        content: payload.content,
+        isError: payload.is_error,
+        seq: sequence,
+      },
+    ];
+  }
+  if (payload.type === "error") {
+    const errorItem: AssistantItem = payload.code !== undefined
+      ? { type: "error", message: payload.message, code: payload.code, seq: sequence }
+      : { type: "error", message: payload.message, seq: sequence };
+    return [...pending, errorItem];
+  }
+  return pending;
+}
+
+function flushPendingAssistant(state: ReducerState): ReducerState {
+  if (state.pendingAssistant === null || state.pendingAssistant.length === 0) {
+    return { ...state, pendingAssistant: null };
+  }
+  const assistantItem: AssistantTranscriptItem = {
+    kind: "assistant",
+    id: `a-${state.counter}`,
+    items: state.pendingAssistant,
+  };
+  return {
+    items: [...state.items, assistantItem],
+    pendingAssistant: null,
+    counter: state.counter + 1,
+  };
+}
+
+export const EMPTY_TRANSCRIPT_STATE: ReducerState = {
+  items: [],
+  pendingAssistant: null,
+  counter: 0,
+};
+
+export function buildTranscript(
+  events: ReadonlyArray<StreamedEvent>,
+): ReadonlyArray<TranscriptItem> {
+  let state: ReducerState = EMPTY_TRANSCRIPT_STATE;
+
+  for (const event of events) {
+    if (event.type === "stream-reset") {
+      state = EMPTY_TRANSCRIPT_STATE;
+      continue;
+    }
+
+    if (event.type === "session.error") {
+      const parsed = parseJson<{ error: string; status: string; message: string }>(event.data);
+      state = flushPendingAssistant(state);
+      const errorEntry: ErrorTranscriptItem = parsed?.status !== undefined
+        ? { kind: "error", id: `e-${state.counter}`, message: parsed.message ?? "Session ended.", code: parsed.status }
+        : { kind: "error", id: `e-${state.counter}`, message: parsed?.message ?? "Session ended." };
+      state = {
+        items: [...state.items, errorEntry],
+        pendingAssistant: null,
+        counter: state.counter + 1,
+      };
+      continue;
+    }
+
+    if (event.type !== "session.event") continue;
+
+    const envelope = parseJson<unknown>(event.data);
+    if (!isChatSessionEventEnvelope(envelope)) continue;
+
+    const { payload, sequence } = envelope;
+
+    if (payload.type === "user_input") {
+      state = flushPendingAssistant(state);
+      state = {
+        items: [
+          ...state.items,
+          { kind: "user", id: `u-${sequence}`, text: payload.text, seq: sequence },
+        ],
+        pendingAssistant: [],
+        counter: state.counter + 1,
+      };
+      continue;
+    }
+
+    const pending = state.pendingAssistant ?? [];
+    state = {
+      ...state,
+      pendingAssistant: appendAssistantItem(pending, payload, sequence),
+    };
+  }
+
+  // Flush any in-progress assistant turn (streaming).
+  if (state.pendingAssistant !== null && state.pendingAssistant.length > 0) {
+    return [
+      ...state.items,
+      { kind: "assistant", id: `a-${state.counter}`, items: state.pendingAssistant },
+    ];
+  }
+
+  return state.items;
+}

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_TEMPO_URL?: string;
+  readonly VITE_FEATURE_CHAT_PANEL?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/hooks/useChatFeatureEnabled.ts
+++ b/frontend/src/hooks/useChatFeatureEnabled.ts
@@ -1,0 +1,9 @@
+// Feature flag gate for the chat panel.
+// Returns true when the tenant has the rb-feature-resolver flag RB_CHAT_PANEL_ENABLED.
+//
+// Current implementation: reads VITE_FEATURE_CHAT_PANEL env var (for local dev and
+// QA flag-on testing). When S5 ships rb-feature-resolver, replace with a
+// /v1/features API call that checks the tenant's flag state.
+export function useChatFeatureEnabled(): boolean {
+  return import.meta.env.VITE_FEATURE_CHAT_PANEL === "true";
+}

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -1,0 +1,16 @@
+import { useEventStream, type UseEventStreamResult } from "./useEventStream";
+
+// Chat sessions reuse the Wave-7 event relay (ADR-013 §3).
+// Event types emitted on GET /v1/chat/sessions/{id}/events mirror
+// the agent session relay: session.event envelope + session.error lifecycle.
+const CHAT_STREAM_EVENT_TYPES = ["session.event", "session.error"] as const;
+
+export function useChatStream(
+  sessionId: string | null,
+  enabled = true,
+): UseEventStreamResult {
+  const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
+  const url = sessionId ? `${apiBase}/v1/chat/sessions/${sessionId}/events` : "";
+
+  return useEventStream(url, CHAT_STREAM_EVENT_TYPES, enabled && sessionId !== null);
+}

--- a/frontend/src/lib/chat-api.ts
+++ b/frontend/src/lib/chat-api.ts
@@ -1,0 +1,64 @@
+// Chat API types derived from ADR-013 contract.
+// TODO: once S3 ships and `npm run gen:api` regenerates the schema,
+// replace these hand-written types with imports from @/api/generated/schema.
+
+export type ChatRuntime = "claude_code" | "opencode" | "pi";
+export type ChatSessionStatus = "active" | "ended" | "failed";
+export type ChatMessageRole = "user" | "assistant" | "system" | "tool";
+
+export interface ChatSession {
+  id: string;
+  tenant_id: string;
+  user_id: string | null;
+  runtime: ChatRuntime;
+  status: ChatSessionStatus;
+  trace_id: string;
+  created_at: string;
+  last_activity_at: string;
+  ended_at: string | null;
+}
+
+export interface ListChatSessionsResponse {
+  sessions: ChatSession[];
+}
+
+export interface CreateChatSessionRequest {
+  runtime: ChatRuntime;
+}
+
+export interface CreateChatSessionResponse {
+  session_id: string;
+}
+
+export interface SendMessageRequest {
+  content: string;
+}
+
+export interface SendMessageResponse {
+  message_id: string;
+}
+
+// SSE event envelope — reuses the same agent-runner relay format (ADR-013 §7).
+// The chat event relay publishes over the same infrastructure as agent sessions,
+// so the envelope shape is identical.
+export type ChatRuntimePayload =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; tool_use_id: string; content: unknown; is_error: boolean }
+  | { type: "error"; message: string; code?: string }
+  | { type: "user_input"; text: string };
+
+export interface ChatSessionEventEnvelope {
+  session_id: string;
+  event_type: string;
+  sequence: number;
+  payload: ChatRuntimePayload;
+}
+
+export interface ChatSessionErrorEnvelope {
+  error: string;
+  status: string;
+  message: string;
+}
+

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -17,6 +17,7 @@ export const routes = {
   agentSessionReplay: "/agents/$sessionId",
   adminGithub: "/admin/github",
   trace: "/trace/$traceId",
+  chat: "/chat",
 } as const;
 
 export type RoutePath = (typeof routes)[keyof typeof routes];

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -45,7 +45,7 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
 
   const sessions = useChatSessions(tenantId);
   const createSession = useCreateChatSession(tenantId);
-  const sendMessage = useSendChatMessage(activeSessionId ?? "");
+  const sendMessage = useSendChatMessage();
 
   const { events, readyState } = useChatStream(activeSessionId);
 
@@ -62,10 +62,10 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
     if (!activeSessionId) {
       const result = await createSession.mutateAsync({ runtime: "claude_code" });
       setActiveSessionId(result.session_id);
-      await sendMessage.mutateAsync({ content });
+      await sendMessage.mutateAsync({ sessionId: result.session_id, content });
       return;
     }
-    await sendMessage.mutateAsync({ content });
+    await sendMessage.mutateAsync({ sessionId: activeSessionId, content });
   };
 
   const sessionList = sessions.data?.sessions ?? [];

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { useMe } from "@/api";
+import {
+  useChatSessions,
+  useCreateChatSession,
+  useSendChatMessage,
+} from "@/api/hooks/useChatSessions";
+import { useChatStream } from "@/hooks/useChatStream";
+import { SessionSidebar } from "@/components/chat/SessionSidebar";
+import { MessageThread } from "@/components/chat/MessageThread";
+import { MessageComposer } from "@/components/chat/MessageComposer";
+import { buildTranscript } from "@/components/chat/transcript";
+import { formatApiError } from "@/lib/errors/api";
+import type { ChatRuntime } from "@/lib/chat-api";
+
+export function ChatPage(): JSX.Element {
+  const me = useMe({ retry: false });
+
+  if (me.isLoading) {
+    return (
+      <div className="flex h-[calc(100vh-3.5rem-4rem)] items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (me.isError || !me.data) {
+    return (
+      <div className="flex h-[calc(100vh-3.5rem-4rem)] items-center justify-center">
+        <p className="text-sm text-muted-foreground">Sign in to use Chat.</p>
+      </div>
+    );
+  }
+
+  return <ChatInner tenantId={me.data.current_tenant.id} />;
+}
+
+interface ChatInnerProps {
+  readonly tenantId: string;
+}
+
+function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [composerValue, setComposerValue] = useState("");
+
+  const sessions = useChatSessions(tenantId);
+  const createSession = useCreateChatSession(tenantId);
+  const sendMessage = useSendChatMessage(activeSessionId ?? "");
+
+  const { events, readyState } = useChatStream(activeSessionId);
+
+  const transcript = useMemo(() => buildTranscript(events), [events]);
+
+  const isStreaming = sendMessage.isPending;
+
+  const handleNewSession = async (runtime: ChatRuntime) => {
+    const result = await createSession.mutateAsync({ runtime });
+    setActiveSessionId(result.session_id);
+  };
+
+  const handleSend = async (content: string) => {
+    if (!activeSessionId) {
+      const result = await createSession.mutateAsync({ runtime: "claude_code" });
+      setActiveSessionId(result.session_id);
+      await sendMessage.mutateAsync({ content });
+      return;
+    }
+    await sendMessage.mutateAsync({ content });
+  };
+
+  const sessionList = sessions.data?.sessions ?? [];
+
+  return (
+    <div className="flex h-[calc(100vh-3.5rem-4rem)]">
+      <SessionSidebar
+        sessions={sessionList}
+        activeSessionId={activeSessionId}
+        isLoading={sessions.isLoading}
+        isError={sessions.isError}
+        error={sessions.error}
+        isCreating={createSession.isPending}
+        onSelectSession={(id) => {
+          setActiveSessionId(id);
+          setComposerValue("");
+        }}
+        onNewSession={handleNewSession}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <ChatHeader
+          sessionId={activeSessionId}
+          readyState={readyState}
+        />
+
+        {sendMessage.isError && (
+          <div
+            role="alert"
+            className="border-b border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive"
+          >
+            {formatApiError(sendMessage.error, "Failed to send message.")}
+          </div>
+        )}
+
+        {activeSessionId === null ? (
+          <div className="flex flex-1 items-center justify-center">
+            <div className="text-center">
+              <p className="text-sm text-muted-foreground">
+                Select a session from the sidebar or start a new one.
+              </p>
+              <button
+                type="button"
+                onClick={() => void handleNewSession("claude_code")}
+                disabled={createSession.isPending}
+                className="mt-3 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {createSession.isPending ? "Starting…" : "New chat session"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <MessageThread items={transcript} isStreaming={isStreaming} />
+            <MessageComposer
+              value={composerValue}
+              onChange={setComposerValue}
+              onSend={(content) => {
+                void handleSend(content);
+              }}
+              isDisabled={isStreaming || createSession.isPending}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ChatHeaderProps {
+  readonly sessionId: string | null;
+  readonly readyState: "connecting" | "open" | "closed";
+}
+
+function ChatHeader({ sessionId, readyState }: ChatHeaderProps): JSX.Element {
+  const connectionColor =
+    readyState === "open"
+      ? "bg-green-500"
+      : readyState === "connecting"
+        ? "bg-yellow-500 animate-pulse"
+        : "bg-muted-foreground";
+
+  const connectionLabel =
+    readyState === "open" ? "Live" : readyState === "connecting" ? "Connecting…" : "";
+
+  return (
+    <div className="flex shrink-0 items-center justify-between border-b border-border bg-background/80 px-4 py-2 backdrop-blur">
+      <h1 className="text-base font-semibold">Chat</h1>
+      <div className="flex items-center gap-3">
+        {sessionId && (
+          <span className="font-mono text-xs text-muted-foreground" title={sessionId}>
+            {sessionId.slice(0, 8)}…
+          </span>
+        )}
+        {sessionId && (
+          <span className="flex items-center gap-1 text-xs text-muted-foreground" aria-live="polite">
+            <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${connectionColor}`} />
+            {connectionLabel}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { AppShell, GlobalSuspenseFallback } from "@/components/AppShell";
 import { ActivityPage } from "@/pages/ActivityPage";
 import { TraceViewerPage } from "@/pages/TraceViewerPage";
+import { ChatPage } from "@/pages/ChatPage";
 import { AgentExecutionPage } from "@/pages/AgentExecutionPage";
 import { AgentSessionDetailPage } from "@/pages/AgentSessionDetailPage";
 import { SessionReplayPage } from "@/pages/SessionReplayPage";
@@ -183,6 +184,19 @@ const traceRoute = createRoute({
   component: TraceViewerPage,
 });
 
+const chatRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: routes.chat,
+  beforeLoad: () => {
+    // Feature flag check: VITE_FEATURE_CHAT_PANEL must be "true" at build/run time.
+    // When rb-feature-resolver (S5) ships this will be replaced with a per-tenant API check.
+    if (import.meta.env.VITE_FEATURE_CHAT_PANEL !== "true") {
+      throw redirect({ to: routes.repos, replace: true });
+    }
+  },
+  component: ChatPage,
+});
+
 const catchAllRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$",
@@ -211,6 +225,7 @@ const routeTree = rootRoute.addChildren([
   agentSessionReplayRoute,
   adminGithubRoute,
   traceRoute,
+  chatRoute,
   catchAllRoute,
 ]);
 


### PR DESCRIPTION
## Summary

- `ChatPage.tsx` — two-panel layout (session sidebar + conversation thread) with streaming token display, tool-call expandable blocks, and message composer
- `useChatSessions` / `useCreateChatSession` / `useSendChatMessage` — typed hooks over `POST /v1/chat/sessions`, `POST /v1/chat/sessions/{id}/messages`, `GET /v1/chat/sessions`
- `useChatStream` — SSE consumer wrapping `GET /v1/chat/sessions/{id}/events` (reuses Wave-7 `session.event`/`session.error` relay)
- `transcript.ts` — functional reducer turning SSE events into an immutable `TranscriptItem[]` (handles streaming tokens, tool_use, tool_result, thinking, error)
- `chat-client.ts` — typed openapi-fetch wrapper for `/v1/chat/*` (temporary until S3 regenerates `openapi.json`)
- Router entry behind `VITE_FEATURE_CHAT_PANEL` guard; AppShell Chat nav link conditionally rendered
- `useChatFeatureEnabled` — env-var stub; will be wired to `rb-feature-resolver` API in S5

## API types

API types are defined in `frontend/src/lib/chat-api.ts` per ADR-013 §7. They will be replaced by generated schema types once S3 (chat-gateway routes) ships and `npm run gen:api` is re-run. The `gen:api:check` passes because the chat client is deliberately separate from the generated `openapi.json` schema.

## Acceptance

1. `ChatPage` renders behind the feature flag; flag-off keeps current nav unchanged ✓
2. End-to-end smoke: send message → receive streamed response → MCP tool calls visible (pending S3 backend)
3. Playwright spec lands as part of S6
4. PR through Gate-2/3

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR

Closes #645