### PR TITLE
[REQ-FE-47] fix(chat): remove thinking blocks, theme-aware colors, RESULT background match

### DIFF
--- a/frontend/src/components/chat/MessageThread.test.tsx
+++ b/frontend/src/components/chat/MessageThread.test.tsx
@@ -26,7 +26,7 @@ describe("getInlineItems — inline chronological rendering (replaces consolidat
     expect(inline.map((i) => i.type)).toEqual(["tool_use", "text"]);
   });
 
-  it("includes thinking items at their original sequence position", () => {
+  it("excludes thinking items (not rendered by UI)", () => {
     const items: AssistantItem[] = [
       thinking("thought", 1),
       toolUse(2),
@@ -34,10 +34,10 @@ describe("getInlineItems — inline chronological rendering (replaces consolidat
       text("answer", 4),
     ];
     const inline = getInlineItems(items);
-    expect(inline.map((i) => i.type)).toEqual(["thinking", "tool_use", "text"]);
+    expect(inline.map((i) => i.type)).toEqual(["tool_use", "text"]);
   });
 
-  it("preserves mid-stream thinking interleaved between tool calls", () => {
+  it("excludes mid-stream thinking interleaved between tool calls", () => {
     const items: AssistantItem[] = [
       toolUse(1),
       toolResult(2),
@@ -47,10 +47,7 @@ describe("getInlineItems — inline chronological rendering (replaces consolidat
       text("done", 6),
     ];
     const inline = getInlineItems(items);
-    expect(inline.map((i) => i.type)).toEqual(["tool_use", "thinking", "tool_use", "text"]);
-    const seqs = inline.map((i) => i.seq);
-    expect(seqs[0]).toBeLessThan(seqs[1] ?? Infinity);
-    expect(seqs[1]).toBeLessThan(seqs[2] ?? Infinity);
+    expect(inline.map((i) => i.type)).toEqual(["tool_use", "tool_use", "text"]);
   });
 
   it("returns empty array for empty input", () => {
@@ -62,8 +59,8 @@ describe("getInlineItems — inline chronological rendering (replaces consolidat
     expect(getInlineItems(items).map((i) => i.type)).toEqual(["text", "text"]);
   });
 
-  it("thinking-only items are preserved inline", () => {
+  it("thinking-only items are excluded (not rendered)", () => {
     const items: AssistantItem[] = [thinking("a", 1), thinking("b", 2)];
-    expect(getInlineItems(items).map((i) => i.type)).toEqual(["thinking", "thinking"]);
+    expect(getInlineItems(items)).toEqual([]);
   });
 });

--- a/frontend/src/components/chat/MessageThread.tsx
+++ b/frontend/src/components/chat/MessageThread.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { MarkdownContent } from "./MarkdownContent";
 import type { TranscriptItem, AssistantItem } from "./transcript";
@@ -69,7 +69,7 @@ function UserBubble({ text }: { readonly text: string }): JSX.Element {
 function TimestampLabel({ ts }: { readonly ts: number }): JSX.Element {
   return (
     <time
-      className="block px-1 text-[10px] text-zinc-600"
+      className="block px-1 text-[10px] text-muted-foreground/70"
       dateTime={new Date(ts).toISOString()}
     >
       {new Date(ts).toLocaleString("en-US", {
@@ -85,25 +85,6 @@ function TimestampLabel({ ts }: { readonly ts: number }): JSX.Element {
   );
 }
 
-function ThinkingBlock({ thinking, ts }: { readonly thinking: string; readonly ts?: number | undefined }): JSX.Element {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="space-y-1">
-      {ts !== undefined && <TimestampLabel ts={ts} />}
-      <details
-        className="rounded-lg border border-zinc-800 bg-zinc-900/40 px-3 py-2 text-xs"
-        open={open}
-        onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}
-      >
-        <summary className="cursor-pointer select-none text-zinc-500 hover:text-zinc-300 transition-colors">
-          + Thinking
-        </summary>
-        <MarkdownContent text={thinking} className="mt-2 text-zinc-400" />
-      </details>
-    </div>
-  );
-}
-
 function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantItem> }): JSX.Element {
   if (items.length === 0) return <></>;
 
@@ -111,11 +92,7 @@ function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantIte
     <div className="flex justify-start">
       <div className="max-w-[90%] space-y-2">
         {items.map((item) => {
-          if (item.type === "tool_result") return null;
-
-          if (item.type === "thinking") {
-            return <ThinkingBlock key={item.seq} thinking={item.thinking} ts={item.ts} />;
-          }
+          if (item.type === "tool_result" || item.type === "thinking") return null;
 
           if (item.type === "text") {
             return (

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -9,8 +9,8 @@ import { ReadResultRenderer } from "./tool-renderers/ReadResultRenderer";
 function InputBlock({ input }: { readonly input: unknown }): JSX.Element {
   const text = JSON.stringify(deepDecodeJsonStrings(input), null, 2);
   return (
-    <div className="overflow-hidden rounded bg-zinc-900">
-      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-zinc-300 whitespace-pre">
+    <div className="overflow-hidden rounded bg-muted">
+      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground/90 whitespace-pre">
         {text}
       </pre>
     </div>
@@ -19,7 +19,7 @@ function InputBlock({ input }: { readonly input: unknown }): JSX.Element {
 
 function SectionLabel({ children }: { readonly children: string }): JSX.Element {
   return (
-    <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-500">
+    <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
       {children}
     </p>
   );
@@ -63,14 +63,14 @@ export function ToolCallBlock({
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-lg border bg-zinc-900/60",
-        error ? "border-destructive/40" : "border-zinc-800",
+        "overflow-hidden rounded-lg border bg-card",
+        error ? "border-destructive/40" : "border-border",
       )}
       data-testid="tool-call-block"
     >
       {timestamp !== undefined && (
         <time
-          className="block px-3 pt-2 text-[10px] text-zinc-600"
+          className="block px-3 pt-2 text-[10px] text-muted-foreground/70"
           dateTime={new Date(timestamp).toISOString()}
         >
           {new Date(timestamp).toLocaleString("en-US", {
@@ -86,7 +86,7 @@ export function ToolCallBlock({
       )}
       <button
         type="button"
-        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-zinc-800/50 transition-colors"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-accent transition-colors"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-label={`${name} tool call — ${statusLabel}`}
@@ -97,11 +97,11 @@ export function ToolCallBlock({
         >
           *
         </span>
-        <span className="shrink-0 font-semibold text-sm text-zinc-200">
+        <span className="shrink-0 font-semibold text-sm text-foreground">
           {name}
         </span>
         {argsPreview && (
-          <span className="min-w-0 flex-1 truncate text-xs text-zinc-500">
+          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
             {argsPreview}
           </span>
         )}
@@ -115,9 +115,9 @@ export function ToolCallBlock({
           )}
           <span className="sr-only">{statusLabel}</span>
           {open ? (
-            <ChevronUp className="h-3.5 w-3.5 text-zinc-500" aria-hidden="true" />
+            <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           ) : (
-            <ChevronDown className="h-3.5 w-3.5 text-zinc-500" aria-hidden="true" />
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           )}
         </span>
       </button>
@@ -129,7 +129,7 @@ export function ToolCallBlock({
         )}
       >
         <div className="overflow-hidden">
-          <div className="border-t border-zinc-800 px-3 py-3 space-y-3">
+          <div className="border-t border-border px-3 py-3 space-y-3">
             {!isEmptyInput(input) && (
               <div>
                 <SectionLabel>Input</SectionLabel>

--- a/frontend/src/components/chat/message-thread-utils.ts
+++ b/frontend/src/components/chat/message-thread-utils.ts
@@ -2,5 +2,5 @@ import type { AssistantItem } from "./transcript";
 
 /** Returns items that render as inline blocks — excludes tool_result entries (consumed by their paired tool_use). */
 export function getInlineItems(items: ReadonlyArray<AssistantItem>): ReadonlyArray<AssistantItem> {
-  return items.filter((item) => item.type !== "tool_result");
+  return items.filter((item) => item.type !== "tool_result" && item.type !== "thinking");
 }

--- a/frontend/src/components/chat/tool-renderers/BashResultRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/BashResultRenderer.tsx
@@ -16,15 +16,15 @@ export function BashResultRenderer({ result }: BashResultRendererProps): JSX.Ele
   const displayText = truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : text;
 
   return (
-    <div className="overflow-hidden rounded bg-zinc-950">
-      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-zinc-200 whitespace-pre">
+    <div className="overflow-hidden rounded bg-muted">
+      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground whitespace-pre">
         {displayText}
       </pre>
       {truncate && (
         <button
           type="button"
           onClick={() => setShowMore((s) => !s)}
-          className="flex w-full items-center justify-center gap-1 bg-zinc-900 py-1.5 text-xs text-zinc-400 hover:text-zinc-200"
+          className="flex w-full items-center justify-center gap-1 bg-accent py-1.5 text-xs text-muted-foreground hover:text-foreground"
         >
           {showMore ? (
             <><ChevronUp className="h-3.5 w-3.5" />Show less</>

--- a/frontend/src/components/chat/tool-renderers/JsonResultRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/JsonResultRenderer.tsx
@@ -37,7 +37,7 @@ function CopyButton({ text }: { readonly text: string }): JSX.Element {
     <button
       type="button"
       onClick={handleCopy}
-      className="rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-100"
+      className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       aria-label={copied ? "Copied" : "Copy to clipboard"}
     >
       {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
@@ -52,8 +52,8 @@ function JsonBlock({ value, copyText }: { readonly value: string; readonly copyT
   const displayValue = truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : value;
 
   return (
-    <div className="overflow-hidden rounded bg-zinc-900">
-      <div className="flex items-center justify-end bg-zinc-800 px-2 py-1">
+    <div className="overflow-hidden rounded bg-muted">
+      <div className="flex items-center justify-end bg-accent px-2 py-1">
         <CopyButton text={copyText ?? value} />
       </div>
       <PrismLight
@@ -68,7 +68,7 @@ function JsonBlock({ value, copyText }: { readonly value: string; readonly copyT
         <button
           type="button"
           onClick={() => setShowMore((s) => !s)}
-          className="flex w-full items-center justify-center gap-1 bg-zinc-800 py-1.5 text-xs text-zinc-400 hover:text-zinc-200"
+          className="flex w-full items-center justify-center gap-1 bg-accent py-1.5 text-xs text-muted-foreground hover:text-foreground"
         >
           {showMore ? (
             <><ChevronUp className="h-3.5 w-3.5" />Show less</>

--- a/frontend/src/components/chat/tool-renderers/ReadResultRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/ReadResultRenderer.tsx
@@ -68,7 +68,7 @@ export function ReadResultRenderer({ result, input }: ReadResultRendererProps): 
   const language = detectLanguage(filePath);
 
   return (
-    <div className="overflow-hidden rounded bg-zinc-900">
+    <div className="overflow-hidden rounded bg-muted">
       <PrismLight
         language={language}
         style={oneDark}
@@ -83,7 +83,7 @@ export function ReadResultRenderer({ result, input }: ReadResultRendererProps): 
         <button
           type="button"
           onClick={() => setShowMore((s) => !s)}
-          className="flex w-full items-center justify-center gap-1 bg-zinc-800 py-1.5 text-xs text-zinc-400 hover:text-zinc-200"
+          className="flex w-full items-center justify-center gap-1 bg-accent py-1.5 text-xs text-muted-foreground hover:text-foreground"
         >
           {showMore ? (
             <><ChevronUp className="h-3.5 w-3.5" />Show less</>


### PR DESCRIPTION
## Summary

- **AC-1**: Drop `ThinkingBlock` component entirely. In `AssistantBubble`, treat `item.type === "thinking"` same as `tool_result` — return null. Update `getInlineItems` to also filter thinking so the utility matches the render contract.
- **AC-2**: Replace all hardcoded `zinc-*` Tailwind classes across `ToolCallBlock.tsx` and all three tool-renderers with semantic tokens (`bg-card`, `bg-muted`, `bg-accent`, `text-foreground`, `text-muted-foreground`, `border-border`, `hover:bg-accent`). Fixes unreadable light-mode text.
- **AC-3**: `JsonResultRenderer` and `InputBlock` now use `bg-muted` / `bg-accent` against a `bg-card` parent — deliberate consistent palette via semantic tokens; no zinc shade mismatch.
- **AC-4**: Updated `MessageThread.test.tsx` — three tests that previously asserted thinking items appear in `getInlineItems` output now assert they are excluded.

## GitHub Issue
Closes #794

## Files changed
- `frontend/src/components/chat/MessageThread.tsx` — drop ThinkingBlock render + component, fix TimestampLabel token
- `frontend/src/components/chat/ToolCallBlock.tsx` — ~10 zinc-* → semantic tokens
- `frontend/src/components/chat/message-thread-utils.ts` — filter thinking in getInlineItems
- `frontend/src/components/chat/MessageThread.test.tsx` — update 3 tests for thinking exclusion
- `frontend/src/components/chat/tool-renderers/JsonResultRenderer.tsx` — semantic tokens
- `frontend/src/components/chat/tool-renderers/BashResultRenderer.tsx` — semantic tokens
- `frontend/src/components/chat/tool-renderers/ReadResultRenderer.tsx` — semantic tokens

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (generated types match openapi.json)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR