### PR TITLE
[RUSAA-1977] feat: add parent_user_id to SSE envelope + backfill legacy turn_id rows

### DIFF
--- a/frontend/src/lib/chat-api.ts
+++ b/frontend/src/lib/chat-api.ts
@@ -59,6 +59,8 @@ export interface ChatSessionEventEnvelope {
   payload: ChatRuntimePayload;
   /** v2: UUID of the turn this event belongs to. Absent for legacy v1 events. */
   turn_id?: string;
+  /** v2: user message id that opened this turn; null on user_input frames. */
+  parent_user_id?: string | null;
   /** v2: protocol version (2 when turn_id is present). */
   protocol_version?: number;
 }

--- a/migrations/control/023_chat_turn_id_backfill.sql
+++ b/migrations/control/023_chat_turn_id_backfill.sql
@@ -1,0 +1,38 @@
+-- Control schema: Wave 9 Rewrite — backfill turn_id + parent_user_id for pre-022 rows
+-- (RUSAA-1977 spec gap: migration 022 was additive-only, this closes the invariant
+-- that every chat_messages row has a non-null turn_id post-migration.)
+--
+-- Only rows where turn_id IS NULL are touched; all post-022 rows are unchanged.
+-- Idempotent: safe to re-run.
+
+-- Step 1: stamp parent_user_id on legacy non-user rows.
+-- Window covers all rows in each session (not just null-turn rows) so that legacy
+-- assistant rows in a mixed session correctly inherit the owning user row even
+-- when that user row was inserted after 022 (and already has a turn_id).
+WITH walked AS (
+    SELECT id, role,
+           max(CASE WHEN role = 'user' THEN id END)
+               OVER (PARTITION BY session_id ORDER BY seq
+                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS user_id
+    FROM control.chat_messages
+)
+UPDATE control.chat_messages m
+    SET parent_user_id = w.user_id
+FROM walked w
+WHERE m.id = w.id
+  AND m.role != 'user'
+  AND m.turn_id IS NULL
+  AND m.parent_user_id IS NULL;
+
+-- Step 2: stamp turn_id on legacy user rows (one fresh UUID per row).
+UPDATE control.chat_messages
+    SET turn_id = gen_random_uuid()
+WHERE role = 'user'
+  AND turn_id IS NULL;
+
+-- Step 3: propagate turn_id from user rows to their legacy non-user rows.
+UPDATE control.chat_messages m
+    SET turn_id = u.turn_id
+FROM control.chat_messages u
+WHERE m.parent_user_id = u.id
+  AND m.turn_id IS NULL;

--- a/services/control-api/src/routes/agents/events_ingest.rs
+++ b/services/control-api/src/routes/agents/events_ingest.rs
@@ -7,6 +7,8 @@
 //! Auth: internal-only route; the `require_internal_secret` middleware is applied at
 //! the router level in `routes/mod.rs`.  No user JWT is required.
 
+use std::collections::HashMap;
+
 use axum::{
     Json,
     extract::{Path, State},
@@ -120,6 +122,38 @@ pub async fn ingest_session_events(
     ingest_chat_session_events(&state, session_id, &req).await
 }
 
+/// Fetch a `turn_id → user_message_id` map for the given `turn_ids` list.
+///
+/// Called once per ingest batch so every v2 SSE frame can carry `parent_user_id` (spec §4.2).
+async fn fetch_parent_user_ids(
+    pool: &PgPool,
+    session_id: Uuid,
+    turn_ids: &[Option<Uuid>],
+) -> HashMap<Uuid, Uuid> {
+    let unique: Vec<Uuid> = {
+        let mut seen = std::collections::HashSet::new();
+        turn_ids
+            .iter()
+            .filter_map(|t| *t)
+            .filter(|id| seen.insert(*id))
+            .collect()
+    };
+    if unique.is_empty() {
+        return HashMap::new();
+    }
+    sqlx::query_as::<_, (Uuid, Uuid)>(
+        "SELECT turn_id, id FROM control.chat_messages \
+         WHERE session_id = $1 AND role = 'user' AND turn_id = ANY($2)",
+    )
+    .bind(session_id)
+    .bind(&unique as &Vec<Uuid>)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .into_iter()
+    .collect()
+}
+
 /// Chat-session path for [`ingest_session_events`]: fans events out to the SSE bus and
 /// persists each assistant turn as a single `role=assistant` row in `control.chat_messages`.
 ///
@@ -127,6 +161,7 @@ pub async fn ingest_session_events(
 /// `[{"type":"text","text":"…"},{"type":"tool_use","id":"…","name":"…","input":{…}},…]`
 /// Plain-`Text`-only turns also use the array format. Pre-1896 rows (plain text) continue
 /// to render as plain text via the frontend fallback path in `buildTranscriptFromHistory`.
+#[allow(clippy::too_many_lines)]
 async fn ingest_chat_session_events(
     state: &AppState,
     session_id: Uuid,
@@ -134,6 +169,11 @@ async fn ingest_chat_session_events(
 ) -> Result<(StatusCode, Json<IngestEventsResponse>), AppError> {
     let tenant_id = TenantId::from(req.tenant_id);
     let mut fanned_out: usize = 0;
+
+    // Pre-fetch turn_id → user_row_id map so every v2 SSE frame carries
+    // parent_user_id (spec §4.2).  One batched query per ingest call.
+    // UserInput frames always get parent_user_id = null (they ARE the user row).
+    let parent_user_map = fetch_parent_user_ids(&state.pool, session_id, &req.turn_ids).await;
 
     // Content-block accumulator for the current assistant turn.
     // Consecutive `Text` payloads are merged into one block via `pending_text`.
@@ -153,9 +193,13 @@ async fn ingest_chat_session_events(
             .unwrap_or(serde_json::Value::Null);
 
         let seq_i64 = i64::try_from(seq + 1).unwrap_or(i64::MAX);
-        // v2 SSE envelope: adds turn_id + protocol_version for identity-aware FE.
-        // Legacy events (turn_id = None) omit both additive fields so old clients
-        // continue to work unchanged (AC-4 backward compat).
+        // v2 SSE envelope: adds turn_id + parent_user_id + protocol_version.
+        // UserInput frames carry parent_user_id = null (they are the user row).
+        // Legacy events (turn_id = None) omit v2 fields for AC-4 backward compat.
+        let parent_user_id: Option<Uuid> = match ev {
+            RuntimeEvent::UserInput { .. } => None,
+            _ => turn_id.and_then(|tid| parent_user_map.get(&tid).copied()),
+        };
         let sse_data = match turn_id {
             Some(tid) => serde_json::json!({
                 "session_id": session_id,
@@ -163,6 +207,7 @@ async fn ingest_chat_session_events(
                 "sequence": seq_i64,
                 "payload": payload_value,
                 "turn_id": tid,
+                "parent_user_id": parent_user_id,
                 "protocol_version": CHAT_PROTOCOL_VERSION,
             }),
             None => serde_json::json!({

--- a/services/control-api/tests/integration_events_ingest_chat_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_chat_tests.rs
@@ -277,3 +277,100 @@ async fn ac8_chat_session_fallback_fans_out_sse_without_db_insert() {
         "AC8: chat session events must NOT be stored in agents.agent_events"
     );
 }
+
+// ---------------------------------------------------------------------------
+// AC-parent_user_id — v2 SSE frames carry parent_user_id (spec §4.2, RUSAA-1977)
+//
+// Verifies that ingest emits parent_user_id on assistant frames and null on
+// user_input frames when turn_ids are present in the request.
+// ---------------------------------------------------------------------------
+
+/// Insert a user `chat_message` row with a specific `turn_id`, simulating the row
+/// that POST /v1/chat/sessions/{id}/messages would have persisted.
+async fn insert_user_message(
+    pool: &PgPool,
+    session_id: Uuid,
+    tenant_id: Uuid,
+    turn_id: Uuid,
+) -> Uuid {
+    let user_msg_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO control.chat_messages \
+         (id, session_id, tenant_id, seq, role, body, turn_id, parent_user_id) \
+         VALUES ($1, $2, $3, 1, 'user', 'hello', $4, NULL)",
+    )
+    .bind(user_msg_id)
+    .bind(session_id)
+    .bind(tenant_id)
+    .bind(turn_id)
+    .execute(pool)
+    .await
+    .expect("insert user chat_message");
+    user_msg_id
+}
+
+#[tokio::test]
+async fn ac_parent_user_id_present_on_assistant_frames_null_on_user_input() {
+    let Some((state, pool)) = real_db_state().await else {
+        return;
+    };
+    let fx = insert_chat_fixture(&pool).await;
+    let turn_id = Uuid::new_v4();
+    // Pre-insert the user message row so the ingest handler can look up parent_user_id.
+    let user_msg_id = insert_user_message(&pool, fx.session_id, fx.tenant_id, turn_id).await;
+
+    let tenant_id = TenantId::from(fx.tenant_id);
+    let (mut rx, _replay) = raw_subscribe(&state.sse_bus, &tenant_id, None);
+
+    let body = json!({
+        "tenant_id": fx.tenant_id,
+        "events": [
+            {"type": "user_input", "text": "hello"},
+            {"type": "text", "text": "world"}
+        ],
+        "turn_ids": [turn_id.to_string(), turn_id.to_string()]
+    });
+
+    let resp = build_internal(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(ingest_uri(fx.session_id))
+                .header("content-type", "application/json")
+                .header("x-internal-secret", INTERNAL_SECRET)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Event 1: user_input — parent_user_id must be null per spec.
+    let env1 = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+        .await
+        .expect("SSE event 1 must arrive")
+        .expect("SSE channel open");
+    let d1: Value = serde_json::from_str(&env1.data).unwrap();
+    assert_eq!(d1["event_type"], "session.user_input");
+    assert_eq!(d1["turn_id"], turn_id.to_string());
+    assert!(
+        d1["parent_user_id"].is_null(),
+        "parent_user_id must be null on user_input frame, got {:?}",
+        d1["parent_user_id"]
+    );
+
+    // Event 2: text — parent_user_id must equal the pre-inserted user message id.
+    let env2 = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+        .await
+        .expect("SSE event 2 must arrive")
+        .expect("SSE channel open");
+    let d2: Value = serde_json::from_str(&env2.data).unwrap();
+    assert_eq!(d2["event_type"], "session.message");
+    assert_eq!(d2["turn_id"], turn_id.to_string());
+    assert_eq!(
+        d2["parent_user_id"],
+        user_msg_id.to_string(),
+        "parent_user_id on assistant frame must equal the user message row id"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the two spec gaps in the Wave 9 turn-identity contract that were identified after the Architect's plan was formally approved:

- **`parent_user_id` missing from SSE frames** — spec §4.2 requires `parent_user_id` on every v2 frame; only `turn_id` was emitted before.
- **No legacy backfill** — migration 022 was additive-only; migration 023 backfills `turn_id` + `parent_user_id` for all pre-022 rows.

### Changes

| File | Change |
|---|---|
| `migrations/control/023_chat_turn_id_backfill.sql` | New: window-function backfill for pre-022 rows |
| `services/control-api/src/routes/agents/events_ingest.rs` | `fetch_parent_user_ids` helper; SSE frame gains `parent_user_id` |
| `frontend/src/lib/chat-api.ts` | `ChatSessionEventEnvelope` gains `parent_user_id?: string \| null` |
| `services/control-api/tests/integration_events_ingest_chat_tests.rs` | New integration test: null on user_input, UUID on text frames |

### Migration notes

Migration 023 is idempotent (only updates rows where `turn_id IS NULL`). Compose/migrate-then-deploy ordering applies: migration runs before the new binary starts, consistent with the Wave 9 deployment sequence.

## GitHub Issue
Closes #752

## Checklist
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p control-api --lib` passes (453 tests)
- [x] `cargo deny check` passes
- [x] No tracker IDs outside the title bracket prefix