### PR TITLE
[REQ-FE-45] fix(code-workspace): pass result.repo_id through to source-view fetch

### DIFF
--- a/frontend/e2e/code-intel-cross-repo.spec.ts
+++ b/frontend/e2e/code-intel-cross-repo.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockModuleTree,
+  mockCallers,
+  mockCallees,
+  mockItem,
+  mockReposList,
+  REPOS_MULTI_RESPONSE,
+  SEARCH_RESPONSE_CROSS_REPO,
+  CROSS_REPO_FQN,
+  CROSS_REPO_FQN_B64,
+} from "./fixtures/mock-api";
+
+const REPO_1_ID = "repo-1";
+const WORKSPACE_URL = `/repos/${REPO_1_ID}/code`;
+
+async function setupMultiRepoWorkspace(page: import("@playwright/test").Page): Promise<void> {
+  await mockAuthenticatedSession(page);
+  await mockReposList(page, REPOS_MULTI_RESPONSE);
+  await mockModuleTree(page);
+  await mockItem(page);
+  await mockCallers(page);
+  await mockCallees(page);
+
+  await page.route("**/v1/search", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ json: SEARCH_RESPONSE_CROSS_REPO });
+    }
+    return route.continue();
+  });
+}
+
+test.describe("Cross-repo search result navigation", () => {
+  test("clicking a same-repo result keeps the current workspace repo in the URL", async ({ page }) => {
+    await setupMultiRepoWorkspace(page);
+    await page.goto(WORKSPACE_URL);
+
+    await page.getByRole("tab", { name: "search" }).click();
+    await page.getByLabel("Search query").fill("Builder");
+    await page.getByRole("button", { name: "Go" }).click();
+
+    const sameRepoResult = SEARCH_RESPONSE_CROSS_REPO.results[0];
+    await page.getByRole("button", { name: `Open ${sameRepoResult.fqn}` }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/repos/${REPO_1_ID}/code`));
+    await expect(page).toHaveURL(/fqn=/);
+  });
+
+  test("clicking a cross-repo result switches workspace to the result's repo", async ({ page }) => {
+    await setupMultiRepoWorkspace(page);
+    await page.goto(WORKSPACE_URL);
+
+    await page.getByRole("tab", { name: "search" }).click();
+    await page.getByLabel("Search query").fill("Builder");
+    await page.getByRole("button", { name: "Go" }).click();
+
+    await page.getByRole("button", { name: `Open ${CROSS_REPO_FQN}` }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/repos/repo-2/code`));
+    await expect(page).toHaveURL(new RegExp(`fqn=${CROSS_REPO_FQN_B64}`));
+  });
+
+  test("repo pill is shown on cross-repo results when repos data is available", async ({ page }) => {
+    await setupMultiRepoWorkspace(page);
+    await page.goto(WORKSPACE_URL);
+
+    await page.getByRole("tab", { name: "search" }).click();
+    await page.getByLabel("Search query").fill("Builder");
+    await page.getByRole("button", { name: "Go" }).click();
+
+    const pills = page.getByTestId("repo-pill");
+    await expect(pills.first()).toBeVisible();
+    await expect(pills.first()).toContainText("acme/");
+  });
+});

--- a/frontend/e2e/fixtures/mock-api.ts
+++ b/frontend/e2e/fixtures/mock-api.ts
@@ -34,7 +34,18 @@ export const REPO_ITEM = {
   connected_by: "user-1",
 };
 
+export const REPO_ITEM_2 = {
+  repo_id: "repo-2",
+  full_name: "acme/api-server",
+  installation_id: "install-uuid-1",
+  default_branch: "main",
+  status: "connected",
+  connected_at: "2024-01-01T00:00:00Z",
+  connected_by: "user-1",
+};
+
 export const REPOS_RESPONSE = { repos: [REPO_ITEM] };
+export const REPOS_MULTI_RESPONSE = { repos: [REPO_ITEM, REPO_ITEM_2] };
 export const REPOS_EMPTY_RESPONSE = { repos: [] };
 
 export const INGEST_RESPONSE = { run_id: "run-id-1" };
@@ -140,6 +151,29 @@ export const SEARCH_RESPONSE = {
       crate_name: "my_crate",
       repo_id: "repo-1",
       score: 0.81,
+    },
+  ],
+};
+
+export const CROSS_REPO_FQN = "api_server::Builder";
+export const CROSS_REPO_FQN_B64 = btoa(CROSS_REPO_FQN)
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_")
+  .replace(/=/g, "");
+
+export const SEARCH_RESPONSE_CROSS_REPO = {
+  results: [
+    {
+      fqn: "my_crate::my_fn",
+      crate_name: "my_crate",
+      repo_id: "repo-1",
+      score: 0.88,
+    },
+    {
+      fqn: CROSS_REPO_FQN,
+      crate_name: "api_server",
+      repo_id: "repo-2",
+      score: 0.85,
     },
   ],
 };

--- a/frontend/src/components/code-intel/SearchPanel.tsx
+++ b/frontend/src/components/code-intel/SearchPanel.tsx
@@ -1,15 +1,19 @@
 import { useState } from "react";
 import { useSearch, fqnToB64, type SearchResult } from "@/api/hooks/useCodeIntel";
+import type { RepoItem } from "@/api/hooks/useRepos";
 import { formatApiError } from "@/lib/errors/api";
 import { cn } from "@/lib/utils";
 
 interface SearchPanelProps {
-  readonly onSelect: (fqn: string, fqnB64: string) => void;
+  readonly onSelect: (fqn: string, fqnB64: string, repoId: string) => void;
+  readonly repos?: readonly RepoItem[];
 }
 
-export function SearchPanel({ onSelect }: SearchPanelProps): JSX.Element {
+export function SearchPanel({ onSelect, repos }: SearchPanelProps): JSX.Element {
   const [query, setQuery] = useState("");
   const search = useSearch();
+
+  const repoMap = new Map((repos ?? []).map((r) => [r.repo_id, r.full_name]));
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -75,6 +79,7 @@ export function SearchPanel({ onSelect }: SearchPanelProps): JSX.Element {
                 key={result.fqn}
                 result={result}
                 onSelect={onSelect}
+                repoMap={repoMap}
               />
             ))}
           </ul>
@@ -86,13 +91,16 @@ export function SearchPanel({ onSelect }: SearchPanelProps): JSX.Element {
 
 interface SearchResultItemProps {
   readonly result: SearchResult;
-  readonly onSelect: (fqn: string, fqnB64: string) => void;
+  readonly onSelect: (fqn: string, fqnB64: string, repoId: string) => void;
+  readonly repoMap: ReadonlyMap<string, string>;
 }
 
-function SearchResultItem({ result, onSelect }: SearchResultItemProps): JSX.Element {
+function SearchResultItem({ result, onSelect, repoMap }: SearchResultItemProps): JSX.Element {
   const handleClick = () => {
-    onSelect(result.fqn, fqnToB64(result.fqn));
+    onSelect(result.fqn, fqnToB64(result.fqn), result.repo_id);
   };
+
+  const repoName = repoMap.get(result.repo_id);
 
   return (
     <li>
@@ -109,9 +117,17 @@ function SearchResultItem({ result, onSelect }: SearchResultItemProps): JSX.Elem
         <p className="truncate font-mono text-xs font-medium text-foreground">
           {result.fqn}
         </p>
-        <p className="mt-0.5 text-[10px] text-muted-foreground">
-          {result.crate_name}
-          <span className="ml-2 opacity-60">{(result.score * 100).toFixed(0)}%</span>
+        <p className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+          <span>{result.crate_name}</span>
+          {repoName != null && (
+            <span
+              data-testid="repo-pill"
+              className="rounded bg-muted px-1 py-0.5 font-medium"
+            >
+              {repoName}
+            </span>
+          )}
+          <span className="ml-auto opacity-60">{(result.score * 100).toFixed(0)}%</span>
         </p>
       </button>
     </li>

--- a/frontend/src/pages/CodeWorkspacePage.tsx
+++ b/frontend/src/pages/CodeWorkspacePage.tsx
@@ -77,6 +77,14 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
     });
   };
 
+  const handleSearchSelect = (_fqn: string, encodedB64: string, resultRepoId: string) => {
+    void navigate({
+      to: routes.codeWorkspace,
+      params: { repoId: resultRepoId },
+      search: { fqn: encodedB64 },
+    });
+  };
+
   return (
     <div className="flex h-screen w-full flex-col overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 border-b border-border bg-background px-4 py-2">
@@ -176,7 +184,7 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
             aria-label="Search"
             className={cn("flex-1 overflow-hidden", sideTab !== "search" && "hidden")}
           >
-            <SearchPanel onSelect={handleSelect} />
+            <SearchPanel onSelect={handleSearchSelect} repos={repos.data?.repos ?? []} />
           </div>
           <div
             id="side-panel-relations"


### PR DESCRIPTION
## Summary

- `SearchPanel.onSelect` now carries `repoId` as a 3rd argument; `handleClick` passes `result.repo_id`
- `CodeWorkspacePage` adds `handleSearchSelect(_fqn, encodedB64, resultRepoId)` that navigates to the result's repo instead of always using the current workspace `repoId`
- Each search result row shows a repo-name pill (resolved via the `repos` prop from `useRepos`) so users can see which repo a symbol belongs to before clicking
- `ModuleTree` and `RelationsPanel` keep the existing 2-arg `handleSelect` — they only surface same-repo items

## Test plan

- [ ] `npm run typecheck` passes (✅ verified locally)
- [ ] `npm run lint` passes (✅ verified locally)
- [ ] `npm run build` passes (✅ verified locally)
- [ ] Playwright specs in `e2e/code-intel-cross-repo.spec.ts` pass in CI
- [ ] QA: open Code Workspace for repo-1, search a symbol present in repo-2, click the cross-repo result — URL switches to `/repos/repo-2/code?fqn=…`, source view renders without 404

Closes #790