### PR TITLE
[REQ-FE-48] fix(chat): RESULT syntax-highlighter switches between oneLight/oneDark based on resolved theme

### DIFF
--- a/frontend/src/components/chat/tool-call-utils.test.ts
+++ b/frontend/src/components/chat/tool-call-utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { selectPrismStyle } from "./tool-call-utils";
+
+// Dynamic imports so the test values are guaranteed-same object references as the implementation.
+const { oneDark } = await import("react-syntax-highlighter/dist/esm/styles/prism");
+const { oneLight } = await import("react-syntax-highlighter/dist/esm/styles/prism");
+
+describe("selectPrismStyle", () => {
+  it("returns oneDark for dark theme", () => {
+    expect(selectPrismStyle("dark")).toBe(oneDark);
+  });
+
+  it("returns oneLight for light theme", () => {
+    expect(selectPrismStyle("light")).toBe(oneLight);
+  });
+});

--- a/frontend/src/components/chat/tool-call-utils.ts
+++ b/frontend/src/components/chat/tool-call-utils.ts
@@ -1,5 +1,11 @@
+import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+
 const TRUNCATE_LINES = 200;
 const TRUNCATE_BYTES = 8192;
+
+export function selectPrismStyle(resolvedTheme: "light" | "dark"): typeof oneDark {
+  return resolvedTheme === "dark" ? oneDark : oneLight;
+}
 
 export type ToolRendererType = "read" | "bash" | "json";
 

--- a/frontend/src/components/chat/tool-renderers/JsonResultRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/JsonResultRenderer.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, Copy, Check } from "lucide-react";
 import PrismLight from "react-syntax-highlighter/dist/esm/prism-light";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
 import { useCallback, useEffect, useRef } from "react";
 import { MarkdownContent } from "../MarkdownContent";
-import { deepDecodeJsonStrings, looksLikeMarkdown, needsTruncation } from "../tool-call-utils";
+import { deepDecodeJsonStrings, looksLikeMarkdown, needsTruncation, selectPrismStyle } from "../tool-call-utils";
+import { useTheme } from "@/components/theme/theme-context";
 
 PrismLight.registerLanguage("json", json);
 
@@ -50,6 +50,8 @@ function JsonBlock({ value, copyText }: { readonly value: string; readonly copyT
   const [showMore, setShowMore] = useState(false);
   const lines = value.split("\n");
   const displayValue = truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : value;
+  const { resolvedTheme } = useTheme();
+  const prismStyle = selectPrismStyle(resolvedTheme);
 
   return (
     <div className="overflow-hidden rounded bg-muted">
@@ -58,7 +60,7 @@ function JsonBlock({ value, copyText }: { readonly value: string; readonly copyT
       </div>
       <PrismLight
         language="json"
-        style={oneDark}
+        style={prismStyle}
         PreTag="div"
         customStyle={{ margin: 0, borderRadius: 0, fontSize: "0.75rem", lineHeight: "1.5" }}
       >

--- a/frontend/src/components/chat/tool-renderers/ReadResultRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/ReadResultRenderer.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import PrismLight from "react-syntax-highlighter/dist/esm/prism-light";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
 import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
@@ -9,7 +8,8 @@ import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
 import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
-import { needsTruncation } from "../tool-call-utils";
+import { needsTruncation, selectPrismStyle } from "../tool-call-utils";
+import { useTheme } from "@/components/theme/theme-context";
 
 PrismLight.registerLanguage("typescript", typescript);
 PrismLight.registerLanguage("ts", typescript);
@@ -61,6 +61,8 @@ export function ReadResultRenderer({ result, input }: ReadResultRendererProps): 
   const [showMore, setShowMore] = useState(false);
   const lines = text.split("\n");
   const displayText = truncate && !showMore ? lines.slice(0, TRUNCATE_LINES).join("\n") : text;
+  const { resolvedTheme } = useTheme();
+  const prismStyle = selectPrismStyle(resolvedTheme);
 
   const filePath = input !== null && typeof input === "object" && !Array.isArray(input)
     ? (input as Record<string, unknown>)["file_path"]
@@ -71,7 +73,7 @@ export function ReadResultRenderer({ result, input }: ReadResultRendererProps): 
     <div className="overflow-hidden rounded bg-muted">
       <PrismLight
         language={language}
-        style={oneDark}
+        style={prismStyle}
         PreTag="div"
         showLineNumbers
         customStyle={{ margin: 0, borderRadius: 0, fontSize: "0.75rem", lineHeight: "1.5" }}


### PR DESCRIPTION
## Summary

- Extract `selectPrismStyle(resolvedTheme)` into `tool-call-utils.ts` — returns `oneDark` for dark, `oneLight` for light.
- Wire it into `JsonResultRenderer` (`JsonBlock`) and `ReadResultRenderer` via `useTheme()` so both renderers track the active theme.
- Confirmed `BashResultRenderer` already uses semantic tokens (`bg-muted`/`text-foreground`) — no change needed.
- Unit tests for `selectPrismStyle`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npm run gen:api:check` — schema in sync
- [x] `npm run build` — passes
- [x] `npm run test` — 83 tests pass (2 new `selectPrismStyle` tests)
- [ ] AC-5: Live QA on mars — trigger a tool call with JSON output, toggle dark ↔ light, confirm Prism theme switches

Closes #796