### PR TITLE
[REQ-FE-34] feat(chat): modernize tool-call UI — status icons, syntax-highlighted I/O, copy, markdown results

### DIFF
--- a/frontend/src/components/chat/ToolCallBlock.test.ts
+++ b/frontend/src/components/chat/ToolCallBlock.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { looksLikeMarkdown, needsTruncation } from "./tool-call-utils";
+
+describe("looksLikeMarkdown", () => {
+  it("returns false for a JSON object string", () => {
+    expect(looksLikeMarkdown('{"key": "value"}')).toBe(false);
+  });
+
+  it("returns false for a JSON array string", () => {
+    expect(looksLikeMarkdown("[1, 2, 3]")).toBe(false);
+  });
+
+  it("returns false for a JSON number string", () => {
+    expect(looksLikeMarkdown("42")).toBe(false);
+  });
+
+  it("returns false for a JSON boolean string", () => {
+    expect(looksLikeMarkdown("true")).toBe(false);
+  });
+
+  it("returns false for a JSON null string", () => {
+    expect(looksLikeMarkdown("null")).toBe(false);
+  });
+
+  it("returns true for plain text", () => {
+    expect(looksLikeMarkdown("Result: success")).toBe(true);
+  });
+
+  it("returns true for markdown with headings", () => {
+    expect(looksLikeMarkdown("# Heading\n\nSome content here.")).toBe(true);
+  });
+
+  it("returns true for multi-line text output", () => {
+    expect(looksLikeMarkdown("Line one\nLine two\nLine three")).toBe(true);
+  });
+
+  it("returns true for an empty string (not valid JSON)", () => {
+    expect(looksLikeMarkdown("")).toBe(true);
+  });
+});
+
+describe("needsTruncation", () => {
+  it("returns false for short content", () => {
+    expect(needsTruncation("a\nb\nc")).toBe(false);
+  });
+
+  it("returns false for exactly 200 lines", () => {
+    const content = Array.from({ length: 200 }, (_, i) => `line ${i}`).join(
+      "\n",
+    );
+    expect(needsTruncation(content)).toBe(false);
+  });
+
+  it("returns true for content over 200 lines", () => {
+    const content = Array.from({ length: 201 }, (_, i) => `line ${i}`).join(
+      "\n",
+    );
+    expect(needsTruncation(content)).toBe(true);
+  });
+
+  it("returns true for content over 8KB regardless of line count", () => {
+    const content = "a".repeat(8193);
+    expect(needsTruncation(content)).toBe(true);
+  });
+
+  it("returns false for content exactly at 8KB limit with few lines", () => {
+    const content = "a".repeat(8192);
+    expect(needsTruncation(content)).toBe(false);
+  });
+});

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -222,6 +222,7 @@ export function ToolCallBlock({
             aria-hidden="true"
           />
         )}
+        <span className="sr-only">{statusLabel}</span>
         <span className="ml-auto shrink-0 text-xs text-muted-foreground" aria-hidden="true">
           {open ? "▲" : "▼"}
         </span>

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -1,4 +1,167 @@
-import { useState } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import PrismLight from "react-syntax-highlighter/dist/esm/prism-light";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
+import { cn } from "@/lib/utils";
+import { MarkdownContent } from "./MarkdownContent";
+import { looksLikeMarkdown, needsTruncation } from "./tool-call-utils";
+
+PrismLight.registerLanguage("json", json);
+
+const TRUNCATE_LINES = 200;
+
+function isEmptyInput(input: unknown): boolean {
+  if (input === null || input === undefined) return true;
+  if (
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    Object.keys(input as Record<string, unknown>).length === 0
+  )
+    return true;
+  return false;
+}
+
+function CopyButton({ text }: { readonly text: string }): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(text).then(
+      () => {
+        setCopied(true);
+        if (timerRef.current !== null) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), 2000);
+      },
+      () => {
+        /* clipboard write rejected — silently fail */
+      },
+    );
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-100"
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
+function JsonBlock({ value }: { readonly value: string }): JSX.Element {
+  const truncate = needsTruncation(value);
+  const [showMore, setShowMore] = useState(false);
+  const lines = value.split("\n");
+  const displayValue =
+    truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : value;
+
+  return (
+    <div className="overflow-hidden rounded bg-zinc-900">
+      <div className="flex items-center justify-end bg-zinc-800 px-2 py-1">
+        <CopyButton text={value} />
+      </div>
+      <PrismLight
+        language="json"
+        style={oneDark}
+        PreTag="div"
+        customStyle={{
+          margin: 0,
+          borderRadius: 0,
+          fontSize: "0.75rem",
+          lineHeight: "1.5",
+        }}
+      >
+        {displayValue}
+      </PrismLight>
+      {truncate && (
+        <button
+          type="button"
+          onClick={() => setShowMore((s) => !s)}
+          className="flex w-full items-center justify-center gap-1 bg-zinc-800 py-1.5 text-xs text-zinc-400 hover:text-zinc-200"
+        >
+          {showMore ? (
+            <>
+              <ChevronUp className="h-3.5 w-3.5" />
+              Show less
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-3.5 w-3.5" />
+              Show more ({lines.length - TRUNCATE_LINES} more lines)
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ResultBlock({ result }: { readonly result: unknown }): JSX.Element {
+  const rawText =
+    typeof result === "string"
+      ? result
+      : JSON.stringify(result, null, 2);
+  const isMarkdown = typeof result === "string" && looksLikeMarkdown(result);
+  const truncate = needsTruncation(rawText);
+  const [showMore, setShowMore] = useState(false);
+  const lines = rawText.split("\n");
+  const displayText =
+    truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : rawText;
+
+  if (isMarkdown) {
+    return (
+      <div className="relative rounded border border-border bg-background p-3 text-sm">
+        <div className="absolute right-2 top-2">
+          <CopyButton text={rawText} />
+        </div>
+        <MarkdownContent text={displayText} />
+        {truncate && (
+          <button
+            type="button"
+            onClick={() => setShowMore((s) => !s)}
+            className="mt-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {showMore ? (
+              <>
+                <ChevronUp className="h-3.5 w-3.5" />
+                Show less
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3.5 w-3.5" />
+                Show more
+              </>
+            )}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return <JsonBlock value={rawText} />;
+}
 
 interface ToolCallBlockProps {
   readonly name: string;
@@ -17,20 +180,16 @@ export function ToolCallBlock({
 }: ToolCallBlockProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const hasResult = result !== null;
+  const running = !hasResult;
+  const error = hasResult && isError;
 
-  const containerClass = hasResult && isError
+  const containerClass = error
     ? "rounded border border-destructive/30 bg-destructive/5 px-3 py-2"
     : hasResult
       ? "rounded border border-green-200 bg-green-50/60 px-3 py-2 dark:border-green-900/40 dark:bg-green-950/20"
       : "rounded border border-blue-200 bg-blue-50/60 px-3 py-2 dark:border-blue-900/40 dark:bg-blue-950/20";
 
-  const statusBadgeClass = hasResult && isError
-    ? "rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive"
-    : hasResult
-      ? "rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/40 dark:text-green-300"
-      : "rounded bg-blue-100 px-1.5 py-0.5 font-mono text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300";
-
-  const statusLabel = hasResult && isError ? "Error" : hasResult ? "Done" : "Running…";
+  const statusLabel = running ? "Running…" : error ? "Error" : "Done";
 
   return (
     <div className={containerClass} data-testid="tool-call-block">
@@ -41,37 +200,59 @@ export function ToolCallBlock({
         aria-expanded={open}
         aria-label={`${name} tool call — ${statusLabel}`}
       >
-        <span className="font-mono text-[10px] text-muted-foreground/50 tabular-nums">
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground/50 tabular-nums">
           #{sequence}
         </span>
-        <span className={statusBadgeClass}>{name}</span>
-        <span className="text-xs text-muted-foreground">{statusLabel}</span>
-        <span className="ml-auto text-xs text-muted-foreground" aria-hidden="true">
+        <span className="max-w-[180px] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs font-medium">
+          {name}
+        </span>
+        {running ? (
+          <Loader2
+            className="h-4 w-4 animate-spin text-blue-500"
+            aria-hidden="true"
+          />
+        ) : error ? (
+          <XCircle
+            className="h-4 w-4 text-destructive"
+            aria-hidden="true"
+          />
+        ) : (
+          <CheckCircle2
+            className="h-4 w-4 text-green-600 dark:text-green-400"
+            aria-hidden="true"
+          />
+        )}
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground" aria-hidden="true">
           {open ? "▲" : "▼"}
         </span>
       </button>
-      {open && (
-        <div className="mt-2 space-y-2">
-          <div>
-            <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Input
-            </p>
-            <pre className="overflow-x-auto whitespace-pre text-xs text-muted-foreground">
-              {JSON.stringify(input, null, 2)}
-            </pre>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-2 space-y-2">
+            {!isEmptyInput(input) && (
+              <div>
+                <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Input
+                </p>
+                <JsonBlock value={JSON.stringify(input, null, 2)} />
+              </div>
+            )}
+            {hasResult && (
+              <div>
+                <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Result
+                </p>
+                <ResultBlock result={result} />
+              </div>
+            )}
           </div>
-          {hasResult && (
-            <div>
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                Result
-              </p>
-              <pre className="overflow-x-auto whitespace-pre text-xs text-muted-foreground">
-                {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
-              </pre>
-            </div>
-          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/tool-call-utils.ts
+++ b/frontend/src/components/chat/tool-call-utils.ts
@@ -1,0 +1,16 @@
+const TRUNCATE_LINES = 200;
+const TRUNCATE_BYTES = 8192;
+
+export function looksLikeMarkdown(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+export function needsTruncation(content: string): boolean {
+  if (new TextEncoder().encode(content).length > TRUNCATE_BYTES) return true;
+  return content.split("\n").length > TRUNCATE_LINES;
+}


### PR DESCRIPTION
## Summary

Modernizes `ToolCallBlock.tsx` to match Claude.ai polish. Replaces raw `<pre>` JSON dumps and plain-text status labels with:

- **Status icons**: `Loader2` (animated spinner) while running, `CheckCircle2` on success, `XCircle` on error — from `lucide-react`; `aria-label` on the button covers screen readers
- **Syntax-highlighted JSON**: `PrismLight` + `oneDark` (same stack as REQ-FE-33) for input and output when value is JSON-shaped
- **Copy buttons**: icon-only (`Copy`/`Check`) on each block, always visible, `aria-label="Copy to clipboard"`. Rationale for always-visible: tool blocks are narrow and hover-only buttons are undetectable on touch.
- **Markdown rendering**: if result is a string that fails `JSON.parse`, renders via `MarkdownContent` from REQ-FE-33 instead of a raw code block
- **Truncation**: outputs >200 lines OR >8KB collapse to first 200 lines with a "Show more / Show less" toggle
- **Hide empty input**: Input section omitted when `input` is `null`, `undefined`, or `{}`
- **Smooth expand/collapse**: CSS `grid-template-rows: 0fr → 1fr` with `transition-[grid-template-rows] duration-200` — no layout jank
- **Tool name chip**: `max-w-[180px] truncate` prevents long tool names breaking the header row

Pure helpers (`looksLikeMarkdown`, `needsTruncation`) extracted to `tool-call-utils.ts` to satisfy `react-refresh/only-export-components` lint rule.

## Changes

| File | Action |
|---|---|
| `frontend/src/components/chat/ToolCallBlock.tsx` | Rewritten (33 → 233 lines) |
| `frontend/src/components/chat/tool-call-utils.ts` | New — pure logic helpers |
| `frontend/src/components/chat/ToolCallBlock.test.ts` | New — 14 unit tests |

## Stack Coordination with REQ-FE-33

Reuses the exact dependency set from PR #757 (`react-syntax-highlighter` PrismLight + `oneDark`, `MarkdownContent`, `lucide-react`). No new dependencies.

## GitHub Issue

Closes #758

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] 49/49 Vitest tests pass (14 new for this PR)
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR
- [x] `data-testid="tool-call-block"` and `aria-expanded` preserved