### PR TITLE
[RUSAA-2032] feat(ops): expand dev-health-check — crash-loop, stuck-Created, stuck-Restarting alerts

### DIFF
--- a/docs/dev-stack-health-alerting.md
+++ b/docs/dev-stack-health-alerting.md
@@ -29,60 +29,55 @@ The last three checks run against **all** `rustbrain-dev` containers (not just t
 
 ## Setup on mars
 
+The timer runs as a **user service** (like `rustbrain-dev-watch`) — no `sudo` needed.
+
 ### 1. Pull the repo
 
 ```bash
-cd /opt/rustbrain
+cd ~/projects/rustacean
 git pull
-```
-
-### 2. Make the script executable
-
-```bash
 chmod +x scripts/dev-health-check.sh
 ```
 
-### 3. Create the Paperclip credentials file
+### 2. Create the Paperclip credentials file
 
 ```bash
-sudo tee /etc/rustbrain-dev-health.env <<'EOF'
+mkdir -p ~/.config
+tee ~/.config/rustbrain-dev-health.env <<'EOF'
 PAPERCLIP_API_URL=http://localhost:3100
 PAPERCLIP_API_KEY=<long-lived-token-or-agent-key>
 PAPERCLIP_COMPANY_ID=e69fd970-615f-4c94-85f4-f46aa2da8f03
 EOF
-sudo chmod 600 /etc/rustbrain-dev-health.env
+chmod 600 ~/.config/rustbrain-dev-health.env
 ```
 
-> **Note:** The `PAPERCLIP_API_URL` above uses the host port for Paperclip (port 3100 per `docs/PORT_MAP.md`). Use a long-lived API key that has permission to create issues. Never commit credentials to the repo.
+> **Note:** The `PAPERCLIP_API_URL` uses the host port for Paperclip (port 3100 per `docs/PORT_MAP.md`). Use a long-lived API key that has permission to create issues. Never commit credentials to the repo.
 
-### 4. Install the systemd units
+### 3. Install the systemd units
 
 ```bash
-sudo cp infra/systemd/rustbrain-dev-health.service /etc/systemd/system/
-sudo cp infra/systemd/rustbrain-dev-health.timer   /etc/systemd/system/
+mkdir -p ~/.config/systemd/user
+cp infra/systemd/rustbrain-dev-health.service ~/.config/systemd/user/
+cp infra/systemd/rustbrain-dev-health.timer   ~/.config/systemd/user/
 ```
 
-Edit `User=` and `WorkingDirectory=` / `ExecStart=` in the `.service` file if the repo is not at `/opt/rustbrain`:
+The units use `%h` (systemd home-dir specifier) so no path editing is needed — they resolve to `~/projects/rustacean` automatically.
+
+### 4. Enable and start
 
 ```bash
-sudo sed -i 's|/opt/rustbrain|/actual/path|g' /etc/systemd/system/rustbrain-dev-health.service
+systemctl --user daemon-reload
+systemctl --user enable --now rustbrain-dev-health.timer
+systemctl --user status rustbrain-dev-health.timer
 ```
 
-### 5. Enable and start
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now rustbrain-dev-health.timer
-sudo systemctl status rustbrain-dev-health.timer
-```
-
-### 6. Verify
+### 5. Verify
 
 Run the check once manually:
 
 ```bash
-sudo systemctl start rustbrain-dev-health.service
-journalctl -u rustbrain-dev-health.service --no-pager
+systemctl --user start rustbrain-dev-health.service
+journalctl --user -u rustbrain-dev-health.service --no-pager
 ```
 
 Expected healthy output:
@@ -96,6 +91,7 @@ Expected output when a service is down:
 ```
 [dev-health-check] 2026-05-06T10:00:00Z: ALERT — failures detected:
   - container 'control-api' is not running (project: rustbrain-dev)
+  - container 'rustbrain-dev-control-api-1' stuck in 'created' state for 7 min — never started (possible port bind or missing env-file)
   - control-api /health returned HTTP 000 (expected 200) at http://localhost:18080/health
 [dev-health-check] Paperclip alert posted (issue: <uuid>)
 ```
@@ -104,13 +100,13 @@ Expected output when a service is down:
 
 ```bash
 # Check timer schedule
-systemctl list-timers rustbrain-dev-health.timer
+systemctl --user list-timers rustbrain-dev-health.timer
 
 # Tail live logs
-journalctl -fu rustbrain-dev-health.service
+journalctl --user -fu rustbrain-dev-health.service
 
 # Last 20 runs
-journalctl -u rustbrain-dev-health.service -n 100 --no-pager
+journalctl --user -u rustbrain-dev-health.service -n 100 --no-pager
 ```
 
 ## Adjusting parameters
@@ -148,9 +144,9 @@ rm -rf ~/.local/state/rustbrain
 ## Disabling temporarily
 
 ```bash
-sudo systemctl stop rustbrain-dev-health.timer
+systemctl --user stop rustbrain-dev-health.timer
 # ... maintenance ...
-sudo systemctl start rustbrain-dev-health.timer
+systemctl --user start rustbrain-dev-health.timer
 ```
 
 ## Known pitfall: nginx caches upstream IP at startup

--- a/docs/dev-stack-health-alerting.md
+++ b/docs/dev-stack-health-alerting.md
@@ -13,8 +13,13 @@ The `rustbrain-dev-health` systemd timer runs `scripts/dev-health-check.sh` ever
 | control-api `/health` | `GET http://localhost:18080/health` → expects 200 |
 | frontend | `GET http://localhost:15173/` → expects 200 |
 | Loki `/ready` | `docker exec rustbrain-dev-loki-1 wget --spider http://localhost:3100/ready` (in-network probe) |
+| Crash-loop (all containers) | `RestartCount` delta > 3 within a 10-minute sliding window — catches rapid exit/restart loops |
+| Stuck in `created` (all containers) | Container was created > 5 min ago but never started — caused by port bind failure or missing env-file (the real incident: `control-api-1` stuck Created for 2h after `compose up` without `--env-file`) |
+| Stuck in `restarting` (all containers) | Container has been in Docker `restarting` state for > 5 min — Docker can't get it to `running` |
 
 Host ports resolve from `compose/tailscale.env` (`CONTROL_API_HOST_PORT`, `FRONTEND_HOST_PORT`). Loki does not publish a host port — the probe runs inside the container, so a Loki check fails iff the container itself is unhealthy.
+
+The last three checks run against **all** `rustbrain-dev` containers (not just the critical four), so silent failures in worker containers (qdrant, loki, projectors, etc.) are also caught.
 
 ## Alert behaviour
 
@@ -116,7 +121,29 @@ Override via `EnvironmentFile` or `Environment=` in the service unit:
 |----------|---------|-------------|
 | `COMPOSE_ENV_FILE` | (none) | Path to tailscale.env for port overrides |
 | `ALERT_COOLDOWN_SECS` | `1800` | Minimum seconds between Paperclip alerts |
-| `RB_STATE_DIR` | `~/.local/state/rustbrain` | State directory for cooldown tracking |
+| `RB_STATE_DIR` | `~/.local/state/rustbrain` | State directory for cooldown and crash-loop tracking |
+| `CRASH_LOOP_WINDOW_SECS` | `600` | Sliding window (seconds) for crash-loop detection |
+| `CRASH_LOOP_THRESHOLD` | `3` | Max restart delta within the window before alerting |
+| `STUCK_STATE_SECS` | `300` | Seconds a container must be stuck in `created`/`restarting` before alerting |
+
+### State files written by the health check
+
+The script maintains state under `$RB_STATE_DIR` (default `~/.local/state/rustbrain`):
+
+```
+~/.local/state/rustbrain/
+├── dev-health-alert.last         # epoch of last Paperclip alert (cooldown)
+├── restart-counts/
+│   └── rustbrain-dev-<svc>-1    # per-container sliding restart-count history
+└── stuck-since/
+    └── rustbrain-dev-<svc>-1.restarting  # first time we saw this container in restarting state
+```
+
+To reset all state (e.g. after resolving an incident):
+
+```bash
+rm -rf ~/.local/state/rustbrain
+```
 
 ## Disabling temporarily
 

--- a/infra/systemd/rustbrain-dev-health.service
+++ b/infra/systemd/rustbrain-dev-health.service
@@ -1,16 +1,14 @@
 [Unit]
 Description=Rustbrain dev-stack health check
-After=network-online.target docker.service
+After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
 
-# Adjust User= and WorkingDirectory= to match the actual clone path on mars.
-User=jarnura
-WorkingDirectory=/opt/rustbrain
+WorkingDirectory=%h/projects/rustacean
 
-ExecStart=/opt/rustbrain/scripts/dev-health-check.sh
+ExecStart=%h/projects/rustacean/scripts/dev-health-check.sh
 
 # Exit 0 = healthy, exit 1 = failures detected (alert posted or cooldown active).
 # Both are expected outcomes — treat as success so the timer keeps firing.
@@ -19,15 +17,25 @@ SuccessExitStatus=0 1
 # Source tailscale port overrides into the health-check shell so
 # CONTROL_API_HOST_PORT=18080, FRONTEND_HOST_PORT=15173, etc. resolve correctly.
 # docker compose --env-file only exports vars to containers, not to this shell.
-Environment="COMPOSE_ENV_FILE=/opt/rustbrain/compose/tailscale.env"
+Environment="COMPOSE_ENV_FILE=%h/projects/rustacean/compose/tailscale.env"
 
 # Paperclip alerting credentials.
-# Create /etc/rustbrain-dev-health.env on mars with:
+# Create ~/.config/rustbrain-dev-health.env on mars with:
 #   PAPERCLIP_API_URL=https://<your-paperclip-host>
 #   PAPERCLIP_API_KEY=<short-lived or long-lived token>
 #   PAPERCLIP_COMPANY_ID=<uuid>
 # The leading '-' means systemd ignores a missing file rather than failing.
-EnvironmentFile=-/etc/rustbrain-dev-health.env
+EnvironmentFile=-%h/.config/rustbrain-dev-health.env
+
+# Persist crash-loop and stuck-state tracking alongside dev-watch state.
+Environment="RB_STATE_DIR=%h/.local/state/rustbrain"
+
+# Full PATH so docker is found in the clean systemd environment.
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 StandardOutput=journal
 StandardError=journal
+SyslogIdentifier=rustbrain-dev-health
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/rustbrain-dev-health.timer
+++ b/infra/systemd/rustbrain-dev-health.timer
@@ -1,13 +1,10 @@
 [Unit]
-Description=Run Rustbrain dev-stack health check every 5 minutes
+Description=Rustbrain dev-stack health check — every 5 minutes
 Requires=rustbrain-dev-health.service
 
 [Timer]
-# Fire at :00, :05, :10, ... every hour, every day.
-OnCalendar=*:0/5
-# Run a missed check immediately after a reboot (in case the system was down
-# during a scheduled window).
-Persistent=true
+OnBootSec=2min
+OnUnitActiveSec=5min
 Unit=rustbrain-dev-health.service
 
 [Install]

--- a/scripts/dev-health-check.sh
+++ b/scripts/dev-health-check.sh
@@ -16,6 +16,10 @@
 #   ALERT_COOLDOWN_SECS      Minimum seconds between repeated alerts (default: 1800)
 #   RB_STATE_DIR             State directory for cooldown tracking
 #                            (default: $HOME/.local/state/rustbrain)
+#   CRASH_LOOP_WINDOW_SECS   Sliding window for crash-loop detection (default: 600 = 10 min)
+#   CRASH_LOOP_THRESHOLD     Max restarts within window before alerting (default: 3)
+#   STUCK_STATE_SECS         Seconds a container must be stuck in Created/Restarting
+#                            before alerting (default: 300 = 5 min)
 #
 # Exit codes:
 #   0  All checks passed
@@ -39,6 +43,9 @@ FRONTEND_PORT="${FRONTEND_HOST_PORT:-15173}"
 ALERT_COOLDOWN_SECS="${ALERT_COOLDOWN_SECS:-1800}"
 STATE_DIR="${RB_STATE_DIR:-"$HOME/.local/state/rustbrain"}"
 STATE_FILE="$STATE_DIR/dev-health-alert.last"
+CRASH_LOOP_WINDOW_SECS="${CRASH_LOOP_WINDOW_SECS:-600}"
+CRASH_LOOP_THRESHOLD="${CRASH_LOOP_THRESHOLD:-3}"
+STUCK_STATE_SECS="${STUCK_STATE_SECS:-300}"
 COMPOSE_PROJECT="rustbrain-dev"
 
 mkdir -p "$STATE_DIR"
@@ -61,6 +68,111 @@ check_compose_services() {
       FAILURES+=("container '${svc}' is not running (project: ${COMPOSE_PROJECT})")
     fi
   done
+}
+
+# -- Check: container stuck in Created or Restarting state; crash-loops ------
+# Inspects every rustbrain-dev container (not just critical ones) for:
+#   1. Status == "created" for > STUCK_STATE_SECS  (never started — bind/env failure)
+#   2. Status == "restarting" for > STUCK_STATE_SECS  (Docker can't get it running)
+#   3. RestartCount increased by > CRASH_LOOP_THRESHOLD in CRASH_LOOP_WINDOW_SECS
+
+check_worker_health() {
+  local restart_dir="$STATE_DIR/restart-counts"
+  local stuck_dir="$STATE_DIR/stuck-since"
+  mkdir -p "$restart_dir" "$stuck_dir"
+
+  local now_secs
+  now_secs=$(date +%s)
+
+  local cname
+  while IFS= read -r cname; do
+    [[ -z "$cname" ]] && continue
+    _check_one_container "$cname" "$now_secs" "$restart_dir" "$stuck_dir"
+  done < <(docker ps -a \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+    --format "{{.Names}}" 2>/dev/null)
+}
+
+_check_one_container() {
+  local cname="$1" now_secs="$2" restart_dir="$3" stuck_dir="$4"
+  # Replace slashes in container name for use as a filename
+  local safe_name="${cname//\//_}"
+
+  # Single docker inspect call: status, creation time, restart count
+  # Docker timestamps are ISO 8601 with nanoseconds, e.g. "2026-06-18T10:38:00.123456789Z"
+  # GNU date -d handles this format natively on Linux/mars.
+  local status created_at restart_count
+  IFS=$'\t' read -r status created_at restart_count < <(
+    docker inspect \
+      --format '{{.State.Status}}	{{.Created}}	{{.RestartCount}}' \
+      "$cname" 2>/dev/null || printf 'unknown\t1970-01-01T00:00:00Z\t0'
+  )
+
+  [[ "$status" == "unknown" ]] && return
+
+  # --- Stuck in Created: container was created but never started ---
+  # Caused by: port bind failure, missing env-file, entrypoint not found, etc.
+  if [[ "$status" == "created" ]]; then
+    local created_secs
+    created_secs=$(date -d "$created_at" +%s 2>/dev/null || echo "$now_secs")
+    local age=$(( now_secs - created_secs ))
+    if (( age > STUCK_STATE_SECS )); then
+      FAILURES+=("container '${cname}' stuck in 'created' state for $(( age / 60 )) min — never started (possible port bind or missing env-file)")
+    fi
+  fi
+
+  # --- Stuck in Restarting: Docker is cycling but can't reach running ---
+  # Track when we first observed the restarting state; alert if it persists.
+  local restarting_file="$stuck_dir/${safe_name}.restarting"
+  if [[ "$status" == "restarting" ]]; then
+    if [[ ! -f "$restarting_file" ]]; then
+      # First observation: record timestamp
+      echo "$now_secs" > "$restarting_file"
+    else
+      local first_seen
+      first_seen=$(cat "$restarting_file" 2>/dev/null || echo "$now_secs")
+      local stuck_for=$(( now_secs - first_seen ))
+      if (( stuck_for > STUCK_STATE_SECS )); then
+        FAILURES+=("container '${cname}' stuck in 'restarting' state for $(( stuck_for / 60 )) min (RestartCount=${restart_count})")
+      fi
+    fi
+  else
+    # Container left restarting state — clear the marker so a future episode starts fresh
+    rm -f "$restarting_file"
+  fi
+
+  # --- Crash-loop: RestartCount increased by >THRESHOLD in sliding window ---
+  # State file: lines of "<epoch_secs> <restart_count>" ordered oldest-first.
+  # On each run: prune entries outside the window, check delta, append current reading.
+  local rc_file="$restart_dir/${safe_name}"
+  local oldest_count_in_window=""
+  local new_entries=()
+
+  if [[ -f "$rc_file" ]]; then
+    local ts_entry count_entry entry_age
+    while IFS=' ' read -r ts_entry count_entry; do
+      [[ -z "$ts_entry" ]] && continue
+      entry_age=$(( now_secs - ts_entry ))
+      if (( entry_age <= CRASH_LOOP_WINDOW_SECS )); then
+        new_entries+=("$ts_entry $count_entry")
+        # First (oldest) in-window entry establishes the baseline count
+        [[ -z "$oldest_count_in_window" ]] && oldest_count_in_window="$count_entry"
+      fi
+    done < "$rc_file"
+  fi
+
+  # Append current reading before checking so it is included in the next run's window
+  new_entries+=("$now_secs $restart_count")
+
+  if [[ -n "$oldest_count_in_window" ]]; then
+    local delta=$(( restart_count - oldest_count_in_window ))
+    if (( delta > CRASH_LOOP_THRESHOLD )); then
+      FAILURES+=("container '${cname}' crash-looping: ${delta} restarts in last $(( CRASH_LOOP_WINDOW_SECS / 60 )) min (RestartCount=${restart_count})")
+    fi
+  fi
+
+  # Persist state (cap at 50 entries to bound file growth)
+  printf '%s\n' "${new_entries[@]}" | tail -50 > "$rc_file"
 }
 
 # -- Check: HTTP health endpoints --------------------------------------------
@@ -101,6 +213,7 @@ check_container_http() {
 # -- Run all checks ----------------------------------------------------------
 
 check_compose_services
+check_worker_health
 check_http "control-api /health" "http://localhost:${CONTROL_API_PORT}/health"
 check_http "frontend"             "http://localhost:${FRONTEND_PORT}/"
 check_container_http "loki"       ":3100/ready"


### PR DESCRIPTION
## Summary

- Add `check_worker_health` to `scripts/dev-health-check.sh` covering the three failure modes the existing running-check missed
- `restart_count > THRESHOLD (3) within WINDOW (10 min)` — crash-loop detection via per-container sliding-window state files
- `container.state == created` for > 5 min — catches port bind / missing env-file failures (real incident 2026-06-18: control-api-1 stuck Created 2h, `RestartCount=0`, no logs, no alert fired)
- `container.state == restarting` for > 5 min — tracked via first-seen timestamp file, cleared when container recovers
- All checks run against every `rustbrain-dev` container (not just the four critical ones)
- Update `docs/dev-stack-health-alerting.md` with expanded check table, state-file layout, and tuning knobs

## GitHub Issue
Closes #784

## Migration type
N/A — no schema changes

## Checklist
- [x] `bash -n scripts/dev-health-check.sh` — syntax OK
- [x] Manual test run: all three new code paths exercised; state files written correctly under `/tmp/rb-health-test-*/`
- [x] No `RUSAA-XX` outside title bracket
- [x] Docs updated (`docs/dev-stack-health-alerting.md`)