### PR TITLE
[RUSAA-1880] fix: defer agent dispatch to first message to avoid claude stdin timeout

### DIFF
--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -2996,13 +2996,6 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Kafka unavailable */
-            readonly 503: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
         };
     };
     readonly get_chat_session: {

--- a/openapi.json
+++ b/openapi.json
@@ -1056,9 +1056,6 @@
           },
           "404": {
             "description": "Feature not enabled"
-          },
-          "503": {
-            "description": "Kafka unavailable"
           }
         }
       }

--- a/services/control-api/src/routes/chat/messages.rs
+++ b/services/control-api/src/routes/chat/messages.rs
@@ -9,12 +9,18 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use rb_auth::{McpTokenClaims, mint_mcp_token};
 use rb_kafka::EventEnvelope;
-use rb_schemas::{AgentSessionCommand, AgentSessionInput, TenantId, agent_session_command};
+use rb_schemas::{
+    AgentSessionCommand, AgentSessionInput, AgentSessionStart, TenantId, agent_session_command,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::AppError, middleware::auth::AuthContext, state::AppState};
+use crate::{
+    error::AppError, middleware::auth::AuthContext,
+    routes::agents::session_lifecycle::parse_runtime, state::AppState,
+};
 
 use super::db::{db_get_chat_session, db_insert_chat_message, db_list_chat_messages};
 use super::sessions::{ChatMessageDto, require_chat_auth};
@@ -85,27 +91,56 @@ pub async fn post_chat_message(
     )
     .await?;
 
-    // Dispatch user turn to the live runtime process via Kafka stdin feed.
     let producer = state
         .agent_commands_producer
         .as_ref()
         .ok_or(AppError::KafkaNotConfigured)?;
 
-    let command = AgentSessionCommand {
-        session_id: session_id.to_string(),
-        command: Some(agent_session_command::Command::Input(AgentSessionInput {
-            input: req.content,
-        })),
+    let tenant_id = TenantId::from(caller.tenant_id);
+
+    // First message (seq == 1): spawn the agent with this message as the initial
+    // prompt so claude receives input immediately, before its 3-second stdin
+    // timeout fires.  Subsequent messages are fed as stdin turns (Input).
+    let command = if seq == 1 {
+        let workspace_path = format!("{}/{}", caller.tenant_id, session_id);
+        let runtime_val: i32 = parse_runtime(&session.runtime)
+            .ok_or(AppError::InvalidInput)?
+            .into();
+        let token = mint_mcp_token(
+            state.mcp_jwt_secret.as_bytes(),
+            state.config.mcp_jwt_ttl_secs,
+            McpTokenClaims {
+                sub: session_id,
+                tenant_id: caller.tenant_id,
+                user_id: caller.user_id,
+            },
+        )
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("JWT mint failed: {e}")))?;
+        AgentSessionCommand {
+            session_id: session_id.to_string(),
+            command: Some(agent_session_command::Command::Start(AgentSessionStart {
+                runtime: runtime_val,
+                initial_prompt: req.content,
+                workspace_path,
+                api_key: token,
+            })),
+        }
+    } else {
+        AgentSessionCommand {
+            session_id: session_id.to_string(),
+            command: Some(agent_session_command::Command::Input(AgentSessionInput {
+                input: req.content,
+            })),
+        }
     };
 
-    let tenant_id = TenantId::from(caller.tenant_id);
     let envelope = EventEnvelope::new(tenant_id, command);
 
     producer
         .publish(TOPIC_AGENT_COMMANDS, session_id.as_bytes(), envelope)
         .await
         .map_err(|e| {
-            tracing::error!("failed to publish chat message input: {e}");
+            tracing::error!("failed to publish chat message: {e}");
             AppError::Internal(anyhow::anyhow!("Kafka publish failed"))
         })?;
 

--- a/services/control-api/src/routes/chat/sessions.rs
+++ b/services/control-api/src/routes/chat/sessions.rs
@@ -1,6 +1,6 @@
 //! Chat session lifecycle routes (ADR-013 §3).
 //!
-//! - `POST /v1/chat/sessions`      — create session, mint MCP JWT, dispatch to agent-runner
+//! - `POST /v1/chat/sessions`      — create session row; agent is dispatched on first message
 //! - `GET  /v1/chat/sessions/{id}` — fetch session with message history (tenant-scoped)
 
 use axum::{
@@ -10,9 +10,6 @@ use axum::{
     response::IntoResponse,
 };
 use chrono::{DateTime, Utc};
-use rb_auth::{McpTokenClaims, mint_mcp_token};
-use rb_kafka::EventEnvelope;
-use rb_schemas::{AgentSessionCommand, AgentSessionStart, TenantId};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -27,8 +24,6 @@ use super::db::{
     ChatMessageRow, ChatSessionRow, db_get_chat_session, db_insert_chat_session,
     db_list_chat_messages, db_list_chat_sessions,
 };
-
-const TOPIC_AGENT_COMMANDS: &str = "rb.agent.commands";
 const MAX_RUNTIME_LEN: usize = 32;
 
 // ---------------------------------------------------------------------------
@@ -138,7 +133,6 @@ pub struct ListChatSessionsResponse {
         (status = 400, description = "Invalid runtime"),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Feature not enabled"),
-        (status = 503, description = "Kafka unavailable"),
     ),
     tag = "chat"
 )]
@@ -157,12 +151,13 @@ pub async fn create_chat_session(
         return Err(AppError::InvalidInput);
     }
 
-    let jwt_secret = &state.mcp_jwt_secret;
-
     let session_id = Uuid::new_v4();
     let trace_id = format!("{}", Uuid::new_v4().as_simple());
 
-    // Insert session row before dispatching to agent-runner.
+    // Insert session row.  Agent dispatch happens on the first user message
+    // (POST /v1/chat/sessions/{id}/messages) so that claude receives the
+    // initial_prompt immediately — avoiding the 3-second stdin-timeout
+    // built into `claude -p` when no input arrives within that window.
     db_insert_chat_session(
         &state.pool,
         session_id,
@@ -172,52 +167,6 @@ pub async fn create_chat_session(
         &trace_id,
     )
     .await?;
-
-    // Mint a short-lived read-scoped MCP JWT for this session.
-    let token = mint_mcp_token(
-        jwt_secret.as_bytes(),
-        state.config.mcp_jwt_ttl_secs,
-        McpTokenClaims {
-            sub: session_id,
-            tenant_id: caller.tenant_id,
-            user_id: caller.user_id,
-        },
-    )
-    .map_err(|e| AppError::Internal(anyhow::anyhow!("JWT mint failed: {e}")))?;
-
-    // Dispatch to agent-runner via existing rb.agent.commands Kafka topic.
-    // The JWT is passed as api_key; agent-runner writes it to .mcp.json (ADR-013 §5.4).
-    let workspace_path = format!("{}/{}", caller.tenant_id, session_id);
-    let runtime_val: i32 = parse_runtime(&req.runtime)
-        .ok_or(AppError::InvalidInput)?
-        .into();
-    let command = AgentSessionCommand {
-        session_id: session_id.to_string(),
-        command: Some(rb_schemas::agent_session_command::Command::Start(
-            AgentSessionStart {
-                runtime: runtime_val,
-                initial_prompt: String::new(),
-                workspace_path,
-                api_key: token,
-            },
-        )),
-    };
-
-    let producer = state
-        .agent_commands_producer
-        .as_ref()
-        .ok_or(AppError::KafkaNotConfigured)?;
-
-    let tenant_id = TenantId::from(caller.tenant_id);
-    let envelope = EventEnvelope::new(tenant_id, command);
-
-    producer
-        .publish(TOPIC_AGENT_COMMANDS, session_id.as_bytes(), envelope)
-        .await
-        .map_err(|e| {
-            tracing::error!("failed to publish chat session start: {e}");
-            AppError::Internal(anyhow::anyhow!("Kafka publish failed"))
-        })?;
 
     Ok((
         StatusCode::ACCEPTED,


### PR DESCRIPTION
## Summary

- `POST /v1/chat/sessions` no longer dispatches a Kafka `Start` command at session-creation time
- `POST /v1/chat/sessions/{id}/messages` now dispatches `Start(initial_prompt=content)` on the first message (seq==1) and `Input(content)` on subsequent messages
- All three gate checks pass: `cargo test --workspace` (1370 tests), `cargo clippy -- -D warnings`, `cargo fmt -- --check`

## Root Cause

`claude -p` (print mode) has a 3-second built-in stdin timeout. When no data arrives within that window it outputs `"Warning: no stdin data received in 3s"` and exits with code 1. The previous code dispatched `Start(initial_prompt="")` at session creation, spawning claude immediately — before the user typed their first message. claude always timed out and the session was immediately marked `failed`.

Verified in Loki logs: session `dee051d7` created 07:26:20Z, marked `failed` at 07:26:24Z — exactly the 3-4 second timeout window. This reproduces for every new session.

## Fix

Defer the agent spawn to the first user message. On `seq == 1`, dispatch `Start(initial_prompt=user_content)` so claude receives its prompt immediately via the CLI arg, with no stdin wait required.

## Test Plan

- [ ] `POST /v1/chat/sessions` → 202, session_id returned, no agent spawned yet
- [ ] `POST /v1/chat/sessions/{id}/messages` (first message) → 202, agent spawned with prompt, streaming response visible via SSE within 5s
- [ ] Session stays `active` while claude runs; becomes `ended` after claude exits
- [ ] Second message to ended session → 422 (correct)

Closes #683