### PR TITLE
[RUSAA-1816] test: chat panel E2E spec + per-runtime CI smoke harness

### DIFF
--- a/.github/workflows/chat-smoke.yml
+++ b/.github/workflows/chat-smoke.yml
@@ -1,0 +1,85 @@
+name: Chat Panel Smoke Tests
+
+# Runs on every PR that touches the chat gateway backend, chat routes, or
+# the chat frontend panel.  The job is always reported (required check) but
+# skips the expensive Playwright step when no relevant files changed.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chat-smoke:
+    name: chat-smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Detect whether chat-relevant files changed.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            chat:
+              - 'services/chat-runtime/**'
+              - 'services/control-api/src/routes/chat/**'
+              - 'frontend/src/pages/ChatPage.tsx'
+              - 'frontend/src/components/chat/**'
+              - 'frontend/src/api/hooks/useChatSessions.ts'
+              - 'frontend/src/hooks/useChatStream.ts'
+              - 'frontend/src/lib/chat-api.ts'
+              - 'frontend/e2e/chat-panel.spec.ts'
+              - 'frontend/e2e/fixtures/chat-mock-api.ts'
+              - '.github/workflows/chat-smoke.yml'
+
+      - name: Skip — no chat-relevant files changed
+        if: steps.changes.outputs.chat != 'true'
+        run: echo "No chat-relevant files changed — skipping chat smoke test."
+
+      - uses: actions/setup-node@v4
+        if: steps.changes.outputs.chat == 'true'
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        if: steps.changes.outputs.chat == 'true'
+        run: npm ci
+
+      - name: Install Playwright browsers (Chromium only)
+        if: steps.changes.outputs.chat == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Build frontend bundle (chat flag on)
+        if: steps.changes.outputs.chat == 'true'
+        run: npm run build
+        env:
+          VITE_FEATURE_CHAT_PANEL: "true"
+          VITE_TEMPO_URL: http://localhost:3200
+
+      - name: Run chat panel smoke spec
+        if: steps.changes.outputs.chat == 'true'
+        run: npx playwright test e2e/chat-panel.spec.ts --project=chromium
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report on failure
+        if: failure() && steps.changes.outputs.chat == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: chat-smoke-report-${{ github.run_id }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 7

--- a/.github/workflows/chat-smoke.yml
+++ b/.github/workflows/chat-smoke.yml
@@ -73,6 +73,7 @@ jobs:
         run: npx playwright test e2e/chat-panel.spec.ts --project=chat-smoke
         env:
           CI: "true"
+          PLAYWRIGHT_CHAT_SMOKE: "1"
 
       - name: Upload Playwright report on failure
         if: failure() && steps.changes.outputs.chat == 'true'

--- a/.github/workflows/chat-smoke.yml
+++ b/.github/workflows/chat-smoke.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run chat panel smoke spec
         if: steps.changes.outputs.chat == 'true'
-        run: npx playwright test e2e/chat-panel.spec.ts --project=chromium
+        run: npx playwright test e2e/chat-panel.spec.ts --project=chat-smoke
         env:
           CI: "true"
 

--- a/docs/qa/chat-panel-e2e.md
+++ b/docs/qa/chat-panel-e2e.md
@@ -1,0 +1,140 @@
+# Chat Panel E2E Test Spec
+
+**Epic**: Wave 9 chat panel
+**Spec file**: `frontend/e2e/chat-panel.spec.ts`
+**Smoke workflow**: `.github/workflows/chat-smoke.yml`
+
+---
+
+## Overview
+
+This document describes the E2E test coverage for the Wave 9 chat panel (S6 deliverable).
+The spec exercises the full frontend journey from opening the chat panel through receiving
+a streamed response with an MCP tool call, using Playwright route mocks for all API calls.
+
+## Feature flag
+
+The chat panel is gated by the `VITE_FEATURE_CHAT_PANEL=true` build-time env variable.
+The smoke CI workflow builds the frontend with this flag set.  The nav link in AppShell
+is conditionally rendered.  The `/chat` route itself is always registered; the gate is
+UI-only.
+
+## Test cases
+
+### Golden path
+
+| ID | Description | Key assertion |
+|----|-------------|---------------|
+| GP-1 | Navigate to `/chat` — sidebar and empty state render | `"No sessions yet."` text visible |
+| GP-2 | Chat heading present in header | `<h1>Chat</h1>` |
+| GP-3 | Click `+ New` in sidebar — composer appears | `aria-label="Chat message"` textarea visible |
+| GP-4 | SSE stream renders user message + text response | user bubble + assistant text |
+| GP-5 | Tool call block shows `Done` badge after `tool_result` arrives | `aria-label` matches `/list_directory tool call — Done/` |
+| GP-6 | Tool call block expands to reveal input + result JSON | `aria-expanded=true`, "Input"/"Result" labels |
+| GP-7 | Session ID short-form appears in header | `title=<full-session-id>` |
+
+### Audit row visibility
+
+| ID | Description | Key assertion |
+|----|-------------|---------------|
+| AV-1 | Activity page `Total audit events` card shows 1 when a chat tool-call audit row is mocked | `SummaryCards` second value `1` |
+
+> **Note**: The frontend `ChatPage` does not directly query `/v1/audit`.  Full audit
+> verification (confirming the backend actually persists the row) requires an
+> integration test against the live dev stack.  `AV-1` validates that the Activity
+> page correctly surfaces audit totals when the backend provides them.
+
+### Error paths
+
+| ID | Description | Key assertion |
+|----|-------------|---------------|
+| EP-1 | POST `/messages` returns 500 — error alert shown | `role=alert` visible |
+| EP-2 | `session.error` SSE event renders as error transcript item | `role=alert` containing "Session timed out" |
+
+## Mock strategy
+
+All API calls are mocked via `page.route()`.  No live backend is required.
+
+| Endpoint | Method | Mock |
+|----------|--------|------|
+| `/v1/me` | GET | `ME_RESPONSE` (from `fixtures/mock-api.ts`) |
+| `/v1/repos` | GET | empty repos list |
+| `/v1/chat/sessions` | GET | empty sessions list |
+| `/v1/chat/sessions` | POST | `{ session_id: "chat-session-001" }` |
+| `/v1/chat/sessions/*/messages` | POST | `{ message_id: "msg-001" }` |
+| `/v1/chat/sessions/chat-session-001/events` | GET | SSE body (text/event-stream) |
+| `/v1/audit` | GET | `AUDIT_WITH_TOOL_CALL` fixture |
+
+The SSE body (`FULL_EXCHANGE_SSE`) delivers four events in sequence:
+
+```
+1. user_input  → "List files in the current directory"
+2. tool_use    → name="list_directory", input={path:"."}
+3. tool_result → content=["file1.txt","file2.rs"], is_error=false
+4. text        → "Here are the files in the current directory."
+```
+
+Playwright's `route.fulfill()` returns the complete SSE body immediately when the
+`EventSource` connects.
+
+## Quarantine bucket
+
+Flaky chat tests (known SSE timing sensitivity) are moved to
+`frontend/e2e/quarantine/chat/`.  The `chat-quarantine` Playwright project runs them
+with `retries: 5` in CI (vs `retries: 2` for the main suite).
+
+Run the quarantine project explicitly:
+
+```bash
+cd frontend
+npx playwright test --project=chat-quarantine
+```
+
+The main `chromium` project excludes `**/quarantine/**` via project-level `testIgnore`.
+
+## CI smoke workflow
+
+File: `.github/workflows/chat-smoke.yml`
+
+Triggers: every PR / push to `main` that touches any of:
+
+- `services/chat-runtime/**`
+- `services/control-api/src/routes/chat/**`
+- `frontend/src/pages/ChatPage.tsx`
+- `frontend/src/components/chat/**`
+- `frontend/src/api/hooks/useChatSessions.ts`
+- `frontend/src/hooks/useChatStream.ts`
+- `frontend/e2e/chat-panel.spec.ts`
+- `.github/workflows/chat-smoke.yml`
+
+Steps: `npm ci` → `npm run build` (with `VITE_FEATURE_CHAT_PANEL=true`) →
+`playwright install --with-deps chromium` → `playwright test e2e/chat-panel.spec.ts`.
+
+## Running locally
+
+```bash
+cd frontend
+
+# Build with feature flag on
+VITE_FEATURE_CHAT_PANEL=true npm run build
+
+# Preview server (playwright.config uses port 4173)
+npm run preview &
+
+# Run chat spec only
+npx playwright test e2e/chat-panel.spec.ts --project=chromium
+
+# Open interactive report
+npx playwright show-report
+```
+
+## Known gaps
+
+- **Live-stack audit assertion**: `AV-1` mocks `/v1/audit`.  A full integration test
+  against the dev stack (with a real DB write from the chat gateway) is tracked as a
+  follow-on in the UAT acceptance checklist.
+- **Multi-session sidebar**: selecting a second session is not yet covered; add to
+  quarantine when flakiness profile is understood.
+- **Streaming deduplication**: the SSE dedup logic (seq ≤ lastHistSeq) is covered by the
+  chat gateway unit tests; frontend dedup E2E coverage can be added once history-join
+  support ships.

--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -32,7 +32,7 @@ async function setupChatPage(page: Page, sseBody = FULL_EXCHANGE_SSE): Promise<v
 // becomes active and MessageComposer is visible.
 async function openNewSession(page: Page): Promise<void> {
   await page.goto(CHAT_URL);
-  await page.getByRole("button", { name: "New chat session" }).click();
+  await page.getByRole("button", { name: "New chat session" }).first().click();
   await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
 }
 
@@ -171,7 +171,7 @@ test.describe("Chat panel — error paths", () => {
     );
 
     await page.goto(CHAT_URL);
-    await page.getByRole("button", { name: "New chat session" }).click();
+    await page.getByRole("button", { name: "New chat session" }).first().click();
     await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
 
     await page.getByRole("textbox", { name: "Chat message" }).fill("This will fail");

--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  CHAT_SESSION_ID,
+  FULL_EXCHANGE_SSE,
+  SESSION_ERROR_SSE,
+  AUDIT_WITH_TOOL_CALL,
+} from "./fixtures/chat-mock-api";
+
+const CHAT_URL = "/chat";
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+async function setupChatPage(page: Page, sseBody = FULL_EXCHANGE_SSE): Promise<void> {
+  await mockAuthenticatedSession(page);
+  await mockReposList(page, REPOS_EMPTY_RESPONSE);
+  await mockChatSessionsListAndCreate(page);
+  await mockSendChatMessage(page);
+  await mockChatStream(page, CHAT_SESSION_ID, sseBody);
+}
+
+// Opens the chat page and clicks the "New chat session" button so a session
+// becomes active and MessageComposer is visible.
+async function openNewSession(page: Page): Promise<void> {
+  await page.goto(CHAT_URL);
+  await page.getByRole("button", { name: "New chat session" }).click();
+  await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Golden path — feature flag on (VITE_FEATURE_CHAT_PANEL=true at build time)
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — golden path", () => {
+  test("renders session sidebar and empty state when no sessions exist", async ({ page }) => {
+    await setupChatPage(page);
+    await page.goto(CHAT_URL);
+
+    await expect(page.getByRole("complementary", { name: "Chat sessions" })).toBeVisible();
+    await expect(page.getByText("No sessions yet. Click + New to start.")).toBeVisible();
+    await expect(
+      page.getByText("Select a session from the sidebar or start a new one."),
+    ).toBeVisible();
+  });
+
+  test("shows chat heading in header", async ({ page }) => {
+    await setupChatPage(page);
+    await page.goto(CHAT_URL);
+
+    await expect(page.getByRole("heading", { name: "Chat", level: 1 })).toBeVisible();
+  });
+
+  test("activates session and shows composer after clicking + New in sidebar", async ({ page }) => {
+    await setupChatPage(page);
+    await page.goto(CHAT_URL);
+
+    await page.getByRole("button", { name: "New chat session", exact: false }).first().click();
+
+    await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  });
+
+  test("renders user message, tool call, and text response from SSE stream", async ({ page }) => {
+    await setupChatPage(page);
+    await openNewSession(page);
+
+    // The SSE mock delivers events immediately on connect — wait for them to render.
+    await expect(
+      page.getByText("List files in the current directory"),
+    ).toBeVisible();
+    await expect(page.getByText("Here are the files in the current directory.")).toBeVisible();
+  });
+
+  test("renders MCP tool call block with Done badge after tool_result arrives", async ({
+    page,
+  }) => {
+    await setupChatPage(page);
+    await openNewSession(page);
+
+    // ToolCallBlock aria-label: "${name} tool call — ${statusLabel}"
+    await expect(
+      page.getByRole("button", { name: /list_directory tool call — Done/ }),
+    ).toBeVisible();
+  });
+
+  test("tool call block expands to reveal input and result JSON on click", async ({ page }) => {
+    await setupChatPage(page);
+    await openNewSession(page);
+
+    const toolBtn = page.getByRole("button", { name: /list_directory tool call/ });
+    await expect(toolBtn).toBeVisible();
+    await toolBtn.click();
+
+    await expect(toolBtn).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByText("Input")).toBeVisible();
+    await expect(page.getByText("Result")).toBeVisible();
+  });
+
+  test("session ID short-form appears in chat header after session is created", async ({
+    page,
+  }) => {
+    await setupChatPage(page);
+    await openNewSession(page);
+
+    // Header renders first 8 chars of session ID (title attr holds full ID)
+    await expect(page.getByTitle(CHAT_SESSION_ID)).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit visibility — verifies the activity page reflects chat tool-call audit rows
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — audit row visibility", () => {
+  test("activity page Total audit events card shows non-zero count with chat audit rows", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+
+    // Mock audit endpoint — include a chat tool-call audit event.
+    await page.route("**/v1/audit**", (route) =>
+      route.fulfill({ json: AUDIT_WITH_TOOL_CALL }),
+    );
+    // Stub other activity-page endpoints so they don't error.
+    await page.route("**/v1/repos**", (route) => route.fulfill({ json: { repos: [] } }));
+    await page.route("**/v1/tenants/*/ingestion-runs**", (route) =>
+      route.fulfill({ json: { runs: [] } }),
+    );
+    await page.route("**/v1/ingest/events**", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+        body: "",
+      }),
+    );
+
+    await page.goto("/activity");
+
+    // SummaryCards renders "Total audit events" with the total count.
+    const summaryGrid = page.locator('[aria-label="Summary metrics"]');
+    await expect(summaryGrid).toBeVisible();
+    await expect(summaryGrid.getByText("Total audit events")).toBeVisible();
+    // Total is 1 (from AUDIT_WITH_TOOL_CALL.total).
+    await expect(summaryGrid.locator("p.text-2xl").nth(1)).toContainText("1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — error paths", () => {
+  test("shows error alert when sending a message returns 500", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page);
+    await mockChatStream(page, CHAT_SESSION_ID, "");
+
+    await page.route("**/v1/chat/sessions/*/messages", (route) =>
+      route.fulfill({ status: 500, json: { error: "Internal server error" } }),
+    );
+
+    await page.goto(CHAT_URL);
+    await page.getByRole("button", { name: "New chat session" }).click();
+    await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
+
+    await page.getByRole("textbox", { name: "Chat message" }).fill("This will fail");
+    await page.getByRole("button", { name: "Send" }).click();
+
+    await expect(page.getByRole("alert")).toBeVisible();
+  });
+
+  test("renders session.error SSE event as error transcript item", async ({ page }) => {
+    await setupChatPage(page, SESSION_ERROR_SSE);
+    await openNewSession(page);
+
+    // session.error delivers an error item with the message text.
+    await expect(
+      page.getByRole("alert").filter({ hasText: "Session timed out" }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -1,0 +1,155 @@
+import { type Page } from "@playwright/test";
+
+export const CHAT_SESSION_ID = "chat-session-001";
+
+export const CHAT_SESSION_FIXTURE = {
+  id: CHAT_SESSION_ID,
+  tenant_id: "tenant-1",
+  user_id: "user-1",
+  runtime: "claude_code" as const,
+  status: "active" as const,
+  trace_id: "trace-abc123",
+  created_at: "2026-06-03T00:00:00Z",
+  last_activity_at: "2026-06-03T00:00:01Z",
+  ended_at: null,
+};
+
+export const LIST_SESSIONS_EMPTY = { sessions: [] };
+
+export const LIST_SESSIONS_ONE = { sessions: [CHAT_SESSION_FIXTURE] };
+
+export const CREATE_SESSION_RESPONSE = { session_id: CHAT_SESSION_ID };
+
+export const SEND_MESSAGE_RESPONSE = { message_id: "msg-001" };
+
+// Full exchange: user_input → tool_use → tool_result → text
+export const FULL_EXCHANGE_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "List files in the current directory" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 2,
+    payload: {
+      type: "tool_use",
+      id: "tool-001",
+      name: "list_directory",
+      input: { path: "." },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 3,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "tool-001",
+      content: ["file1.txt", "file2.rs"],
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 4,
+    payload: { type: "text", text: "Here are the files in the current directory." },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+export const SESSION_ERROR_SSE = [
+  "event: session.error",
+  `data: ${JSON.stringify({
+    error: "timeout",
+    status: "504",
+    message: "Session timed out",
+  })}`,
+  "",
+  "",
+].join("\n");
+
+export const AUDIT_WITH_TOOL_CALL = {
+  total: 1,
+  events: [
+    {
+      id: "audit-001",
+      tenant_id: "tenant-1",
+      actor_kind: "user",
+      actor_id: "user-1",
+      action: "chat.tool_call",
+      resource_kind: "chat_message",
+      resource_id: CHAT_SESSION_ID,
+      ip: "127.0.0.1",
+      user_agent: "playwright-test",
+      created_at: "2026-06-03T00:00:02Z",
+    },
+  ],
+};
+
+export async function mockChatSessionsList(
+  page: Page,
+  response = LIST_SESSIONS_EMPTY,
+): Promise<void> {
+  await page.route("**/v1/chat/sessions", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: response });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockCreateChatSession(page: Page): Promise<void> {
+  await page.route("**/v1/chat/sessions", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ json: CREATE_SESSION_RESPONSE });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockChatSessionsListAndCreate(
+  page: Page,
+  listResponse = LIST_SESSIONS_EMPTY,
+): Promise<void> {
+  await page.route("**/v1/chat/sessions", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ json: CREATE_SESSION_RESPONSE });
+    }
+    return route.fulfill({ json: listResponse });
+  });
+}
+
+export async function mockSendChatMessage(page: Page): Promise<void> {
+  await page.route("**/v1/chat/sessions/*/messages", (route) =>
+    route.fulfill({ json: SEND_MESSAGE_RESPONSE }),
+  );
+}
+
+export async function mockChatStream(
+  page: Page,
+  sessionId: string,
+  sseBody: string,
+): Promise<void> {
+  await page.route(`**/v1/chat/sessions/${sessionId}/events`, (route) =>
+    route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+      body: sseBody,
+    }),
+  );
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,15 +49,18 @@ export default defineConfig({
         ]
       : []),
     // Dedicated project for the chat-smoke CI job.
-    // chat-panel.spec.ts is excluded from the main chromium project because it
-    // requires VITE_FEATURE_CHAT_PANEL=true at build time; the smoke job builds
-    // with that flag set and targets this project explicitly.
-    {
-      name: "chat-smoke",
-      testMatch: "**/chat-panel.spec.ts",
-      use: { ...devices["Desktop Chrome"] },
-      retries: process.env.CI ? 2 : 0,
-    },
+    // Only registered when PLAYWRIGHT_CHAT_SMOKE=1 so the main CI run
+    // (which does not set that env var) never picks up chat-panel.spec.ts.
+    ...(process.env.PLAYWRIGHT_CHAT_SMOKE
+      ? [
+          {
+            name: "chat-smoke",
+            testMatch: "**/chat-panel.spec.ts",
+            use: { ...devices["Desktop Chrome"] },
+            retries: process.env.CI ? 2 : 0,
+          },
+        ]
+      : []),
     // Quarantine bucket: flaky chat tests, 5 retries in CI.
     // Run explicitly: npx playwright test --project=chat-quarantine
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -29,20 +29,22 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      // Quarantine specs run under their own project with elevated retries.
-      testIgnore: "**/quarantine/**",
+      // Quarantine specs and feature-flag-gated specs run under dedicated projects.
+      // chat-panel.spec.ts requires VITE_FEATURE_CHAT_PANEL=true at build time;
+      // it is exercised by the chat-smoke CI job, not the main suite.
+      testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts"],
     },
     ...(isNightly
       ? [
           {
             name: "firefox",
             use: { ...devices["Desktop Firefox"] },
-            testIgnore: "**/quarantine/**",
+            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts"],
           },
           {
             name: "webkit",
             use: { ...devices["Desktop Safari"] },
-            testIgnore: "**/quarantine/**",
+            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts"],
           },
         ]
       : []),

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,6 +48,16 @@ export default defineConfig({
           },
         ]
       : []),
+    // Dedicated project for the chat-smoke CI job.
+    // chat-panel.spec.ts is excluded from the main chromium project because it
+    // requires VITE_FEATURE_CHAT_PANEL=true at build time; the smoke job builds
+    // with that flag set and targets this project explicitly.
+    {
+      name: "chat-smoke",
+      testMatch: "**/chat-panel.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+      retries: process.env.CI ? 2 : 0,
+    },
     // Quarantine bucket: flaky chat tests, 5 retries in CI.
     // Run explicitly: npx playwright test --project=chat-quarantine
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -29,19 +29,31 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      // Quarantine specs run under their own project with elevated retries.
+      testIgnore: "**/quarantine/**",
     },
     ...(isNightly
       ? [
           {
             name: "firefox",
             use: { ...devices["Desktop Firefox"] },
+            testIgnore: "**/quarantine/**",
           },
           {
             name: "webkit",
             use: { ...devices["Desktop Safari"] },
+            testIgnore: "**/quarantine/**",
           },
         ]
       : []),
+    // Quarantine bucket: flaky chat tests, 5 retries in CI.
+    // Run explicitly: npx playwright test --project=chat-quarantine
+    {
+      name: "chat-quarantine",
+      testDir: "./e2e/quarantine/chat",
+      use: { ...devices["Desktop Chrome"] },
+      retries: process.env.CI ? 5 : 1,
+    },
   ],
   outputDir: "test-results",
 });


### PR DESCRIPTION
## Summary

- **Playwright spec** (`frontend/e2e/chat-panel.spec.ts`): 9 tests — golden path (session create, SSE stream with tool call Done badge, expand), audit row visibility via Activity page, and error paths.
- **Chat mock fixtures** (`frontend/e2e/fixtures/chat-mock-api.ts`): typed helpers for sessions, SSE body (user_input/tool_use/tool_result/text), and audit stubs.
- **Quarantine bucket** (`frontend/e2e/quarantine/chat/`): `chat-quarantine` Playwright project with 5 retries in CI; main projects exclude via `testIgnore`.
- **CI smoke workflow** (`.github/workflows/chat-smoke.yml`): path-filtered, builds with `VITE_FEATURE_CHAT_PANEL=true`, runs `chat-panel.spec.ts` on PRs touching chat gateway or frontend.
- **Route wiring**: `/chat` in `routes.ts`, `router.tsx`, and feature-flag-gated `AppShell` nav link.
- **S4 chat components** included (were in working tree, untracked).
- **Docs**: `docs/qa/chat-panel-e2e.md` with test matrix, mock strategy, and quarantine runbook.

## GitHub Issue

Closes #656

## Checklist

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] TypeScript clean (`npx tsc --noEmit` in `frontend/`)
- [ ] No `RUSAA-1816` outside title bracket prefix