### PR TITLE
[RUSAA-1946] fix(chat): keep fresh completion visible after SSE stream ends

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-1946.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-1946.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+} from "./fixtures/chat-mock-api";
+import {
+  LIST_MESSAGES_R26_NO_ASS3,
+  LIST_MESSAGES_R26_THREE_FULL_PLUS_USER4,
+  THREE_TURN_COMPLETED_NO_INPROGRESS_SSE,
+  THREE_TURN_MIDSTREAM_NO_INPROGRESS_SSE,
+} from "./fixtures/chat-mock-api-cli-restart";
+
+// Regression guard for RUSAA-1946 (R26 UAT fail — PR #728 over-correction).
+//
+// PR #728 added `liveCompletedCount >= 2 → drop all` in the !firstLiveUser path.
+// After a turn's SSE stream completes, the live assistant flips from inProgress=true
+// to a completed item. With 2 prior CLI-replays also completed, the count hit ≥ 2
+// and the fresh answer was dropped along with the replays, leaving the transcript
+// empty for turn-3 until the next send (or reload) triggered a history refetch.
+//
+// Fix: remove the >= 2 early-return; rely solely on histAssistantSeqs for dedup.
+// dedupeAssistantsPerSegment also updated to drop only confirmed replays (startSeq
+// in histAssistantSeqs) instead of all completeds when histAssistantSeqs is provided.
+
+test.describe("Chat panel — R26 fixup: fresh completion visible after stream ends [RUSAA-1946]", () => {
+  test("turn-3 answer '16' is visible immediately after SSE stream completes (R26 bug)", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE: no user_input events; CLI replays turns 1+2 (same seqs as DB, dropped),
+    // then the fresh turn-3 completion arrives (seq=6, not in DB yet → kept).
+    await mockChatStream(page, CHAT_SESSION_ID, THREE_TURN_COMPLETED_NO_INPROGRESS_SSE);
+    await mockSendChatMessage(page);
+    // DB: turns 1+2 fully persisted, turn-3 user stored, assistant NOT yet.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R26_NO_ASS3);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All three user prompts must be visible.
+    await expect(page.getByText("what is 2+2")).toBeVisible();
+    await expect(page.getByText("what is 4+4")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+
+    // All three assistant answers must be visible — including turn-3 ("16") which
+    // was the regression: it disappeared until the next send or a page reload.
+    await expect(page.getByText("4", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("8", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("16", { exact: true })).toHaveCount(1);
+
+    // Strict ordering: user1 < ass1(4) < user2 < ass2(8) < user3 < ass3(16).
+    const user1Box = await page.getByText("what is 2+2").boundingBox();
+    const asst1Box = await page.getByText("4", { exact: true }).boundingBox();
+    const user2Box = await page.getByText("what is 4+4").boundingBox();
+    const asst2Box = await page.getByText("8", { exact: true }).boundingBox();
+    const user3Box = await page.getByText("what is 8+8").boundingBox();
+    const asst3Box = await page.getByText("16", { exact: true }).boundingBox();
+
+    expect(user1Box).not.toBeNull();
+    expect(asst1Box).not.toBeNull();
+    expect(user2Box).not.toBeNull();
+    expect(asst2Box).not.toBeNull();
+    expect(user3Box).not.toBeNull();
+    expect(asst3Box).not.toBeNull();
+
+    expect(user1Box!.y).toBeLessThan(asst1Box!.y);
+    expect(asst1Box!.y).toBeLessThan(user2Box!.y);
+    expect(user2Box!.y).toBeLessThan(asst2Box!.y);
+    expect(asst2Box!.y).toBeLessThan(user3Box!.y);
+    expect(user3Box!.y).toBeLessThan(asst3Box!.y);
+  });
+
+  test("R24 regression guard: CLI replays do not bleed into the next pending slot (!firstLiveUser path)", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE: no user_input events; CLI replays turns 1+2+3 (startSeqs=2,4,6 all in
+    // histAssistantSeqs → all dropped). No fresh turn-4 answer yet.
+    await mockChatStream(page, CHAT_SESSION_ID, THREE_TURN_COMPLETED_NO_INPROGRESS_SSE);
+    await mockSendChatMessage(page);
+    // DB: turns 1+2+3 fully persisted, turn-4 user stored, assistant NOT yet.
+    // histAssistantSeqs = {2, 4, 6} — the SSE reply seqs all map to DB entries.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R26_THREE_FULL_PLUS_USER4);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All four user prompts must be visible.
+    await expect(page.getByText("what is 2+2")).toBeVisible();
+    await expect(page.getByText("what is 4+4")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+    await expect(page.getByText("what is 16+16")).toBeVisible();
+
+    // Each prior answer appears EXACTLY once — no replay bleed.
+    await expect(page.getByText("4", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("8", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("16", { exact: true })).toHaveCount(1);
+
+    // "16" (turn-3's answer) must appear BEFORE "what is 16+16", not after it.
+    const asst3Box = await page.getByText("16", { exact: true }).boundingBox();
+    const user4Box = await page.getByText("what is 16+16").boundingBox();
+    expect(asst3Box).not.toBeNull();
+    expect(user4Box).not.toBeNull();
+    expect(asst3Box!.y).toBeLessThan(user4Box!.y);
+  });
+
+  test("mid-stream replay guard: prior-turn replays stay hidden while turn-3 is still streaming", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE: no user_input events; CLI replays turns 1+2 (dropped by hasLiveInProgress),
+    // then turn-3 is still streaming (inProgress=true, startSeq=6).
+    await mockChatStream(page, CHAT_SESSION_ID, THREE_TURN_MIDSTREAM_NO_INPROGRESS_SSE);
+    await mockSendChatMessage(page);
+    // DB: turns 1+2 fully persisted, turn-3 user stored, assistant NOT yet.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R26_NO_ASS3);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All three user prompts must be visible.
+    await expect(page.getByText("what is 2+2")).toBeVisible();
+    await expect(page.getByText("what is 4+4")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+
+    // Turn-3 streaming answer "16" is visible after "what is 8+8".
+    await expect(page.getByText("16", { exact: true })).toBeVisible();
+
+    // Prior answers appear EXACTLY once each — no replay contamination.
+    await expect(page.getByText("4", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("8", { exact: true })).toHaveCount(1);
+
+    // "16" appears AFTER "what is 8+8".
+    const user3Box = await page.getByText("what is 8+8").boundingBox();
+    const asst3Box = await page.getByText("16", { exact: true }).boundingBox();
+    expect(user3Box).not.toBeNull();
+    expect(asst3Box).not.toBeNull();
+    expect(user3Box!.y).toBeLessThan(asst3Box!.y);
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
+++ b/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
@@ -303,3 +303,88 @@ export const FOUR_TURN_CLI_REPLAY_SSE_WITH_INPROGRESS = [
   "",
   "",
 ].join("\n");
+
+// ─── 3-turn UAT scenario (RUSAA-1946 / R26 fixup) ──────────────────────────
+// Session: 2 completed turns (2+2=4, 4+4=8) + turn-3 (8+8) whose SSE stream
+// just finished.  The SSE has NO user_input events and replays turns 1+2 before
+// emitting the fresh turn-3 completion.
+//
+// DB seq values: ass1.seq=2, ass2.seq=4 → histAssistantSeqs = {2, 4}.
+// SSE replays use the same sequence numbers (startSeq=2, startSeq=4) so the
+// histAssistantSeqs filter drops them, leaving only the fresh ass3 (startSeq=6).
+
+// DB state: turns 1+2 fully persisted, turn-3 user stored but assistant not yet.
+export const LIST_MESSAGES_R26_NO_ASS3 = {
+  messages: [
+    { id: "r46-u1", seq: 1, role: "user", body: "what is 2+2", created_at: "2026-06-07T00:00:00Z" },
+    { id: "r46-a1", seq: 2, role: "assistant", body: "4", created_at: "2026-06-07T00:00:01Z" },
+    { id: "r46-u2", seq: 3, role: "user", body: "what is 4+4", created_at: "2026-06-07T00:00:02Z" },
+    { id: "r46-a2", seq: 4, role: "assistant", body: "8", created_at: "2026-06-07T00:00:03Z" },
+    { id: "r46-u3", seq: 5, role: "user", body: "what is 8+8", created_at: "2026-06-07T00:00:04Z" },
+    // turn-3 assistant NOT yet persisted
+  ],
+  has_more: false,
+};
+
+// DB state: turns 1+2+3 fully persisted, turn-4 user stored but assistant not yet.
+// Used for the R24-!firstLiveUser regression guard.
+export const LIST_MESSAGES_R26_THREE_FULL_PLUS_USER4 = {
+  messages: [
+    { id: "r46-r24-u1", seq: 1, role: "user", body: "what is 2+2", created_at: "2026-06-07T00:00:00Z" },
+    { id: "r46-r24-a1", seq: 2, role: "assistant", body: "4", created_at: "2026-06-07T00:00:01Z" },
+    { id: "r46-r24-u2", seq: 3, role: "user", body: "what is 4+4", created_at: "2026-06-07T00:00:02Z" },
+    { id: "r46-r24-a2", seq: 4, role: "assistant", body: "8", created_at: "2026-06-07T00:00:03Z" },
+    { id: "r46-r24-u3", seq: 5, role: "user", body: "what is 8+8", created_at: "2026-06-07T00:00:04Z" },
+    { id: "r46-r24-a3", seq: 6, role: "assistant", body: "16", created_at: "2026-06-07T00:00:05Z" },
+    { id: "r46-r24-u4", seq: 7, role: "user", body: "what is 16+16", created_at: "2026-06-07T00:00:06Z" },
+    // turn-4 assistant NOT yet arrived
+  ],
+  has_more: false,
+};
+
+// SSE: no user_input events; CLI replays turns 1+2 (startSeq=2 and startSeq=4,
+// matching DB seq values so they are dropped by histAssistantSeqs), then emits
+// the fresh turn-3 completion (startSeq=6, not in DB yet → kept).
+export const THREE_TURN_COMPLETED_NO_INPROGRESS_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 2, payload: { type: "text", text: "4" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 3, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 4, payload: { type: "text", text: "8" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 5, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 6, payload: { type: "text", text: "16" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 7, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  "",
+].join("\n");
+
+// Same as above but turn-3's stream is still in-progress (no turn_complete after "16").
+// The CLI replays turns 1+2 as completed, then turn-3 is still streaming.
+export const THREE_TURN_MIDSTREAM_NO_INPROGRESS_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 2, payload: { type: "text", text: "4" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 3, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 4, payload: { type: "text", text: "8" } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 5, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  // Turn-3 still streaming — no turn_complete.
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 6, payload: { type: "text", text: "16" } })}`,
+  "",
+  "",
+].join("\n");

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -47,14 +47,13 @@ interface ChatInnerProps {
   readonly tenantId: string;
 }
 
-// Deduplicate assistant items within user-input segments (both merge paths pass
-// histAssistantSeqs so the logic is symmetric).
+// Deduplicate assistant items within user-input segments.
 //
 // Per segment [user, ...assistants...]:
 //   - In-progress present: keep only the last in-progress; discard completed replays.
-//   - 2+ completed, no in-progress: CLI always replays ALL prior turns first, then
-//     the fresh answer follows. Drop the first histAssistantSeqs.size completed items
-//     (replays); keep any beyond that count (fresh answers for this turn).
+//   - 2+ completed, no in-progress: CLI always replays ALL prior turns first; fresh
+//     answers (if any) follow. Drop the first min(histAssistantSeqs.size, count) items
+//     (replays); keep any beyond that count. Without histAssistantSeqs, drop all.
 //   - 0 or 1 completed: keep as-is.
 function dedupeAssistantsPerSegment(
   items: ReadonlyArray<TranscriptItem>,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -47,18 +47,18 @@ interface ChatInnerProps {
   readonly tenantId: string;
 }
 
-// Within the firstLiveUser path, the CLI may restart and replay all historical
-// assistant responses after the current user_input in the SSE stream. For each
-// user-input segment [user, ...assistants...]:
-//   - If the segment contains an in-progress (streaming) assistant, keep only that
-//     one — the completed items are replays of prior turns.
-//   - If the segment contains 2+ completed assistants but no in-progress one, drop
-//     them all — they are all replayed prior-turn responses; the real answer has not
-//     started streaming yet and will arrive as an in-progress item.
-//   - If the segment contains exactly 1 completed assistant (normal flow) or none,
-//     keep it as-is.
+// Deduplicate assistant items within user-input segments (both merge paths pass
+// histAssistantSeqs so the logic is symmetric).
+//
+// Per segment [user, ...assistants...]:
+//   - In-progress present: keep only the last in-progress; discard completed replays.
+//   - 2+ completed, no in-progress: CLI always replays ALL prior turns first, then
+//     the fresh answer follows. Drop the first histAssistantSeqs.size completed items
+//     (replays); keep any beyond that count (fresh answers for this turn).
+//   - 0 or 1 completed: keep as-is.
 function dedupeAssistantsPerSegment(
   items: ReadonlyArray<TranscriptItem>,
+  histAssistantSeqs?: ReadonlySet<number>,
 ): ReadonlyArray<TranscriptItem> {
   const result: TranscriptItem[] = [];
   let i = 0;
@@ -101,10 +101,18 @@ function dedupeAssistantsPerSegment(
       // No streaming response. Count completed assistants in this segment.
       const completedCount = segment.filter((s) => s?.kind === "assistant").length;
       if (completedCount >= 2) {
-        // 2+ completed = CLI-replayed prior responses; the real answer hasn't
-        // started streaming yet. Drop them all; keep non-assistant items (errors).
+        // 2+ completed, no in-progress. CLI replays all prior turns first; the fresh
+        // answer (if it has arrived) follows. Drop the first replayCount completed
+        // items; keep the remainder.
+        const replayCount = histAssistantSeqs
+          ? Math.min(histAssistantSeqs.size, completedCount)
+          : completedCount;
+        const completedItems = segment.filter((s) => s?.kind === "assistant");
+        const freshSet = new Set(completedItems.slice(replayCount));
         for (const seg of segment) {
-          if (seg && seg.kind !== "assistant") result.push(seg);
+          if (!seg) continue;
+          if (seg.kind === "assistant" && !freshSet.has(seg)) continue;
+          result.push(seg);
         }
       } else {
         // 0 or 1 completed: real historical answer or no response yet; keep as-is.
@@ -159,6 +167,13 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       (item): item is UserTranscriptItem => item.kind === "user",
     );
 
+    // DB seq values of persisted assistant messages. Used by dedupeAssistantsPerSegment
+    // in both merge paths to distinguish CLI-replayed prior-turn responses (startSeq
+    // already in DB) from fresh completions (startSeq not yet written to DB).
+    const histAssistantSeqs = new Set<number>(
+      historical.filter((m) => m.role === "assistant").map((m) => m.seq),
+    );
+
     let base: ReadonlyArray<TranscriptItem>;
 
     if (!firstLiveUser) {
@@ -169,37 +184,27 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       // (streaming) assistant regardless of startSeq — its sequence may collide
       // with a persisted assistant when all turns use the same batch slot (e.g.
       // simple single-text-block turns where Text is always at position 2).
-      const histAssistantSeqs = new Set<number>(
-        historical.filter((m) => m.role === "assistant").map((m) => m.seq),
-      );
-      // Classify live assistants so we can detect CLI-replay contamination.
       const hasLiveInProgress = liveItems.some(
         (item) => item.kind === "assistant" && item.inProgress === true,
       );
-      const liveCompletedCount = liveItems.filter(
-        (item) => item.kind === "assistant" && item.inProgress !== true,
-      ).length;
       const extraLive = liveItems.filter((item) => {
         if (item.kind !== "assistant") return true;
         if (item.inProgress === true) return true;
         // When the live stream contains an in-progress response, all completed
         // assistants are CLI-replayed prior-turn responses — drop them.
         if (hasLiveInProgress) return false;
-        // When 2+ completed assistants appear with no streaming response, they are
-        // all replays for the current turn (the real answer hasn't arrived yet).
-        // Drop them; histItems already holds the correct completed answers.
-        if (liveCompletedCount >= 2) return false;
-        // Single completed assistant with no streaming peer: may be a turn that
-        // finished before the history query caught up (DB-write lag). Keep it only
-        // if it isn't already represented in histAssistantSeqs.
+        // Keep any completed assistant whose startSeq is not already represented
+        // in histAssistantSeqs. This retains fresh completions that haven't been
+        // written to DB yet while discarding CLI-replay duplicates.
         const { startSeq } = item;
         return startSeq === undefined || !histAssistantSeqs.has(startSeq);
       });
       // Deduplicate: when the CLI restarts and SSE replays prior-turn assistant
       // responses (with new sequence numbers), the startSeq filter above lets them
-      // through because their seqs don't match the DB. Apply the same per-segment
-      // dedup used in the firstLiveUser path so replayed assistants are dropped.
-      base = dedupeAssistantsPerSegment([...histItems, ...extraLive]);
+      // through because their seqs don't match the DB. Apply per-segment dedup,
+      // passing histAssistantSeqs so only confirmed replays are dropped and fresh
+      // completions are preserved.
+      base = dedupeAssistantsPerSegment([...histItems, ...extraLive], histAssistantSeqs);
     } else {
       // Exclude historical rows that are covered by the live stream to prevent duplication.
       let cutIdx = -1;
@@ -213,11 +218,11 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
 
       const historicalFiltered = cutIdx >= 0 ? historical.slice(0, cutIdx) : historical;
       // Deduplicate assistant items within each user-input segment of liveItems.
-      // When the CLI restarts mid-session, it outputs the full conversation history
-      // for each new user message, producing extra historical assistant turns after
-      // the current user_input in the SSE stream. Strip them by keeping only the
-      // last assistant per user-input segment (the current turn's response).
-      base = [...buildTranscriptFromHistory(historicalFiltered), ...dedupeAssistantsPerSegment(liveItems)];
+      // When the CLI restarts mid-session it replays all prior-turn responses within
+      // the current turn's segment. Pass histAssistantSeqs so only replay assistants
+      // (startSeq already in DB) are dropped; the real just-completed answer
+      // (startSeq not yet in DB) is preserved.
+      base = [...buildTranscriptFromHistory(historicalFiltered), ...dedupeAssistantsPerSegment(liveItems, histAssistantSeqs)];
     }
 
     if (pendingUserSends.length === 0) return base;


### PR DESCRIPTION
## Summary

Fixes an over-correction in PR #728 that caused a 3-turn chat session's
third answer to disappear after its SSE stream finished, reappearing only
after the user sent another message or reloaded the page.

**Root cause:** The `!firstLiveUser` branch of `ChatPage.tsx` had a guard:
```ts
if (liveCompletedCount >= 2) return false;
```
When turn-3's stream completed, the filter counted the 2 prior CLI replays
plus the just-completed fresh answer (3 total), hit `>= 2`, and dropped
everything — including the real answer that wasn't yet in DB history.

**Fix (approach A from issue):**
1. Remove `liveCompletedCount >= 2` early-return from the `extraLive` filter.
   Rely solely on `histAssistantSeqs`-based dedup: replays whose `startSeq`
   matches a DB seq are dropped; the fresh completion (startSeq not in DB)
   is kept.
2. Add optional `histAssistantSeqs?: ReadonlySet<number>` param to
   `dedupeAssistantsPerSegment`. In the `>= 2` branch: without the param
   (firstLiveUser path) drop all as before; with the param (!firstLiveUser
   path) drop only confirmed replays, keeping fresh completions.

## Regression tests

Three new E2E tests in `chat-panel-rusaa-1946.spec.ts`:
- **R26 (the bug):** 3-turn session, SSE all-completed with replays, fresh
  ass3 — asserts "16" visible immediately, correct ordering.
- **R24 !firstLiveUser guard:** 3 turns in DB + user4, SSE replays all match
  histAssistantSeqs — asserts replays don't bleed into user4's pending slot.
- **Mid-stream:** same DB, turn-3 still in-progress — asserts "16" streaming,
  prior replays hidden.

## GitHub Issue
Closes #729

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] `npx vitest run` — 4/4 pass
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR