### PR TITLE
[REQ-FE-49] feat(code-workspace): resizable left/right side panels

### DIFF
--- a/frontend/src/hooks/usePanelResize.ts
+++ b/frontend/src/hooks/usePanelResize.ts
@@ -1,0 +1,139 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+const STORAGE_KEY = "code-workspace.panel-widths.v1";
+const MIN_PANEL = 160;
+const MIN_CENTER = 320;
+const DEFAULT_LEFT = 224; // equivalent to w-56
+const DEFAULT_RIGHT = 256; // equivalent to w-64
+
+interface PanelWidths {
+  left: number;
+  right: number;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function loadWidths(): PanelWidths {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof parsed.left === "number" && typeof parsed.right === "number") {
+        return { left: parsed.left, right: parsed.right };
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { left: DEFAULT_LEFT, right: DEFAULT_RIGHT };
+}
+
+function saveWidths(w: PanelWidths): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(w));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+type Side = "left" | "right";
+
+interface DragState {
+  side: Side;
+  startX: number;
+  startWidth: number;
+}
+
+export interface PanelResizeHandlers {
+  leftWidth: number;
+  rightWidth: number;
+  startLeftDrag: (e: React.MouseEvent) => void;
+  startRightDrag: (e: React.MouseEvent) => void;
+  handleLeftKey: (e: React.KeyboardEvent) => void;
+  handleRightKey: (e: React.KeyboardEvent) => void;
+}
+
+export function usePanelResize(): PanelResizeHandlers {
+  const [widths, setWidths] = useState<PanelWidths>(loadWidths);
+  const dragRef = useRef<DragState | null>(null);
+
+  // Stable helpers that read window.innerWidth at call time (full-width page layout)
+  const maxLeft = useCallback((w: PanelWidths) =>
+    Math.max(MIN_PANEL, window.innerWidth - w.right - MIN_CENTER), []);
+
+  const maxRight = useCallback((w: PanelWidths) =>
+    Math.max(MIN_PANEL, window.innerWidth - w.left - MIN_CENTER), []);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const delta = e.clientX - d.startX;
+      setWidths((prev) => {
+        if (d.side === "left") {
+          return { ...prev, left: clamp(d.startWidth + delta, MIN_PANEL, maxLeft(prev)) };
+        }
+        return { ...prev, right: clamp(d.startWidth - delta, MIN_PANEL, maxRight(prev)) };
+      });
+    };
+
+    const onUp = () => {
+      if (!dragRef.current) return;
+      dragRef.current = null;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      setWidths((w) => { saveWidths(w); return w; });
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+  }, [maxLeft, maxRight]);
+
+  const startLeftDrag = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragRef.current = { side: "left", startX: e.clientX, startWidth: widths.left };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [widths.left]);
+
+  const startRightDrag = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragRef.current = { side: "right", startX: e.clientX, startWidth: widths.right };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [widths.right]);
+
+  // Left handle: ArrowRight grows panel, ArrowLeft shrinks panel
+  const handleLeftKey = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const step = e.shiftKey ? 50 : 10;
+    const delta = e.key === "ArrowRight" ? step : -step;
+    setWidths((prev) => {
+      const next = { ...prev, left: clamp(prev.left + delta, MIN_PANEL, maxLeft(prev)) };
+      saveWidths(next);
+      return next;
+    });
+  }, [maxLeft]);
+
+  // Right handle: ArrowLeft grows panel, ArrowRight shrinks panel
+  const handleRightKey = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const step = e.shiftKey ? 50 : 10;
+    const delta = e.key === "ArrowLeft" ? step : -step;
+    setWidths((prev) => {
+      const next = { ...prev, right: clamp(prev.right + delta, MIN_PANEL, maxRight(prev)) };
+      saveWidths(next);
+      return next;
+    });
+  }, [maxRight]);
+
+  return { leftWidth: widths.left, rightWidth: widths.right, startLeftDrag, startRightDrag, handleLeftKey, handleRightKey };
+}

--- a/frontend/src/pages/CodeWorkspacePage.tsx
+++ b/frontend/src/pages/CodeWorkspacePage.tsx
@@ -8,6 +8,7 @@ import {
   SearchPanel,
   RelationsPanel,
 } from "@/components/code-intel";
+import { usePanelResize } from "@/hooks/usePanelResize";
 import { routes } from "@/lib/routes";
 import { formatApiError } from "@/lib/errors/api";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,37 @@ export function CodeWorkspacePage(): JSX.Element {
   }
 
   return <CodeWorkspaceInner repoId={repoId} tenantId={me.data.current_tenant.id} />;
+}
+
+interface DragHandleProps {
+  "aria-label": string;
+  side: "left" | "right";
+  onMouseDown: (e: React.MouseEvent) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+function DragHandle({ "aria-label": ariaLabel, side, onMouseDown, onKeyDown }: DragHandleProps): JSX.Element {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      tabIndex={0}
+      className={cn(
+        "group hidden w-1 shrink-0 cursor-col-resize items-center justify-center bg-background",
+        "focus:outline-none focus-visible:bg-primary/10",
+        "hover:bg-primary/5",
+        side === "left"
+          ? "border-r border-border hover:border-primary/50 focus-visible:border-primary/70"
+          : "border-l border-border hover:border-primary/50 focus-visible:border-primary/70",
+        "md:flex",
+      )}
+      onMouseDown={onMouseDown}
+      onKeyDown={onKeyDown}
+    >
+      <span className="h-8 w-[2px] rounded-full bg-transparent transition-colors group-hover:bg-primary/30 group-focus-visible:bg-primary/50" />
+    </div>
+  );
 }
 
 interface WorkspaceShellProps {
@@ -65,6 +97,8 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
   const item = useItem(repoId, fqnB64 ?? "", { enabled: fqnB64 != null && fqnB64.length > 0 });
 
   const [sideTab, setSideTab] = useState<SideTab>("search");
+  const { leftWidth, rightWidth, startLeftDrag, startRightDrag, handleLeftKey, handleRightKey } =
+    usePanelResize();
 
   const repo = repos.data?.repos.find((r) => r.repo_id === repoId) ?? null;
   const selectedFqn = fqnB64 != null ? b64ToFqn(fqnB64) : null;
@@ -103,7 +137,8 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
         {/* Left: Module tree */}
         <aside
           aria-label="Module tree"
-          className="flex w-56 shrink-0 flex-col overflow-hidden border-r border-border bg-muted/20"
+          style={{ width: leftWidth }}
+          className="flex shrink-0 flex-col overflow-hidden border-r border-border bg-muted/20 md:border-r-0"
         >
           <div className="shrink-0 border-b border-border px-3 py-2">
             <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -124,6 +159,13 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
             />
           ) : null}
         </aside>
+
+        <DragHandle
+          aria-label="Resize left panel"
+          side="left"
+          onMouseDown={startLeftDrag}
+          onKeyDown={handleLeftKey}
+        />
 
         {/* Center: Source viewer */}
         <main className="flex flex-1 flex-col overflow-hidden" aria-label="Source viewer">
@@ -148,10 +190,18 @@ function CodeWorkspaceInner({ repoId, tenantId }: CodeWorkspaceInnerProps): JSX.
           )}
         </main>
 
+        <DragHandle
+          aria-label="Resize right panel"
+          side="right"
+          onMouseDown={startRightDrag}
+          onKeyDown={handleRightKey}
+        />
+
         {/* Right: Tabbed side panel */}
         <aside
           aria-label="Side panel"
-          className="flex w-64 shrink-0 flex-col overflow-hidden border-l border-border"
+          style={{ width: rightWidth }}
+          className="flex shrink-0 flex-col overflow-hidden border-l border-border md:border-l-0"
         >
           <div
             role="tablist"


### PR DESCRIPTION
## Summary
- Add drag-to-resize handles on the right edge of the Module tree panel and the left edge of the Search/Relations panel
- New `usePanelResize` hook handles mouse drag, keyboard nudge (←/→ ±10px, Shift+arrow ±50px), and localStorage persistence
- Center source viewer absorbs remaining width via `flex-1`; min 160px per side panel, center viewer keeps ≥320px
- Handles use `role="separator" aria-orientation="vertical"` and are fully keyboard-accessible
- Below 768px: handles hidden, panels fall back to fixed widths with aside borders restored

## GitHub Issue
Closes #798

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run gen:api:check` passes (schema in sync)
- [x] `npm run build` passes locally
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR