### PR TITLE
[RUSAA-1893] fix: persist assistant chat messages to DB on event ingest

### DIFF
--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -106,6 +106,16 @@ pub async fn ingest_session_events(
         return Err(AppError::Unauthorized);
     }
 
+    ingest_chat_session_events(&state, session_id, &req).await
+}
+
+/// Chat-session path for [`ingest_session_events`]: fans events out to the SSE bus and
+/// persists `Text` events as `role=assistant` rows in `control.chat_messages`.
+async fn ingest_chat_session_events(
+    state: &AppState,
+    session_id: Uuid,
+    req: &IngestEventsRequest,
+) -> Result<(StatusCode, Json<IngestEventsResponse>), AppError> {
     // Fan-out to the SSE bus (sequences are synthetic, 1-based within each batch).
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
@@ -156,12 +166,7 @@ pub async fn ingest_session_events(
         }
     }
 
-    Ok((
-        StatusCode::OK,
-        Json(IngestEventsResponse {
-            inserted: fanned_out,
-        }),
-    ))
+    Ok((StatusCode::OK, Json(IngestEventsResponse { inserted: fanned_out })))
 }
 
 /// Agent-session path for [`ingest_session_events`]: bulk-inserts events into

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -166,7 +166,12 @@ async fn ingest_chat_session_events(
         }
     }
 
-    Ok((StatusCode::OK, Json(IngestEventsResponse { inserted: fanned_out })))
+    Ok((
+        StatusCode::OK,
+        Json(IngestEventsResponse {
+            inserted: fanned_out,
+        }),
+    ))
 }
 
 /// Agent-session path for [`ingest_session_events`]: bulk-inserts events into

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -17,7 +17,7 @@ use rb_schemas::{RuntimeEvent, TenantId};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::AppError, state::AppState};
+use crate::{error::AppError, routes::chat::db::db_insert_chat_message, state::AppState};
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -91,9 +91,9 @@ pub async fn ingest_session_events(
     }
 
     // Chat session fallback: validate against control.chat_sessions.
-    // Chat events are NOT inserted into agents.agent_events — they persist via
-    // control.chat_messages through the db_insert_chat_message path. Here we only
-    // fan-out to the SSE bus so the frontend receives streaming tokens.
+    // Chat events are NOT inserted into agents.agent_events — they are fanned out to
+    // the SSE bus (live streaming) and Text events are persisted to control.chat_messages
+    // as role=assistant rows so GET /messages can return full history on reload.
     let chat_row: Option<(Uuid,)> =
         sqlx::query_as("SELECT tenant_id FROM control.chat_sessions WHERE id = $1")
             .bind(session_id)
@@ -106,7 +106,7 @@ pub async fn ingest_session_events(
         return Err(AppError::Unauthorized);
     }
 
-    // Fan-out to the SSE bus without a DB insert — sequences are synthetic (1-based).
+    // Fan-out to the SSE bus (sequences are synthetic, 1-based within each batch).
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
     for (seq, ev) in req.events.iter().enumerate() {
@@ -128,6 +128,31 @@ pub async fn ingest_session_events(
         if let Ok(data) = serde_json::to_string(&sse_data) {
             state.sse_bus.publish_raw(&tenant_id, "session.event", data);
             fanned_out += 1;
+        }
+    }
+
+    // Persist assistant turns so GET /messages returns full history on reload.
+    // Only Text events represent the visible assistant reply; thinking/tool events are
+    // internal and intentionally excluded from the message history.
+    for ev in &req.events {
+        if let RuntimeEvent::Text { text } = ev {
+            let msg_id = Uuid::new_v4();
+            if let Err(e) = db_insert_chat_message(
+                &state.pool,
+                msg_id,
+                session_id,
+                req.tenant_id,
+                "assistant",
+                text,
+            )
+            .await
+            {
+                tracing::error!(
+                    session_id = %session_id,
+                    error = %e,
+                    "failed to persist assistant chat message — history may be incomplete on reload"
+                );
+            }
         }
     }
 

--- a/services/control-api/src/routes/chat/mod.rs
+++ b/services/control-api/src/routes/chat/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! All routes return 404 when `RB_CHAT_PANEL_ENABLED` is false (feature gate).
 
-mod db;
+pub(crate) mod db;
 pub mod events;
 pub mod messages;
 pub mod sessions;


### PR DESCRIPTION
## Summary
- GET /v1/chat/sessions/{id}/messages only returned user rows on reload because the ingest handler for chat sessions never wrote assistant text to the DB
- Each RuntimeEvent::Text event is now persisted as a role=assistant row in control.chat_messages immediately after SSE fan-out
- routes/chat/db promoted to pub(crate) so events_ingest.rs can reach db_insert_chat_message

## GitHub Issue
Closes #694

## Root cause
events_ingest.rs line 97 comment claimed "they persist via control.chat_messages through the db_insert_chat_message path" but no such call existed. The chat ingest path only fanned out to the SSE bus.

## Changes
- `services/control-api/src/routes/agents/events_ingest.rs` — add loop after SSE fan-out to call db_insert_chat_message for every RuntimeEvent::Text
- `services/control-api/src/routes/chat/mod.rs` — `mod db` → `pub(crate) mod db`

## Checklist
- [x] `cargo-locked test --workspace` passes (all tests green)
- [x] `cargo clippy -p control-api --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes
- [x] No RUSAA-XX outside the title bracket