### PR TITLE
[RUSAA-1942] fix(chat): dedup replayed assistants in !firstLiveUser SSE path

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-1942.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-1942.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+} from "./fixtures/chat-mock-api";
+import {
+  LIST_MESSAGES_TWO_TURNS_MATH_IN_PROGRESS,
+  TWO_TURN_NO_USER_INPUT_REPLAY_SSE,
+} from "./fixtures/chat-mock-api-cli-restart";
+
+// Regression guard for RUSAA-1942.
+//
+// When the CLI restarts mid-session AFTER user_input("8+8") has been processed,
+// the SSE stream reconnects without a user_input event — only assistant tokens
+// arrive. The !firstLiveUser path in ChatPage concatenates these liveItems onto
+// history without per-segment deduplication.  The replayed turn-1 assistant ("8")
+// has a new sequence number that passes the startSeq filter and appears as a
+// duplicate bubble after "what is 8+8".
+//
+// Fix: apply dedupeAssistantsPerSegment to the combined base in the !firstLiveUser
+// branch so replayed assistants landing in the same user-segment are dropped.
+
+test.describe("Chat panel — no-user-input SSE dedup (!firstLiveUser path) [RUSAA-1942]", () => {
+  test("only turn-2's answer (16) appears after 'what is 8+8' — no replayed turn-1 duplicate", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE has NO user_input events: [text("8"), turn_complete, text("16")].
+    // "8" is the replayed turn-1 assistant; "16" is the streaming turn-2 answer.
+    await mockChatStream(page, CHAT_SESSION_ID, TWO_TURN_NO_USER_INPUT_REPLAY_SSE);
+    await mockSendChatMessage(page);
+    // DB: turn-1 complete, turn-2 user stored but no asst yet.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_TWO_TURNS_MATH_IN_PROGRESS);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Both user bubbles must be visible.
+    await expect(page.getByText("what is 4+4")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+
+    // Turn-1 answer must appear exactly once.
+    await expect(page.getByText("8", { exact: true })).toHaveCount(1);
+
+    // Turn-2 answer must appear exactly once.
+    await expect(page.getByText("16", { exact: true })).toHaveCount(1);
+
+    // Strict ordering: user1 < asst1 < user2 < asst2.
+    const user1Box = await page.getByText("what is 4+4").boundingBox();
+    const asst1Box = await page.getByText("8", { exact: true }).boundingBox();
+    const user2Box = await page.getByText("what is 8+8").boundingBox();
+    const asst2Box = await page.getByText("16", { exact: true }).boundingBox();
+
+    expect(user1Box).not.toBeNull();
+    expect(asst1Box).not.toBeNull();
+    expect(user2Box).not.toBeNull();
+    expect(asst2Box).not.toBeNull();
+
+    expect(user1Box!.y).toBeLessThan(asst1Box!.y);
+    expect(asst1Box!.y).toBeLessThan(user2Box!.y);
+    expect(user2Box!.y).toBeLessThan(asst2Box!.y);
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
+++ b/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
@@ -5,6 +5,53 @@
 
 import { CHAT_SESSION_ID } from "./chat-mock-api";
 
+// ─── 2-turn UAT scenario (RUSAA-1942) ──────────────────────────────────────
+// Session: 2 turns of math (4+4=8, 8+8=16).
+// CLI restarts AFTER user_input("8+8") was processed; the SSE stream reconnects
+// mid-turn-2 and has NO user_input event — only replayed + streaming assistant tokens.
+// Without the fix, the replayed "8" appears as a duplicate after "what is 8+8".
+
+// DB state: turn-1 complete, turn-2 user stored but asst not yet flushed.
+export const LIST_MESSAGES_TWO_TURNS_MATH_IN_PROGRESS = {
+  messages: [
+    { id: "r42-u1", seq: 1, role: "user", body: "what is 4+4", created_at: "2026-06-07T00:00:00Z" },
+    { id: "r42-a1", seq: 2, role: "assistant", body: "8", created_at: "2026-06-07T00:00:01Z" },
+    { id: "r42-u2", seq: 3, role: "user", body: "what is 8+8", created_at: "2026-06-07T00:00:02Z" },
+  ],
+  has_more: false,
+};
+
+// SSE: no user_input event (CLI restarted mid-turn-2 after user_input processed).
+// text("8") is the replayed turn-1 assistant; turn_complete flushes it.
+// text("16") is the actual turn-2 response, still streaming (no final turn_complete).
+export const TWO_TURN_NO_USER_INPUT_REPLAY_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: { type: "text", text: "8" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 7,
+    payload: { type: "text", text: "16" },
+  })}`,
+  "",
+  "",
+].join("\n");
+
 // 3-turn session history (turns 1+2 complete, turn 3 in progress).
 export const LIST_MESSAGES_THREE_TURNS_IN_PROGRESS = {
   messages: [

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -148,7 +148,11 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
         const { startSeq } = item;
         return startSeq === undefined || !histAssistantSeqs.has(startSeq);
       });
-      base = [...histItems, ...extraLive];
+      // Deduplicate: when the CLI restarts and SSE replays prior-turn assistant
+      // responses (with new sequence numbers), the startSeq filter above lets them
+      // through because their seqs don't match the DB. Apply the same per-segment
+      // dedup used in the firstLiveUser path so replayed assistants are dropped.
+      base = dedupeAssistantsPerSegment([...histItems, ...extraLive]);
     } else {
       // Exclude historical rows that are covered by the live stream to prevent duplication.
       let cutIdx = -1;


### PR DESCRIPTION
## Summary

- In the `!firstLiveUser` branch of `ChatPage.tsx`, apply `dedupeAssistantsPerSegment` to the full combined `base` array (history + extraLive)
- When the CLI restarts mid-session and SSE reconnects without a `user_input` event, replayed prior-turn assistants have new sequence numbers — the existing `startSeq` filter passes them through, creating a duplicate bubble after the last user message
- Wrapping with `dedupeAssistantsPerSegment` drops any replayed assistant sharing a user-segment with the real answer, keeping only the last one

## Root Cause

SSE stream: `[text("8"), turn_complete, text("16")]` (no `user_input` — CLI restarted after user_input was processed)

- `firstLiveUser = null` → `!firstLiveUser` branch
- `histItems = [user-1("4+4"), asst-1(8), user-2("8+8")]` from DB
- `extraLive = [asst-replay(8, startSeq=5), asst-2(16, inProgress)]` — replay passes startSeq filter (5 ≠ DB seq 2)
- Old: `base = [...histItems, ...extraLive]` → rendered `asst-replay(8)` as a duplicate after user-2
- New: `base = dedupeAssistantsPerSegment([...histItems, ...extraLive])` → replayed assistant dropped

## GitHub Issue

Closes #725

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR
- [x] Regression spec `chat-panel-rusaa-1942.spec.ts` added covering 2-turn UAT scenario