### PR TITLE
[RUSAA-2043] fix(mcp): normalize query before embed; nomic-embed-text collapses CamelCase to constant vector

### DIFF
--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -143,6 +143,43 @@ pub(super) async fn dispatch_get_item(
     }
 }
 
+/// Normalize a raw search query before embedding.
+///
+/// nomic-embed-text collapses single CamelCase tokens (e.g. `AnalyticsFlow`)
+/// to a constant degenerate vector because the tokenizer treats the whole
+/// token as a single unit. Splitting at camelCase boundaries, replacing Rust
+/// separators, and prepending the Nomic task prefix restores distinct vectors.
+fn normalize_query(query: &str) -> String {
+    // Replace Rust path separators and underscores with spaces.
+    let s = query.replace("::", " ").replace('_', " ");
+
+    // Insert spaces at camelCase boundaries.
+    let mut with_spaces = String::with_capacity(s.len() + 16);
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_uppercase() && i > 0 {
+            let prev = chars[i - 1];
+            if prev.is_lowercase() || prev.is_ascii_digit() {
+                // lowercase→uppercase: always split ("FooBar" → "Foo Bar")
+                with_spaces.push(' ');
+            } else if prev.is_uppercase() {
+                // acronym run: split before the last uppercase that precedes
+                // a lowercase ("FQNMethod" → "FQN Method")
+                if let Some(&next) = chars.get(i + 1) {
+                    if next.is_lowercase() {
+                        with_spaces.push(' ');
+                    }
+                }
+            }
+        }
+        with_spaces.push(c);
+    }
+
+    // Collapse whitespace, lowercase, and add the Nomic asymmetric task prefix.
+    let normalized = with_spaces.split_whitespace().collect::<Vec<_>>().join(" ");
+    format!("search_query: {}", normalized.to_lowercase())
+}
+
 async fn embed_query(
     http: &reqwest::Client,
     ollama_url: &str,
@@ -150,7 +187,8 @@ async fn embed_query(
     query: &str,
 ) -> Result<Vec<f32>, AppError> {
     let url = format!("{}/api/embeddings", ollama_url.trim_end_matches('/'));
-    let body = serde_json::json!({ "model": model, "prompt": query });
+    let prompt = normalize_query(query);
+    let body = serde_json::json!({ "model": model, "prompt": prompt });
 
     let resp = http.post(&url).json(&body).send().await.map_err(|e| {
         tracing::warn!("Ollama request failed: {e}");
@@ -191,6 +229,47 @@ async fn embed_query(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_query_splits_camel_case() {
+        assert_eq!(
+            normalize_query("AnalyticsFlow"),
+            "search_query: analytics flow"
+        );
+        assert_eq!(normalize_query("HelloWorld"), "search_query: hello world");
+        assert_eq!(normalize_query("FooBar"), "search_query: foo bar");
+    }
+
+    #[test]
+    fn normalize_query_handles_underscores_and_colons() {
+        assert_eq!(
+            normalize_query("analytics_flow"),
+            "search_query: analytics flow"
+        );
+        assert_eq!(normalize_query("module::Type"), "search_query: module type");
+        assert_eq!(
+            normalize_query("my_crate::MyStruct"),
+            "search_query: my crate my struct"
+        );
+    }
+
+    #[test]
+    fn normalize_query_handles_acronym_runs() {
+        // FQNMethod → FQN Method
+        assert_eq!(normalize_query("FQNMethod"), "search_query: fqn method");
+    }
+
+    #[test]
+    fn normalize_query_single_words_differ() {
+        // Single CamelCase tokens must produce distinct normalized strings
+        // so they embed to distinct vectors (the core bug fix).
+        let a = normalize_query("AnalyticsFlow");
+        let b = normalize_query("HelloWorld");
+        let c = normalize_query("FooBar");
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
 
     #[test]
     fn search_items_requires_query_field() {


### PR DESCRIPTION
## Summary

- `embed_query` sent raw user strings to nomic-embed-text without any normalization
- Single CamelCase tokens (`AnalyticsFlow`, `HelloWorld`, `FooBar`) all collapsed to an identical 768-dim vector, causing every CamelCase code-search query to return the same Qdrant top-K hit
- Fix: add `normalize_query` that splits camelCase boundaries, expands `_`/`::`, lowercases, and prepends the Nomic asymmetric task prefix `search_query: `

## Changes

`services/control-api/src/routes/mcp/dispatch.rs`
- New `normalize_query(query: &str) -> String` function (pure, no I/O)
- `embed_query` now calls `normalize_query` before building the Ollama JSON body
- 7 unit tests: camelCase splitting, underscore/colon handling, acronym runs (`FQNMethod` → `fqn method`), and string-level distinctness assertion

## GitHub Issue

Closes #786

## Test plan

- [x] `cargo test -p control-api --lib -- routes::mcp::dispatch::tests` — 7/7 pass
- [x] `cargo clippy -p control-api --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual smoke: `AnalyticsFlow`, `HelloWorld`, `FooBar` return distinct top hits via `/v1/mcp/tools/search_items`

🤖 Generated with [Claude Code](https://claude.com/claude-code)