### PR TITLE
[REQ-FE-35] feat(chat): recursively decode JSON-encoded string fields in tool-call I/O

### DIFF
--- a/frontend/src/components/chat/ToolCallBlock.test.ts
+++ b/frontend/src/components/chat/ToolCallBlock.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { looksLikeMarkdown, needsTruncation } from "./tool-call-utils";
+import {
+  deepDecodeJsonStrings,
+  looksLikeMarkdown,
+  needsTruncation,
+} from "./tool-call-utils";
 
 describe("looksLikeMarkdown", () => {
   it("returns false for a JSON object string", () => {
@@ -36,6 +40,47 @@ describe("looksLikeMarkdown", () => {
 
   it("returns true for an empty string (not valid JSON)", () => {
     expect(looksLikeMarkdown("")).toBe(true);
+  });
+});
+
+describe("deepDecodeJsonStrings", () => {
+  it("(a) decodes board reproducer payload — text field expands to inner array", () => {
+    const innerArray = [{ crate_name: "src_legacy_monad", version: "0.1.0" }];
+    const input = [{ text: JSON.stringify(innerArray), type: "text" }];
+    const result = deepDecodeJsonStrings(input);
+    expect(result).toEqual([{ text: innerArray, type: "text" }]);
+  });
+
+  it("(b) leaves numeric-looking string fields intact", () => {
+    const input = { count: "42", flag: "true", label: "hello" };
+    expect(deepDecodeJsonStrings(input)).toEqual(input);
+  });
+
+  it("(c) decodes doubly-encoded JSON through both layers", () => {
+    // layer1: inner object
+    const inner = { deepest: 1 };
+    // layer2: inner JSON string nested inside an array of objects
+    const layer1Str = JSON.stringify(inner);              // '{"deepest":1}'  — starts with {
+    const midArray = [{ nested: layer1Str }];             // [{ nested: '{"deepest":1}' }]
+    const layer2Str = JSON.stringify(midArray);           // '[{"nested":"..."}]' — starts with [
+    const input = { payload: layer2Str };
+    // Expected: both layers decoded
+    expect(deepDecodeJsonStrings(input)).toEqual({
+      payload: [{ nested: inner }],
+    });
+  });
+
+  it("(d) leaves malformed JSON strings intact", () => {
+    const input = { bad: "{not json" };
+    expect(deepDecodeJsonStrings(input)).toEqual(input);
+  });
+
+  it("decodes a top-level stringified empty array", () => {
+    expect(deepDecodeJsonStrings("[]")).toEqual([]);
+  });
+
+  it("decodes a top-level stringified empty object", () => {
+    expect(deepDecodeJsonStrings("{}")).toEqual({});
   });
 });
 

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -13,7 +13,11 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
 import { cn } from "@/lib/utils";
 import { MarkdownContent } from "./MarkdownContent";
-import { looksLikeMarkdown, needsTruncation } from "./tool-call-utils";
+import {
+  deepDecodeJsonStrings,
+  looksLikeMarkdown,
+  needsTruncation,
+} from "./tool-call-utils";
 
 PrismLight.registerLanguage("json", json);
 
@@ -70,7 +74,13 @@ function CopyButton({ text }: { readonly text: string }): JSX.Element {
   );
 }
 
-function JsonBlock({ value }: { readonly value: string }): JSX.Element {
+function JsonBlock({
+  value,
+  copyText,
+}: {
+  readonly value: string;
+  readonly copyText?: string;
+}): JSX.Element {
   const truncate = needsTruncation(value);
   const [showMore, setShowMore] = useState(false);
   const lines = value.split("\n");
@@ -80,7 +90,7 @@ function JsonBlock({ value }: { readonly value: string }): JSX.Element {
   return (
     <div className="overflow-hidden rounded bg-zinc-900">
       <div className="flex items-center justify-end bg-zinc-800 px-2 py-1">
-        <CopyButton text={value} />
+        <CopyButton text={copyText ?? value} />
       </div>
       <PrismLight
         language="json"
@@ -160,7 +170,8 @@ function ResultBlock({ result }: { readonly result: unknown }): JSX.Element {
     );
   }
 
-  return <JsonBlock value={rawText} />;
+  const decodedText = JSON.stringify(deepDecodeJsonStrings(result), null, 2) ?? rawText;
+  return <JsonBlock value={decodedText} copyText={rawText} />;
 }
 
 interface ToolCallBlockProps {
@@ -240,7 +251,10 @@ export function ToolCallBlock({
                 <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                   Input
                 </p>
-                <JsonBlock value={JSON.stringify(input, null, 2)} />
+                <JsonBlock
+                  value={JSON.stringify(deepDecodeJsonStrings(input), null, 2)}
+                  copyText={JSON.stringify(input, null, 2)}
+                />
               </div>
             )}
             {hasResult && (

--- a/frontend/src/components/chat/tool-call-utils.ts
+++ b/frontend/src/components/chat/tool-call-utils.ts
@@ -1,6 +1,32 @@
 const TRUNCATE_LINES = 200;
 const TRUNCATE_BYTES = 8192;
 
+export function deepDecodeJsonStrings(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepDecodeJsonStrings);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        deepDecodeJsonStrings(v),
+      ]),
+    );
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        const parsed: unknown = JSON.parse(value);
+        if (parsed !== null && typeof parsed === "object") {
+          return deepDecodeJsonStrings(parsed);
+        }
+      } catch {
+        // not valid JSON — leave as-is
+      }
+    }
+  }
+  return value;
+}
+
 export function looksLikeMarkdown(value: string): boolean {
   try {
     JSON.parse(value);


### PR DESCRIPTION
## Summary

MCP tool responses commonly return content-block arrays where string fields hold nested JSON. The current renderer calls `JSON.stringify` once — so `[{"text": "[{\"crate_name\":...}]", "type": "text"}]` displays as an escaped wall of `\"` characters instead of an expanded inner array.

This PR adds a **recursive decode pass** (`deepDecodeJsonStrings`) that, while walking tool-call input/result, replaces any string value whose content is a JSON object or array with the parsed form, then recurses. Primitives (`"42"`, `"true"`, plain text) are left intact. The copy button continues to copy the **original wire-format** text.

**Changes:**

- `tool-call-utils.ts` — `deepDecodeJsonStrings` (≤25 LOC, pure JS, no new dependency)
- `ToolCallBlock.tsx` — `JsonBlock` gains an optional `copyText` prop; `ResultBlock` (non-markdown path) and input rendering path both apply the decode before display
- `ToolCallBlock.test.ts` — 6 new unit tests (board reproducer, numeric-string no-decode, double-encode, malformed JSON, empty array/object)

## Before / After

**Before** (board reproducer payload `[{"text": "[{\"crate_name\":\"src_legacy_monad\"}]", "type": "text"}]`):
```
[
  {
    "text": "[{\"crate_name\":\"src_legacy_monad\"}]",
    "type": "text"
  }
]
```

**After** (text field decoded to its inner array, syntax-highlighted):
```
[
  {
    "text": [
      {
        "crate_name": "src_legacy_monad"
      }
    ],
    "type": "text"
  }
]
```

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (no API types changed)
- [x] `npm run build` passes
- [x] 20/20 Vitest tests pass (6 new)
- [x] No internal tracker IDs in diff

## GitHub Issue

Closes #760