### PR TITLE
[REQ-FE-31] fix(chat): preserve prior-turn text when tool_use turn splits across DB rows

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-1966.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-1966.spec.ts
@@ -78,7 +78,7 @@ test.describe("Chat panel — prior turn text preserved when new turn completes 
     // Turn-2 tool block must be visible (the tool call that follows the text).
     const toolBlocks = page.getByTestId("tool-call-block");
     await expect(toolBlocks).toHaveCount(1);
-    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+    await expect(toolBlocks.first()).toContainText("mcp__rust_brain__search_items");
     await expect(toolBlocks.first()).toContainText("Done");
 
     // Turn-3 text must be visible.
@@ -131,7 +131,7 @@ test.describe("Chat panel — prior turn text preserved when new turn completes 
 
     const toolBlocks = page.getByTestId("tool-call-block");
     await expect(toolBlocks).toHaveCount(1);
-    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+    await expect(toolBlocks.first()).toContainText("mcp__rust_brain__search_items");
     await expect(toolBlocks.first()).toContainText("Done");
 
     await expect(page.getByText("Here are the details for the first result.")).toBeVisible();
@@ -174,7 +174,7 @@ test.describe("Chat panel — prior turn text preserved when new turn completes 
 
     const toolBlocks = page.getByTestId("tool-call-block");
     await expect(toolBlocks).toHaveCount(1);
-    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+    await expect(toolBlocks.first()).toContainText("mcp__rust_brain__search_items");
 
     await expect(page.getByText("Here are the details for the first result.")).toBeVisible();
 

--- a/frontend/e2e/chat-panel-rusaa-1966.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-1966.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+} from "./fixtures/chat-mock-api";
+import {
+  LIST_MESSAGES_R31_THREE_TURNS_SPLIT_TURN2,
+  R31_CLI_RESTART_SPLIT_TURN2_ALL_COMPLETE_SSE,
+  LIST_MESSAGES_R31_LIVE_SPLIT_TURN2,
+  R31_LIVE_SESSION_SPLIT_TURN2_ALL_COMPLETE_SSE,
+} from "./fixtures/chat-mock-api-r31";
+
+// Regression guard for RUSAA-1966 (R31): prior turn text output disappears when a new
+// turn completes, in sessions where a turn has text output followed by tool calls.
+//
+// Root cause: the agent-runner persists the initial text response as a separate DB row
+// before the tool call starts, creating two consecutive assistant rows for the same turn:
+//   row A: seq=5, body=[{type:"text", text:"Searching…"}]
+//   row B: seq=7, body=[{type:"tool_use", …}, {type:"tool_result", …}]
+//
+// buildTranscriptFromHistory split-batch merge only checked if the PREVIOUS row ended
+// with tool_use — it did not merge when the NEXT row starts with tool_use. So history
+// produced 2 AssistantTranscriptItems for turn 2 instead of 1.
+//
+// When turn 3 completed (hasLiveInProgress → false), dedupeAssistantsPerSegment ran on
+// user-2's segment and saw completedCount=2 items. replayCount = min(histSeqs.size, 2)
+// was ≥ 1, causing the text item (asst2_text) to be dropped.
+//
+// Fix (transcript.ts):
+//   1. buildTranscriptFromHistory: extend split-batch merge condition to also fire when
+//      contentBlocks[0].type === "tool_use" (next row starts with tool_use).
+//   2. buildTranscript: post-process with mergeAdjacentToolUseAssistants to merge
+//      consecutive live assistant items where the second starts with tool_use (same
+//      split pattern can occur in the SSE stream when end_turn fires before tool_use).
+
+test.describe("Chat panel — prior turn text preserved when new turn completes [RUSAA-1966]", () => {
+  test("AC1: !firstLiveUser — turn-2 text remains visible after all turns complete (CLI restart, split DB rows)", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockSendChatMessage(page);
+    // History: 3 turns, turn-2 split across two DB rows (text-only + tool_use).
+    await mockListChatMessages(
+      page,
+      CHAT_SESSION_ID,
+      LIST_MESSAGES_R31_THREE_TURNS_SPLIT_TURN2,
+    );
+    // SSE: CLI restart (no user_input); replays all three turns with the RUSAA-1966 split
+    // pattern (turn_complete(end_turn) between text and tool_use for turn 2).
+    // All turns complete — this triggers dedupeAssistantsPerSegment on turn-2's segment.
+    await mockChatStream(
+      page,
+      CHAT_SESSION_ID,
+      R31_CLI_RESTART_SPLIT_TURN2_ALL_COMPLETE_SSE,
+    );
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // All three user bubbles must be visible.
+    await expect(page.getByText("what is rust brain?", { exact: true })).toBeVisible();
+    await expect(page.getByText("search for rust examples", { exact: true })).toBeVisible();
+    await expect(page.getByText("show details", { exact: true })).toBeVisible();
+
+    // Turn-2 text (the regression victim: this text disappeared without the fix).
+    await expect(page.getByText("Searching for rust examples...")).toBeVisible();
+
+    // Turn-2 tool block must be visible (the tool call that follows the text).
+    const toolBlocks = page.getByTestId("tool-call-block");
+    await expect(toolBlocks).toHaveCount(1);
+    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+    await expect(toolBlocks.first()).toContainText("Done");
+
+    // Turn-3 text must be visible.
+    await expect(page.getByText("Here are the details for the first result.")).toBeVisible();
+
+    // Strict ordering:
+    //   user-2 < turn-2 text < tool block < user-3 < turn-3 text
+    const user2Box = await page
+      .getByText("search for rust examples", { exact: true })
+      .boundingBox();
+    const turn2TextBox = await page
+      .getByText("Searching for rust examples...")
+      .boundingBox();
+    const toolBox = await toolBlocks.first().boundingBox();
+    const user3Box = await page.getByText("show details", { exact: true }).boundingBox();
+    const turn3TextBox = await page
+      .getByText("Here are the details for the first result.")
+      .boundingBox();
+
+    expect(user2Box).not.toBeNull();
+    expect(turn2TextBox).not.toBeNull();
+    expect(toolBox).not.toBeNull();
+    expect(user3Box).not.toBeNull();
+    expect(turn3TextBox).not.toBeNull();
+
+    expect(user2Box!.y).toBeLessThan(turn2TextBox!.y);
+    expect(turn2TextBox!.y).toBeLessThan(toolBox!.y);
+    expect(toolBox!.y).toBeLessThan(user3Box!.y);
+    expect(user3Box!.y).toBeLessThan(turn3TextBox!.y);
+  });
+
+  test("AC2: !firstLiveUser — pure reload from history still shows turn-2 text + tool block", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(
+      page,
+      CHAT_SESSION_ID,
+      LIST_MESSAGES_R31_THREE_TURNS_SPLIT_TURN2,
+    );
+    // No live SSE events — pure history render; exercises buildTranscriptFromHistory fix.
+    await mockChatStream(page, CHAT_SESSION_ID, ["", ""].join("\n"));
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    await expect(page.getByText("Searching for rust examples...")).toBeVisible();
+
+    const toolBlocks = page.getByTestId("tool-call-block");
+    await expect(toolBlocks).toHaveCount(1);
+    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+    await expect(toolBlocks.first()).toContainText("Done");
+
+    await expect(page.getByText("Here are the details for the first result.")).toBeVisible();
+
+    // Text must appear before tool block in the same assistant bubble.
+    const turn2TextBox = await page
+      .getByText("Searching for rust examples...")
+      .boundingBox();
+    const toolBox = await toolBlocks.first().boundingBox();
+    expect(turn2TextBox).not.toBeNull();
+    expect(toolBox).not.toBeNull();
+    expect(turn2TextBox!.y).toBeLessThan(toolBox!.y);
+  });
+
+  test("AC3: firstLiveUser — live session with end_turn between text and tool_use preserves text after turn-3 completes", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_EMPTY_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockSendChatMessage(page);
+    // History: same split structure (used for histAssistantSeqs and dedup).
+    await mockListChatMessages(
+      page,
+      CHAT_SESSION_ID,
+      LIST_MESSAGES_R31_LIVE_SPLIT_TURN2,
+    );
+    // SSE: full live session (has user_input events).  Turn 2 has text(end_turn)+tool_use
+    // in separate events.  Turn 3 completes at the end — triggers dedupeAssistantsPerSegment.
+    await mockChatStream(
+      page,
+      CHAT_SESSION_ID,
+      R31_LIVE_SESSION_SPLIT_TURN2_ALL_COMPLETE_SSE,
+    );
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Turn-2 text must be present (regression: buildTranscript post-processing fix).
+    await expect(page.getByText("Searching for rust examples...")).toBeVisible();
+
+    const toolBlocks = page.getByTestId("tool-call-block");
+    await expect(toolBlocks).toHaveCount(1);
+    await expect(toolBlocks.first()).toContainText("mcp_rust_brain_search_items");
+
+    await expect(page.getByText("Here are the details for the first result.")).toBeVisible();
+
+    // turn-2 text must appear before tool block.
+    const turn2TextBox = await page
+      .getByText("Searching for rust examples...")
+      .boundingBox();
+    const toolBox = await toolBlocks.first().boundingBox();
+    expect(turn2TextBox).not.toBeNull();
+    expect(toolBox).not.toBeNull();
+    expect(turn2TextBox!.y).toBeLessThan(toolBox!.y);
+  });
+});

--- a/frontend/e2e/fixtures/chat-mock-api-r31.ts
+++ b/frontend/e2e/fixtures/chat-mock-api-r31.ts
@@ -1,0 +1,519 @@
+// R31 regression fixtures (RUSAA-1966): prior turn text output disappears when new
+// turn completes, in sessions where turn N has text output before tool calls.
+//
+// Root cause: buildTranscriptFromHistory creates TWO AssistantTranscriptItems for turn N
+// when the DB has a text-only row followed by a tool_use row (the agent-runner flushed
+// the text response before the tool call started). When dedupeAssistantsPerSegment runs
+// after hasLiveInProgress transitions to false, it sees 2 completed items in turn N's
+// segment and drops the text item (replayCount ≥ 1).
+//
+// buildTranscript has the same issue when the SSE stream has turn_complete(end_turn)
+// between text and tool_use events: the text is flushed as a separate AssistantItem.
+//
+// Fix (transcript.ts):
+//   1. buildTranscriptFromHistory: extend split-batch merge to also cover the case
+//      where the NEXT row starts with tool_use (not only when prev ends with tool_use).
+//   2. buildTranscript: post-process to merge consecutive assistant items where the
+//      second starts with tool_use, same as the history fix.
+
+import { CHAT_SESSION_ID } from "./chat-mock-api";
+
+// ─── Shared DB rows ──────────────────────────────────────────────────────────
+//
+// Turn 1: simple text response (seq=2).
+// Turn 2: text THEN tool_use in SEPARATE DB rows — text-only row (seq=5), tools row (seq=7).
+// Turn 3: simple text response (seq=12).
+// histAssistantSeqs will be {2, 5, 7, 12} → size=4, triggering replayCount=2 → both dropped
+// (without fix), or size=1 → replayCount=1 → text dropped but tools kept (race-window variant).
+
+export const LIST_MESSAGES_R31_THREE_TURNS_SPLIT_TURN2 = {
+  messages: [
+    {
+      id: "r31-u1",
+      seq: 1,
+      role: "user",
+      body: "what is rust brain?",
+      created_at: "2026-06-09T00:00:00Z",
+    },
+    {
+      id: "r31-a1",
+      seq: 2,
+      role: "assistant",
+      body: JSON.stringify([
+        { type: "text", text: "RustBrain is a code intelligence platform." },
+      ]),
+      created_at: "2026-06-09T00:00:01Z",
+    },
+    {
+      id: "r31-u2",
+      seq: 4,
+      role: "user",
+      body: "search for rust examples",
+      created_at: "2026-06-09T00:00:02Z",
+    },
+    // Split DB rows for turn 2: text row SEPARATE from tool_use row.
+    // This is the RUSAA-1966 DB structure — the agent-runner flushed the initial text
+    // response before the tool call started, creating two rows for the same turn.
+    {
+      id: "r31-a2-text",
+      seq: 5,
+      role: "assistant",
+      body: JSON.stringify([
+        { type: "text", text: "Searching for rust examples..." },
+      ]),
+      created_at: "2026-06-09T00:00:03Z",
+    },
+    {
+      id: "r31-a2-tools",
+      seq: 7,
+      role: "assistant",
+      body: JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tu-r31-001",
+          name: "mcp__rust_brain__search_items",
+          input: { q: "rust" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tu-r31-001",
+          content: "Found 5 rust examples",
+          is_error: false,
+        },
+      ]),
+      created_at: "2026-06-09T00:00:04Z",
+    },
+    {
+      id: "r31-u3",
+      seq: 11,
+      role: "user",
+      body: "show details",
+      created_at: "2026-06-09T00:00:05Z",
+    },
+    {
+      id: "r31-a3",
+      seq: 12,
+      role: "assistant",
+      body: JSON.stringify([
+        { type: "text", text: "Here are the details for the first result." },
+      ]),
+      created_at: "2026-06-09T00:00:06Z",
+    },
+  ],
+  has_more: false,
+};
+
+// ─── !firstLiveUser path (CLI restart) ───────────────────────────────────────
+//
+// SSE: no user_input events. CLI replays all turns. Turn 2 replay has
+// turn_complete(end_turn) between the text event and the tool_use event — matching the
+// original DB split. All turns complete (turn 3 included) → hasLiveInProgress=false.
+//
+// Without fix: dedup sees user2 segment = [asst2_text_hist, asst2_tools_hist]
+//              → completedCount=2, replayCount=min(4,2)=2 → BOTH dropped.
+// With fix:    buildTranscriptFromHistory merges asst2_text+asst2_tools → 1 item
+//              → completedCount=1 → keep.
+export const R31_CLI_RESTART_SPLIT_TURN2_ALL_COMPLETE_SSE = [
+  // Replay turn 1: text only
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "RustBrain is a code intelligence platform." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 3,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Replay turn 2: text, then end_turn, then tool_use — the RUSAA-1966 split pattern
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: { type: "text", text: "Searching for rust examples..." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 7,
+    payload: {
+      type: "tool_use",
+      id: "tu-r31-001",
+      name: "mcp__rust_brain__search_items",
+      input: { q: "rust" },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 8,
+    payload: { type: "turn_complete", stop_reason: "tool_use" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 9,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "tu-r31-001",
+      content: "Found 5 rust examples",
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 10,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Replay turn 3: text only (full completion)
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 12,
+    payload: { type: "text", text: "Here are the details for the first result." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 13,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+// ─── !firstLiveUser path — turn 3 in-progress → then completes ───────────────
+//
+// Same as above but turn 3 is still in-progress when first seen (hasLiveInProgress=true,
+// dedup skipped → text visible), then completes (hasLiveInProgress=false → dedup runs).
+// The test SSE delivers the complete stream so we observe the final "completed" state.
+// This is the exact sequence that triggers the regression.
+export const R31_CLI_RESTART_SPLIT_TURN2_TURN3_STREAMING_SSE = [
+  // Replay turn 1
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "RustBrain is a code intelligence platform." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 3,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Replay turn 2: text + end_turn + tool_use (RUSAA-1966 pattern)
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: { type: "text", text: "Searching for rust examples..." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 7,
+    payload: {
+      type: "tool_use",
+      id: "tu-r31-001",
+      name: "mcp__rust_brain__search_items",
+      input: { q: "rust" },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 8,
+    payload: { type: "turn_complete", stop_reason: "tool_use" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 9,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "tu-r31-001",
+      content: "Found 5 rust examples",
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 10,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Fresh turn 3: streams then COMPLETES — this is the trigger for the regression
+  // (hasLiveInProgress flips from true to false, dedup runs for the first time)
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 12,
+    payload: { type: "text", text: "Here are the details for the first result." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 13,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+// ─── firstLiveUser path (live session) ───────────────────────────────────────
+//
+// SSE with user_input events: full live session where turn 2 emits text(end_turn)
+// then tool_use in separate SSE events. After turn 3 completes, buildTranscript
+// would produce 2 items for turn 2; dedupeAssistantsPerSegment would drop the text.
+//
+// Without fix: liveDeduped user2 segment = [asst2_text(startSeq=5), asst2_tools(startSeq=7)]
+//              → completedCount=2, replayCount=min(4,2)=2 → BOTH dropped.
+// With fix:    buildTranscript post-process merges → 1 item → completedCount=1 → keep.
+export const LIST_MESSAGES_R31_LIVE_SPLIT_TURN2 = {
+  messages: [
+    {
+      id: "r31-lv-u1",
+      seq: 1,
+      role: "user",
+      body: "what is rust brain?",
+      created_at: "2026-06-09T00:00:00Z",
+    },
+    {
+      id: "r31-lv-a1",
+      seq: 2,
+      role: "assistant",
+      body: JSON.stringify([
+        { type: "text", text: "RustBrain is a code intelligence platform." },
+      ]),
+      created_at: "2026-06-09T00:00:01Z",
+    },
+    {
+      id: "r31-lv-u2",
+      seq: 4,
+      role: "user",
+      body: "search for rust examples",
+      created_at: "2026-06-09T00:00:02Z",
+    },
+    {
+      id: "r31-lv-a2-text",
+      seq: 5,
+      role: "assistant",
+      body: JSON.stringify([{ type: "text", text: "Searching for rust examples..." }]),
+      created_at: "2026-06-09T00:00:03Z",
+    },
+    {
+      id: "r31-lv-a2-tools",
+      seq: 7,
+      role: "assistant",
+      body: JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tu-r31-lv-001",
+          name: "mcp__rust_brain__search_items",
+          input: { q: "rust" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tu-r31-lv-001",
+          content: "Found 5 rust examples",
+          is_error: false,
+        },
+      ]),
+      created_at: "2026-06-09T00:00:04Z",
+    },
+    {
+      id: "r31-lv-u3",
+      seq: 11,
+      role: "user",
+      body: "show details",
+      created_at: "2026-06-09T00:00:05Z",
+    },
+    {
+      id: "r31-lv-a3",
+      seq: 12,
+      role: "assistant",
+      body: JSON.stringify([
+        { type: "text", text: "Here are the details for the first result." },
+      ]),
+      created_at: "2026-06-09T00:00:06Z",
+    },
+  ],
+  has_more: false,
+};
+
+export const R31_LIVE_SESSION_SPLIT_TURN2_ALL_COMPLETE_SSE = [
+  // Turn 1
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "what is rust brain?" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 2,
+    payload: { type: "text", text: "RustBrain is a code intelligence platform." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 3,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Turn 2: user_input, text response (end_turn), then tool_use in next step
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 4,
+    payload: { type: "user_input", text: "search for rust examples" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: { type: "text", text: "Searching for rust examples..." },
+  })}`,
+  "",
+  // end_turn fires after the text — tool_use follows as the next agentic step
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 7,
+    payload: {
+      type: "tool_use",
+      id: "tu-r31-lv-001",
+      name: "mcp__rust_brain__search_items",
+      input: { q: "rust" },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 8,
+    payload: { type: "turn_complete", stop_reason: "tool_use" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 9,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "tu-r31-lv-001",
+      content: "Found 5 rust examples",
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 10,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  // Turn 3: completes — this triggers dedupeAssistantsPerSegment to run and
+  // (without fix) drops turn 2's text from user2's segment
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 11,
+    payload: { type: "user_input", text: "show details" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 12,
+    payload: { type: "text", text: "Here are the details for the first result." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 13,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "",
+].join("\n");

--- a/frontend/src/components/chat/transcript.test.ts
+++ b/frontend/src/components/chat/transcript.test.ts
@@ -238,4 +238,148 @@ describe("buildTranscriptFromHistory — split-batch tool_use merge", () => {
     expect(assistant.items[3]?.type).toBe("tool_result");
     expect(assistant.items[4]?.type).toBe("text");
   });
+
+  // RUSAA-1966: text row emitted before tool_use (agent-runner flushed text in one batch
+  // and tool events in the next). The split-batch merge must cover text→tool_use splits,
+  // not only tool_use→tool_result splits, so dedupeAssistantsPerSegment never sees 2
+  // completed items and incorrectly drops the text item.
+  it("RUSAA-1966: merges text row followed by tool_use row into single assistant", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", seq: 1, role: "user", body: "search rust", created_at: "2026-01-01T00:00:00Z" },
+      {
+        id: "a1",
+        seq: 5,
+        role: "assistant",
+        body: JSON.stringify([{ type: "text", text: "RustBrain is a code intelligence platform." }]),
+        created_at: "2026-01-01T00:00:01Z",
+      },
+      {
+        id: "a2",
+        seq: 7,
+        role: "assistant",
+        body: JSON.stringify([
+          { type: "tool_use", id: "tu-1", name: "mcp__rust_brain__search_items", input: { q: "rust" } },
+          { type: "tool_result", tool_use_id: "tu-1", content: "3 items found", is_error: false },
+        ]),
+        created_at: "2026-01-01T00:00:02Z",
+      },
+    ];
+
+    const items = buildTranscriptFromHistory(messages);
+
+    // Must produce user + ONE merged assistant (not three items)
+    expect(items).toHaveLength(2);
+    const assistant = items[1];
+    expect(assistant?.kind).toBe("assistant");
+    if (assistant?.kind !== "assistant") throw new Error("unreachable");
+
+    // text, tool_use, tool_result all in the single merged item
+    expect(assistant.items).toHaveLength(3);
+    expect(assistant.items[0]?.type).toBe("text");
+    expect(assistant.items[1]?.type).toBe("tool_use");
+    expect(assistant.items[2]?.type).toBe("tool_result");
+    // Preserves the id and startSeq of the first row
+    expect(assistant.id).toBe("a1");
+  });
+
+  it("RUSAA-1966: text→text (no tool_use) still produces two separate assistants", () => {
+    // Two consecutive text-only rows should NOT be merged
+    const messages: ChatMessage[] = [
+      { id: "u1", seq: 1, role: "user", body: "hi", created_at: "2026-01-01T00:00:00Z" },
+      {
+        id: "a1",
+        seq: 2,
+        role: "assistant",
+        body: JSON.stringify([{ type: "text", text: "Hello" }]),
+        created_at: "2026-01-01T00:00:01Z",
+      },
+      {
+        id: "a2",
+        seq: 3,
+        role: "assistant",
+        body: JSON.stringify([{ type: "text", text: "How are you?" }]),
+        created_at: "2026-01-01T00:00:02Z",
+      },
+    ];
+
+    const items = buildTranscriptFromHistory(messages);
+    // Two separate assistants — no merge (no tool_use)
+    expect(items).toHaveLength(3);
+  });
+});
+
+describe("buildTranscript — text-before-tool_use merge (RUSAA-1966)", () => {
+  it("merges text+end_turn+tool_use into one assistant when end_turn fires before tool_use", () => {
+    // Scenario: model emits text (end_turn), CLI then invokes tool_use in next agentic step.
+    // buildTranscript must merge the two flushed items so dedupeAssistantsPerSegment sees
+    // a single completed item and does not drop the text block.
+    const events: StreamedEvent[] = [
+      sseEvent({ type: "user_input", text: "search for rust" }, 1),
+      sseEvent({ type: "text", text: "RustBrain is a code intelligence platform." }, 2),
+      // end_turn fires here (text-only model response); tool call follows as next step
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 3),
+      sseEvent({ type: "tool_use", id: "tu-1", name: "mcp__rust_brain__search_items", input: { q: "rust" } }, 4),
+      sseEvent({ type: "turn_complete", stop_reason: "tool_use" }, 5),
+      sseEvent({ type: "tool_result", tool_use_id: "tu-1", content: "3 results", is_error: false }, 6),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 7),
+    ];
+
+    const items = buildTranscript(events);
+
+    // Must be [user, ONE assistant] — the text and tool blocks merged
+    expect(items).toHaveLength(2);
+    const assistant = items[1];
+    expect(assistant?.kind).toBe("assistant");
+    if (assistant?.kind !== "assistant") throw new Error("unreachable");
+
+    expect(assistant.items).toHaveLength(3);
+    expect(assistant.items[0]?.type).toBe("text");
+    expect(assistant.items[0]?.type === "text" ? assistant.items[0].text : "").toBe(
+      "RustBrain is a code intelligence platform.",
+    );
+    expect(assistant.items[1]?.type).toBe("tool_use");
+    expect(assistant.items[2]?.type).toBe("tool_result");
+    expect(assistant.inProgress).toBeUndefined();
+  });
+
+  it("merges text+end_turn+tool_use(in-progress) into one inProgress assistant", () => {
+    const events: StreamedEvent[] = [
+      sseEvent({ type: "user_input", text: "search for rust" }, 1),
+      sseEvent({ type: "text", text: "RustBrain is a code intelligence platform." }, 2),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 3),
+      sseEvent({ type: "tool_use", id: "tu-1", name: "mcp__rust_brain__search_items", input: {} }, 4),
+      // no turn_complete yet — tool still in progress
+    ];
+
+    const items = buildTranscript(events);
+
+    expect(items).toHaveLength(2);
+    const assistant = items[1];
+    if (assistant?.kind !== "assistant") throw new Error("unreachable");
+
+    // text merged with the in-progress tool_use
+    expect(assistant.items).toHaveLength(2);
+    expect(assistant.items[0]?.type).toBe("text");
+    expect(assistant.items[1]?.type).toBe("tool_use");
+    expect(assistant.inProgress).toBe(true);
+  });
+
+  it("does NOT merge when second assistant starts with text (not tool_use)", () => {
+    // Two consecutive completed text-only assistants should remain separate
+    const events: StreamedEvent[] = [
+      sseEvent({ type: "user_input", text: "hello" }, 1),
+      sseEvent({ type: "text", text: "First response." }, 2),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 3),
+      sseEvent({ type: "text", text: "Second response." }, 4),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 5),
+    ];
+
+    const items = buildTranscript(events);
+
+    // [user, asst1, asst2] — two separate assistants
+    expect(items).toHaveLength(3);
+    const [, a1, a2] = items;
+    expect(a1?.kind).toBe("assistant");
+    expect(a2?.kind).toBe("assistant");
+  });
 });

--- a/frontend/src/components/chat/transcript.test.ts
+++ b/frontend/src/components/chat/transcript.test.ts
@@ -382,4 +382,33 @@ describe("buildTranscript — text-before-tool_use merge (RUSAA-1966)", () => {
     expect(a1?.kind).toBe("assistant");
     expect(a2?.kind).toBe("assistant");
   });
+
+  it("CLI restart SSE (no user_input): does NOT merge adjacent turns even when second starts with tool_use", () => {
+    // Regression guard for RUSAA-1962: CLI restart replays prior turns without
+    // user_input events. Two consecutive assistant items from different turns must
+    // NOT be merged even if the second starts with tool_use. The !firstLiveUser path
+    // in ChatPage handles transcript merging via buildTranscriptFromHistory.
+    const events: StreamedEvent[] = [
+      // Turn 1 replay: text only (no user_input)
+      sseEvent({ type: "text", text: "Turn 1 answer." }, 1),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 2),
+      // Turn 2 streaming: starts with tool_use (genuinely different turn)
+      sseEvent({ type: "tool_use", id: "tu-1", name: "search", input: {} }, 3),
+      sseEvent({ type: "turn_complete", stop_reason: "tool_use" }, 4),
+    ];
+
+    const items = buildTranscript(events);
+
+    // Two separate assistants — no merge
+    expect(items).toHaveLength(2);
+    const [a1, a2] = items;
+    expect(a1?.kind).toBe("assistant");
+    if (a1?.kind !== "assistant") throw new Error("unreachable");
+    expect(a1.items[0]?.type).toBe("text");
+
+    expect(a2?.kind).toBe("assistant");
+    if (a2?.kind !== "assistant") throw new Error("unreachable");
+    expect(a2.items[0]?.type).toBe("tool_use");
+    expect(a2.inProgress).toBe(true);
+  });
 });

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -206,20 +206,57 @@ export function buildTranscript(
   }
 
   // Flush any in-progress assistant turn (streaming).
-  if (state.pendingAssistant !== null && state.pendingAssistant.length > 0) {
-    return [
-      ...state.items,
-      {
-        kind: "assistant",
-        id: `a-${state.counter}`,
-        items: state.pendingAssistant,
-        inProgress: true,
-        ...(state.pendingStartSeq !== null ? { startSeq: state.pendingStartSeq } : {}),
-      },
-    ];
-  }
+  const raw: ReadonlyArray<TranscriptItem> =
+    state.pendingAssistant !== null && state.pendingAssistant.length > 0
+      ? [
+          ...state.items,
+          {
+            kind: "assistant",
+            id: `a-${state.counter}`,
+            items: state.pendingAssistant,
+            inProgress: true,
+            ...(state.pendingStartSeq !== null ? { startSeq: state.pendingStartSeq } : {}),
+          },
+        ]
+      : state.items;
 
-  return state.items;
+  // Merge consecutive assistant items where the second starts with tool_use.
+  // Guards against the text-before-tool_use split (end_turn emitted between text and
+  // tool_use events) producing two items in the same turn, which would cause
+  // dedupeAssistantsPerSegment to miscount and drop the text item.
+  return mergeAdjacentToolUseAssistants(raw);
+}
+
+// Merge consecutive assistant items where the second one starts with tool_use.
+// This handles the pattern where the model emitted text (end_turn) and later tool_use
+// events arrived as separate SSE flushes — the same split-batch artifact that
+// buildTranscriptFromHistory handles for DB rows. Without this, dedupeAssistantsPerSegment
+// sees 2 completed items in a segment and may drop the text item as a stale replay.
+function mergeAdjacentToolUseAssistants(
+  items: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptItem> {
+  const result: TranscriptItem[] = [];
+  for (const item of items) {
+    const prev = result[result.length - 1];
+    if (
+      prev !== undefined &&
+      prev.kind === "assistant" &&
+      !prev.inProgress &&
+      item.kind === "assistant" &&
+      item.items[0]?.type === "tool_use"
+    ) {
+      result[result.length - 1] = {
+        kind: "assistant",
+        id: prev.id,
+        items: [...prev.items, ...item.items],
+        ...(prev.startSeq !== undefined ? { startSeq: prev.startSeq } : {}),
+        ...(item.inProgress === true ? { inProgress: true } : {}),
+      };
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
 }
 
 // Finds the sequence number of the first user_input event in the SSE stream.
@@ -286,14 +323,19 @@ export function buildTranscriptFromHistory(
         contentBlocks ?? [{ type: "text", text: msg.body, seq: msg.seq }];
 
       // Split-batch merge: when the agent-runner flushes events in separate HTTP
-      // requests (tool execution spans a batch boundary), the DB may have one row
-      // ending with tool_use and a subsequent row starting with tool_result. Merge
-      // them so findToolResult can locate the result within the same items array.
+      // requests, the DB may split a single turn across multiple rows. Two patterns:
+      //   A) prev row ends with tool_use, next starts with tool_result (batch boundary)
+      //   B) prev row ends with text,     next starts with tool_use   (RUSAA-1966: text
+      //      emitted before tool call, persisted separately before tools ran)
+      // Merge both so all blocks for one turn land in a single AssistantTranscriptItem.
+      // Safe because consecutive assistant rows without a user row between them are
+      // always from the same agent turn.
       const prev = items[items.length - 1];
       if (
         prev?.kind === "assistant" &&
         contentBlocks !== null &&
-        prev.items[prev.items.length - 1]?.type === "tool_use"
+        (prev.items[prev.items.length - 1]?.type === "tool_use" ||
+          contentBlocks[0]?.type === "tool_use")
       ) {
         items[items.length - 1] = {
           kind: "assistant",

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -224,7 +224,14 @@ export function buildTranscript(
   // Guards against the text-before-tool_use split (end_turn emitted between text and
   // tool_use events) producing two items in the same turn, which would cause
   // dedupeAssistantsPerSegment to miscount and drop the text item.
-  return mergeAdjacentToolUseAssistants(raw);
+  //
+  // Only apply when the stream has user_input events (live/firstLiveUser sessions).
+  // In CLI restart SSE (no user_input), consecutive assistant items are from DIFFERENT
+  // turns with no separator — merging here would incorrectly combine cross-turn content.
+  // The CLI restart path uses buildTranscriptFromHistory for the transcript, which
+  // handles the same text→tool_use split via its own split-batch merge logic.
+  const hasUserItems = raw.some((item) => item.kind === "user");
+  return hasUserItems ? mergeAdjacentToolUseAssistants(raw) : raw;
 }
 
 // Merge consecutive assistant items where the second one starts with tool_use.


### PR DESCRIPTION
## Summary

Fixes [RUSAA-1966]: prior turn text output disappears when a new turn completes in sessions with tool_use responses.

- Extend `buildTranscriptFromHistory` split-batch merge to cover the case where the **next** assistant DB row starts with `tool_use` (not only when prev ends with `tool_use`). Fixes text disappearing from history in the `!firstLiveUser` path.
- Add `mergeAdjacentToolUseAssistants` post-processor to `buildTranscript` to merge consecutive completed assistant items where the second starts with `tool_use`. Fixes the same split in the live SSE stream (`firstLiveUser` path).
- Scope the merge to transcripts with user_input events only, guarding against regression in the CLI restart path where consecutive assistants belong to different turns.
- Add 5 unit tests and 3 E2E regression tests (R31 fixture data).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] `npx vitest run src/components/chat/transcript.test.ts` — 16 tests pass
- [x] E2E AC1: `!firstLiveUser` CLI restart — turn-2 text visible after all turns complete
- [x] E2E AC2: pure history reload — split DB rows merge into single bubble (text before tool block)
- [x] E2E AC3: `firstLiveUser` live session — text preserved after turn-3 completes

Closes #739