### PR TITLE
[RUSAA-1855] fix(frontend): wire VITE_FEATURE_CHAT_PANEL into Docker build

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -623,6 +623,8 @@ services:
     build:
       context: ..
       dockerfile: docker/frontend/Dockerfile
+      args:
+        VITE_FEATURE_CHAT_PANEL: "true"
     image: rustbrain/frontend:dev
     pull_policy: never
     ports:

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -5,6 +5,11 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Build-time feature flag — baked into the static bundle at build time.
+# Safe default is off; set to "true" via compose build.args to enable.
+ARG VITE_FEATURE_CHAT_PANEL=false
+ENV VITE_FEATURE_CHAT_PANEL=${VITE_FEATURE_CHAT_PANEL}
+
 # Cache npm install layer separately from source
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary

- Added `ARG VITE_FEATURE_CHAT_PANEL=false` + `ENV VITE_FEATURE_CHAT_PANEL=${VITE_FEATURE_CHAT_PANEL}` to the builder stage in `docker/frontend/Dockerfile`. Default is `false` — prod builds that omit the arg stay safe.
- Set `VITE_FEATURE_CHAT_PANEL: "true"` under `frontend.build.args` in `compose/dev.yml` so the dev/mars image bakes chat enabled.
- `compose/full.yml` only includes `dev.yml`, so no change needed there.

## GitHub Issue

Closes #666

## Checklist
- [x] `docker/frontend/Dockerfile` has `ARG`/`ENV` for the flag (safe default off)
- [x] `compose/dev.yml` build.args sets flag to `"true"`
- [x] No frontend source changes
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR

## Deploy

After merge, rebuild on mars:
```bash
docker compose -f compose/dev.yml build frontend
docker compose -f compose/dev.yml up -d frontend
```