### PR TITLE
[RUSAA-1928] feat: emit turn_complete runtime event (rb-schemas + proto + agent-runner + control-api)

### DIFF
--- a/crates/rb-schemas/src/stream_json.rs
+++ b/crates/rb-schemas/src/stream_json.rs
@@ -63,6 +63,10 @@ pub enum RuntimeEvent {
 
     /// User input relayed into the session.
     UserInput { text: String },
+
+    /// Signals that the assistant has completed a turn (maps to `result.subtype == "success"`).
+    /// This is a control signal only — it is NOT persisted as a content row.
+    TurnComplete { stop_reason: String },
 }
 
 impl RuntimeEvent {
@@ -76,6 +80,7 @@ impl RuntimeEvent {
             RuntimeEvent::ToolResult { .. } => AgentEventKind::ToolResult,
             RuntimeEvent::Error { .. } => AgentEventKind::Error,
             RuntimeEvent::UserInput { .. } => AgentEventKind::UserInput,
+            RuntimeEvent::TurnComplete { .. } => AgentEventKind::TurnComplete,
         }
     }
 
@@ -258,6 +263,26 @@ mod tests {
             text: "hello".into(),
         };
         assert_eq!(ev.kind(), AgentEventKind::UserInput);
+    }
+
+    #[test]
+    fn turn_complete_roundtrip() {
+        let ev = RuntimeEvent::TurnComplete {
+            stop_reason: "success".into(),
+        };
+        assert_eq!(roundtrip(&ev), ev);
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "turn_complete");
+        assert_eq!(v["stop_reason"], "success");
+    }
+
+    #[test]
+    fn kind_mapping_turn_complete() {
+        let ev = RuntimeEvent::TurnComplete {
+            stop_reason: "success".into(),
+        };
+        assert_eq!(ev.kind(), AgentEventKind::TurnComplete);
     }
 
     #[test]

--- a/proto/rust_brain/v1/agent.proto
+++ b/proto/rust_brain/v1/agent.proto
@@ -27,7 +27,8 @@ enum AgentEventKind {
   AGENT_EVENT_KIND_THINKING    = 7;  // extended thinking block
   AGENT_EVENT_KIND_TOOL_USE    = 8;  // tool invocation by the assistant
   AGENT_EVENT_KIND_TOOL_RESULT = 9;  // tool result returned to the assistant
-  AGENT_EVENT_KIND_USER_INPUT  = 10; // user input relayed into the session
+  AGENT_EVENT_KIND_USER_INPUT    = 10; // user input relayed into the session
+  AGENT_EVENT_KIND_TURN_COMPLETE = 11; // assistant turn complete control signal
 }
 
 enum AgentErrorCategory {

--- a/services/agent-runner/src/normalizer.rs
+++ b/services/agent-runner/src/normalizer.rs
@@ -199,7 +199,9 @@ fn extract_result_events(payload: ResultPayload) -> Vec<RuntimeEvent> {
             code: Some(payload.subtype),
         }]
     } else {
-        vec![]
+        vec![RuntimeEvent::TurnComplete {
+            stop_reason: payload.subtype,
+        }]
     }
 }
 
@@ -414,7 +416,7 @@ mod tests {
     // --- result: success ---
 
     #[test]
-    fn result_success_produces_no_events() {
+    fn result_success_produces_turn_complete_event() {
         let line = json!({
             "type": "result",
             "subtype": "success",
@@ -426,7 +428,14 @@ mod tests {
         })
         .to_string();
 
-        assert!(normalize(&line).is_empty());
+        let events = normalize(&line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            RuntimeEvent::TurnComplete {
+                stop_reason: "success".into()
+            }
+        );
     }
 
     // --- result: error ---

--- a/services/agent-runner/tests/normalizer_integration.rs
+++ b/services/agent-runner/tests/normalizer_integration.rs
@@ -28,9 +28,10 @@ fn basic_session_event_count() {
     // thinking + text + tool_use = 3 from first assistant turn
     // tool_result = 1 from user turn
     // text = 1 from second assistant turn
-    // system init and success result produce no events
-    // Total = 6
-    assert_eq!(events.len(), 6, "events: {events:?}");
+    // turn_complete = 1 from success result
+    // system init produces no events
+    // Total = 7
+    assert_eq!(events.len(), 7, "events: {events:?}");
 }
 
 #[test]
@@ -93,12 +94,12 @@ fn basic_session_tool_result_is_not_error() {
 }
 
 #[test]
-fn basic_session_last_event_is_text() {
+fn basic_session_last_event_is_turn_complete() {
     let events = normalize_fixture("session_basic.ndjson");
     let last = events.last().expect("at least one event");
     assert!(
-        matches!(last, RuntimeEvent::Text { .. }),
-        "last event should be Text, got: {last:?}"
+        matches!(last, RuntimeEvent::TurnComplete { .. }),
+        "last event should be TurnComplete, got: {last:?}"
     );
 }
 

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -51,6 +51,7 @@ fn event_type(ev: &RuntimeEvent) -> &'static str {
         RuntimeEvent::ToolResult { .. } => "session.tool_result",
         RuntimeEvent::Error { .. } => "session.error",
         RuntimeEvent::UserInput { .. } => "session.user_input",
+        RuntimeEvent::TurnComplete { .. } => "session.turn_complete",
     }
 }
 
@@ -182,7 +183,8 @@ async fn ingest_chat_session_events(
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks.push(serde_json::json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content, "is_error": is_error }));
             }
-            RuntimeEvent::Error { .. } => {}
+            // Error and TurnComplete are control signals — not content rows.
+            RuntimeEvent::Error { .. } | RuntimeEvent::TurnComplete { .. } => {}
         }
     }
 
@@ -368,6 +370,12 @@ mod tests {
                 text: "hello".into()
             }),
             "session.user_input"
+        );
+        assert_eq!(
+            event_type(&RuntimeEvent::TurnComplete {
+                stop_reason: "success".into()
+            }),
+            "session.turn_complete"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `RuntimeEvent::TurnComplete { stop_reason: String }` to rb-schemas (`serde` tag `turn_complete`)
- Add `AGENT_EVENT_KIND_TURN_COMPLETE = 11` to `proto/rust_brain/v1/agent.proto`
- `agent-runner` normalizer: emit `TurnComplete` on the success path of `extract_result_events` (was dead-drop `vec![]`); update the renamed test
- `control-api` events_ingest: add exhaustive match arms — `event_type()` maps to `"session.turn_complete"`, persistence switch is a no-op (control signal, not a content row)

## GitHub Issue
Closes #716

## Test results
- `cargo test -p rb-schemas`: 29/29 ✓
- `cargo test -p agent-runner --lib`: 25/25 ✓ (new: `result_success_produces_turn_complete_event`)
- `cargo test -p control-api --lib`: 450/450 ✓
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p rb-schemas -p agent-runner -p control-api -- -D warnings`: clean
- `cargo deny check`: ok

## Checklist
- [x] `cargo test` passes (scoped to affected crates)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo deny check` clean
- [x] No tracker IDs outside this title bracket
- [x] Architecture boundary clean (crates ← services one-way)
- [x] Merge before FE PR (sibling child B)