### PR TITLE
[RUSAA-1864] fix: close stdin after write in send_input to trigger claude processing

### DIFF
--- a/services/agent-runner/src/adapters/claude_code.rs
+++ b/services/agent-runner/src/adapters/claude_code.rs
@@ -103,14 +103,18 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     }
 
     async fn send_input(&self, proc: &mut AgentProcess, input: &str) -> Result<()> {
-        if let Some(stdin) = proc.stdin.as_mut() {
-            stdin.write_all(input.as_bytes()).await?;
-            stdin.write_all(b"\n").await?;
-            stdin.flush().await?;
-            Ok(())
-        } else {
+        // Take (and drop) stdin after writing so tokio flushes and sends EOF to
+        // claude.  claude --print reads all stdin as one prompt; without EOF it
+        // blocks indefinitely waiting for more input.
+        let Some(mut stdin) = proc.stdin.take() else {
             anyhow::bail!("Process stdin not available")
-        }
+        };
+        stdin.write_all(input.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
+        // Dropping stdin closes the write-end, sending EOF → claude processes.
+        drop(stdin);
+        Ok(())
     }
 
     async fn terminate(&self, proc: &mut AgentProcess, force: bool) -> Result<()> {


### PR DESCRIPTION
## Summary

`ClaudeCodeAdapter::send_input` was using `as_mut()` to write to stdin but kept the pipe open. The `claude --print` CLI reads all stdin until EOF before processing; with an open pipe it blocked indefinitely, producing no output. This caused chat sessions to receive no streaming reply.

Fix: use `take()` so stdin is dropped after writing, sending EOF to claude immediately.

## GitHub Issue

Closes #678

## Live Probe Evidence

Session `530bab6d` on mars dev stack (`2026-06-04`):
- `POST /v1/chat/sessions` → `active`
- SSE subscribed, then `POST /v1/chat/sessions/{id}/messages` with `content: "Say PONG"`
- SSE delivers `session.event` → `{"type":"text","text":"PONG"}` at **3s**
- Exit code 0

## Checklist
- [x] `cargo check -p agent-runner` passes
- [x] Live probe confirms streaming reply in ≤ 15s
- [x] No internal tracker IDs in source/commits