### PR TITLE
[RUSAA-1904] fix(chat): restore liveHasUserEcho guard to fix turn-2 pending bubble ordering

### DIFF
--- a/frontend/e2e/chat-panel.spec.ts
+++ b/frontend/e2e/chat-panel.spec.ts
@@ -18,6 +18,8 @@ import {
   LIST_MESSAGES_WITH_TOOL_USE,
   MID_SEND_SSE,
   IN_PROGRESS_NO_ECHO_SSE,
+  TURN1_COMPLETE_STALE_INPROGRESS_SSE,
+  TURN2_WITH_ECHO_SSE,
   LIST_MESSAGES_EMPTY,
 } from "./fixtures/chat-mock-api";
 
@@ -431,6 +433,99 @@ test.describe("Chat panel — turn-1 pending bubble ordering (Bug C turn-1)", ()
     expect(pendingBox).not.toBeNull();
     expect(inProgressBox).not.toBeNull();
     expect(pendingBox!.y).toBeLessThan(inProgressBox!.y);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug C turn-2 regression — stale inProgress after completed turn-1
+// ---------------------------------------------------------------------------
+
+test.describe("Chat panel — turn-2 pending bubble ordering (Bug C turn-2)", () => {
+  // Regression guard for RUSAA-1904: PR #701 removed the user-guard entirely,
+  // fixing turn-1 but breaking turn-2.  After turn-1 completes (user_input echo
+  // arrived + all text tokens received), the assistant's inProgress flag stays
+  // true until a NEW user_input event flushes it.  The slot predicate previously
+  // found this stale-inProgress assistant and mis-slotted the turn-2 pending
+  // bubble before it: [user-1, user-2-pending, assistant-1] instead of
+  // [user-1, assistant-1, user-2-pending].
+  //
+  // Scenario: SSE has completed turn-1 (user_input + text, both received);
+  // user sends U2 optimistically.  Pending U2 must appear AFTER assistant-1.
+  test("turn-2: pending user bubble appears after completed assistant-1, not before it", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE has full turn-1 (user_input + text) but no turn-2 user_input.
+    // The assistant-1 item keeps inProgress: true (stale — no flush event).
+    await mockChatStream(page, CHAT_SESSION_ID, TURN1_COMPLETE_STALE_INPROGRESS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Both turn-1 items must be visible from SSE.
+    await expect(page.getByText("what are the tools available")).toBeVisible();
+    await expect(page.getByText("Here are the available tools.")).toBeVisible();
+
+    // Send turn-2 optimistically.
+    await page.getByRole("textbox", { name: "Chat message" }).fill("second message");
+    await page.getByRole("button", { name: "Send" }).click();
+
+    // Pending bubble must be visible.
+    await expect(page.getByText("second message")).toBeVisible();
+
+    // The pending U2 bubble must appear BELOW (after) assistant-1, not before it.
+    const pendingBubble = page.getByText("second message");
+    const assistantContent = page.getByText("Here are the available tools.");
+
+    const pendingBox = await pendingBubble.boundingBox();
+    const assistantBox = await assistantContent.boundingBox();
+
+    expect(pendingBox).not.toBeNull();
+    expect(assistantBox).not.toBeNull();
+    // pending bubble renders below the completed assistant-1 content
+    expect(pendingBox!.y).toBeGreaterThan(assistantBox!.y);
+  });
+
+  // AC3: after turn-2's user_input echo arrives, transcript reads
+  // [user-1, assistant-1, user-2, assistant-2-streaming] — items 1 and 2
+  // retain correct order with no visual reshuffle.
+  test("turn-2 echo: completed exchange maintains [user-1, assistant-1, user-2, assistant-2] order", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE delivers both turns: user_input(1)+text(1)+user_input(2)+text(2).
+    // buildTranscript produces [user-1, assistant-1, user-2, assistant-2(inProgress)].
+    await mockChatStream(page, CHAT_SESSION_ID, TURN2_WITH_ECHO_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All four items must be visible.
+    await expect(page.getByText("what are the tools available")).toBeVisible();
+    await expect(page.getByText("Here are the available tools.")).toBeVisible();
+    await expect(page.getByText("Tell me about ownership")).toBeVisible();
+    await expect(page.getByText("Ownership is Rust's key memory feature.")).toBeVisible();
+
+    // Verify top-to-bottom order: user-1 < assistant-1 < user-2 < assistant-2.
+    const user1Box = await page.getByText("what are the tools available").boundingBox();
+    const asst1Box = await page.getByText("Here are the available tools.").boundingBox();
+    const user2Box = await page.getByText("Tell me about ownership").boundingBox();
+    const asst2Box = await page.getByText("Ownership is Rust's key memory feature.").boundingBox();
+
+    expect(user1Box).not.toBeNull();
+    expect(asst1Box).not.toBeNull();
+    expect(user2Box).not.toBeNull();
+    expect(asst2Box).not.toBeNull();
+
+    expect(user1Box!.y).toBeLessThan(asst1Box!.y);
+    expect(asst1Box!.y).toBeLessThan(user2Box!.y);
+    expect(user2Box!.y).toBeLessThan(asst2Box!.y);
   });
 });
 

--- a/frontend/e2e/fixtures/chat-mock-api.ts
+++ b/frontend/e2e/fixtures/chat-mock-api.ts
@@ -217,6 +217,72 @@ export const IN_PROGRESS_NO_ECHO_SSE = [
   "",
 ].join("\n");
 
+// Simulates the turn-2 stale-inProgress race: a completed turn-1 exchange
+// (user_input + text) where inProgress is never cleared because no subsequent
+// user_input arrived.  buildTranscript marks the trailing assistant as
+// inProgress: true even though turn-1 is fully done.
+// Used to assert that the turn-2 pending bubble is placed AFTER assistant-1,
+// NOT slotted before it.
+export const TURN1_COMPLETE_STALE_INPROGRESS_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "what are the tools available" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "Here are the available tools." },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+// Simulates two completed turns including the turn-2 user_input echo.
+// buildTranscript produces: [user-1, assistant-1, user-2, assistant-2(inProgress)]
+// Used to verify AC3: after turn-2 echo arrives, ordering is stable and
+// no visual reshuffle of items 1 (user-1) and 2 (assistant-1) occurs.
+export const TURN2_WITH_ECHO_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "what are the tools available" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "Here are the available tools." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 3,
+    payload: { type: "user_input", text: "Tell me about ownership" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 4,
+    payload: { type: "text", text: "Ownership is Rust's key memory feature." },
+  })}`,
+  "",
+  "",
+].join("\n");
+
 export const AUDIT_WITH_TOOL_CALL = {
   total: 1,
   events: [

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -142,16 +142,20 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
     // assistant response, reversing chronological order during the SSE echo race
     // window (between POST completing and user_input echo arriving).
     //
-    // The inProgress flag only exists on streaming assistant turns, which are
-    // always in response to a user message — so the slot is always correct even
-    // on turn-1 where base has no prior user item yet.
+    // Guard: only slot when the live SSE stream has NO user_input echo yet.
+    // If liveItems already contains a user_input event, the in-progress assistant
+    // is the stale-inProgress completed response from the prior turn (inProgress is
+    // only cleared when a subsequent user_input flushes pendingAssistant).
+    // Slotting before it would misplace turn-2's pending bubble between user-1 and
+    // the completed assistant-1.
     const firstInProgressIdx = liveItems.findIndex(
       (item): item is AssistantTranscriptItem =>
         item.kind === "assistant" && item.inProgress === true,
     );
+    const liveHasUserEcho = liveItems.some((item) => item.kind === "user");
 
     let insertAt = base.length;
-    if (firstInProgressIdx !== -1) {
+    if (firstInProgressIdx !== -1 && !liveHasUserEcho) {
       insertAt = base.length - liveItems.length + firstInProgressIdx;
     }
 


### PR DESCRIPTION
## Summary

PR #701 fixed turn-1 by removing the `base.some("user")` guard. That was correct for turn-1 but it introduced a turn-2 regression: `[user-1, user-2-pending, assistant-1]` instead of `[user-1, assistant-1, user-2-pending]`.

## Root cause

`buildTranscript` only clears `inProgress: true` when a new `user_input` event calls `flushPendingAssistant`. After turn-1 finishes streaming but before turn-2's `user_input` echo arrives, `liveItems = [user-1, assistant-1(inProgress=true, stale)]`. PR #701's unconditional slot predicate found `firstInProgressIdx = 1` and inserted the pending bubble before assistant-1.

## Fix

```diff
+    const liveHasUserEcho = liveItems.some((item) => item.kind === "user");
     let insertAt = base.length;
-    if (firstInProgressIdx !== -1) {
+    if (firstInProgressIdx !== -1 && !liveHasUserEcho) {
```

Only slot the pending bubble before an in-progress assistant when the live SSE stream has **no user_input echo yet**. If `liveItems` has a user_input, the in-progress assistant is a stale completed-turn response; the pending bubble belongs after it.

## Correctness across all cases

| Scenario | `liveItems` shape | `liveHasUserEcho` | Slot? | Result |
|---|---|---|---|---|
| Turn-1 race (no echo yet) | `[assistant(inProgress)]` | false | ✓ yes | `[pending, assistant]` |
| Turn-2 stale (echo arrived, turn-1 done) | `[user-1, assistant-1(stale)]` | true | ✗ no | `[user-1, assistant-1, pending]` |

## Tests

- **New** `TURN1_COMPLETE_STALE_INPROGRESS_SSE` fixture + turn-2 race test: sends U2 after turn-1 completes, asserts pending Y > assistant-1 Y.
- **New** `TURN2_WITH_ECHO_SSE` fixture + turn-2 echo-arrived test: after echo, ordering is stable.
- **Existing** turn-1 test (PR #701) still passes.
- **Existing** turn-2 `Bug C` test (PR #699) still passes.

## GitHub Issue

Closes #704

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR