### PR TITLE
[REQ-FE-41] fix(chat): merge consecutive thinking deltas — eliminate duplicate #0 Thinking accordions

### DIFF
--- a/frontend/src/components/chat/merge-transcript.test.ts
+++ b/frontend/src/components/chat/merge-transcript.test.ts
@@ -302,3 +302,60 @@ describe("mergeTranscript — signal shape 10: three-turn v2 all from DB, no liv
     expect(texts).toEqual(["a1", "a2", "a3"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// RUSAA-2035: thinking-delta merge — split-batch concat path
+// ---------------------------------------------------------------------------
+
+describe("mergeTranscript — RUSAA-2035: thinking blocks collapsed on split-batch concat", () => {
+  it("collapses trailing thinking + leading thinking when merging two split-batch rows", () => {
+    // Control-api emitted two rows for the same turn_id:
+    // row 1: [thinking:"chunk1"]
+    // row 2: [thinking:"chunk2", text:"Answer."]
+    const hist: ChatMessage[] = [
+      histMsg("u1", 1, "user", "q", TURN_X),
+      histMsg("a1", 2, "assistant", JSON.stringify([
+        { type: "thinking", thinking: "chunk1" },
+      ]), TURN_X),
+      histMsg("a2", 3, "assistant", JSON.stringify([
+        { type: "thinking", thinking: "chunk2" },
+        { type: "text", text: "Answer." },
+      ]), TURN_X),
+    ];
+    const items = mergeTranscript(hist, []);
+
+    expect(items).toHaveLength(2);
+    const a = items[1];
+    expect(a?.kind).toBe("assistant");
+    if (a?.kind !== "assistant") throw new Error("unreachable");
+    // Must be ONE thinking + ONE text — not two thinking items
+    expect(a.items).toHaveLength(2);
+    expect(a.items[0]).toMatchObject({ type: "thinking", thinking: "chunk1chunk2" });
+    expect(a.items[1]).toMatchObject({ type: "text", text: "Answer." });
+  });
+
+  it("does NOT collapse thinking blocks separated by another item type", () => {
+    // row 1: [thinking:"before", text:"middle"]
+    // row 2: [thinking:"after"]
+    // The thinking blocks are not adjacent after concat so should stay separate.
+    const hist: ChatMessage[] = [
+      histMsg("u1", 1, "user", "q", TURN_X),
+      histMsg("a1", 2, "assistant", JSON.stringify([
+        { type: "thinking", thinking: "before" },
+        { type: "text", text: "middle" },
+      ]), TURN_X),
+      histMsg("a2", 3, "assistant", JSON.stringify([
+        { type: "thinking", thinking: "after" },
+      ]), TURN_X),
+    ];
+    const items = mergeTranscript(hist, []);
+
+    expect(items).toHaveLength(2);
+    const a = items[1];
+    if (a?.kind !== "assistant") throw new Error("unreachable");
+    expect(a.items).toHaveLength(3);
+    expect(a.items[0]?.type).toBe("thinking");
+    expect(a.items[1]?.type).toBe("text");
+    expect(a.items[2]?.type).toBe("thinking");
+  });
+});

--- a/frontend/src/components/chat/merge-transcript.ts
+++ b/frontend/src/components/chat/merge-transcript.ts
@@ -20,6 +20,23 @@ import {
 // v2 identity-based merge: buildLiveTurnMap + mergeTranscript
 // ---------------------------------------------------------------------------
 
+/** Concatenate two item arrays, merging a trailing thinking block with a leading thinking block. */
+function concatMergingThinking(
+  a: ReadonlyArray<AssistantItem>,
+  b: ReadonlyArray<AssistantItem>,
+): ReadonlyArray<AssistantItem> {
+  const lastA = a[a.length - 1];
+  const firstB = b[0];
+  if (lastA?.type === "thinking" && firstB?.type === "thinking") {
+    return [
+      ...a.slice(0, -1),
+      { type: "thinking", thinking: lastA.thinking + firstB.thinking, seq: lastA.seq },
+      ...b.slice(1),
+    ];
+  }
+  return [...a, ...b];
+}
+
 /** Concatenate text items from a live turn for content-based dedup. */
 function extractLiveText(items: ReadonlyArray<AssistantItem>): string {
   return items
@@ -207,7 +224,7 @@ export function mergeTranscript(
         const existing = result[existingIdx] as AssistantTranscriptItem;
         const mergedItems = live?.isInProgress
           ? live.items
-          : [...existing.items, ...newItems];
+          : concatMergingThinking(existing.items, newItems);
         const updatedItem: AssistantTranscriptItem = {
           kind: "assistant",
           id: existing.id,

--- a/frontend/src/components/chat/transcript.test.ts
+++ b/frontend/src/components/chat/transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTranscript, buildTranscriptFromHistory } from "./transcript";
+import { buildTranscript, buildTranscriptFromHistory, appendAssistantItem, tryParseContentBlocks } from "./transcript";
 import type { StreamedEvent } from "@/hooks/useEventStream";
 import type { ChatMessage } from "@/lib/chat-api";
 
@@ -410,6 +410,133 @@ describe("buildTranscript — text-before-tool_use merge (RUSAA-1966)", () => {
     if (a2?.kind !== "assistant") throw new Error("unreachable");
     expect(a2.items[0]?.type).toBe("tool_use");
     expect(a2.inProgress).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RUSAA-2035: thinking-delta merge
+// ---------------------------------------------------------------------------
+
+describe("appendAssistantItem — consecutive thinking deltas merged (live-stream path)", () => {
+  it("merges two consecutive thinking payloads into one item", () => {
+    let items = appendAssistantItem([], { type: "thinking", thinking: "Step 1." }, 1);
+    items = appendAssistantItem(items, { type: "thinking", thinking: " Step 2." }, 2);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "thinking", thinking: "Step 1. Step 2.", seq: 1 });
+  });
+
+  it("merges N consecutive thinking payloads into one item", () => {
+    let items = appendAssistantItem([], { type: "thinking", thinking: "A" }, 1);
+    items = appendAssistantItem(items, { type: "thinking", thinking: "B" }, 2);
+    items = appendAssistantItem(items, { type: "thinking", thinking: "C" }, 3);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "thinking", thinking: "ABC", seq: 1 });
+  });
+
+  it("does NOT merge thinking with a following text item", () => {
+    let items = appendAssistantItem([], { type: "thinking", thinking: "Thinking..." }, 1);
+    items = appendAssistantItem(items, { type: "text", text: "Answer." }, 2);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.type).toBe("thinking");
+    expect(items[1]?.type).toBe("text");
+  });
+
+  it("does NOT merge text with a following thinking item", () => {
+    let items = appendAssistantItem([], { type: "text", text: "prefix" }, 1);
+    items = appendAssistantItem(items, { type: "thinking", thinking: "Thinking..." }, 2);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.type).toBe("text");
+    expect(items[1]?.type).toBe("thinking");
+  });
+
+  it("buildTranscript: live stream with many thinking chunks yields one thinking item", () => {
+    const events: StreamedEvent[] = [
+      sseEvent({ type: "user_input", text: "hello" }, 1),
+      sseEvent({ type: "thinking", thinking: "chunk1" }, 2),
+      sseEvent({ type: "thinking", thinking: "chunk2" }, 3),
+      sseEvent({ type: "thinking", thinking: "chunk3" }, 4),
+      sseEvent({ type: "text", text: "Answer." }, 5),
+      sseEvent({ type: "turn_complete", stop_reason: "end_turn" }, 6),
+    ];
+    const items = buildTranscript(events);
+
+    expect(items).toHaveLength(2);
+    const assistant = items[1];
+    if (assistant?.kind !== "assistant") throw new Error("unreachable");
+    expect(assistant.items).toHaveLength(2);
+    expect(assistant.items[0]).toMatchObject({ type: "thinking", thinking: "chunk1chunk2chunk3", seq: 2 });
+    expect(assistant.items[1]).toMatchObject({ type: "text", text: "Answer." });
+  });
+});
+
+describe("tryParseContentBlocks — adjacent thinking blocks collapsed (single-row parse path)", () => {
+  it("collapses two adjacent thinking blocks in a single DB row", () => {
+    const body = JSON.stringify([
+      { type: "thinking", thinking: "Part A." },
+      { type: "thinking", thinking: " Part B." },
+    ]);
+    const blocks = tryParseContentBlocks(body);
+
+    expect(blocks).not.toBeNull();
+    expect(blocks).toHaveLength(1);
+    expect(blocks![0]).toMatchObject({ type: "thinking", thinking: "Part A. Part B.", seq: 0 });
+  });
+
+  it("collapses N adjacent thinking blocks in a single DB row", () => {
+    const body = JSON.stringify([
+      { type: "thinking", thinking: "X" },
+      { type: "thinking", thinking: "Y" },
+      { type: "thinking", thinking: "Z" },
+    ]);
+    const blocks = tryParseContentBlocks(body);
+
+    expect(blocks).not.toBeNull();
+    expect(blocks).toHaveLength(1);
+    expect(blocks![0]).toMatchObject({ type: "thinking", thinking: "XYZ", seq: 0 });
+  });
+
+  it("does NOT collapse thinking blocks separated by a text block", () => {
+    const body = JSON.stringify([
+      { type: "thinking", thinking: "Before." },
+      { type: "text", text: "Response." },
+      { type: "thinking", thinking: "After." },
+    ]);
+    const blocks = tryParseContentBlocks(body);
+
+    expect(blocks).not.toBeNull();
+    expect(blocks).toHaveLength(3);
+    expect(blocks![0]?.type).toBe("thinking");
+    expect(blocks![1]?.type).toBe("text");
+    expect(blocks![2]?.type).toBe("thinking");
+  });
+
+  it("buildTranscriptFromHistory: historical row with many thinking blocks renders as one accordion", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", seq: 1, role: "user", body: "q", created_at: "2026-01-01T00:00:00Z" },
+      {
+        id: "a1",
+        seq: 2,
+        role: "assistant",
+        body: JSON.stringify([
+          { type: "thinking", thinking: "chunk1" },
+          { type: "thinking", thinking: "chunk2" },
+          { type: "text", text: "Done." },
+        ]),
+        created_at: "2026-01-01T00:00:01Z",
+      },
+    ];
+    const items = buildTranscriptFromHistory(messages);
+
+    expect(items).toHaveLength(2);
+    const a = items[1];
+    if (a?.kind !== "assistant") throw new Error("unreachable");
+    expect(a.items).toHaveLength(2);
+    expect(a.items[0]).toMatchObject({ type: "thinking", thinking: "chunk1chunk2" });
+    expect(a.items[1]).toMatchObject({ type: "text", text: "Done." });
   });
 });
 

--- a/frontend/src/components/chat/transcript.ts
+++ b/frontend/src/components/chat/transcript.ts
@@ -82,6 +82,13 @@ export function appendAssistantItem(
   if (payload.type === "thinking") {
     // Guard: server may omit `thinking` or use a different field; skip the item rather than storing undefined.
     if (typeof payload.thinking !== "string") return pending;
+    const lastThinking = pending[pending.length - 1];
+    if (lastThinking?.type === "thinking") {
+      return [
+        ...pending.slice(0, -1),
+        { type: "thinking", thinking: lastThinking.thinking + payload.thinking, seq: lastThinking.seq },
+      ];
+    }
     return [...pending, { type: "thinking", thinking: payload.thinking, seq: sequence }];
   }
   if (payload.type === "tool_use") {
@@ -131,7 +138,12 @@ export function tryParseContentBlocks(body: string): ReadonlyArray<AssistantItem
     if (b.type === "text" && typeof b.text === "string") {
       result.push({ type: "text", text: b.text, seq: idx });
     } else if (b.type === "thinking" && typeof b.thinking === "string") {
-      result.push({ type: "thinking", thinking: b.thinking, seq: idx });
+      const lastThinking = result[result.length - 1];
+      if (lastThinking?.type === "thinking") {
+        result[result.length - 1] = { type: "thinking", thinking: lastThinking.thinking + b.thinking, seq: lastThinking.seq };
+      } else {
+        result.push({ type: "thinking", thinking: b.thinking, seq: idx });
+      }
     } else if (b.type === "tool_use" && typeof b.id === "string" && typeof b.name === "string") {
       result.push({ type: "tool_use", id: b.id, name: b.name, input: b.input, seq: idx });
     } else if (b.type === "tool_result" && typeof b.tool_use_id === "string") {


### PR DESCRIPTION
## Summary

- `appendAssistantItem()` in `transcript.ts`: mirrors the text-branch accumulator for consecutive thinking payloads during live streaming.
- `tryParseContentBlocks()` in `transcript.ts`: collapses adjacent thinking blocks during single-row historical parse so old data renders as one accordion.
- `mergeTranscript()` in `merge-transcript.ts`: new `concatMergingThinking()` helper fuses a trailing+leading thinking pair when concatenating split-batch DB rows sharing the same `turn_id`.
- New tests in `transcript.test.ts` and `merge-transcript.test.ts` cover all three merge paths (live stream, single-row parse, split-batch concat).

## GitHub Issue
Closes #778

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR