### PR TITLE
[RUSAA-1896] fix(chat): optimistic user bubble + persist tool_use blocks on reload

### DIFF
--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -15,6 +15,7 @@ import {
   AUDIT_WITH_TOOL_CALL,
   LIST_SESSIONS_ONE,
   LIST_MESSAGES_MCP_EXCHANGE,
+  LIST_MESSAGES_WITH_TOOL_USE,
   MID_SEND_SSE,
 } from "./fixtures/chat-mock-api";
 
@@ -218,6 +219,73 @@ test.describe("Chat panel — mid-send message persistence", () => {
     await expect(
       page.getByText("You can use the bash tool to run shell commands in the workspace."),
     ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug A — Optimistic user bubble: visible before SSE user_input echo
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — optimistic user bubble (Bug A)", () => {
+  // AC1: user bubble visible BEFORE any SSE user_input event arrives.
+  // SSE stream is empty (never delivers user_input), so the bubble must come
+  // from the optimistic pending-send path in ChatPage.
+  test("user bubble appears immediately after send with no SSE events yet", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // Empty SSE — no user_input echo will ever arrive.
+    await mockChatStream(page, CHAT_SESSION_ID, "");
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_MCP_EXCHANGE);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Wait for history to load so we know the session is active.
+    await expect(page.getByText("What MCP tools are available?")).toBeVisible();
+
+    // Type and send a new message — do NOT wait for any SSE event.
+    await page.getByRole("textbox", { name: "Chat message" }).fill("Tell me about Rust");
+    await page.getByRole("button", { name: "Send" }).click();
+
+    // Bubble must appear immediately from the optimistic path (no SSE yet).
+    await expect(page.getByText("Tell me about Rust")).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug B — Tool-use blocks survive reload
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — tool_use blocks survive reload (Bug B)", () => {
+  // AC2: tool_use block present after reload (loaded from DB history with JSON body).
+  test("tool_use block from JSON content-block history renders on load and after reload", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // History contains an assistant message with tool_use in JSON array body.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_WITH_TOOL_USE);
+    await mockChatStream(page, CHAT_SESSION_ID, "");
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // User prompt and tool_use block are visible on initial load.
+    await expect(page.getByText("Search for recent Rust news")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /mcp__rust_brain__search_demo tool call/ }),
+    ).toBeVisible();
+    await expect(page.getByText("Here are the recent Rust news results.")).toBeVisible();
+
+    // Hard reload — both must survive (history re-fetched from mocked listMessages).
+    await page.reload();
+
+    await expect(page.getByText("Search for recent Rust news")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /mcp__rust_brain__search_demo tool call/ }),
+    ).toBeVisible();
+    await expect(page.getByText("Here are the recent Rust news results.")).toBeVisible();
   });
 });
 

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -157,6 +157,45 @@ export const MID_SEND_SSE = [
   "",
 ].join("\n");
 
+// Tool-use exchange stored in the new JSON content-block body format (post-1896).
+// body is a JSON array: [tool_use block, tool_result block, text block].
+export const LIST_MESSAGES_WITH_TOOL_USE = {
+  messages: [
+    {
+      id: "msg-tool-u1",
+      seq: 1,
+      role: "user",
+      body: "Search for recent Rust news",
+      created_at: "2026-06-04T00:00:00Z",
+    },
+    {
+      id: "msg-tool-a1",
+      seq: 2,
+      role: "assistant",
+      body: JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tu-001",
+          name: "mcp__rust_brain__search_demo",
+          input: { q: "recent Rust news" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tu-001",
+          content: "Found 5 results for recent Rust news",
+          is_error: false,
+        },
+        {
+          type: "text",
+          text: "Here are the recent Rust news results.",
+        },
+      ]),
+      created_at: "2026-06-04T00:00:01Z",
+    },
+  ],
+  has_more: false,
+};
+
 export const AUDIT_WITH_TOOL_CALL = {
   total: 1,
   events: [

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -204,6 +204,43 @@ export function getMinSseUserInputSeq(events: ReadonlyArray<StreamedEvent>): num
   return null;
 }
 
+// Try to parse a message body as a JSON content-block array (post-1896 format).
+// Returns null if the body is plain text (pre-1896 rows) or invalid JSON.
+function tryParseContentBlocks(body: string): ReadonlyArray<AssistantItem> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+
+  const result: AssistantItem[] = [];
+  for (let idx = 0; idx < parsed.length; idx++) {
+    const block: unknown = parsed[idx];
+    if (typeof block !== "object" || block === null) continue;
+    const b = block as Record<string, unknown>;
+
+    if (b.type === "text" && typeof b.text === "string") {
+      result.push({ type: "text", text: b.text, seq: idx });
+    } else if (b.type === "thinking" && typeof b.thinking === "string") {
+      result.push({ type: "thinking", thinking: b.thinking, seq: idx });
+    } else if (b.type === "tool_use" && typeof b.id === "string" && typeof b.name === "string") {
+      result.push({ type: "tool_use", id: b.id, name: b.name, input: b.input, seq: idx });
+    } else if (b.type === "tool_result" && typeof b.tool_use_id === "string") {
+      result.push({
+        type: "tool_result",
+        toolUseId: b.tool_use_id as string,
+        content: b.content,
+        isError: Boolean(b.is_error),
+        seq: idx,
+      });
+    }
+  }
+
+  return result.length > 0 ? result : null;
+}
+
 export function buildTranscriptFromHistory(
   messages: ReadonlyArray<ChatMessage>,
 ): ReadonlyArray<TranscriptItem> {
@@ -212,10 +249,12 @@ export function buildTranscriptFromHistory(
     if (msg.role === "user") {
       items.push({ kind: "user", id: msg.id, text: msg.body, seq: msg.seq });
     } else if (msg.role === "assistant") {
+      // Try JSON content-block array (post-1896); fall back to plain text for old rows.
+      const contentBlocks = tryParseContentBlocks(msg.body);
       items.push({
         kind: "assistant",
         id: msg.id,
-        items: [{ type: "text", text: msg.body, seq: msg.seq }],
+        items: contentBlocks ?? [{ type: "text", text: msg.body, seq: msg.seq }],
       });
     }
     // system / tool rows are not rendered in the transcript UI

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useMe } from "@/api";
 import {
@@ -14,6 +14,7 @@ import { MessageComposer } from "@/components/chat/MessageComposer";
 import {
   buildTranscript,
   buildTranscriptFromHistory,
+  type TranscriptItem,
   type UserTranscriptItem,
 } from "@/components/chat/transcript";
 import { formatApiError } from "@/lib/errors/api";
@@ -50,6 +51,11 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
   const navigate = useNavigate();
   const { sessionId: activeSessionId = null } = useSearch({ from: routes.chat });
   const [composerValue, setComposerValue] = useState("");
+  // Optimistic user bubbles: entries pushed immediately on send, removed once SSE
+  // echoes user_input or the DB history reflects the message (Bug A fix).
+  const [pendingUserSends, setPendingUserSends] = useState<
+    ReadonlyArray<{ id: string; text: string }>
+  >([]);
 
   const setActiveSessionId = (id: string | null) => {
     void navigate({
@@ -58,6 +64,11 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       replace: false,
     });
   };
+
+  // Clear pending sends when the user navigates to a different session.
+  useEffect(() => {
+    setPendingUserSends([]);
+  }, [activeSessionId]);
 
   const sessions = useChatSessions(tenantId);
   const createSession = useCreateChatSession(tenantId);
@@ -75,31 +86,56 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       (item): item is UserTranscriptItem => item.kind === "user",
     );
 
+    let base: ReadonlyArray<TranscriptItem>;
+
     if (!firstLiveUser) {
       // No live user turn in SSE — show historical + any live non-user items (e.g. session.error).
-      return [...buildTranscriptFromHistory(historical), ...liveItems];
-    }
-
-    // The SSE stream is covering at least one user turn.  Find the last historical
-    // user message whose body matches the first SSE user turn and exclude it (and
-    // all subsequent rows) from the historical slice — those rows will be supplied
-    // by the live stream instead, preventing duplication.
-    //
-    // If the matching message is not yet in the DB cache (common: messages query
-    // has a 30 s staleTime and POST /messages doesn't invalidate it), cutIdx stays
-    // -1 and all historical messages are shown before the live items.
-    let cutIdx = -1;
-    for (let i = historical.length - 1; i >= 0; i--) {
-      const msg = historical[i];
-      if (msg && msg.role === "user" && msg.body === firstLiveUser.text) {
-        cutIdx = i;
-        break;
+      base = [...buildTranscriptFromHistory(historical), ...liveItems];
+    } else {
+      // The SSE stream is covering at least one user turn.  Find the last historical
+      // user message whose body matches the first SSE user turn and exclude it (and
+      // all subsequent rows) from the historical slice — those rows will be supplied
+      // by the live stream instead, preventing duplication.
+      //
+      // If the matching message is not yet in the DB cache (common: messages query
+      // has a 30 s staleTime and POST /messages doesn't invalidate it), cutIdx stays
+      // -1 and all historical messages are shown before the live items.
+      let cutIdx = -1;
+      for (let i = historical.length - 1; i >= 0; i--) {
+        const msg = historical[i];
+        if (msg && msg.role === "user" && msg.body === firstLiveUser.text) {
+          cutIdx = i;
+          break;
+        }
       }
+
+      const historicalFiltered = cutIdx >= 0 ? historical.slice(0, cutIdx) : historical;
+      base = [...buildTranscriptFromHistory(historicalFiltered), ...liveItems];
     }
 
-    const historicalFiltered = cutIdx >= 0 ? historical.slice(0, cutIdx) : historical;
-    return [...buildTranscriptFromHistory(historicalFiltered), ...liveItems];
-  }, [historicalMessages.data, events]);
+    if (pendingUserSends.length === 0) return base;
+
+    // Collect user texts already present in live SSE or historical so we don't
+    // duplicate a pending send that has already been echoed.
+    const coveredTexts = new Set<string>();
+    for (const item of liveItems) {
+      if (item.kind === "user") coveredTexts.add(item.text);
+    }
+    for (const msg of historical) {
+      if (msg.role === "user") coveredTexts.add(msg.body);
+    }
+
+    const pendingItems: UserTranscriptItem[] = pendingUserSends
+      .filter((p) => !coveredTexts.has(p.text))
+      .map((p, i) => ({
+        kind: "user" as const,
+        id: p.id,
+        text: p.text,
+        seq: -(i + 1),
+      }));
+
+    return pendingItems.length > 0 ? [...base, ...pendingItems] : base;
+  }, [historicalMessages.data, events, pendingUserSends]);
 
   const isStreaming = sendMessage.isPending;
 
@@ -109,6 +145,11 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
   };
 
   const handleSend = async (content: string) => {
+    if (activeSessionId) {
+      // Optimistic: show user bubble immediately before the SSE user_input echo arrives.
+      const pendingId = `p-${Date.now().toString()}`;
+      setPendingUserSends((prev) => [...prev, { id: pendingId, text: content }]);
+    }
     if (!activeSessionId) {
       const result = await createSession.mutateAsync({ runtime: "claude_code" });
       setActiveSessionId(result.session_id);

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -15,6 +15,7 @@ use axum::{
 };
 use rb_schemas::{RuntimeEvent, TenantId};
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::{error::AppError, routes::chat::db::db_insert_chat_message, state::AppState};
@@ -110,7 +111,12 @@ pub async fn ingest_session_events(
 }
 
 /// Chat-session path for [`ingest_session_events`]: fans events out to the SSE bus and
-/// persists accumulated `Text` events as `role=assistant` rows in `control.chat_messages`.
+/// persists each assistant turn as a single `role=assistant` row in `control.chat_messages`.
+///
+/// The row `body` is a JSON array of content blocks so all block types survive reload:
+/// `[{"type":"text","text":"…"},{"type":"tool_use","id":"…","name":"…","input":{…}},…]`
+/// Plain-`Text`-only turns also use the array format. Pre-1896 rows (plain text) continue
+/// to render as plain text via the frontend fallback path in `buildTranscriptFromHistory`.
 async fn ingest_chat_session_events(
     state: &AppState,
     session_id: Uuid,
@@ -118,7 +124,11 @@ async fn ingest_chat_session_events(
 ) -> Result<(StatusCode, Json<IngestEventsResponse>), AppError> {
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
-    let mut pending_assistant_text = String::new();
+
+    // Content-block accumulator for the current assistant turn.
+    // Consecutive `Text` payloads are merged into one block via `pending_text`.
+    let mut pending_blocks: Vec<serde_json::Value> = Vec::new();
+    let mut pending_text = String::new();
 
     for (seq, ev) in req.events.iter().enumerate() {
         let et = event_type(ev);
@@ -143,53 +153,29 @@ async fn ingest_chat_session_events(
 
         match ev {
             RuntimeEvent::UserInput { .. } => {
-                if !pending_assistant_text.is_empty() {
-                    let msg_id = Uuid::new_v4();
-                    if let Err(e) = db_insert_chat_message(
-                        &state.pool,
-                        msg_id,
-                        session_id,
-                        req.tenant_id,
-                        "assistant",
-                        &pending_assistant_text,
-                    )
-                    .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %e,
-                            "chat ingest: failed to persist assistant turn — reload may miss this message"
-                        );
-                    }
-                    pending_assistant_text.clear();
-                }
+                flush_pending_turn(&state.pool, session_id, req.tenant_id, &mut pending_text, &mut pending_blocks).await;
             }
             RuntimeEvent::Text { text } => {
-                pending_assistant_text.push_str(text);
+                pending_text.push_str(text);
+            }
+            RuntimeEvent::Thinking { thinking } => {
+                commit_text_block(&mut pending_text, &mut pending_blocks);
+                pending_blocks.push(serde_json::json!({ "type": "thinking", "thinking": thinking }));
+            }
+            RuntimeEvent::ToolUse { id, name, input } => {
+                commit_text_block(&mut pending_text, &mut pending_blocks);
+                pending_blocks.push(serde_json::json!({ "type": "tool_use", "id": id, "name": name, "input": input }));
+            }
+            RuntimeEvent::ToolResult { tool_use_id, content, is_error } => {
+                commit_text_block(&mut pending_text, &mut pending_blocks);
+                pending_blocks.push(serde_json::json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content, "is_error": is_error }));
             }
             _ => {}
         }
     }
 
-    if !pending_assistant_text.is_empty() {
-        let msg_id = Uuid::new_v4();
-        if let Err(e) = db_insert_chat_message(
-            &state.pool,
-            msg_id,
-            session_id,
-            req.tenant_id,
-            "assistant",
-            &pending_assistant_text,
-        )
-        .await
-        {
-            tracing::warn!(
-                session_id = %session_id,
-                error = %e,
-                "chat ingest: failed to persist final assistant turn — reload may miss this message"
-            );
-        }
-    }
+    // Flush the final assistant turn.
+    flush_pending_turn(&state.pool, session_id, req.tenant_id, &mut pending_text, &mut pending_blocks).await;
 
     Ok((
         StatusCode::OK,
@@ -197,6 +183,47 @@ async fn ingest_chat_session_events(
             inserted: fanned_out,
         }),
     ))
+}
+
+/// Move any buffered text into `pending_blocks` as a `{"type":"text",…}` entry.
+fn commit_text_block(pending_text: &mut String, pending_blocks: &mut Vec<serde_json::Value>) {
+    if !pending_text.is_empty() {
+        pending_blocks.push(serde_json::json!({ "type": "text", "text": pending_text.as_str() }));
+        pending_text.clear();
+    }
+}
+
+/// Flush accumulated content blocks as a single `role=assistant` chat message (JSON array body).
+async fn flush_pending_turn(
+    pool: &PgPool,
+    session_id: Uuid,
+    tenant_id: Uuid,
+    pending_text: &mut String,
+    pending_blocks: &mut Vec<serde_json::Value>,
+) {
+    commit_text_block(pending_text, pending_blocks);
+    if pending_blocks.is_empty() {
+        return;
+    }
+    let body = match serde_json::to_string(pending_blocks.as_slice()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(session_id = %session_id, error = %e, "chat ingest: failed to serialize content blocks");
+            pending_blocks.clear();
+            return;
+        }
+    };
+    let msg_id = Uuid::new_v4();
+    if let Err(e) =
+        db_insert_chat_message(pool, msg_id, session_id, tenant_id, "assistant", &body).await
+    {
+        tracing::warn!(
+            session_id = %session_id,
+            error = %e,
+            "chat ingest: failed to persist assistant turn — reload may miss this message"
+        );
+    }
+    pending_blocks.clear();
 }
 
 /// Agent-session path for [`ingest_session_events`]: bulk-inserts events into

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -153,29 +153,48 @@ async fn ingest_chat_session_events(
 
         match ev {
             RuntimeEvent::UserInput { .. } => {
-                flush_pending_turn(&state.pool, session_id, req.tenant_id, &mut pending_text, &mut pending_blocks).await;
+                flush_pending_turn(
+                    &state.pool,
+                    session_id,
+                    req.tenant_id,
+                    &mut pending_text,
+                    &mut pending_blocks,
+                )
+                .await;
             }
             RuntimeEvent::Text { text } => {
                 pending_text.push_str(text);
             }
             RuntimeEvent::Thinking { thinking } => {
                 commit_text_block(&mut pending_text, &mut pending_blocks);
-                pending_blocks.push(serde_json::json!({ "type": "thinking", "thinking": thinking }));
+                pending_blocks
+                    .push(serde_json::json!({ "type": "thinking", "thinking": thinking }));
             }
             RuntimeEvent::ToolUse { id, name, input } => {
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks.push(serde_json::json!({ "type": "tool_use", "id": id, "name": name, "input": input }));
             }
-            RuntimeEvent::ToolResult { tool_use_id, content, is_error } => {
+            RuntimeEvent::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks.push(serde_json::json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content, "is_error": is_error }));
             }
-            _ => {}
+            RuntimeEvent::Error { .. } => {}
         }
     }
 
     // Flush the final assistant turn.
-    flush_pending_turn(&state.pool, session_id, req.tenant_id, &mut pending_text, &mut pending_blocks).await;
+    flush_pending_turn(
+        &state.pool,
+        session_id,
+        req.tenant_id,
+        &mut pending_text,
+        &mut pending_blocks,
+    )
+    .await;
 
     Ok((
         StatusCode::OK,


### PR DESCRIPTION
## Summary

- **Bug A (FE)**: Add `pendingUserSends` state to `ChatPage` — user bubble inserted optimistically on `handleSend` before SSE `user_input` echo arrives. Entry suppressed once covered by live SSE or DB history. Cleared on session navigation.
- **Bug B (FE+BE)**: Extend `ingest_chat_session_events` to accumulate `Thinking`, `ToolUse`, `ToolResult` alongside `Text` between `UserInput` boundaries, flush as a JSON content-block array in `control.chat_messages.body`. `buildTranscriptFromHistory` parses the array to render tool-use chains on reload; falls back to plain text for pre-fix rows (no schema change).

## Persistence model (ADR)

Lighter path: JSON content-block array in existing `body TEXT` column — no migration. Pre-1896 plain-text rows use the fallback path. Backend flush produces `[{"type":"tool_use",…},{"type":"tool_result",…},{"type":"text",…}]`.

## Files changed

- `frontend/src/pages/ChatPage.tsx` — `pendingUserSends` state + `useEffect` clear + useMemo append
- `frontend/src/components/chat/transcript.ts` — `tryParseContentBlocks` helper + updated `buildTranscriptFromHistory`
- `services/control-api/src/routes/agents/events_ingest.rs` — `ingest_chat_session_events` + `commit_text_block` + `flush_pending_turn`
- `frontend/e2e/fixtures/chat-mock-api.ts` — `LIST_MESSAGES_WITH_TOOL_USE` fixture
- `frontend/e2e/chat-panel.spec.ts` — 2 new tests (Bug A + Bug B)

## GitHub Issue

Closes #696

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] `cargo check -p control-api` passes
- [x] No internal tracker IDs in source/commits