### PR TITLE
[REQ-FE-36] fix(theme): white overscroll band — set html background in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,8 +53,13 @@
   * {
     @apply border-border;
   }
+  html {
+    @apply bg-background;
+    min-height: 100%;
+  }
   body {
     @apply bg-background text-foreground antialiased;
+    min-height: 100%;
     font-family:
       ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
       "Helvetica Neue", Arial, "Noto Sans", sans-serif;


### PR DESCRIPTION
## Summary

- Adds `html { @apply bg-background; min-height: 100%; }` to `@layer base` in `frontend/src/index.css`.
- Adds `min-height: 100%` to `body` for belt-and-braces coverage.

Previously only `body` had `bg-background`, leaving `<html>` transparent. The browser's white canvas showed through on macOS/iOS rubber-band overscroll and any moment the body bounding box didn't reach the viewport edge. With `<html>` now themed, the dark background fills the entire document root in dark mode.

No other files changed. No overscroll-behavior change applied (not required by the acceptance criteria reproducer).

## GitHub Issue
Closes #762

## Screenshots

> Dark mode before: white band visible below footer on overscroll bounce.
> Dark mode after: dark background extends to the canvas edge — no white flash.
> (Screenshot to be confirmed by QA on mars deploy.)

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR