### PR TITLE
[RUSAA-1893] fix(chat): persist assistant turns and fix mid-send transcript merge

### DIFF
--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -14,6 +14,8 @@ import {
   SESSION_ERROR_SSE,
   AUDIT_WITH_TOOL_CALL,
   LIST_SESSIONS_ONE,
+  LIST_MESSAGES_MCP_EXCHANGE,
+  MID_SEND_SSE,
 } from "./fixtures/chat-mock-api";
 
 const CHAT_URL = "/chat";
@@ -158,6 +160,61 @@ test.describe("Chat panel — reload persistence", () => {
     // URL should now include sessionId search param
     const url = new URL(page.url());
     expect(url.searchParams.get("sessionId")).toBe(CHAT_SESSION_ID);
+  });
+
+  // AC3: reload of a 2-turn session renders both user prompt and assistant reply.
+  test("renders user prompt and assistant reply after hard reload on a 2-turn session", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_MCP_EXCHANGE);
+    await mockChatStream(page, CHAT_SESSION_ID, "");
+
+    // First visit — session restores from URL param.
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+    await expect(page.getByText("What MCP tools are available?")).toBeVisible();
+    await expect(page.getByText("The following MCP tools are registered:")).toBeVisible();
+
+    // Hard reload — both messages must survive.
+    await page.reload();
+    await expect(page.getByText("What MCP tools are available?")).toBeVisible();
+    await expect(page.getByText("The following MCP tools are registered:")).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-send regression — prior messages must survive while SSE streams a reply
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — mid-send message persistence", () => {
+  // AC4: user bubble and prior history both remain visible alongside the
+  // streaming assistant reply (no replacement / disappearing messages).
+  test("prior history and user bubble both visible while assistant reply streams", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // Existing session has a completed 1-turn history (user + assistant).
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_MCP_EXCHANGE);
+    // SSE mock delivers a new exchange immediately on connect (simulates a
+    // mid-send state where user_input + assistant text have arrived).
+    await mockChatStream(page, CHAT_SESSION_ID, MID_SEND_SSE);
+    await mockSendChatMessage(page);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Prior turn from history is visible.
+    await expect(page.getByText("What MCP tools are available?")).toBeVisible();
+    await expect(page.getByText("The following MCP tools are registered:")).toBeVisible();
+
+    // New turn from SSE is also visible (no replacement — both coexist).
+    await expect(page.getByText("How do I use the bash tool?")).toBeVisible();
+    await expect(
+      page.getByText("You can use the bash tool to run shell commands in the workspace."),
+    ).toBeVisible();
   });
 });
 

--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -197,12 +197,15 @@ test.describe("Chat panel — mid-send message persistence", () => {
     await mockAuthenticatedSession(page);
     await mockReposList(page, REPOS_EMPTY_RESPONSE);
     await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
-    // Existing session has a completed 1-turn history (user + assistant).
-    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_MCP_EXCHANGE);
     // SSE mock delivers a new exchange immediately on connect (simulates a
     // mid-send state where user_input + assistant text have arrived).
     await mockChatStream(page, CHAT_SESSION_ID, MID_SEND_SSE);
+    // Register mockSendChatMessage before mockListChatMessages so Playwright's
+    // LIFO route priority makes mockListChatMessages (registered last) win for
+    // GET requests to the messages endpoint.
     await mockSendChatMessage(page);
+    // Existing session has a completed 1-turn history (user + assistant).
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_MCP_EXCHANGE);
 
     await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
 

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -114,6 +114,49 @@ export const LIST_MESSAGES_TWO_TURNS = {
   has_more: false,
 };
 
+// Two-turn history using "What MCP tools…" prompt (matches AC3 reload assertion).
+export const LIST_MESSAGES_MCP_EXCHANGE = {
+  messages: [
+    {
+      id: "msg-mcp-001",
+      seq: 1,
+      role: "user",
+      body: "What MCP tools are available?",
+      created_at: "2026-06-03T00:00:00Z",
+    },
+    {
+      id: "msg-mcp-002",
+      seq: 2,
+      role: "assistant",
+      body: "The following MCP tools are registered: bash, read_file, write_file.",
+      created_at: "2026-06-03T00:00:01Z",
+    },
+  ],
+  has_more: false,
+};
+
+// SSE fixture for a new exchange sent after prior history is already loaded.
+// Represents: user sends "How do I use the bash tool?", assistant replies.
+export const MID_SEND_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "How do I use the bash tool?" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "You can use the bash tool to run shell commands in the workspace." },
+  })}`,
+  "",
+  "",
+].join("\n");
+
 export const AUDIT_WITH_TOOL_CALL = {
   total: 1,
   events: [

--- a/frontend/src/hooks/useEventStream.ts
+++ b/frontend/src/hooks/useEventStream.ts
@@ -36,6 +36,10 @@ export function useEventStream(
       return;
     }
 
+    // Clear accumulated events whenever the URL (i.e. session) changes so stale
+    // events from a previous session never pollute the new session's transcript.
+    setEvents([]);
+    setLastEventId(null);
     cancelledRef.current = false;
 
     let es: EventSource | null = null;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -14,7 +14,7 @@ import { MessageComposer } from "@/components/chat/MessageComposer";
 import {
   buildTranscript,
   buildTranscriptFromHistory,
-  getMinSseUserInputSeq,
+  type UserTranscriptItem,
 } from "@/components/chat/transcript";
 import { formatApiError } from "@/lib/errors/api";
 import { routes } from "@/lib/routes";
@@ -68,15 +68,37 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
 
   const transcript = useMemo(() => {
     const historical = historicalMessages.data?.messages ?? [];
-    const minLiveSeq = getMinSseUserInputSeq(events);
-
-    const historicalFiltered =
-      minLiveSeq !== null ? historical.filter((m) => m.seq < minLiveSeq) : historical;
-
-    const historicalItems = buildTranscriptFromHistory(historicalFiltered);
     const liveItems = buildTranscript(events);
 
-    return [...historicalItems, ...liveItems];
+    // Find the first user turn emitted by the live SSE stream.
+    const firstLiveUser = liveItems.find(
+      (item): item is UserTranscriptItem => item.kind === "user",
+    );
+
+    if (!firstLiveUser) {
+      // No live user turn in SSE — show all historical messages (reload path).
+      return buildTranscriptFromHistory(historical);
+    }
+
+    // The SSE stream is covering at least one user turn.  Find the last historical
+    // user message whose body matches the first SSE user turn and exclude it (and
+    // all subsequent rows) from the historical slice — those rows will be supplied
+    // by the live stream instead, preventing duplication.
+    //
+    // If the matching message is not yet in the DB cache (common: messages query
+    // has a 30 s staleTime and POST /messages doesn't invalidate it), cutIdx stays
+    // -1 and all historical messages are shown before the live items.
+    let cutIdx = -1;
+    for (let i = historical.length - 1; i >= 0; i--) {
+      const msg = historical[i];
+      if (msg && msg.role === "user" && msg.body === firstLiveUser.text) {
+        cutIdx = i;
+        break;
+      }
+    }
+
+    const historicalFiltered = cutIdx >= 0 ? historical.slice(0, cutIdx) : historical;
+    return [...buildTranscriptFromHistory(historicalFiltered), ...liveItems];
   }, [historicalMessages.data, events]);
 
   const isStreaming = sendMessage.isPending;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -76,8 +76,8 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
     );
 
     if (!firstLiveUser) {
-      // No live user turn in SSE — show all historical messages (reload path).
-      return buildTranscriptFromHistory(historical);
+      // No live user turn in SSE — show historical + any live non-user items (e.g. session.error).
+      return [...buildTranscriptFromHistory(historical), ...liveItems];
     }
 
     // The SSE stream is covering at least one user turn.  Find the last historical

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -106,13 +106,16 @@ pub async fn ingest_session_events(
         return Err(AppError::Unauthorized);
     }
 
-    // Fan-out to the SSE bus and persist assistant turns to control.chat_messages
-    // so that message history survives a hard reload (RUSAA-1893).
-    //
-    // Accumulate Text payloads between UserInput boundaries: flush the accumulated
-    // text as a single role=assistant row whenever a new UserInput arrives or after
-    // the last event in the batch.  Persistence errors are logged and swallowed so a
-    // transient DB failure never blocks the SSE fan-out.
+    ingest_chat_session_events(&state, session_id, &req).await
+}
+
+/// Chat-session path for [`ingest_session_events`]: fans events out to the SSE bus and
+/// persists accumulated `Text` events as `role=assistant` rows in `control.chat_messages`.
+async fn ingest_chat_session_events(
+    state: &AppState,
+    session_id: Uuid,
+    req: &IngestEventsRequest,
+) -> Result<(StatusCode, Json<IngestEventsResponse>), AppError> {
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
     let mut pending_assistant_text = String::new();
@@ -140,8 +143,6 @@ pub async fn ingest_session_events(
 
         match ev {
             RuntimeEvent::UserInput { .. } => {
-                // A new user turn starts: flush any accumulated assistant text from the
-                // preceding assistant turn as a persisted row before moving on.
                 if !pending_assistant_text.is_empty() {
                     let msg_id = Uuid::new_v4();
                     if let Err(e) = db_insert_chat_message(
@@ -170,7 +171,6 @@ pub async fn ingest_session_events(
         }
     }
 
-    // Flush the final assistant turn (if any) at the end of the batch.
     if !pending_assistant_text.is_empty() {
         let msg_id = Uuid::new_v4();
         if let Err(e) = db_insert_chat_message(

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -17,7 +17,7 @@ use rb_schemas::{RuntimeEvent, TenantId};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::AppError, state::AppState};
+use crate::{error::AppError, routes::chat::db::db_insert_chat_message, state::AppState};
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -106,9 +106,17 @@ pub async fn ingest_session_events(
         return Err(AppError::Unauthorized);
     }
 
-    // Fan-out to the SSE bus without a DB insert — sequences are synthetic (1-based).
+    // Fan-out to the SSE bus and persist assistant turns to control.chat_messages
+    // so that message history survives a hard reload (RUSAA-1893).
+    //
+    // Accumulate Text payloads between UserInput boundaries: flush the accumulated
+    // text as a single role=assistant row whenever a new UserInput arrives or after
+    // the last event in the batch.  Persistence errors are logged and swallowed so a
+    // transient DB failure never blocks the SSE fan-out.
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
+    let mut pending_assistant_text = String::new();
+
     for (seq, ev) in req.events.iter().enumerate() {
         let et = event_type(ev);
         let payload_value: serde_json::Value = ev
@@ -128,6 +136,58 @@ pub async fn ingest_session_events(
         if let Ok(data) = serde_json::to_string(&sse_data) {
             state.sse_bus.publish_raw(&tenant_id, "session.event", data);
             fanned_out += 1;
+        }
+
+        match ev {
+            RuntimeEvent::UserInput { .. } => {
+                // A new user turn starts: flush any accumulated assistant text from the
+                // preceding assistant turn as a persisted row before moving on.
+                if !pending_assistant_text.is_empty() {
+                    let msg_id = Uuid::new_v4();
+                    if let Err(e) = db_insert_chat_message(
+                        &state.pool,
+                        msg_id,
+                        session_id,
+                        req.tenant_id,
+                        "assistant",
+                        &pending_assistant_text,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %e,
+                            "chat ingest: failed to persist assistant turn — reload may miss this message"
+                        );
+                    }
+                    pending_assistant_text.clear();
+                }
+            }
+            RuntimeEvent::Text { text } => {
+                pending_assistant_text.push_str(text);
+            }
+            _ => {}
+        }
+    }
+
+    // Flush the final assistant turn (if any) at the end of the batch.
+    if !pending_assistant_text.is_empty() {
+        let msg_id = Uuid::new_v4();
+        if let Err(e) = db_insert_chat_message(
+            &state.pool,
+            msg_id,
+            session_id,
+            req.tenant_id,
+            "assistant",
+            &pending_assistant_text,
+        )
+        .await
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %e,
+                "chat ingest: failed to persist final assistant turn — reload may miss this message"
+            );
         }
     }
 

--- a/services/control-api/src/routes/chat/mod.rs
+++ b/services/control-api/src/routes/chat/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! All routes return 404 when `RB_CHAT_PANEL_ENABLED` is false (feature gate).
 
-mod db;
+pub(crate) mod db;
 pub mod events;
 pub mod messages;
 pub mod sessions;


### PR DESCRIPTION
## Summary

Two regressions in the Wave-9 chat panel:

- **Reload regression**: `GET /messages` returned user-only rows because assistant replies were never written to `control.chat_messages`. Fix: in `ingest_session_events` (chat path), accumulate `Text` payloads between `UserInput` boundaries and write one `role=assistant` row per completed assistant turn.
- **Mid-send regression**: SSE batch sequence numbers (synthetic, 1-indexed per batch) were compared against DB message sequence numbers (same integer space, different namespace), causing `filter(m => m.seq < 1)` to drop all historical messages. Fix: replace seq-based boundary detection with content-based — find the last historical user message whose body matches the first SSE `user_input` text and exclude it + later rows.
- **Session event leak**: `useEventStream` never cleared accumulated events on session/URL change. Fix: reset `events` and `lastEventId` at the start of the effect.

Adds two Playwright e2e tests (AC3 reload + AC4 mid-send coexistence).

## GitHub Issue
Closes #692

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] `cargo check -p control-api` passes
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR