### PR TITLE
[RUSAA-1829] chore(compose): add Hindsight memory service to dev stack

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -632,6 +632,26 @@ services:
     depends_on:
       - control-api
 
+  # Hindsight — shared long-term memory for Paperclip "rustacean" company agents.
+  # Full image (local reranker); LLM + embeddings routed via the LiteLLM proxy.
+  # Config + secrets live in compose/hindsight.env (gitignored via compose/*.env).
+  hindsight:
+    image: ghcr.io/vectorize-io/hindsight:latest
+    env_file: hindsight.env
+    volumes:
+      - hindsight_pg0:/home/hindsight/.pg0
+    ports:
+      - "${HINDSIGHT_API_HOST_PORT:-8888}:8888"
+      - "${HINDSIGHT_CP_HOST_PORT:-9999}:9999"
+    networks:
+      - rb-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8888/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
 networks:
   rb-net:
     driver: bridge
@@ -650,3 +670,4 @@ volumes:
   blob-data:
   agent-workspace-data:
   claude-credentials:
+  hindsight_pg0:

--- a/compose/env.schema.toml
+++ b/compose/env.schema.toml
@@ -135,6 +135,18 @@ default = "8082"
 description = "Host port for kafka-ui. Remapped on Mars."
 services = ["_compose"]
 
+[var.HINDSIGHT_API_HOST_PORT]
+required = false
+default = "8888"
+description = "Host port for the Hindsight memory API/MCP server. Remapped on Mars (18888)."
+services = ["_compose"]
+
+[var.HINDSIGHT_CP_HOST_PORT]
+required = false
+default = "9999"
+description = "Host port for the Hindsight Control Plane UI. Remapped on Mars (19999)."
+services = ["_compose"]
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Database — PostgreSQL
 # ─────────────────────────────────────────────────────────────────────────────

--- a/compose/hindsight.env.example
+++ b/compose/hindsight.env.example
@@ -1,0 +1,16 @@
+# Hindsight memory service config — copy to compose/hindsight.env and fill in.
+HINDSIGHT_API_LLM_PROVIDER=openai
+HINDSIGHT_API_LLM_BASE_URL=https://grid.ai.juspay.net/v1
+HINDSIGHT_API_LLM_MODEL=minimaxai/minimax-m2
+HINDSIGHT_API_LLM_API_KEY=<litellm-key>
+HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm
+HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE=https://grid.ai.juspay.net
+HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY=<litellm-key>
+HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL=embed-marqo-ecommerce-b
+HINDSIGHT_API_RERANKER_PROVIDER=local
+HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension
+HINDSIGHT_API_TENANT_API_KEY=<generate-strong-key>
+HINDSIGHT_CP_DATAPLANE_API_KEY=<same-as-tenant-key>
+HINDSIGHT_CP_ACCESS_KEY=<same-as-tenant-key>
+HINDSIGHT_API_WORKER_ID=hindsight-mars
+HINDSIGHT_MCP_BANK_ID=rustacean

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -50,6 +50,12 @@ FRONTEND_HOST_PORT=15173
 PGWEB_HOST_PORT=18081
 KAFKA_UI_HOST_PORT=18082
 
+# --- Hindsight memory service ---
+# Secrets/model config live in compose/hindsight.env (gitignored); only port
+# remaps belong here (these are _compose vars, not read by Rust binaries).
+HINDSIGHT_API_HOST_PORT=18888
+HINDSIGHT_CP_HOST_PORT=19999
+
 # --- Runtime credentials (agent CLIs) ---
 # ANTHROPIC_API_KEY is NOT defined here because env-files cannot expand shell
 # variables.  Export it in your shell before running docker compose:

--- a/compose/tailscale.yml
+++ b/compose/tailscale.yml
@@ -53,6 +53,9 @@ services:
   kafka-ui:
     restart: unless-stopped
 
+  hindsight:
+    restart: unless-stopped
+
   agent-runner:
     restart: unless-stopped
 

--- a/docs/PORT_MAP.md
+++ b/docs/PORT_MAP.md
@@ -34,6 +34,8 @@ docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/ta
 | 10443 | 443 | caddy | HTTPS | Reverse proxy HTTPS |
 | 18081 | 8081 | pgweb | HTTP | pgweb DB browser (read-only) |
 | 18082 | 8082 | kafka-ui | HTTP | Kafka UI |
+| 18888 | 8888 | hindsight | HTTP | Hindsight memory API + MCP server (`/mcp/rustacean/`) |
+| 19999 | 9999 | hindsight | HTTP | Hindsight Control Plane UI |
 | ${CLAUDE_SSH_HOST_PORT:-12222} | 22 | claude-login | SSH | Claude OAuth login sidecar — shares `claude-credentials` volume with agent-runner |
 
 ### Quick access via Tailscale
@@ -47,6 +49,8 @@ docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/ta
 | pgweb | http://100.87.157.74:18081 |
 | Kafka UI | http://100.87.157.74:18082 |
 | Neo4j browser | http://100.87.157.74:17474 |
+| Hindsight API/MCP | http://100.87.157.74:18888 |
+| Hindsight Control Plane | http://100.87.157.74:19999 |
 
 ---
 


### PR DESCRIPTION
## Summary

Formalizes the **Hindsight shared long-term memory service** into the Rustacean dev stack. The service is already deployed and running on mars — this PR makes the wiring tracked, reviewable, and reproducible.

Hindsight provides shared recall/retain memory for all Paperclip agents via an MCP server (`bank=rustacean`). LLM + embeddings route through the LiteLLM proxy; the reranker runs locally.

## Changes (6 files)

- **`compose/dev.yml`** — adds `hindsight` service (`ghcr.io/vectorize-io/hindsight:latest`) with a named volume (`hindsight_pg0`), port bindings via env-var overrides, and a healthcheck.
- **`compose/tailscale.yml`** — adds `restart: unless-stopped` for `hindsight` in the mars overlay so it survives host reboots / docker restarts.
- **`compose/tailscale.env`** — sets mars port remaps (`HINDSIGHT_API_HOST_PORT=18888`, `HINDSIGHT_CP_HOST_PORT=19999`).
- **`compose/env.schema.toml`** — registers `HINDSIGHT_API_HOST_PORT` and `HINDSIGHT_CP_HOST_PORT` (optional, defaults 8888/9999).
- **`docs/PORT_MAP.md`** — adds hindsight rows to the mars port table and the Tailscale quick-access table.
- **`compose/hindsight.env.example`** _(new)_ — sanitised config template with placeholders; the real `compose/hindsight.env` is operator-provided and gitignored via `compose/*.env`.

## Operator notes

- Copy `compose/hindsight.env.example` → `compose/hindsight.env` and fill in the LiteLLM key and tenant API key before starting the stack.
- Mars deployment: `http://100.87.157.74:18888` (API/MCP) and `http://100.87.157.74:19999` (Control Plane UI).

## GitHub Issue
Closes #654

## Checklist
- [x] No real API keys committed
- [x] `compose/hindsight.env` is gitignored (`compose/*.env` rule in root `.gitignore`)
- [x] `docker compose --env-file compose/tailscale.env -f compose/dev.yml -f compose/tailscale.yml config` resolves the `hindsight` service
- [x] Infra wiring only — no application code touched