### PR TITLE
[REQ-FE-38] fix(chat): lock chat to 100vh — no scroll-past-AppShell, no exposed page bg

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -12,7 +12,7 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
   const chatEnabled = useChatFeatureEnabled();
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
       <header className="border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-14 items-center justify-between gap-4">
           <Link
@@ -75,7 +75,7 @@ export function AppShell({ children }: AppShellProps): JSX.Element {
           </div>
         </div>
       </header>
-      <main className="flex-1">{children}</main>
+      <main className="flex-1 min-h-0 overflow-auto">{children}</main>
       <footer className="border-t border-border py-4">
         <div className="container text-xs text-muted-foreground">
           Rustacean control plane

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -24,7 +24,7 @@ export function ChatPage(): JSX.Element {
 
   if (me.isLoading) {
     return (
-      <div className="flex h-[calc(100vh-3.5rem-4rem)] items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <p className="text-sm text-muted-foreground">Loading…</p>
       </div>
     );
@@ -32,7 +32,7 @@ export function ChatPage(): JSX.Element {
 
   if (me.isError || !me.data) {
     return (
-      <div className="flex h-[calc(100vh-3.5rem-4rem)] items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <p className="text-sm text-muted-foreground">Sign in to use Chat.</p>
       </div>
     );
@@ -135,7 +135,7 @@ function ChatInner({ tenantId }: ChatInnerProps): JSX.Element {
   const sessionList = sessions.data?.sessions ?? [];
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem-4rem)]">
+    <div className="flex h-full overflow-hidden">
       <SessionSidebar
         sessions={sessionList}
         activeSessionId={activeSessionId}


### PR DESCRIPTION
## Summary

Fixes a structural layout bug that allowed 6–14 px of document scroll on `/chat`, exposing bare page background below the chat surface.

**Root cause:** `AppShell` used `min-h-screen` (allows document growth past 100vh) and `ChatPage` used `h-[calc(100vh-3.5rem-4rem)]` assuming a 64 px footer when the actual footer is ~49 px (`border-t py-4`). The arithmetic mismatch meant the chat surface was shorter than the available viewport, and `min-h-screen` allowed the extra whitespace to be scrollable.

**Fix (Option C — remove pixel arithmetic entirely):**

| Location | Before | After |
|---|---|---|
| `AppShell` outer div | `flex min-h-screen flex-col` | `flex h-screen flex-col overflow-hidden` |
| `AppShell` `<main>` | `flex-1` | `flex-1 min-h-0 overflow-auto` |
| `ChatPage` container | `flex h-[calc(100vh-3.5rem-4rem)]` | `flex h-full overflow-hidden` |
| `ChatPage` loading/error states | `flex h-[calc(…)] items-center justify-center` | `flex h-full items-center justify-center` |

AppShell is now locked to exactly 100vh. The `<main>` element distributes remaining height via flex and provides its own `overflow-auto` so non-chat pages still scroll normally within the main content area. ChatPage fills `<main>` exactly with `h-full`; `overflow-hidden` on the chat div prevents any wheel event from reaching document scroll.

## GitHub Issue

Closes #766

## Screenshots

*(Before/after screenshots to be captured on mars after deploy — dark and light mode)*

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR