### PR TITLE
[RUSAA-1861] fix: wire RB_CHAT_PANEL_ENABLED into control-api compose env

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -269,6 +269,7 @@ services:
       RB_INTERNAL_SECRET: "${RB_INTERNAL_SECRET:-dev-internal-secret-change-me}"
       RB_ADMIN_TOKEN: "${RB_ADMIN_TOKEN:-}"
       RB_TEMPO_BASE_URL: "${RB_TEMPO_BASE_URL:-http://localhost:3000}"
+      RB_CHAT_PANEL_ENABLED: "${RB_CHAT_PANEL_ENABLED:-true}"
     volumes:
       - ../migrations:/migrations:ro
     ports:


### PR DESCRIPTION
## Summary

- Adds `RB_CHAT_PANEL_ENABLED: "${RB_CHAT_PANEL_ENABLED:-true}"` to control-api environment block in `compose/dev.yml`
- Mirrors the frontend `VITE_FEATURE_CHAT_PANEL=true` already wired in PR #667
- Without this, every `/v1/chat/*` handler returns 404 because the flag defaults to `false` in `config.rs`

## Migration type

N/A — compose-only change, no schema changes.

## Root cause

`services/control-api/src/config.rs` defaults `chat_panel_enabled` to `false`. The deploy env `compose/dev.yml` sets the frontend flag but never set the backend flag, so all chat routes short-circuit to 404.

## Test plan

- [ ] PR CI green (compose-only, no Rust rebuild needed)
- [ ] On mars: `docker compose -f compose/dev.yml up -d --force-recreate control-api`
- [ ] Live probe: `curl -i http://100.87.157.74:15173/v1/chat/sessions/00000000-0000-0000-0000-000000000000` → **401** (not 404)
- [ ] Authenticated probe: `GET /v1/chat/sessions` → 200 `{"sessions":[]}`
- [ ] UI smoke: login → Chat panel → create session → streaming reply

Closes #670