### PR TITLE
[RUSAA-1949] fix(chat): turn-2 fresh-answer dedup

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-1949.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-1949.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+} from "./fixtures/chat-mock-api";
+import {
+  LIST_MESSAGES_R27_TURN2_IN_PROGRESS,
+  TWO_TURN_R27_FRESH_FIRST_REPLAY_SECOND_SSE,
+  THREE_TURN_COMPLETED_NO_INPROGRESS_SSE,
+  LIST_MESSAGES_R26_NO_ASS3,
+} from "./fixtures/chat-mock-api-cli-restart";
+
+// Regression guard for RUSAA-1949 (R27 — R26 under-correction).
+//
+// R26 (PR #730) fixed turn-3 but left turn-2 broken. The root cause:
+//   - The CLI restart assigns NEW sequence numbers to replayed responses.
+//   - The seq-based filter in the !firstLiveUser path cannot drop these replays.
+//   - The SSE stream emits the fresh turn-2 answer FIRST (lower seqs), then the
+//     turn-1 replay SECOND (higher seqs).
+//   - dedupeAssistantsPerSegment's position-based slice kept the SECOND item
+//     (= replay of turn-1's content) instead of the first (= fresh turn-2 answer).
+//
+// Fix (Approach Y variant): add content-based replay detection in the extraLive
+// filter. A live completed assistant whose text matches any historical assistant's
+// text verbatim is a replay — drop it regardless of its sequence number.
+
+test.describe("Chat panel — R27 fixup: turn-2 fresh answer shown, not prior-turn replay [RUSAA-1949]", () => {
+  test("turn-2 slot shows fresh answer 'Then 2+2=4.' not replayed turn-1 content (AC1)", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    // SSE: no user_input events; CLI uses NEW seqs.
+    // Fresh turn-2 answer arrives first (seq=100), then turn-1 replay arrives
+    // second (seq=102) with the same text as the historical ass-1 row.
+    await mockChatStream(page, CHAT_SESSION_ID, TWO_TURN_R27_FRESH_FIRST_REPLAY_SECOND_SSE);
+    await mockSendChatMessage(page);
+    // DB: turn-1 fully persisted, turn-2 user stored but assistant not yet.
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R27_TURN2_IN_PROGRESS);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Both user prompts must be visible.
+    await expect(page.getByText("what is 2+@")).toBeVisible();
+    await expect(page.getByText("@ is 2")).toBeVisible();
+
+    // Turn-1 assistant ("Did you mean 2+2? That equals 4.") must appear exactly once
+    // — from historical, not duplicated from the replay.
+    await expect(page.getByText("Did you mean 2+2? That equals 4.")).toHaveCount(1);
+
+    // Turn-2 assistant must show the FRESH answer ("Then 2+2=4."), NOT a duplicate
+    // of turn-1's content. This is AC1 — the exact R26 failure mode.
+    await expect(page.getByText("Then 2+2=4.")).toBeVisible();
+
+    // Strict ordering: user1 < ass1 < user2 < ass2.
+    const user1Box = await page.getByText("what is 2+@").boundingBox();
+    const asst1Box = await page.getByText("Did you mean 2+2? That equals 4.").boundingBox();
+    const user2Box = await page.getByText("@ is 2").boundingBox();
+    const asst2Box = await page.getByText("Then 2+2=4.").boundingBox();
+
+    expect(user1Box).not.toBeNull();
+    expect(asst1Box).not.toBeNull();
+    expect(user2Box).not.toBeNull();
+    expect(asst2Box).not.toBeNull();
+
+    expect(user1Box!.y).toBeLessThan(asst1Box!.y);
+    expect(asst1Box!.y).toBeLessThan(user2Box!.y);
+    expect(user2Box!.y).toBeLessThan(asst2Box!.y);
+  });
+
+  test("turn-1 replay not present after user-2 (no-bleed AC3)", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, TWO_TURN_R27_FRESH_FIRST_REPLAY_SECOND_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R27_TURN2_IN_PROGRESS);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // The replay text "Did you mean 2+2? That equals 4." appears exactly ONCE
+    // (from historical turn-1), never duplicated after user-2 (AC3: no bleed).
+    await expect(page.getByText("Did you mean 2+2? That equals 4.")).toHaveCount(1);
+    // The fresh text "Then 2+2=4." appears exactly once in turn-2 slot.
+    await expect(page.getByText("Then 2+2=4.")).toHaveCount(1);
+  });
+
+  test("R26 regression guard still passes: turn-3 answer '16' is visible after SSE completes", async ({
+    page,
+  }) => {
+    // Ensure the R26 fix (same-seq CLI replay, fresh at turn-3) still works.
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, THREE_TURN_COMPLETED_NO_INPROGRESS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_R26_NO_ASS3);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    await expect(page.getByText("what is 2+2")).toBeVisible();
+    await expect(page.getByText("what is 4+4")).toBeVisible();
+    await expect(page.getByText("what is 8+8")).toBeVisible();
+
+    // All three assistant answers visible (R26 core AC).
+    await expect(page.getByText("4", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("8", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("16", { exact: true })).toHaveCount(1);
+
+    // Correct ordering.
+    const user3Box = await page.getByText("what is 8+8").boundingBox();
+    const asst3Box = await page.getByText("16", { exact: true }).boundingBox();
+    expect(user3Box).not.toBeNull();
+    expect(asst3Box).not.toBeNull();
+    expect(user3Box!.y).toBeLessThan(asst3Box!.y);
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
+++ b/frontend/e2e/fixtures/chat-mock-api-cli-restart.ts
@@ -367,6 +367,52 @@ export const THREE_TURN_COMPLETED_NO_INPROGRESS_SSE = [
   "",
 ].join("\n");
 
+// ─── 2-turn R27 scenario (RUSAA-1949) ──────────────────────────────────────
+// Session: turn-1 complete, turn-2 just completed.
+// CLI restart with NEW sequence numbers (does NOT reuse DB seqs).
+// The SSE stream emits the fresh turn-2 answer FIRST (lower seqs), then
+// the CLI replays turn-1's response SECOND (higher seqs).
+// The existing seq-based filter cannot drop the replay (new seq not in histAssistantSeqs);
+// the content-based filter catches it because the replay text matches historical ass-1.
+//
+// Bug (R26 under-correction): position-based slice kept the SECOND item = replay of
+// turn-1's "Did you mean 2+2?" instead of fresh turn-2's "Then 2+2=4".
+// Fix: content-match filter drops the replay before dedupeAssistantsPerSegment runs.
+
+// DB state: turn-1 fully persisted; turn-2 user stored, assistant not yet.
+// histAssistantSeqs = {2} (only ass-1 in DB).
+export const LIST_MESSAGES_R27_TURN2_IN_PROGRESS = {
+  messages: [
+    { id: "r49-u1", seq: 1, role: "user", body: "what is 2+@", created_at: "2026-06-07T00:00:00Z" },
+    { id: "r49-a1", seq: 2, role: "assistant", body: "Did you mean 2+2? That equals 4.", created_at: "2026-06-07T00:00:01Z" },
+    { id: "r49-u2", seq: 3, role: "user", body: "@ is 2", created_at: "2026-06-07T00:00:02Z" },
+    // turn-2 assistant NOT yet persisted
+  ],
+  has_more: false,
+};
+
+// SSE: no user_input events; CLI uses NEW seqs (not matching DB).
+// Fresh turn-2 answer arrives FIRST (seq=100), then turn-1 replay arrives SECOND (seq=102).
+// This is the R27 bug ordering: fresh first, replay second.
+export const TWO_TURN_R27_FRESH_FIRST_REPLAY_SECOND_SSE = [
+  // Fresh answer to "@ is 2": "Then 2+2=4." arrives first (seq=100).
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 100, payload: { type: "text", text: "Then 2+2=4." } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 101, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  // CLI replay of turn-1 ("Did you mean 2+2? That equals 4.") arrives second (seq=102).
+  // Same text as DB ass-1 body → content filter must drop it.
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "text", sequence: 102, payload: { type: "text", text: "Did you mean 2+2? That equals 4." } })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({ session_id: CHAT_SESSION_ID, event_type: "turn_complete", sequence: 103, payload: { type: "turn_complete", stop_reason: "end_turn" } })}`,
+  "",
+  "",
+].join("\n");
+
 // Same as above but turn-3's stream is still in-progress (no turn_complete after "16").
 // The CLI replays turns 1+2 as completed, then turn-3 is still streaming.
 export const THREE_TURN_MIDSTREAM_NO_INPROGRESS_SSE = [

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -186,23 +186,50 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
       const hasLiveInProgress = liveItems.some(
         (item) => item.kind === "assistant" && item.inProgress === true,
       );
+
+      // Build a set of historical assistant text bodies for content-based replay
+      // detection. When the CLI restarts and assigns NEW sequence numbers to
+      // replayed responses (not reusing original DB seqs), the seq-based filter
+      // below cannot distinguish replays from the fresh answer. As a fallback,
+      // if a live completed assistant's full text matches any historical
+      // assistant's body verbatim it is a replay and must be dropped.
+      // This handles the turn-2 bug (R27): fresh arrives first in SSE (lower
+      // startSeq), prior-turn replay arrives second — content matching identifies
+      // which is which regardless of SSE ordering.
+      const histAssistantTexts = new Set<string>();
+      for (const histItem of histItems) {
+        if (histItem.kind !== "assistant") continue;
+        const text = histItem.items
+          .filter((i) => i.type === "text")
+          .map((i) => (i.type === "text" ? i.text : ""))
+          .join("");
+        if (text) histAssistantTexts.add(text);
+      }
+
       const extraLive = liveItems.filter((item) => {
         if (item.kind !== "assistant") return true;
         if (item.inProgress === true) return true;
         // When the live stream contains an in-progress response, all completed
         // assistants are CLI-replayed prior-turn responses — drop them.
         if (hasLiveInProgress) return false;
-        // Keep any completed assistant whose startSeq is not already represented
-        // in histAssistantSeqs. This retains fresh completions that haven't been
-        // written to DB yet while discarding CLI-replay duplicates.
+        // Drop replays identified by seq (same-seq CLI restart: CLI reuses the
+        // original DB sequence numbers when replaying prior-turn responses).
         const { startSeq } = item;
-        return startSeq === undefined || !histAssistantSeqs.has(startSeq);
+        if (startSeq !== undefined && histAssistantSeqs.has(startSeq)) return false;
+        // Drop replays identified by content (new-seq CLI restart: CLI assigns
+        // new sequence numbers to replayed responses, so seq matching fails).
+        // If the live assistant's text matches any historical assistant verbatim,
+        // it is a prior-turn replay regardless of sequence number.
+        const liveText = item.items
+          .filter((i) => i.type === "text")
+          .map((i) => (i.type === "text" ? i.text : ""))
+          .join("");
+        if (liveText && histAssistantTexts.has(liveText)) return false;
+        return true;
       });
-      // Deduplicate: when the CLI restarts and SSE replays prior-turn assistant
-      // responses (with new sequence numbers), the startSeq filter above lets them
-      // through because their seqs don't match the DB. Apply per-segment dedup,
-      // passing histAssistantSeqs so only confirmed replays are dropped and fresh
-      // completions are preserved.
+      // Deduplicate: per-segment safety net in case a replay slips past both
+      // the seq and content filters (e.g. new seqs AND novel content — edge
+      // case). histAssistantSeqs bounds the replay count in those cases.
       base = dedupeAssistantsPerSegment([...histItems, ...extraLive], histAssistantSeqs);
     } else {
       // Exclude historical rows that are covered by the live stream to prevent duplication.


### PR DESCRIPTION
## Summary

- **Root cause**: In the `!firstLiveUser` path, the CLI restart sometimes assigns **new sequence numbers** to replayed prior-turn responses (not reusing DB seqs). The existing `histAssistantSeqs` filter cannot identify these replays. When the SSE then emits the fresh turn-2 answer **first** (lower seqs) and the prior-turn replay **second** (higher seqs), `dedupeAssistantsPerSegment`'s position-based `slice(replayCount)` keeps the wrong item — the replay — and shows turn-1's content in the turn-2 slot.
- **Fix (Approach Y variant)**: In the `extraLive` filter, build `histAssistantTexts` from already-computed `histItems` and add a content-based check: any live completed assistant whose concatenated text matches a historical assistant verbatim is a replay and is dropped. The existing seq check remains as the primary (fast) path.
- **SSE ordering observed in production**: `[fresh-turn-2 (seq≈100), turn_complete, replay-turn-1 (seq≈102), turn_complete]` — fresh arrives first, replay arrives second. This breaks position-based slice but is solved by content matching.

## Investigation evidence (AC from issue)

- The bug shape confirms SSE order `[fresh, replay]` at turn-2: the `slice(replayCount)` code kept the 2nd completed item (= replay with turn-1's content "Did you mean 2+2?") instead of the 1st (= fresh "Then 2+2=4.").
- Turn-3 was unaffected because `histAssistantSeqs.size = 2` there, so `replayCount = min(2, 3) = 2` and the 3rd item (fresh) was correctly kept — same-position heuristic worked by luck when there were more replays to account for.

## Approach chosen: Approach Y variant (content-based fallback)

**Why not Approach X** (highest seq = fresh): The bug ordering is `[fresh(seq=100), replay(seq=102)]`, so the replay has the highest seq — Approach X would select the replay.

**Why not Approach Z** (drop all completed, wait for history): No history invalidation fires on `turn_complete`; `staleTime = 30s`. The turn-2 slot would stay blank until the user sends turn-3 (which triggers `sendMessage.onSuccess → invalidateQueries`). Unacceptable blank.

**Approach Y (content matching)**: A replay emits the same text as the DB entry it mirrors. Content matching is a reliable discriminator at turn-2 (different questions, different answers). Known edge case: if the fresh answer happens to have identical text to a prior turn's answer, the content check would incorrectly drop it. This is an accepted trade-off — far less common and less harmful than always showing wrong content.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] `pnpm chat-smoke` (43/43) passes locally including all R26/R24 regression guards
- [x] 3 new E2E tests in `chat-panel-rusaa-1949.spec.ts` (AC1 + AC3 + R26 guard)
- [x] No internal tracker IDs in diff

Closes #731