### PR TITLE
[REQ-FE-40] fix(chat): guard slice calls on undefined during session switch

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-2026.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-2026.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_EMPTY_RESPONSE,
+} from "./fixtures/mock-api";
+import {
+  mockChatStream,
+  mockListChatMessages,
+  LIST_MESSAGES_EMPTY,
+} from "./fixtures/chat-mock-api";
+
+// ---------------------------------------------------------------------------
+// RUSAA-2026 regression guard: session switch must never throw a JS error
+//
+// Root cause: two `.slice()` calls on potentially-undefined values:
+//  1. SessionSidebar.tsx — session.id.slice(0,8) when server returns session_id
+//  2. MessageThread.tsx  — thinking.slice(0,80) when thinking payload is undefined
+//
+// Fix: nullish guards at both call sites + Zod parse in listSessions hook.
+// ---------------------------------------------------------------------------
+
+const CHAT_URL = "/chat";
+
+const SESSION_A_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const SESSION_B_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const TWO_SESSIONS_RESPONSE = {
+  sessions: [
+    {
+      id: SESSION_A_ID,
+      tenant_id: "tenant-1",
+      user_id: "user-1",
+      runtime: "claude_code",
+      status: "active",
+      trace_id: "trace-aaa",
+      created_at: "2026-06-01T00:00:00Z",
+      last_activity_at: "2026-06-01T00:01:00Z",
+      ended_at: null,
+    },
+    {
+      id: SESSION_B_ID,
+      tenant_id: "tenant-1",
+      user_id: "user-1",
+      runtime: "claude_code",
+      status: "active",
+      trace_id: "trace-bbb",
+      created_at: "2026-06-02T00:00:00Z",
+      last_activity_at: "2026-06-02T00:01:00Z",
+      ended_at: null,
+    },
+  ],
+};
+
+// A sessions list where the server uses `session_id` instead of `id` (legacy shape).
+// The Zod normaliser in useChatSessions must coerce this without crashing.
+const SESSION_ID_SNAKE_CASE_RESPONSE = {
+  sessions: [
+    {
+      session_id: SESSION_A_ID,
+      tenant_id: "tenant-1",
+      user_id: "user-1",
+      runtime: "claude_code",
+      status: "active",
+      trace_id: "trace-aaa",
+      created_at: "2026-06-01T00:00:00Z",
+      last_activity_at: "2026-06-01T00:01:00Z",
+      ended_at: null,
+    },
+    {
+      session_id: SESSION_B_ID,
+      tenant_id: "tenant-1",
+      user_id: "user-1",
+      runtime: "claude_code",
+      status: "active",
+      trace_id: "trace-bbb",
+      created_at: "2026-06-02T00:00:00Z",
+      last_activity_at: "2026-06-02T00:01:00Z",
+      ended_at: null,
+    },
+  ],
+};
+
+// SSE stream with a thinking event that has an undefined `thinking` field (malformed).
+const SSE_MALFORMED_THINKING = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: SESSION_A_ID,
+    event_type: "thinking",
+    sequence: 1,
+    payload: { type: "thinking" /* missing `thinking` field */ },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+async function setupTwoSessionsPage(
+  page: Page,
+  sessionsResponse: { sessions: unknown[] } = TWO_SESSIONS_RESPONSE,
+  sseBodyA = "",
+  sseBodyB = "",
+): Promise<void> {
+  await mockAuthenticatedSession(page);
+  await mockReposList(page, REPOS_EMPTY_RESPONSE);
+
+  // Mock session list (GET returns both sessions; POST creates)
+  await page.route("**/v1/chat/sessions", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: sessionsResponse });
+    }
+    return route.continue();
+  });
+
+  await mockListChatMessages(page, SESSION_A_ID, LIST_MESSAGES_EMPTY);
+  await mockListChatMessages(page, SESSION_B_ID, LIST_MESSAGES_EMPTY);
+  await mockChatStream(page, SESSION_A_ID, sseBodyA);
+  await mockChatStream(page, SESSION_B_ID, sseBodyB);
+}
+
+test.describe("Chat session switch — no JS crash (RUSAA-2026)", () => {
+  test("switching between two sessions 10 times emits no pageerror", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await setupTwoSessionsPage(page);
+    await page.goto(`${CHAT_URL}?sessionId=${SESSION_A_ID}`);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+
+    const sessionButtons = page.getByRole("list").getByRole("button");
+    await expect(sessionButtons).toHaveCount(2);
+
+    // Click between the two sessions 10 times (5 round-trips).
+    for (let i = 0; i < 10; i++) {
+      const target = i % 2 === 0 ? SESSION_B_ID : SESSION_A_ID;
+      await page.goto(`${CHAT_URL}?sessionId=${target}`);
+      await page.waitForSelector("aside[aria-label='Chat sessions']");
+    }
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("sessions with snake_case session_id render without crash", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await setupTwoSessionsPage(page, SESSION_ID_SNAKE_CASE_RESPONSE);
+    await page.goto(CHAT_URL);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+
+    // Sessions should still be rendered (normalised from session_id → id)
+    const sessionButtons = page.getByRole("list").getByRole("button");
+    await expect(sessionButtons).toHaveCount(2);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("malformed thinking SSE event (missing thinking field) does not crash", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await setupTwoSessionsPage(page, TWO_SESSIONS_RESPONSE, SSE_MALFORMED_THINKING);
+    await page.goto(`${CHAT_URL}?sessionId=${SESSION_A_ID}`);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+
+    // Switch away and back
+    await page.goto(`${CHAT_URL}?sessionId=${SESSION_B_ID}`);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+    await page.goto(`${CHAT_URL}?sessionId=${SESSION_A_ID}`);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("no 'Something went wrong' error boundary after session switch", async ({ page }) => {
+    await setupTwoSessionsPage(page);
+    await page.goto(`${CHAT_URL}?sessionId=${SESSION_A_ID}`);
+    await page.waitForSelector("aside[aria-label='Chat sessions']");
+
+    for (let i = 0; i < 6; i++) {
+      const target = i % 2 === 0 ? SESSION_B_ID : SESSION_A_ID;
+      await page.goto(`${CHAT_URL}?sessionId=${target}`);
+      await page.waitForSelector("aside[aria-label='Chat sessions']");
+    }
+
+    await expect(page.getByText("Something went wrong")).toHaveCount(0);
+    await expect(page.getByText("Cannot read properties of undefined")).toHaveCount(0);
+  });
+});

--- a/frontend/src/api/hooks/useChatSessions.ts
+++ b/frontend/src/api/hooks/useChatSessions.ts
@@ -3,6 +3,7 @@
 // in the generated openapi.json (S3 is a peer stream). Once S3 ships and
 // `npm run gen:api` regenerates the schema, migrate to the main apiClient.
 
+import { z } from "zod";
 import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from "@tanstack/react-query";
 import { toApiError, type ApiError } from "../client";
 import { chatApiClient } from "../chat-client";
@@ -15,6 +16,49 @@ import type {
   SendMessageResponse,
   ChatSession,
 } from "@/lib/chat-api";
+
+// Zod schema that accepts both `id` (current) and `session_id` (server legacy shape) and
+// normalises either to `id`. Any session row missing both is dropped rather than crashing.
+const chatSessionSchema = z
+  .object({
+    id: z.string().optional(),
+    session_id: z.string().optional(),
+    tenant_id: z.string().default(""),
+    user_id: z.string().nullable().default(null),
+    runtime: z.enum(["claude_code", "opencode", "pi"]).default("claude_code"),
+    status: z.enum(["active", "ended", "failed"]).default("active"),
+    trace_id: z.string().default(""),
+    created_at: z.string().default(""),
+    last_activity_at: z.string().default(""),
+    ended_at: z.string().nullable().default(null),
+  })
+  .transform((raw) => {
+    const id = raw.id ?? raw.session_id ?? "";
+    return {
+      id,
+      tenant_id: raw.tenant_id,
+      user_id: raw.user_id,
+      runtime: raw.runtime,
+      status: raw.status,
+      trace_id: raw.trace_id,
+      created_at: raw.created_at,
+      last_activity_at: raw.last_activity_at,
+      ended_at: raw.ended_at,
+    };
+  });
+
+function parseSessionsResponse(raw: unknown): ListChatSessionsResponse {
+  const envelope = z.object({ sessions: z.array(z.unknown()).default([]) }).safeParse(raw);
+  if (!envelope.success) return { sessions: [] };
+  const sessions: ChatSession[] = [];
+  for (const item of envelope.data.sessions) {
+    const result = chatSessionSchema.safeParse(item);
+    if (result.success && result.data.id.length > 0) {
+      sessions.push(result.data as ChatSession);
+    }
+  }
+  return { sessions };
+}
 
 export const chatSessionsQueryKey = (tenantId: string) =>
   ["tenants", tenantId, "chat-sessions"] as const;
@@ -33,7 +77,7 @@ export function useChatSessions(
       if (error || !data) {
         throw toApiError(response.status, error, response);
       }
-      return data;
+      return parseSessionsResponse(data);
     },
     enabled: tenantId.length > 0,
     staleTime: 15_000,

--- a/frontend/src/components/chat/MessageThread.tsx
+++ b/frontend/src/components/chat/MessageThread.tsx
@@ -125,13 +125,14 @@ function ThinkingBlock({
   readonly thinking: string;
   readonly sequence: number;
 }): JSX.Element {
-  const preview = thinking.slice(0, 80);
+  const safeThinking = thinking ?? "";
+  const preview = safeThinking.slice(0, 80);
   return (
     <details className="rounded border border-border/40 bg-muted/10 px-3 py-2 text-xs">
       <summary className="cursor-pointer text-muted-foreground">
-        #{sequence} Thinking: {preview}{thinking.length > 80 ? "…" : ""}
+        #{sequence} Thinking: {preview}{safeThinking.length > 80 ? "…" : ""}
       </summary>
-      <MarkdownContent text={thinking} className="mt-2 text-muted-foreground" />
+      <MarkdownContent text={safeThinking} className="mt-2 text-muted-foreground" />
     </details>
   );
 }

--- a/frontend/src/components/chat/SessionSidebar.tsx
+++ b/frontend/src/components/chat/SessionSidebar.tsx
@@ -111,7 +111,7 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps): JSX.Elemen
           <span className="text-xs font-medium">{runtimeLabel}</span>
         </div>
         <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
-          {session.id.slice(0, 8)}…
+          {(session.id ?? "").slice(0, 8)}…
         </p>
         <p className="mt-0.5 text-[10px] text-muted-foreground/60">{created}</p>
       </button>

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -80,6 +80,8 @@ export function appendAssistantItem(
     return [...pending, { type: "text", text: payload.text, seq: sequence }];
   }
   if (payload.type === "thinking") {
+    // Guard: server may omit `thinking` or use a different field; skip the item rather than storing undefined.
+    if (typeof payload.thinking !== "string") return pending;
     return [...pending, { type: "thinking", thinking: payload.thinking, seq: sequence }];
   }
   if (payload.type === "tool_use") {


### PR DESCRIPTION
## Summary

- Three `.slice()` (and related) call sites in the chat render path could throw \"Cannot read properties of undefined (reading 'slice')\" when switching sessions, firing the React error boundary and leaving the page half-blank.
- Root causes: `SessionSidebar.tsx` hit `session.id.slice(0,8)` when server returned `session_id`; `MessageThread.tsx` hit `thinking.slice(0,80)` when thinking payload was missing the `thinking` field; `transcript.ts` passed `undefined` downstream without a guard.
- Fixed with nullish coalescing at each call site, an early-return guard in `transcript.ts`, and a Zod parse at the `useChatSessions` API boundary that normalises `session_id → id` and drops malformed rows fail-soft.

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] `PLAYWRIGHT_CHAT_SMOKE=1 npx playwright test --project=chat-smoke chat-panel-rusaa-2026` — 4/4 pass
  - switching 10 times emits no `pageerror`
  - snake_case `session_id` response renders without crash
  - malformed thinking SSE event does not crash
  - no "Something went wrong" error boundary after session switch

## Closes
Closes #774