### PR TITLE
[RUSAA-2031] chore(compose): upgrade qdrant depends_on to service_healthy

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -285,7 +285,7 @@ services:
       neo4j:
         condition: service_healthy
       qdrant:
-        condition: service_started
+        condition: service_healthy
       ollama:
         condition: service_started
       otel-collector:
@@ -514,7 +514,7 @@ services:
       kafka:
         condition: service_healthy
       qdrant:
-        condition: service_started
+        condition: service_healthy
       ollama:
         condition: service_started
       otel-collector:


### PR DESCRIPTION
## Summary

- `control-api` and `embed-worker` declared `depends_on: qdrant: condition: service_started`, allowing them to start before qdrant's REST port was accepting connections.
- Qdrant already has a `healthcheck` in `compose/dev.yml`; upgrading both entries to `condition: service_healthy` gates startup on the healthcheck passing.

## GitHub Issue

Closes #776

## Migration type

No schema migration.

## Verification

Verified on mars dev stack after restoring qdrant + ollama + otel-collector (all exited exit-255 4 days ago — host event, same root cause):

```
rustbrain-dev-qdrant-1     Up 5 min (healthy)    # restart:unless-stopped via tailscale.yml
rustbrain-dev-embed-worker-1  Up 5 min           # vector upserted logs confirm ollama→qdrant pipeline live
```

```
curl http://127.0.0.1:16333/healthz  →  healthz check passed
POST /mcp tools/call search_items    →  HTTP 200, ranked results
```

## Checklist
- [x] No Rust code changed — compose-only, no cargo build needed
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] Docs unchanged (no architecture change)