### PR TITLE
[RUSAA-1886] feat(frontend): persist chat session in URL and fetch message history on reload

### DIFF
--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -8,10 +8,12 @@ import {
   mockChatSessionsListAndCreate,
   mockSendChatMessage,
   mockChatStream,
+  mockListChatMessages,
   CHAT_SESSION_ID,
   FULL_EXCHANGE_SSE,
   SESSION_ERROR_SSE,
   AUDIT_WITH_TOOL_CALL,
+  LIST_SESSIONS_ONE,
 } from "./fixtures/chat-mock-api";
 
 const CHAT_URL = "/chat";
@@ -113,6 +115,49 @@ test.describe("Chat panel — golden path", () => {
 
     // Header renders first 8 chars of session ID (title attr holds full ID)
     await expect(page.getByTitle(CHAT_SESSION_ID)).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reload persistence — session + message history survive a hard reload
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — reload persistence", () => {
+  test("restores active session and renders message history after reload", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    // List endpoint returns the existing session; SSE stream is empty (session not streaming)
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockListChatMessages(page, CHAT_SESSION_ID);
+    await mockChatStream(page, CHAT_SESSION_ID, "");
+
+    // Navigate directly to the chat page with sessionId search param (simulates post-reload URL)
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Session sidebar is visible
+    await expect(page.getByRole("complementary", { name: "Chat sessions" })).toBeVisible();
+
+    // Both messages from LIST_MESSAGES_TWO_TURNS are rendered
+    await expect(page.getByText("Hello from reload test")).toBeVisible();
+    await expect(page.getByText("Hello back! I remember your message.")).toBeVisible();
+    await expect(page.getByText("Second message")).toBeVisible();
+    await expect(page.getByText("Got your second message.")).toBeVisible();
+
+    // Session ID still shows in header
+    await expect(page.getByTitle(CHAT_SESSION_ID)).toBeVisible();
+  });
+
+  test("URL search param persists sessionId so reload can restore session", async ({ page }) => {
+    await setupChatPage(page);
+    await page.goto(CHAT_URL);
+
+    // Create a new session
+    await page.getByRole("button", { name: "New chat session" }).first().click();
+    await expect(page.getByRole("textbox", { name: "Chat message" })).toBeVisible();
+
+    // URL should now include sessionId search param
+    const url = new URL(page.url());
+    expect(url.searchParams.get("sessionId")).toBe(CHAT_SESSION_ID);
   });
 });
 

--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -140,7 +140,7 @@ test.describe("Chat panel — reload persistence", () => {
     // Both messages from LIST_MESSAGES_TWO_TURNS are rendered
     await expect(page.getByText("Hello from reload test")).toBeVisible();
     await expect(page.getByText("Hello back! I remember your message.")).toBeVisible();
-    await expect(page.getByText("Second message")).toBeVisible();
+    await expect(page.getByText("Second message", { exact: true })).toBeVisible();
     await expect(page.getByText("Got your second message.")).toBeVisible();
 
     // Session ID still shows in header

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -80,6 +80,40 @@ export const SESSION_ERROR_SSE = [
   "",
 ].join("\n");
 
+export const LIST_MESSAGES_TWO_TURNS = {
+  messages: [
+    {
+      id: "msg-001",
+      seq: 1,
+      role: "user",
+      body: "Hello from reload test",
+      created_at: "2026-06-03T00:00:00Z",
+    },
+    {
+      id: "msg-002",
+      seq: 2,
+      role: "assistant",
+      body: "Hello back! I remember your message.",
+      created_at: "2026-06-03T00:00:01Z",
+    },
+    {
+      id: "msg-003",
+      seq: 3,
+      role: "user",
+      body: "Second message",
+      created_at: "2026-06-03T00:00:02Z",
+    },
+    {
+      id: "msg-004",
+      seq: 4,
+      role: "assistant",
+      body: "Got your second message.",
+      created_at: "2026-06-03T00:00:03Z",
+    },
+  ],
+  has_more: false,
+};
+
 export const AUDIT_WITH_TOOL_CALL = {
   total: 1,
   events: [
@@ -100,7 +134,7 @@ export const AUDIT_WITH_TOOL_CALL = {
 
 export async function mockChatSessionsList(
   page: Page,
-  response = LIST_SESSIONS_EMPTY,
+  response: { sessions: unknown[] } = LIST_SESSIONS_EMPTY,
 ): Promise<void> {
   await page.route("**/v1/chat/sessions", (route) => {
     if (route.request().method() === "GET") {
@@ -121,7 +155,7 @@ export async function mockCreateChatSession(page: Page): Promise<void> {
 
 export async function mockChatSessionsListAndCreate(
   page: Page,
-  listResponse = LIST_SESSIONS_EMPTY,
+  listResponse: { sessions: unknown[] } = LIST_SESSIONS_EMPTY,
 ): Promise<void> {
   await page.route("**/v1/chat/sessions", (route) => {
     if (route.request().method() === "POST") {
@@ -135,6 +169,19 @@ export async function mockSendChatMessage(page: Page): Promise<void> {
   await page.route("**/v1/chat/sessions/*/messages", (route) =>
     route.fulfill({ json: SEND_MESSAGE_RESPONSE }),
   );
+}
+
+export async function mockListChatMessages(
+  page: Page,
+  sessionId: string,
+  response = LIST_MESSAGES_TWO_TURNS,
+): Promise<void> {
+  await page.route(`**/v1/chat/sessions/${sessionId}/messages`, (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: response });
+    }
+    return route.continue();
+  });
 }
 
 export async function mockChatStream(

--- a/frontend/src/api/chat-client.ts
+++ b/frontend/src/api/chat-client.ts
@@ -8,6 +8,7 @@ import type {
   CreateChatSessionRequest,
   CreateChatSessionResponse,
   ListChatSessionsResponse,
+  ListMessagesResponse,
   SendMessageRequest,
   SendMessageResponse,
 } from "@/lib/chat-api";
@@ -60,4 +61,14 @@ export const chatApiClient = {
         opts: { params: { path: { id: string } }; body: SendMessageRequest },
       ) => Promise<FetchResponse<SendMessageResponse>>
     )("/v1/chat/sessions/{id}/messages", { params: { path: { id: sessionId } }, body }),
+
+  listMessages: (
+    sessionId: string,
+  ): Promise<FetchResponse<ListMessagesResponse>> =>
+    (
+      _rawClient.GET as (
+        path: string,
+        opts: { params: { path: { id: string } } },
+      ) => Promise<FetchResponse<ListMessagesResponse>>
+    )("/v1/chat/sessions/{id}/messages", { params: { path: { id: sessionId } } }),
 };

--- a/frontend/src/api/hooks/useChatSessions.ts
+++ b/frontend/src/api/hooks/useChatSessions.ts
@@ -8,6 +8,7 @@ import { toApiError, type ApiError } from "../client";
 import { chatApiClient } from "../chat-client";
 import type {
   ListChatSessionsResponse,
+  ListMessagesResponse,
   CreateChatSessionRequest,
   CreateChatSessionResponse,
   SendMessageRequest,
@@ -57,6 +58,24 @@ export function useCreateChatSession(tenantId: string) {
   });
 }
 
+export const chatMessagesQueryKey = (sessionId: string) =>
+  ["chat-sessions", sessionId, "messages"] as const;
+
+export function useChatMessages(sessionId: string | null) {
+  return useQuery<ListMessagesResponse, ApiError>({
+    queryKey: chatMessagesQueryKey(sessionId ?? ""),
+    queryFn: async () => {
+      const { data, error, response } = await chatApiClient.listMessages(sessionId!);
+      if (error || !data) {
+        throw toApiError(response.status, error, response);
+      }
+      return data;
+    },
+    enabled: sessionId !== null,
+    staleTime: 30_000,
+  });
+}
+
 export type SendMessageVariables = SendMessageRequest & { sessionId: string };
 
 export function useSendChatMessage() {
@@ -74,6 +93,7 @@ export function useSendChatMessage() {
 export type {
   ChatSession,
   ListChatSessionsResponse,
+  ListMessagesResponse,
   CreateChatSessionRequest,
   CreateChatSessionResponse,
   SendMessageRequest,

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -1,7 +1,7 @@
 // Transcript types and reducer for building a conversational view from SSE events.
 
 import type { StreamedEvent } from "@/hooks/useEventStream";
-import type { ChatSessionEventEnvelope, ChatRuntimePayload } from "@/lib/chat-api";
+import type { ChatMessage, ChatSessionEventEnvelope, ChatRuntimePayload } from "@/lib/chat-api";
 
 export interface UserTranscriptItem {
   kind: "user";
@@ -189,4 +189,36 @@ export function buildTranscript(
   }
 
   return state.items;
+}
+
+// Finds the sequence number of the first user_input event in the SSE stream.
+// Used to determine the cutoff point when merging historical + live transcripts.
+export function getMinSseUserInputSeq(events: ReadonlyArray<StreamedEvent>): number | null {
+  for (const event of events) {
+    if (event.type !== "session.event") continue;
+    const envelope = parseJson<{ sequence: number; payload: { type: string } }>(event.data);
+    if (envelope?.payload?.type === "user_input" && typeof envelope.sequence === "number") {
+      return envelope.sequence;
+    }
+  }
+  return null;
+}
+
+export function buildTranscriptFromHistory(
+  messages: ReadonlyArray<ChatMessage>,
+): ReadonlyArray<TranscriptItem> {
+  const items: TranscriptItem[] = [];
+  for (const msg of messages) {
+    if (msg.role === "user") {
+      items.push({ kind: "user", id: msg.id, text: msg.body, seq: msg.seq });
+    } else if (msg.role === "assistant") {
+      items.push({
+        kind: "assistant",
+        id: msg.id,
+        items: [{ type: "text", text: msg.body, seq: msg.seq }],
+      });
+    }
+    // system / tool rows are not rendered in the transcript UI
+  }
+  return items;
 }

--- a/frontend/src/lib/chat-api.ts
+++ b/frontend/src/lib/chat-api.ts
@@ -62,3 +62,16 @@ export interface ChatSessionErrorEnvelope {
   message: string;
 }
 
+export interface ChatMessage {
+  id: string;
+  seq: number;
+  role: ChatMessageRole;
+  body: string;
+  created_at: string;
+}
+
+export interface ListMessagesResponse {
+  messages: ChatMessage[];
+  has_more: boolean;
+}
+

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,16 +1,23 @@
 import { useMemo, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useMe } from "@/api";
 import {
   useChatSessions,
   useCreateChatSession,
   useSendChatMessage,
+  useChatMessages,
 } from "@/api/hooks/useChatSessions";
 import { useChatStream } from "@/hooks/useChatStream";
 import { SessionSidebar } from "@/components/chat/SessionSidebar";
 import { MessageThread } from "@/components/chat/MessageThread";
 import { MessageComposer } from "@/components/chat/MessageComposer";
-import { buildTranscript } from "@/components/chat/transcript";
+import {
+  buildTranscript,
+  buildTranscriptFromHistory,
+  getMinSseUserInputSeq,
+} from "@/components/chat/transcript";
 import { formatApiError } from "@/lib/errors/api";
+import { routes } from "@/lib/routes";
 import type { ChatRuntime } from "@/lib/chat-api";
 
 export function ChatPage(): JSX.Element {
@@ -40,16 +47,37 @@ interface ChatInnerProps {
 }
 
 function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { sessionId: activeSessionId = null } = useSearch({ from: routes.chat });
   const [composerValue, setComposerValue] = useState("");
+
+  const setActiveSessionId = (id: string | null) => {
+    void navigate({
+      to: routes.chat,
+      search: id !== null ? { sessionId: id } : {},
+      replace: false,
+    });
+  };
 
   const sessions = useChatSessions(tenantId);
   const createSession = useCreateChatSession(tenantId);
   const sendMessage = useSendChatMessage();
+  const historicalMessages = useChatMessages(activeSessionId);
 
   const { events, readyState } = useChatStream(activeSessionId);
 
-  const transcript = useMemo(() => buildTranscript(events), [events]);
+  const transcript = useMemo(() => {
+    const historical = historicalMessages.data?.messages ?? [];
+    const minLiveSeq = getMinSseUserInputSeq(events);
+
+    const historicalFiltered =
+      minLiveSeq !== null ? historical.filter((m) => m.seq < minLiveSeq) : historical;
+
+    const historicalItems = buildTranscriptFromHistory(historicalFiltered);
+    const liveItems = buildTranscript(events);
+
+    return [...historicalItems, ...liveItems];
+  }, [historicalMessages.data, events]);
 
   const isStreaming = sendMessage.isPending;
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -184,9 +184,14 @@ const traceRoute = createRoute({
   component: TraceViewerPage,
 });
 
+const chatSearchSchema = z.object({
+  sessionId: z.string().optional(),
+});
+
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: routes.chat,
+  validateSearch: chatSearchSchema,
   beforeLoad: () => {
     // Feature flag check: VITE_FEATURE_CHAT_PANEL must be "true" at build/run time.
     // When rb-feature-resolver (S5) ships this will be replaced with a per-tenant API check.


### PR DESCRIPTION
## Summary

- Adds `listMessages` API wrapper + `useChatMessages` hook to fetch `GET /v1/chat/sessions/{id}/messages`
- Persists `activeSessionId` as URL search param (`/chat?sessionId=`) via TanStack Router `validateSearch` — reload restores the session from the URL
- Merges historical REST messages with live SSE events (`buildTranscriptFromHistory` + `getMinSseUserInputSeq` to cut off history at the point the live feed starts)
- Two new E2E cases: reload renders historical messages; URL param persists after session creation

## GitHub Issue
Closes #687

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR