### PR TITLE
[RUSAA-1876] fix: propagate command errors to SSE bus when session not in memory

### DIFF
--- a/services/agent-runner/src/adapters/mod.rs
+++ b/services/agent-runner/src/adapters/mod.rs
@@ -381,8 +381,8 @@ mod tests {
         assert_eq!(status.code(), Some(0), "cat must exit 0 after stdin closes");
     }
 
-    /// Regression for RUSAA-1870 — non-empty initial_prompt path: stdin is extracted
-    /// but the child exits naturally without any send_input call (no deadlock risk).
+    /// Regression for RUSAA-1870 — non-empty `initial_prompt` path: stdin is extracted
+    /// but the child exits naturally without any `send_input` call (no deadlock risk).
     /// Mirrors the existing agent-session path where the initial prompt is a CLI arg.
     #[tokio::test]
     async fn extracted_stdin_allows_natural_exit_without_send_input() {

--- a/services/agent-runner/src/consumer.rs
+++ b/services/agent-runner/src/consumer.rs
@@ -205,6 +205,20 @@ async fn handle_command(
             tracing::error!(session_id = %session_id, "Command failed: {e}");
             counter!("rb_agent_commands_total", "outcome" => "err").increment(1);
             emit_error_event(&ctx.producer, tenant_id, &session_id, &e).await;
+            // Propagate the failure to control-api via HTTP so the SSE bus notifies the
+            // subscriber.  emit_error_event publishes to rb.agent.events (Kafka) which
+            // has no consumer — without this call the user sees "no response and no error"
+            // (RUSAA-1876: stale session after agent-runner restart).
+            ctx.session_manager
+                .update_session_status(
+                    &session_id,
+                    tenant_id,
+                    "failed",
+                    None,
+                    None,
+                    Some(&e.to_string()),
+                )
+                .await;
             // H1: Commit the offset even on unrecoverable errors to prevent infinite retry.
             // The error has been logged and emitted as an event; dropping the message
             // here would cause Kafka to redeliver it forever, blocking the partition.

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -419,7 +419,7 @@ impl SessionManager {
         Ok(())
     }
 
-    async fn update_session_status(
+    pub async fn update_session_status(
         &self,
         session_id: &str,
         tenant_id: TenantId,


### PR DESCRIPTION
## Summary

- When agent-runner restarts, sessions that were `active` in the database become orphaned (in-memory map cleared, DB row stays `active`).
- A Kafka command arriving for such a session previously published the error only to `rb.agent.events` (Kafka) — a **write-only topic with no consumer** — so the error never reached the control-api SSE bus.
- User symptom: "sent a message, no response and no error" (Wave 9 UAT re-failure).
- Fix: after `emit_error_event`, also call `session_manager.update_session_status("failed", …)` via the existing internal HTTP endpoint. The DB row is updated and the SSE bus notifies the subscriber.

**Investigation findings** (RUSAA-1876):
1. PR #679 (`da6f9e5b`) IS deployed — image built with `GIT_SHA=da6f9e5b`, EROFS workaround present.
2. Board reused session `58b8aefb` (June 3rd, orphaned after restart at 05:40:13Z). Manually marked `failed` in DB to unblock re-UAT.
3. Dead Kafka path: `rb.agent.events` has no consumer → errors are silently dropped. This PR fixes that.

## Changes

- `session/mod.rs`: make `update_session_status` `pub` so `consumer.rs` can call it.
- `consumer.rs`: call `update_session_status("failed")` in the error branch of `handle_command`, after `emit_error_event`.
- `adapters/mod.rs`: fix two pre-existing `doc_markdown` clippy lints (backtick identifiers in test doc comments).

## Test plan
- [x] `cargo-locked test --workspace` — 1370/1370 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check` — clean
- [x] Deploy and re-UAT: board creates a new session on http://100.87.157.74:15173, sends a prompt, streaming reply appears in ≤5s

Closes #680
Closes #681