### PR TITLE
[RUSAA-1900] fix(chat): slot pending user bubble before in-progress assistant on turn-1

### DIFF
--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -18,6 +18,7 @@ import {
   LIST_MESSAGES_WITH_TOOL_USE,
   MID_SEND_SSE,
   IN_PROGRESS_NO_ECHO_SSE,
+  LIST_MESSAGES_EMPTY,
 } from "./fixtures/chat-mock-api";
 
 const CHAT_URL = "/chat";
@@ -378,6 +379,57 @@ test.describe("Chat panel — pending bubble ordering (Bug C)", () => {
     expect(pendingBox).not.toBeNull();
     expect(inProgressBox).not.toBeNull();
     // pending bubble renders above the in-progress assistant content
+    expect(pendingBox!.y).toBeLessThan(inProgressBox!.y);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug C turn-1 regression — ordering on first turn of a brand-new session
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — turn-1 pending bubble ordering (Bug C turn-1)", () => {
+  // Regression guard for RUSAA-1900: on the very first turn of a fresh session
+  // the slot predicate guard (base.some("user")) was false because base held
+  // only the streaming assistant item with no prior user row, so the pending
+  // bubble was appended AFTER the assistant turn instead of slotted before it.
+  //
+  // Scenario: fresh session (empty history); SSE delivers assistant tokens
+  // WITHOUT a user_input echo; user sends U1 optimistically.  The pending
+  // bubble must appear BEFORE the in-progress assistant content.
+  test("turn-1: pending user bubble appears before in-progress assistant on a fresh session", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE delivers assistant tokens with no user_input echo.
+    await mockChatStream(page, CHAT_SESSION_ID, IN_PROGRESS_NO_ECHO_SSE);
+    await mockSendChatMessage(page);
+    // Empty history — this is the first turn of a brand-new session.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Wait for the in-progress assistant content from SSE to render.
+    await expect(page.getByText("I'm analyzing your request now...")).toBeVisible();
+
+    // Send the first user message — no SSE user_input echo will arrive.
+    await page.getByRole("textbox", { name: "Chat message" }).fill("what are the tools available");
+    await page.getByRole("button", { name: "Send" }).click();
+
+    // Pending bubble must be visible.
+    await expect(page.getByText("what are the tools available")).toBeVisible();
+
+    // The pending bubble must render ABOVE (before) the in-progress assistant
+    // content — smaller Y coordinate means higher on the page.
+    const pendingBubble = page.getByText("what are the tools available");
+    const inProgressContent = page.getByText("I'm analyzing your request now...");
+
+    const pendingBox = await pendingBubble.boundingBox();
+    const inProgressBox = await inProgressContent.boundingBox();
+
+    expect(pendingBox).not.toBeNull();
+    expect(inProgressBox).not.toBeNull();
     expect(pendingBox!.y).toBeLessThan(inProgressBox!.y);
   });
 });

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -114,6 +114,11 @@ export const LIST_MESSAGES_TWO_TURNS = {
   has_more: false,
 };
 
+export const LIST_MESSAGES_EMPTY = {
+  messages: [] as never[],
+  has_more: false,
+};
+
 // Two-turn history using "What MCP tools…" prompt (matches AC3 reload assertion).
 export const LIST_MESSAGES_MCP_EXCHANGE = {
   messages: [

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -142,15 +142,16 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
     // assistant response, reversing chronological order during the SSE echo race
     // window (between POST completing and user_input echo arriving).
     //
-    // Corner case: no prior user turn yet (session-start greeting only) → append
-    // at the end so the greeting stays first.
+    // The inProgress flag only exists on streaming assistant turns, which are
+    // always in response to a user message — so the slot is always correct even
+    // on turn-1 where base has no prior user item yet.
     const firstInProgressIdx = liveItems.findIndex(
       (item): item is AssistantTranscriptItem =>
         item.kind === "assistant" && item.inProgress === true,
     );
 
     let insertAt = base.length;
-    if (firstInProgressIdx !== -1 && base.some((item) => item.kind === "user")) {
+    if (firstInProgressIdx !== -1) {
       insertAt = base.length - liveItems.length + firstInProgressIdx;
     }
 


### PR DESCRIPTION
## Summary

- Removes the `base.some((item) => item.kind === "user")` guard from the slot predicate in `ChatPage.tsx`. On turn-1 of a fresh session `base` contains only the in-progress assistant turn (no prior user row), so the guard was falsely blocking the insert and the optimistic pending bubble fell after the streaming assistant reply.
- An `inProgress` assistant turn only exists when the model is actively streaming — always in response to a user message — so inserting the pending user before it is always correct.
- Adds a Playwright regression test for the turn-1 case: empty session history + SSE tokens arriving before `user_input` echo.

## GitHub Issue

Closes #700

## Screenshots

Before (turn-1): assistant streaming reply renders above user bubble (inverted)  
After (turn-1): user bubble renders above streaming assistant reply (correct)

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally (new bundle hash `index-Dpfun3cA.js`)
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR