### PR TITLE
[RUSAA-1939] fix(chat): dedup replayed assistant history in firstLiveUser SSE path

### DIFF
--- a/frontend/e2e/chat-panel-cli-restart-replay.spec.ts
+++ b/frontend/e2e/chat-panel-cli-restart-replay.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+} from "./fixtures/chat-mock-api";
+import {
+  LIST_MESSAGES_THREE_TURNS_IN_PROGRESS,
+  THREE_TURN_REPLAY_SSE,
+} from "./fixtures/chat-mock-api-cli-restart";
+
+// Regression guard: when the CLI restarts mid-session and SSE delivers
+// historical assistant responses after the current user_input event
+// (firstLiveUser !== null path), only the LAST assistant per user-input
+// segment must appear in the transcript — not the full replay from prior turns.
+//
+// Symptom (pre-fix): after sending "what is 8+8", the response area showed
+// three separate assistant bubbles ("4", "14", "16") instead of just "16".
+// The SSE stream replayed the full history after user_input("8+8"), and
+// dedupeAssistantsPerSegment was missing, so liveItems was used as-is.
+
+test.describe("Chat panel — CLI restart replay dedup (firstLiveUser path)", () => {
+  test("only the last assistant response is shown after the current user message", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE: 3 user_input turns with the CLI replaying full history after turn 3.
+    // Turn 3 segment in SSE: user_input("8+8"), text("4"), tc, text("14"), tc, text("16").
+    // Only "16" (the last assistant in segment 3) must render after "what is 8+8".
+    await mockChatStream(page, CHAT_SESSION_ID, THREE_TURN_REPLAY_SSE);
+    await mockSendChatMessage(page);
+    // History: turns 1+2 complete, user-3 in-flight (no asst-3 in DB yet).
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_THREE_TURNS_IN_PROGRESS);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All 3 user bubbles must be visible.
+    await expect(page.getByText("what is 2+2")).toBeVisible();
+    await expect(page.getByText("what is 7+7")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+
+    // The correct per-turn assistant responses must be visible.
+    await expect(page.getByText("4", { exact: true })).toBeVisible();
+    await expect(page.getByText("14", { exact: true })).toBeVisible();
+    await expect(page.getByText("16", { exact: true })).toBeVisible();
+
+    // "4" and "14" must each appear exactly ONCE — as the responses to turns 1 and 2,
+    // not as extra bubbles after "what is 8+8".
+    await expect(page.getByText("4", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("14", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("16", { exact: true })).toHaveCount(1);
+
+    // Strict ordering: user1 < asst1 < user2 < asst2 < user3 < asst3.
+    const user1Box = await page.getByText("what is 2+2").boundingBox();
+    const asst1Box = await page.getByText("4", { exact: true }).boundingBox();
+    const user2Box = await page.getByText("what is 7+7").boundingBox();
+    const asst2Box = await page.getByText("14", { exact: true }).boundingBox();
+    const user3Box = await page.getByText("what is 8+8").boundingBox();
+    const asst3Box = await page.getByText("16", { exact: true }).boundingBox();
+
+    expect(user1Box).not.toBeNull();
+    expect(asst1Box).not.toBeNull();
+    expect(user2Box).not.toBeNull();
+    expect(asst2Box).not.toBeNull();
+    expect(user3Box).not.toBeNull();
+    expect(asst3Box).not.toBeNull();
+
+    expect(user1Box!.y).toBeLessThan(asst1Box!.y);
+    expect(asst1Box!.y).toBeLessThan(user2Box!.y);
+    expect(user2Box!.y).toBeLessThan(asst2Box!.y);
+    expect(asst2Box!.y).toBeLessThan(user3Box!.y);
+    // The turn-3 assistant ("16") must appear AFTER "what is 8+8", not before it.
+    expect(user3Box!.y).toBeLessThan(asst3Box!.y);
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
+++ b/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
@@ -1,0 +1,124 @@
+// Fixtures for the CLI-restart replay dedup regression spec.
+// The CLI replays the full conversation history after user_input("8+8"), which
+// without the fix causes historical assistant responses ("4", "14") to appear
+// as extra bubbles after the current user message.
+
+import { CHAT_SESSION_ID } from "./chat-mock-api";
+
+// 3-turn session history (turns 1+2 complete, turn 3 in progress).
+export const LIST_MESSAGES_THREE_TURNS_IN_PROGRESS = {
+  messages: [
+    { id: "r57-u1", seq: 1, role: "user", body: "what is 2+2", created_at: "2026-06-07T00:00:00Z" },
+    { id: "r57-a1", seq: 2, role: "assistant", body: "4", created_at: "2026-06-07T00:00:01Z" },
+    { id: "r57-u2", seq: 3, role: "user", body: "what is 7+7", created_at: "2026-06-07T00:00:02Z" },
+    { id: "r57-a2", seq: 4, role: "assistant", body: "14", created_at: "2026-06-07T00:00:03Z" },
+    { id: "r57-u3", seq: 5, role: "user", body: "what is 8+8", created_at: "2026-06-07T00:00:04Z" },
+  ],
+  has_more: false,
+};
+
+// SSE for the CLI-restart scenario. After user_input("8+8") the CLI replays
+// the full history: text("4")+tc (turn-1 replay) + text("14")+tc (turn-2 replay)
+// + text("16") (actual turn-3 response, still streaming).
+// With dedupeAssistantsPerSegment, only "16" renders after "what is 8+8".
+export const THREE_TURN_REPLAY_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "what is 2+2" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "4" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 3,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 4,
+    payload: { type: "user_input", text: "what is 7+7" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: { type: "text", text: "14" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Turn 3: user_input followed by REPLAYED historical responses (turns 1+2),
+  // then the actual turn-3 response (still streaming, no turn_complete).
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 7,
+    payload: { type: "user_input", text: "what is 8+8" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 8,
+    payload: { type: "text", text: "4" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 9,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 10,
+    payload: { type: "text", text: "14" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 11,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 12,
+    payload: { type: "text", text: "16" },
+  })}`,
+  "",
+  "",
+].join("\n");

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,21 +30,21 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
       // Quarantine specs and feature-flag-gated specs run under dedicated projects.
-      // chat-panel*.spec.ts files require VITE_FEATURE_CHAT_PANEL=true at build time;
+      // chat-panel-*.spec.ts files require VITE_FEATURE_CHAT_PANEL=true at build time;
       // they are exercised by the chat-smoke CI job, not the main suite.
-      testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-rusaa-1907.spec.ts", "**/chat-panel-turn-complete-flush.spec.ts", "**/chat-panel-rusaa-1932.spec.ts", "**/chat-panel-rusaa-1934.spec.ts"],
+      testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-*.spec.ts"],
     },
     ...(isNightly
       ? [
           {
             name: "firefox",
             use: { ...devices["Desktop Firefox"] },
-            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-rusaa-1907.spec.ts", "**/chat-panel-turn-complete-flush.spec.ts", "**/chat-panel-rusaa-1932.spec.ts", "**/chat-panel-rusaa-1934.spec.ts"],
+            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-*.spec.ts"],
           },
           {
             name: "webkit",
             use: { ...devices["Desktop Safari"] },
-            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-rusaa-1907.spec.ts", "**/chat-panel-turn-complete-flush.spec.ts", "**/chat-panel-rusaa-1932.spec.ts", "**/chat-panel-rusaa-1934.spec.ts"],
+            testIgnore: ["**/quarantine/**", "**/chat-panel.spec.ts", "**/chat-panel-*.spec.ts"],
           },
         ]
       : []),
@@ -55,7 +55,7 @@ export default defineConfig({
       ? [
           {
             name: "chat-smoke",
-            testMatch: ["**/chat-panel.spec.ts", "**/chat-panel-rusaa-1907.spec.ts", "**/chat-panel-turn-complete-flush.spec.ts", "**/chat-panel-rusaa-1932.spec.ts", "**/chat-panel-rusaa-1934.spec.ts"],
+            testMatch: ["**/chat-panel.spec.ts", "**/chat-panel-*.spec.ts"],
             use: { ...devices["Desktop Chrome"] },
             retries: process.env.CI ? 2 : 0,
           },

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -47,6 +47,46 @@ interface ChatInnerProps {
   readonly tenantId: string;
 }
 
+// Within the firstLiveUser path, the CLI may restart and replay all historical
+// assistant responses after the current user_input in the SSE stream. For each
+// user-input segment [user, ...assistants...], keep only the LAST assistant.
+// Non-assistant items and single-assistant segments are unaffected.
+function dedupeAssistantsPerSegment(
+  items: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> {
+  const result: TranscriptItem[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const item = items[i];
+    if (!item) { i++; continue; }
+    if (item.kind !== "user") {
+      result.push(item);
+      i++;
+      continue;
+    }
+    // Collect this user-input and everything until the next user-input.
+    result.push(item);
+    i++;
+    const segStart = i;
+    while (i < items.length && items[i]?.kind !== "user") {
+      i++;
+    }
+    const segment = items.slice(segStart, i);
+    // Find the last assistant in the segment (current turn's response).
+    let lastAsstIdx = -1;
+    for (let k = segment.length - 1; k >= 0; k--) {
+      if (segment[k]?.kind === "assistant") { lastAsstIdx = k; break; }
+    }
+    for (let k = 0; k < segment.length; k++) {
+      const seg = segment[k];
+      if (!seg) continue;
+      if (seg.kind === "assistant" && k !== lastAsstIdx) continue;
+      result.push(seg);
+    }
+  }
+  return result;
+}
+
 function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
   const navigate = useNavigate();
   const { sessionId: activeSessionId = null } = useSearch({ from: routes.chat });
@@ -95,14 +135,16 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       const histItems = buildTranscriptFromHistory(historical);
       // SSE has no user_input events; liveItems holds only assistant turns.
       // Deduplicate by matching each live assistant's startSeq against the DB
-      // seq values of persisted assistant messages. This correctly handles both
-      // the 4-turn replay case (RUSAA-1934) and the normal reconnect case where
-      // only the current in-progress turn streams (no false positives from count).
+      // seq values of persisted assistant messages. Always keep the in-progress
+      // (streaming) assistant regardless of startSeq — its sequence may collide
+      // with a persisted assistant when all turns use the same batch slot (e.g.
+      // simple single-text-block turns where Text is always at position 2).
       const histAssistantSeqs = new Set<number>(
         historical.filter((m) => m.role === "assistant").map((m) => m.seq),
       );
       const extraLive = liveItems.filter((item) => {
         if (item.kind !== "assistant") return true;
+        if (item.inProgress === true) return true;
         const { startSeq } = item;
         return startSeq === undefined || !histAssistantSeqs.has(startSeq);
       });
@@ -119,7 +161,12 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       }
 
       const historicalFiltered = cutIdx >= 0 ? historical.slice(0, cutIdx) : historical;
-      base = [...buildTranscriptFromHistory(historicalFiltered), ...liveItems];
+      // Deduplicate assistant items within each user-input segment of liveItems.
+      // When the CLI restarts mid-session, it outputs the full conversation history
+      // for each new user message, producing extra historical assistant turns after
+      // the current user_input in the SSE stream. Strip them by keeping only the
+      // last assistant per user-input segment (the current turn's response).
+      base = [...buildTranscriptFromHistory(historicalFiltered), ...dedupeAssistantsPerSegment(liveItems)];
     }
 
     if (pendingUserSends.length === 0) return base;


### PR DESCRIPTION
## Summary

- **Root cause**: When the Claude CLI restarts mid-session, it replays the full conversation history in the same event batch. In the `firstLiveUser !== null` merge path, `liveItems` was used directly without deduplication, causing historical assistant responses for prior turns to appear as separate bubbles after the current user message.
- **Fix 1 (`firstLiveUser !== null` path)**: Added `dedupeAssistantsPerSegment` helper that keeps only the LAST assistant per user-input segment in `liveItems`. The last assistant in each segment is the actual response for that turn; earlier ones are historical replays.
- **Fix 2 (`!firstLiveUser` path)**: Added `inProgress === true` guard to always keep the streaming in-progress assistant even when its `startSeq` collides with a persisted assistant's DB seq. On simple single-text-block turns, all turns share `startSeq=2`, causing the current response to be wrongly excluded.
- **Regression test**: New `chat-panel-cli-restart-replay.spec.ts` exercises the CLI-restart replay scenario (3-turn session, `user_input("8+8")` followed by replayed `text("4")+tc+text("14")+tc+text("16")`). Asserts only `"16"` appears after `"what is 8+8"`.
- **Playwright config**: Collapsed explicit per-spec entries in `testIgnore`/`testMatch` to a `chat-panel-*.spec.ts` glob so new specs are picked up automatically.

## GitHub Issue

Closes #723

## Test plan

- [ ] CLI-restart replay dedup spec passes
- [ ] Prior turn-completion dedup regression spec passes
- [ ] turn_complete flush regression spec passes
- [ ] Queue-drain regression spec passes
- [ ] Vitest unit tests (`transcript.test.ts`)

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR