### PR TITLE
[REQ-FE-50] feat(code-workspace): module-tree search by module path

### DIFF
--- a/frontend/src/components/code-intel/ModuleTree.test.ts
+++ b/frontend/src/components/code-intel/ModuleTree.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { filterTree } from "./module-tree-utils";
+import type { components } from "@/api/generated/schema";
+
+type ModuleNodeItem = components["schemas"]["ModuleNodeItem"];
+
+function node(
+  fqn: string,
+  children: ModuleNodeItem[] = [],
+  kind = "MOD",
+): ModuleNodeItem {
+  return { fqn, name: fqn.split("::").at(-1) ?? fqn, kind, children, source: null };
+}
+
+// 4-level fixture:
+// root
+//   routes        (depth 1)
+//     routes::chat  (depth 2)
+//       routes::chat::handler  (depth 3 — fn)
+//     routes::admin (depth 2)
+//   utils         (depth 1)
+//     utils::fmt  (depth 2)
+const FIXTURE: ModuleNodeItem = node("root", [
+  node("routes", [
+    node("routes::chat", [
+      node("routes::chat::handler", [], "FN"),
+    ]),
+    node("routes::admin", []),
+  ]),
+  node("utils", [
+    node("utils::fmt", []),
+  ]),
+]);
+
+describe("filterTree", () => {
+  it("returns unfiltered tree with matchCount 0 when query is empty", () => {
+    const { filteredNode, matchCount } = filterTree(FIXTURE, "");
+    // empty query handled upstream; filterTree is still called with empty string
+    expect(filteredNode).toBe(FIXTURE);
+    expect(matchCount).toBe(0);
+  });
+
+  it("matches on substring of FQN (case-insensitive)", () => {
+    const { filteredNode, matchCount } = filterTree(FIXTURE, "CHAT");
+    expect(matchCount).toBe(2); // routes::chat + routes::chat::handler
+    expect(filteredNode).not.toBeNull();
+    // root is preserved as ancestor
+    expect(filteredNode?.fqn).toBe("root");
+    // routes is preserved as ancestor
+    const routes = filteredNode?.children[0];
+    expect(routes?.fqn).toBe("routes");
+    // routes::chat preserved
+    const chat = routes?.children[0];
+    expect(chat?.fqn).toBe("routes::chat");
+    // routes::admin NOT preserved (no match)
+    expect(routes?.children).toHaveLength(1);
+    // utils NOT preserved (no match)
+    expect(filteredNode?.children).toHaveLength(1);
+  });
+
+  it("returns null when nothing matches", () => {
+    const { filteredNode, matchCount } = filterTree(FIXTURE, "zzznomatch");
+    expect(filteredNode).toBeNull();
+    expect(matchCount).toBe(0);
+  });
+
+  it("self-matching leaf node is included without children", () => {
+    const { filteredNode, matchCount } = filterTree(FIXTURE, "handler");
+    expect(matchCount).toBe(1);
+    // Leaf itself
+    const handler = filteredNode?.children[0]?.children[0]?.children[0];
+    expect(handler?.fqn).toBe("routes::chat::handler");
+    expect(handler?.children).toHaveLength(0);
+  });
+
+  it("self-matching ancestor exposes its matching children", () => {
+    const { filteredNode, matchCount } = filterTree(FIXTURE, "routes::chat");
+    // routes::chat matches (1) AND routes::chat::handler matches (2)
+    expect(matchCount).toBe(2);
+    const chat = filteredNode?.children[0]?.children[0];
+    expect(chat?.fqn).toBe("routes::chat");
+    // handler is included because it also matches
+    expect(chat?.children).toHaveLength(1);
+  });
+
+  it("non-ancestor siblings are excluded", () => {
+    const { filteredNode } = filterTree(FIXTURE, "utils");
+    // Only utils branch; routes branch must be absent
+    expect(filteredNode?.children).toHaveLength(1);
+    expect(filteredNode?.children[0]?.fqn).toBe("utils");
+  });
+
+  it("match count reflects every matched FQN", () => {
+    const { matchCount } = filterTree(FIXTURE, "routes");
+    // routes, routes::chat, routes::chat::handler, routes::admin all contain "routes"
+    expect(matchCount).toBe(4);
+  });
+});

--- a/frontend/src/components/code-intel/ModuleTree.tsx
+++ b/frontend/src/components/code-intel/ModuleTree.tsx
@@ -1,9 +1,19 @@
-import { useState } from "react";
-import { ChevronDown, ChevronRight, Box, FunctionSquare, Layers, Package, type LucideProps } from "lucide-react";
+import { useState, useMemo, useRef } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Box,
+  FunctionSquare,
+  Layers,
+  Package,
+  Search,
+  type LucideProps,
+} from "lucide-react";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
 import type { components } from "@/api/generated/schema";
 import { fqnToB64 } from "@/api/hooks/useCodeIntel";
 import { cn } from "@/lib/utils";
+import { filterTree } from "./module-tree-utils";
 
 type ModuleNodeItem = components["schemas"]["ModuleNodeItem"];
 type LucideIcon = ForwardRefExoticComponent<Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>>;
@@ -15,9 +25,69 @@ interface ModuleTreeProps {
 }
 
 export function ModuleTree({ tree, selectedFqn, onSelect }: ModuleTreeProps): JSX.Element {
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const { filteredNode, matchCount } = useMemo(() => {
+    const q = searchQuery.trim();
+    if (!q) return { filteredNode: tree, matchCount: 0 };
+    return filterTree(tree, q);
+  }, [tree, searchQuery]);
+
+  const isSearchActive = searchQuery.trim().length > 0;
+
+  const handleNavKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    }
+  };
+
   return (
-    <nav aria-label="Module tree" className="h-full overflow-y-auto py-2 text-sm">
-      <TreeNode node={tree} depth={0} selectedFqn={selectedFqn} onSelect={onSelect} />
+    <nav className="flex h-full flex-col text-sm" onKeyDown={handleNavKeyDown}>
+      <div className="shrink-0 border-b border-border px-2 py-1.5">
+        <div className="relative flex items-center">
+          <Search className="pointer-events-none absolute left-2 h-3 w-3 shrink-0 text-muted-foreground" />
+          <input
+            ref={searchInputRef}
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setSearchQuery("");
+                (e.currentTarget as HTMLInputElement).blur();
+              }
+            }}
+            placeholder="Filter by path…"
+            aria-label="Search module paths"
+            className="w-full min-w-0 rounded-sm border border-input bg-background py-1 pl-6 pr-2 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        </div>
+        {isSearchActive && (
+          <p
+            className="mt-0.5 text-right text-[10px] text-muted-foreground"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {matchCount} {matchCount === 1 ? "match" : "matches"}
+          </p>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto py-2">
+        {filteredNode === null ? (
+          <p className="px-3 py-4 text-xs text-muted-foreground">No matches</p>
+        ) : (
+          <TreeNode
+            node={filteredNode}
+            depth={0}
+            selectedFqn={selectedFqn}
+            onSelect={onSelect}
+            isSearchActive={isSearchActive}
+          />
+        )}
+      </div>
     </nav>
   );
 }
@@ -55,9 +125,16 @@ interface TreeNodeProps {
   readonly depth: number;
   readonly selectedFqn: string | null;
   readonly onSelect: (fqn: string, fqnB64: string) => void;
+  readonly isSearchActive?: boolean;
 }
 
-function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.Element {
+function TreeNode({
+  node,
+  depth,
+  selectedFqn,
+  onSelect,
+  isSearchActive = false,
+}: TreeNodeProps): JSX.Element {
   const hasChildren = node.children.length > 0;
   const [expanded, setExpanded] = useState(depth < 2);
 
@@ -65,6 +142,10 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
   const isSelectable = !isModule || node.source != null;
   const isSelected = selectedFqn === node.fqn;
   const Icon = kindIcon(node.kind);
+
+  // During search, auto-expand all nodes with children — they are ancestors of matches.
+  // The local `expanded` state is not modified, so it restores naturally when search clears.
+  const effectiveExpanded = (isSearchActive && hasChildren) || expanded;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -76,10 +157,10 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
         setExpanded((v) => !v);
       }
     }
-    if (e.key === "ArrowRight" && hasChildren && !expanded) {
+    if (e.key === "ArrowRight" && hasChildren && !effectiveExpanded) {
       setExpanded(true);
     }
-    if (e.key === "ArrowLeft" && hasChildren && expanded) {
+    if (e.key === "ArrowLeft" && hasChildren && effectiveExpanded) {
       setExpanded(false);
     }
   };
@@ -88,7 +169,7 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
     <div>
       <div
         role={isSelectable ? "treeitem" : "group"}
-        aria-expanded={hasChildren ? expanded : undefined}
+        aria-expanded={hasChildren ? effectiveExpanded : undefined}
         aria-selected={isSelected}
         aria-label={`${node.name} — ${kindLabel(node.kind)}`}
         tabIndex={0}
@@ -111,7 +192,7 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
       >
         {hasChildren ? (
           <span className="shrink-0 text-muted-foreground">
-            {expanded ? (
+            {effectiveExpanded ? (
               <ChevronDown className="h-3 w-3" />
             ) : (
               <ChevronRight className="h-3 w-3" />
@@ -124,7 +205,7 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
         <span className="truncate font-mono text-xs">{node.name}</span>
       </div>
 
-      {hasChildren && expanded && (
+      {hasChildren && effectiveExpanded && (
         <div role="group">
           {node.children.map((child) => (
             <TreeNode
@@ -133,6 +214,7 @@ function TreeNode({ node, depth, selectedFqn, onSelect }: TreeNodeProps): JSX.El
               depth={depth + 1}
               selectedFqn={selectedFqn}
               onSelect={onSelect}
+              isSearchActive={isSearchActive}
             />
           ))}
         </div>

--- a/frontend/src/components/code-intel/module-tree-utils.ts
+++ b/frontend/src/components/code-intel/module-tree-utils.ts
@@ -1,0 +1,33 @@
+import type { components } from "@/api/generated/schema";
+
+type ModuleNodeItem = components["schemas"]["ModuleNodeItem"];
+
+/** Returns a pruned copy of the tree containing only nodes whose FQN contains
+ *  `query` (case-insensitive) and their ancestors. Also returns the match count.
+ *  Returns the original node unchanged with matchCount 0 when query is empty. */
+export function filterTree(
+  node: ModuleNodeItem,
+  query: string,
+): { filteredNode: ModuleNodeItem | null; matchCount: number } {
+  if (!query) return { filteredNode: node, matchCount: 0 };
+
+  const lowerQuery = query.toLowerCase();
+  let matchCount = 0;
+
+  function process(n: ModuleNodeItem): ModuleNodeItem | null {
+    const selfMatches = n.fqn.toLowerCase().includes(lowerQuery);
+    if (selfMatches) matchCount++;
+
+    const filteredChildren = n.children
+      .map((child) => process(child))
+      .filter((c): c is ModuleNodeItem => c !== null);
+
+    if (!selfMatches && filteredChildren.length === 0) {
+      return null;
+    }
+
+    return { ...n, children: filteredChildren };
+  }
+
+  return { filteredNode: process(node), matchCount };
+}


### PR DESCRIPTION
## Summary

- Adds a filter input at the top of the Module tree panel (inside the existing `<aside aria-label="Module tree">`)
- Case-insensitive substring match on FQN — all node kinds searchable (MOD, FN, STRUCT, ENUM, TRAIT, IMPL, TYPE, CONST, STATIC, MACRO)
- Ancestor branches auto-expand while query is active; non-matching nodes are hidden
- Clearing the query restores the original collapse state (depth < 2) — local expansion state is never mutated during search, only overridden for display via `isSearchActive` prop
- Match count shown below the input with `aria-live="polite"` for screen readers
- ⌘/Ctrl+K on the nav focuses the search input; Esc clears and blurs
- `filterTree` extracted to `module-tree-utils.ts` (pure utility, avoids `react-refresh/only-export-components` lint violation)
- 7 Vitest unit tests for `filterTree` with a 4-level synthetic fixture

## GitHub Issue

Closes #799

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run gen:api:check` passes
- [x] `npm run build` passes
- [x] 7/7 Vitest unit tests pass (`ModuleTree.test.ts`)
- [x] No internal tracker IDs in source/commits
- [x] One REQ per PR