### PR TITLE
[REQ-FE-42] fix(chat): consolidate thinking accordions into one reasoning section per assistant bubble

### DIFF
--- a/frontend/src/components/chat/MessageThread.test.tsx
+++ b/frontend/src/components/chat/MessageThread.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { extractThinkingPhases, buildConsolidatedContent } from "./message-thread-utils";
+import type { AssistantItem } from "./transcript";
+
+const text = (t: string, seq: number): AssistantItem => ({ type: "text", text: t, seq });
+const thinking = (t: string, seq: number): AssistantItem => ({ type: "thinking", thinking: t, seq });
+const toolUse = (seq: number): AssistantItem => ({
+  type: "tool_use",
+  id: `tu-${seq}`,
+  name: "bash",
+  input: {},
+  seq,
+});
+const toolResult = (seq: number): AssistantItem => ({
+  type: "tool_result",
+  toolUseId: `tu-${seq - 1}`,
+  content: "ok",
+  isError: false,
+  seq,
+});
+
+describe("extractThinkingPhases", () => {
+  it("returns empty array when there are no thinking items", () => {
+    const items: AssistantItem[] = [text("hello", 1), toolUse(2), toolResult(3)];
+    expect(extractThinkingPhases(items)).toEqual([]);
+  });
+
+  it("returns single thinking content for one thinking block", () => {
+    const items: AssistantItem[] = [thinking("first thought", 1), text("answer", 2)];
+    expect(extractThinkingPhases(items)).toEqual(["first thought"]);
+  });
+
+  it("extracts all thinking phases from interleaved items", () => {
+    const items: AssistantItem[] = [
+      thinking("phase one", 1),
+      toolUse(2),
+      toolResult(3),
+      thinking("phase two", 4),
+      text("final answer", 5),
+    ];
+    expect(extractThinkingPhases(items)).toEqual(["phase one", "phase two"]);
+  });
+
+  it("includes empty thinking content in returned phases", () => {
+    const items: AssistantItem[] = [thinking("", 1), thinking("   ", 2)];
+    expect(extractThinkingPhases(items)).toEqual(["", "   "]);
+  });
+});
+
+describe("buildConsolidatedContent", () => {
+  it("returns null for empty array (no accordion)", () => {
+    expect(buildConsolidatedContent([])).toBeNull();
+  });
+
+  it("returns null when all phases are empty or whitespace (no accordion)", () => {
+    expect(buildConsolidatedContent(["", "  ", "\n"])).toBeNull();
+  });
+
+  it("returns content string for a single non-empty phase (one accordion)", () => {
+    const result = buildConsolidatedContent(["some reasoning"]);
+    expect(result).toBe("some reasoning");
+  });
+
+  it("joins multiple phases with separator for interleaved thinking (one accordion)", () => {
+    const result = buildConsolidatedContent(["phase one", "phase two"]);
+    expect(result).toBe("phase one\n\n---\n\nphase two");
+  });
+
+  it("strips empty phases so separators only appear between substantive content", () => {
+    const result = buildConsolidatedContent(["phase one", "", "phase two"]);
+    expect(result).toBe("phase one\n\n---\n\nphase two");
+  });
+});

--- a/frontend/src/components/chat/MessageThread.tsx
+++ b/frontend/src/components/chat/MessageThread.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { MarkdownContent } from "./MarkdownContent";
 import type { TranscriptItem, AssistantItem } from "./transcript";
+import { extractThinkingPhases, buildConsolidatedContent } from "./message-thread-utils";
 
 interface MessageThreadProps {
   readonly items: ReadonlyArray<TranscriptItem>;
@@ -69,15 +70,16 @@ function UserBubble({ text }: { readonly text: string }): JSX.Element {
 function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantItem> }): JSX.Element {
   if (items.length === 0) return <></>;
 
+  const consolidated = buildConsolidatedContent(extractThinkingPhases(items));
+
   return (
     <div className="flex justify-start">
       <div className="max-w-[90%] space-y-2">
+        {consolidated !== null && <ConsolidatedReasoning content={consolidated} />}
         {items.map((item) => {
+          if (item.type === "thinking") return null;
           if (item.type === "text") {
             return <MarkdownContent key={item.seq} text={item.text} />;
-          }
-          if (item.type === "thinking") {
-            return <ThinkingBlock key={item.seq} thinking={item.thinking} sequence={item.seq} />;
           }
           if (item.type === "tool_use") {
             const result = findToolResult(items, item.id);
@@ -118,21 +120,11 @@ function findToolResult(
   return null;
 }
 
-function ThinkingBlock({
-  thinking,
-  sequence,
-}: {
-  readonly thinking: string;
-  readonly sequence: number;
-}): JSX.Element {
-  const safeThinking = thinking ?? "";
-  const preview = safeThinking.slice(0, 80);
+function ConsolidatedReasoning({ content }: { readonly content: string }): JSX.Element {
   return (
     <details className="rounded border border-border/40 bg-muted/10 px-3 py-2 text-xs">
-      <summary className="cursor-pointer text-muted-foreground">
-        #{sequence} Thinking: {preview}{safeThinking.length > 80 ? "…" : ""}
-      </summary>
-      <MarkdownContent text={safeThinking} className="mt-2 text-muted-foreground" />
+      <summary className="cursor-pointer text-muted-foreground">Reasoning</summary>
+      <MarkdownContent text={content} className="mt-2 text-muted-foreground" />
     </details>
   );
 }

--- a/frontend/src/components/chat/message-thread-utils.ts
+++ b/frontend/src/components/chat/message-thread-utils.ts
@@ -1,0 +1,12 @@
+import type { AssistantItem } from "./transcript";
+
+export function extractThinkingPhases(items: ReadonlyArray<AssistantItem>): string[] {
+  return items
+    .filter((item): item is Extract<AssistantItem, { type: "thinking" }> => item.type === "thinking")
+    .map((item) => item.thinking);
+}
+
+export function buildConsolidatedContent(phases: string[]): string | null {
+  const nonEmpty = phases.filter((p) => p.trim().length > 0);
+  return nonEmpty.length > 0 ? nonEmpty.join("\n\n---\n\n") : null;
+}


### PR DESCRIPTION
## Summary

- Extracts all `thinking` blocks from an assistant turn and consolidates them into a single **Reasoning** `<details>` accordion, rendered as the first element in the assistant bubble.
- Phases separated by `---` when multiple thinking blocks exist (e.g. interleaved with tool calls).
- Empty/whitespace-only thinking produces no accordion at all.
- Non-thinking items (`tool_use`, `tool_result`, `text`, `error`) remain in their original relative order after the consolidated accordion.

Root cause: PR #779 (REQ-FE-41) merged only adjacent thinking deltas. When thinking blocks are separated by `tool_use`/`tool_result` events, `lastThinking?.type === "thinking"` fails and each thinking becomes a separate `<details>` accordion. This PR fixes the display layer regardless of how many thinking events exist or where they appear.

## Changes

- `MessageThread.tsx` — `AssistantBubble` pre-processes items, replaces `ThinkingBlock` with `ConsolidatedReasoning`
- `message-thread-utils.ts` — new pure helpers: `extractThinkingPhases`, `buildConsolidatedContent`
- `MessageThread.test.tsx` — 9 new unit tests covering all 4 AC cases

## GitHub Issue
Closes #782

## Before / After

**Before**: Multiple `#1 Thinking:` accordions for interleaved thinking+tool calls.  
**After**: Single `Reasoning` accordion at top of bubble; all phases joined with `---`.

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] `npm run test` passes — 75 tests (9 new)
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR