### PR TITLE
[REQ-FE-37] fix(theme): scope auth.css to .auth-shell — global body bg leaks into dark mode

### DIFF
--- a/frontend/src/styles/auth.css
+++ b/frontend/src/styles/auth.css
@@ -1,22 +1,15 @@
-/* REQ-FE-02: minimal styling for auth surfaces. Tailwind/shadcn arrives with
-   REQ-FE-01 (app shell). Until then, keep the CSS surface tiny and scoped. */
-:root {
-  color-scheme: light;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-}
-
-body {
-  margin: 0;
-  background: #f6f7fb;
-  color: #111827;
-}
-
+/* Auth-only surface styles — intentionally light regardless of system theme.
+   Global :root and body rules removed; Tailwind base (index.css) owns those. */
 .auth-shell {
+  color-scheme: light;
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 2rem 1rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: #f6f7fb;
+  color: #111827;
 }
 
 .auth-card {


### PR DESCRIPTION
## Summary

- Removes the unscoped `:root { color-scheme: light; font-family: ... }` and `body { background: #f6f7fb; color: #111827; }` blocks from `auth.css`
- Moves all three properties (`background`, `color`, `font-family`) plus `color-scheme: light` into `.auth-shell` so they apply only to auth pages
- `body { background }` in `auth.css` was imported after `index.css` in `main.tsx`, overriding Tailwind's `bg-background` on `body` and painting the macOS rubber-band overscroll region light-gray in dark mode

## GitHub Issue

Closes #764

## Root cause

`main.tsx` import order:
```ts
import "@/index.css";       // Tailwind base — body { @apply bg-background }
import "./styles/auth.css"; // ← imported AFTER, wins on body selector
```

`auth.css` had `body { background: #f6f7fb }` — a light-gray value that beat the dark theme color. The fix scopes everything to `.auth-shell`.

## Verification

- Auth pages (`/login`, OAuth callback) keep the light-gray centered-card look (`.auth-shell` still sets `background: #f6f7fb`)
- Dark-mode non-auth pages (chat, repos, agents, …) no longer bleed light-gray on overscroll

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR