### PR TITLE
[RUSAA-1973] feat: add turn_id + parent_user_id to chat events and SSE envelope

### DIFF
--- a/migrations/control/022_chat_turn_id.sql
+++ b/migrations/control/022_chat_turn_id.sql
@@ -1,0 +1,13 @@
+-- Control schema: Wave 9 Rewrite — turn_id + parent_user_id on chat events (RUSAA-1973)
+-- Additive only; no backfill. Legacy rows have turn_id = NULL, parent_user_id = NULL.
+-- AC-4: sessions with only pre-migration rows render identically to today.
+
+ALTER TABLE control.chat_messages
+    ADD COLUMN IF NOT EXISTS turn_id        UUID NULL,
+    ADD COLUMN IF NOT EXISTS parent_user_id UUID NULL
+        REFERENCES control.chat_messages(id) ON DELETE SET NULL;
+
+-- Index for join-by-turn_id in SSE ingest (flush_pending_turn parent_user_id lookup).
+CREATE INDEX IF NOT EXISTS chat_messages_turn_id_idx
+    ON control.chat_messages(session_id, turn_id)
+    WHERE turn_id IS NOT NULL;

--- a/proto/rust_brain/v1/agent.proto
+++ b/proto/rust_brain/v1/agent.proto
@@ -48,7 +48,8 @@ message AgentSessionStart {
 }
 
 message AgentSessionInput {
-  string input = 1;
+  string input   = 1;
+  string turn_id = 2;  // UUID v4 minted by control-api per user message; empty = legacy
 }
 
 message AgentSessionTerminate {

--- a/services/agent-runner/src/event_relay/dispatch.rs
+++ b/services/agent-runner/src/event_relay/dispatch.rs
@@ -88,21 +88,28 @@ async fn flush_session(
 
     // Serialize each RuntimeEvent directly so the body matches IngestEventsRequest.events:
     // Vec<RuntimeEvent> with serde tag {"type": "text", "text": "..."}
-    let events_body: Vec<serde_json::Value> = items
-        .iter()
-        .filter_map(|i| match serde_json::to_value(&i.event) {
-            Ok(v) => Some(v),
+    // turn_ids is a parallel array; None entries are serialized as JSON null.
+    let mut events_body: Vec<serde_json::Value> = Vec::with_capacity(items.len());
+    let mut turn_ids: Vec<serde_json::Value> = Vec::with_capacity(items.len());
+    for item in items {
+        match serde_json::to_value(&item.event) {
+            Ok(v) => {
+                events_body.push(v);
+                turn_ids.push(match item.turn_id {
+                    Some(id) => serde_json::Value::String(id.to_string()),
+                    None => serde_json::Value::Null,
+                });
+            }
             Err(e) => {
                 tracing::warn!(
                     session_id = %session_id,
-                    seq = i.seq,
+                    seq = item.seq,
                     error = %e,
                     "relay: failed to serialize event — skipping"
                 );
-                None
             }
-        })
-        .collect();
+        }
+    }
 
     if events_body.is_empty() {
         return;
@@ -112,6 +119,7 @@ async fn flush_session(
     let body = serde_json::json!({
         "tenant_id": tenant_id,
         "events": events_body,
+        "turn_ids": turn_ids,
     });
 
     post_with_retry(client, &url, &body, session_id, event_count).await;

--- a/services/agent-runner/src/event_relay/mod.rs
+++ b/services/agent-runner/src/event_relay/mod.rs
@@ -48,6 +48,9 @@ pub struct RelayItem {
     pub seq: i64,
     pub event: RuntimeEvent,
     pub emitted_at_ms: i64,
+    /// UUID v4 of the user message that triggered this turn.  `None` for
+    /// pre-migration sessions or when the Input command had no `turn_id`.
+    pub turn_id: Option<uuid::Uuid>,
 }
 
 /// Cloneable sender handle for the relay buffer.
@@ -97,6 +100,7 @@ pub fn relay_stdout_events(
     tenant_id: &str,
     seq: i64,
     line: &str,
+    turn_id: Option<uuid::Uuid>,
 ) {
     let now_ms = Utc::now().timestamp_millis();
     for runtime_event in crate::StreamJsonNormalizer::normalize_line(line) {
@@ -106,6 +110,7 @@ pub fn relay_stdout_events(
             seq,
             event: runtime_event,
             emitted_at_ms: now_ms,
+            turn_id,
         });
     }
 }
@@ -169,6 +174,7 @@ mod tests {
                 text: format!("event-{seq}"),
             },
             emitted_at_ms: 0,
+            turn_id: None,
         }
     }
 

--- a/services/agent-runner/src/session/mod.rs
+++ b/services/agent-runner/src/session/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -60,6 +60,10 @@ struct SessionHandle {
     /// The actual decrement at session-end is performed by `caps.release()` /
     /// `natural_exit` — the guard is defused before insertion into the map.
     _tenant_guard: caps::TenantCountGuard,
+    /// The `turn_id` of the most recently dispatched Input command for this
+    /// session.  Set by `send_input`; read by the stdout relay task so each
+    /// `RuntimeEvent` is stamped with the correct turn.
+    current_turn_id: Arc<RwLock<Option<uuid::Uuid>>>,
 }
 
 fn safe_join(base: &std::path::Path, rel: &str) -> Result<PathBuf> {
@@ -214,6 +218,8 @@ impl SessionManager {
             .take()
             .context("Process stderr not available")?;
 
+        let current_turn_id: Arc<RwLock<Option<uuid::Uuid>>> = Arc::new(RwLock::new(None));
+
         let (stdout_handle, stderr_handle) = self.spawn_output_handlers(
             session_id.to_string(),
             tenant_id,
@@ -222,6 +228,7 @@ impl SessionManager {
             event_sender.clone(),
             adapter,
             live_token,
+            Arc::clone(&current_turn_id),
         );
 
         let process_arc = Arc::new(Mutex::new(process));
@@ -274,6 +281,7 @@ impl SessionManager {
                     tenant_id,
                     _node_permit: node_permit,
                     _tenant_guard: tenant_guard,
+                    current_turn_id,
                 },
             );
         }
@@ -304,13 +312,26 @@ impl SessionManager {
     }
 
     pub async fn send_input(&self, session_id: &str, input: &AgentSessionInput) -> Result<()> {
-        let process = {
+        let (process, current_turn_id) = {
             let sessions = self.sessions.lock().await;
-            sessions
-                .get(session_id)
-                .map(|h| Arc::clone(&h.process))
-                .context("Session not found")?
+            let handle = sessions.get(session_id).context("Session not found")?;
+            (
+                Arc::clone(&handle.process),
+                Arc::clone(&handle.current_turn_id),
+            )
         };
+
+        // Stamp the session's active turn before forwarding the input so that
+        // any RuntimeEvents flushed from the buffer during this turn carry the
+        // correct turn_id.  Empty string = legacy caller; keep previous value.
+        if !input.turn_id.is_empty() {
+            if let Ok(tid) = input.turn_id.parse::<uuid::Uuid>() {
+                if let Ok(mut guard) = current_turn_id.write() {
+                    *guard = Some(tid);
+                }
+            }
+        }
+
         let mut proc = process.lock().await;
         let adapter = adapter_for_runtime(proc.runtime)?;
         adapter.send_input(&mut proc, &input.input).await
@@ -472,6 +493,7 @@ impl SessionManager {
         event_sender: tokio::sync::mpsc::Sender<(TenantId, AgentEvent)>,
         adapter: Box<dyn RuntimeAdapter>,
         live_token: String,
+        current_turn_id: Arc<RwLock<Option<uuid::Uuid>>>,
     ) -> (JoinHandle<()>, JoinHandle<()>) {
         let seq_counters = self.seq_counters.clone();
         let seq_timestamps = self.seq_counter_timestamps.clone();
@@ -524,12 +546,18 @@ impl SessionManager {
                             ) else {
                                 continue;
                             };
+                            // Snapshot the current turn_id atomically for this relay item.
+                            let turn_id = current_turn_id
+                                .read()
+                                .ok()
+                                .and_then(|g| *g);
                             agent_runner::relay_stdout_events(
                                 &relay_sender,
                                 &sid_stdout,
                                 &tenant_id.to_string(),
                                 seq,
                                 &redacted_line,
+                                turn_id,
                             );
                         }
                     }

--- a/services/agent-runner/src/session/tests.rs
+++ b/services/agent-runner/src/session/tests.rs
@@ -217,6 +217,7 @@ fn make_stub_handle(
         tenant_id,
         _node_permit: permit,
         _tenant_guard: caps::TenantCountGuard::new_defused_for_test(),
+        current_turn_id: Arc::new(std::sync::RwLock::new(None)),
     }
 }
 

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -491,9 +491,12 @@ mod tests {
         }))
         .unwrap();
         let req: IngestEventsRequest = serde_json::from_str(&json_str).unwrap();
-        assert!(req.turn_ids.is_empty(), "legacy payload must default to empty turn_ids");
-        // get with out-of-bounds → None (AC-4 backward compat)
-        assert_eq!(req.turn_ids.get(0).copied().flatten(), None);
+        assert!(
+            req.turn_ids.is_empty(),
+            "legacy payload must default to empty turn_ids"
+        );
+        // out-of-bounds → None (AC-4 backward compat)
+        assert_eq!(req.turn_ids.first().copied().flatten(), None);
     }
 
     #[test]

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -24,6 +24,10 @@ use crate::{error::AppError, routes::chat::db::db_insert_chat_message, state::Ap
 // Request / response types
 // ---------------------------------------------------------------------------
 
+/// Protocol version stamped on every chat SSE envelope.
+/// v1 = seq-only (pre-1973); v2 = `turn_id` present.
+pub const CHAT_PROTOCOL_VERSION: u32 = 2;
+
 #[derive(Debug, Deserialize)]
 pub struct IngestEventsRequest {
     /// Tenant that owns this session.  Verified against the DB row to prevent
@@ -31,6 +35,11 @@ pub struct IngestEventsRequest {
     pub tenant_id: Uuid,
     /// Ordered batch of runtime events from the agent-runner relay.
     pub events: Vec<RuntimeEvent>,
+    /// `turn_id` per event (parallel array; absent or shorter = legacy, defaults to None).
+    /// Each entry is the UUID v4 minted by control-api for the user message that
+    /// triggered the agent turn that produced this event.
+    #[serde(default)]
+    pub turn_ids: Vec<Option<Uuid>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -130,9 +139,13 @@ async fn ingest_chat_session_events(
     // Consecutive `Text` payloads are merged into one block via `pending_text`.
     let mut pending_blocks: Vec<serde_json::Value> = Vec::new();
     let mut pending_text = String::new();
+    // turn_id for the blocks currently being accumulated.
+    let mut pending_turn_id: Option<Uuid> = None;
 
     for (seq, ev) in req.events.iter().enumerate() {
         let et = event_type(ev);
+        let turn_id: Option<Uuid> = req.turn_ids.get(seq).copied().flatten();
+
         let payload_value: serde_json::Value = ev
             .to_payload_json()
             .ok()
@@ -140,12 +153,25 @@ async fn ingest_chat_session_events(
             .unwrap_or(serde_json::Value::Null);
 
         let seq_i64 = i64::try_from(seq + 1).unwrap_or(i64::MAX);
-        let sse_data = serde_json::json!({
-            "session_id": session_id,
-            "event_type": et,
-            "sequence": seq_i64,
-            "payload": payload_value,
-        });
+        // v2 SSE envelope: adds turn_id + protocol_version for identity-aware FE.
+        // Legacy events (turn_id = None) omit both additive fields so old clients
+        // continue to work unchanged (AC-4 backward compat).
+        let sse_data = match turn_id {
+            Some(tid) => serde_json::json!({
+                "session_id": session_id,
+                "event_type": et,
+                "sequence": seq_i64,
+                "payload": payload_value,
+                "turn_id": tid,
+                "protocol_version": CHAT_PROTOCOL_VERSION,
+            }),
+            None => serde_json::json!({
+                "session_id": session_id,
+                "event_type": et,
+                "sequence": seq_i64,
+                "payload": payload_value,
+            }),
+        };
 
         if let Ok(data) = serde_json::to_string(&sse_data) {
             state.sse_bus.publish_raw(&tenant_id, "session.event", data);
@@ -160,18 +186,30 @@ async fn ingest_chat_session_events(
                     req.tenant_id,
                     &mut pending_text,
                     &mut pending_blocks,
+                    pending_turn_id.take(),
                 )
                 .await;
+                // turn_id from the UserInput event marks the start of the next turn.
+                pending_turn_id = turn_id;
             }
             RuntimeEvent::Text { text } => {
+                if pending_turn_id.is_none() {
+                    pending_turn_id = turn_id;
+                }
                 pending_text.push_str(text);
             }
             RuntimeEvent::Thinking { thinking } => {
+                if pending_turn_id.is_none() {
+                    pending_turn_id = turn_id;
+                }
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks
                     .push(serde_json::json!({ "type": "thinking", "thinking": thinking }));
             }
             RuntimeEvent::ToolUse { id, name, input } => {
+                if pending_turn_id.is_none() {
+                    pending_turn_id = turn_id;
+                }
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks.push(serde_json::json!({ "type": "tool_use", "id": id, "name": name, "input": input }));
             }
@@ -180,6 +218,9 @@ async fn ingest_chat_session_events(
                 content,
                 is_error,
             } => {
+                if pending_turn_id.is_none() {
+                    pending_turn_id = turn_id;
+                }
                 commit_text_block(&mut pending_text, &mut pending_blocks);
                 pending_blocks.push(serde_json::json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content, "is_error": is_error }));
             }
@@ -195,6 +236,7 @@ async fn ingest_chat_session_events(
         req.tenant_id,
         &mut pending_text,
         &mut pending_blocks,
+        pending_turn_id.take(),
     )
     .await;
 
@@ -221,6 +263,7 @@ async fn flush_pending_turn(
     tenant_id: Uuid,
     pending_text: &mut String,
     pending_blocks: &mut Vec<serde_json::Value>,
+    turn_id: Option<Uuid>,
 ) {
     commit_text_block(pending_text, pending_blocks);
     if pending_blocks.is_empty() {
@@ -234,9 +277,35 @@ async fn flush_pending_turn(
             return;
         }
     };
+    // Look up the parent user row ID so AC-2 is satisfied: every assistant row
+    // has parent_user_id pointing at the user row with the same turn_id.
+    let parent_user_id = if let Some(tid) = turn_id {
+        sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM control.chat_messages \
+             WHERE session_id = $1 AND turn_id = $2 AND role = 'user' \
+             LIMIT 1",
+        )
+        .bind(session_id)
+        .bind(tid)
+        .fetch_optional(pool)
+        .await
+        .unwrap_or(None)
+    } else {
+        None
+    };
+
     let msg_id = Uuid::new_v4();
-    if let Err(e) =
-        db_insert_chat_message(pool, msg_id, session_id, tenant_id, "assistant", &body).await
+    if let Err(e) = db_insert_chat_message(
+        pool,
+        msg_id,
+        session_id,
+        tenant_id,
+        "assistant",
+        &body,
+        turn_id,
+        parent_user_id,
+    )
+    .await
     {
         tracing::warn!(
             session_id = %session_id,
@@ -412,5 +481,53 @@ mod tests {
         let resp = IngestEventsResponse { inserted: 5 };
         let v: serde_json::Value = serde_json::to_value(&resp).unwrap();
         assert_eq!(v["inserted"], 5);
+    }
+
+    #[test]
+    fn turn_ids_defaults_to_empty_when_absent() {
+        let json_str = serde_json::to_string(&serde_json::json!({
+            "tenant_id": "00000000-0000-0000-0000-000000000001",
+            "events": [{"type": "text", "text": "hi"}]
+        }))
+        .unwrap();
+        let req: IngestEventsRequest = serde_json::from_str(&json_str).unwrap();
+        assert!(req.turn_ids.is_empty(), "legacy payload must default to empty turn_ids");
+        // get with out-of-bounds → None (AC-4 backward compat)
+        assert_eq!(req.turn_ids.get(0).copied().flatten(), None);
+    }
+
+    #[test]
+    fn turn_ids_parallel_array_deserializes() {
+        let tid = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let json_str = serde_json::to_string(&serde_json::json!({
+            "tenant_id": "00000000-0000-0000-0000-000000000001",
+            "events": [
+                {"type": "text", "text": "hello"},
+                {"type": "turn_complete", "stop_reason": "end_turn"}
+            ],
+            "turn_ids": [tid.to_string(), tid.to_string()]
+        }))
+        .unwrap();
+        let req: IngestEventsRequest = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(req.turn_ids.len(), 2);
+        assert_eq!(req.turn_ids[0], Some(tid));
+        assert_eq!(req.turn_ids[1], Some(tid));
+    }
+
+    #[test]
+    fn turn_ids_null_entries_deserialize_to_none() {
+        let tid = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let json_str = serde_json::to_string(&serde_json::json!({
+            "tenant_id": "00000000-0000-0000-0000-000000000001",
+            "events": [
+                {"type": "user_input", "text": "hi"},
+                {"type": "text", "text": "hello"}
+            ],
+            "turn_ids": [null, tid.to_string()]
+        }))
+        .unwrap();
+        let req: IngestEventsRequest = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(req.turn_ids[0], None);
+        assert_eq!(req.turn_ids[1], Some(tid));
     }
 }

--- a/services/control-api/src/routes/chat/db.rs
+++ b/services/control-api/src/routes/chat/db.rs
@@ -31,6 +31,11 @@ pub struct ChatMessageRow {
     pub role: String,
     pub body: String,
     pub created_at: DateTime<Utc>,
+    /// UUID v4 minted by control-api per user message (AC-1). NULL for legacy rows.
+    pub turn_id: Option<Uuid>,
+    /// ID of the user row that triggered this assistant turn (AC-2). NULL for user rows
+    /// and for legacy assistant rows inserted before migration 022.
+    pub parent_user_id: Option<Uuid>,
 }
 
 // ---------------------------------------------------------------------------
@@ -87,6 +92,7 @@ pub async fn db_get_chat_session(
 // Message helpers
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 pub async fn db_insert_chat_message(
     pool: &PgPool,
     id: Uuid,
@@ -94,6 +100,8 @@ pub async fn db_insert_chat_message(
     tenant_id: Uuid,
     role: &str,
     body: &str,
+    turn_id: Option<Uuid>,
+    parent_user_id: Option<Uuid>,
 ) -> Result<i32, AppError> {
     let mut tx = pool
         .begin()
@@ -119,10 +127,10 @@ pub async fn db_insert_chat_message(
 
     let (seq,): (i32,) = sqlx::query_as(
         r"
-        INSERT INTO control.chat_messages (id, session_id, tenant_id, seq, role, body)
+        INSERT INTO control.chat_messages (id, session_id, tenant_id, seq, role, body, turn_id, parent_user_id)
         SELECT $1, $2, $3,
                COALESCE((SELECT MAX(seq) FROM control.chat_messages WHERE session_id = $2), 0) + 1,
-               $4, $5
+               $4, $5, $6, $7
         RETURNING seq
         ",
     )
@@ -131,6 +139,8 @@ pub async fn db_insert_chat_message(
     .bind(tenant_id)
     .bind(role)
     .bind(body)
+    .bind(turn_id)
+    .bind(parent_user_id)
     .fetch_one(&mut *tx)
     .await
     .map_err(|e| {
@@ -181,7 +191,7 @@ pub async fn db_list_chat_messages(
 ) -> Result<Vec<ChatMessageRow>, AppError> {
     if let Some(after) = after_seq {
         sqlx::query_as::<_, ChatMessageRow>(
-            "SELECT id, session_id, seq, role, body, created_at \
+            "SELECT id, session_id, seq, role, body, created_at, turn_id, parent_user_id \
              FROM control.chat_messages \
              WHERE session_id = $1 AND tenant_id = $2 AND seq > $3 \
              ORDER BY seq ASC LIMIT $4",
@@ -194,7 +204,7 @@ pub async fn db_list_chat_messages(
         .await
     } else {
         sqlx::query_as::<_, ChatMessageRow>(
-            "SELECT id, session_id, seq, role, body, created_at \
+            "SELECT id, session_id, seq, role, body, created_at, turn_id, parent_user_id \
              FROM control.chat_messages \
              WHERE session_id = $1 AND tenant_id = $2 \
              ORDER BY seq ASC LIMIT $3",

--- a/services/control-api/src/routes/chat/messages.rs
+++ b/services/control-api/src/routes/chat/messages.rs
@@ -39,8 +39,11 @@ pub struct PostMessageRequest {
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct PostMessageResponse {
+    /// UUID of the persisted user row (`user_message_id` alias per AC-3).
     pub message_id: Uuid,
     pub seq: i32,
+    /// UUID v4 minted per-turn; used by FE to self-identify the optimistic bubble (AC-3).
+    pub turn_id: Uuid,
 }
 
 #[utoipa::path(
@@ -82,6 +85,7 @@ pub async fn post_chat_message(
     }
 
     let message_id = Uuid::new_v4();
+    let turn_id = Uuid::new_v4();
     let seq = db_insert_chat_message(
         &state.pool,
         message_id,
@@ -89,6 +93,8 @@ pub async fn post_chat_message(
         caller.tenant_id,
         "user",
         &req.content,
+        Some(turn_id),
+        None, // user rows have no parent_user_id
     )
     .await?;
 
@@ -158,6 +164,7 @@ pub async fn post_chat_message(
             session_id: session_id.to_string(),
             command: Some(agent_session_command::Command::Input(AgentSessionInput {
                 input: req.content,
+                turn_id: turn_id.to_string(),
             })),
         };
         producer
@@ -177,6 +184,7 @@ pub async fn post_chat_message(
             session_id: session_id.to_string(),
             command: Some(agent_session_command::Command::Input(AgentSessionInput {
                 input: req.content,
+                turn_id: turn_id.to_string(),
             })),
         };
         producer
@@ -194,7 +202,11 @@ pub async fn post_chat_message(
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(PostMessageResponse { message_id, seq }),
+        Json(PostMessageResponse {
+            message_id,
+            seq,
+            turn_id,
+        }),
     ))
 }
 

--- a/services/control-api/src/routes/chat/sessions.rs
+++ b/services/control-api/src/routes/chat/sessions.rs
@@ -49,6 +49,13 @@ pub struct ChatMessageDto {
     pub role: String,
     pub body: String,
     pub created_at: DateTime<Utc>,
+    /// UUID v4 of the turn this message belongs to. NULL for legacy rows (pre-022).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<Uuid>,
+    /// ID of the user row that triggered this assistant turn. NULL for user rows
+    /// and for legacy assistant rows (pre-022).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_user_id: Option<Uuid>,
 }
 
 impl From<ChatMessageRow> for ChatMessageDto {
@@ -59,6 +66,8 @@ impl From<ChatMessageRow> for ChatMessageDto {
             role: r.role,
             body: r.body,
             created_at: r.created_at,
+            turn_id: r.turn_id,
+            parent_user_id: r.parent_user_id,
         }
     }
 }

--- a/services/control-api/src/routes/chat/tests.rs
+++ b/services/control-api/src/routes/chat/tests.rs
@@ -208,6 +208,8 @@ async fn concurrent_message_inserts_have_unique_seq() {
                     tenant_id,
                     "user",
                     "concurrent test message",
+                    None,
+                    None,
                 )
                 .await
             })


### PR DESCRIPTION
## Summary

- Migration 022 adds nullable `turn_id UUID` and `parent_user_id UUID` to `control.chat_messages` (additive, no backfill — legacy rows stay NULL, AC-4)
- `POST /v1/chat/sessions/{id}/messages` mints a UUID v4 `turn_id`, stamps the user row, threads it through `AgentSessionInput` proto to agent-runner, and returns `{ message_id, seq, turn_id }` in the response (AC-3)
- agent-runner stores `current_turn_id` per session; every `RelayItem` from stdout is stamped; `dispatch.rs` sends `turn_ids[]` parallel array to the ingest endpoint
- `events_ingest.rs` reads `turn_ids` per-event, emits v2 SSE envelopes with `turn_id + protocol_version=2` for assistant events, and persists `turn_id` + `parent_user_id` (looked up by FK) on assistant rows (AC-1/AC-2)
- `ChatMessageDto` exposes `turn_id` and `parent_user_id` on the GET messages endpoint so the FE identity-based reducer can use them for historical replay
- `CHAT_PROTOCOL_VERSION = 2` constant on both sides; FE path-selects on presence of `turn_id` field (AC-5)

## Gate checklist

- [x] `cargo-locked test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check` — clean
- [x] No `RUSAA-XX` in source/commits/branches
- [x] GitHub issue: Closes #743

## GitHub Issue

Closes #743