### PR TITLE
[RUSAA-2089] feat: hybrid retrieval tracer-bullet (FTS + RRF + CitationV1 + flag)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "protox",
  "serde",
  "serde_json",
+ "utoipa",
  "uuid",
 ]
 

--- a/crates/rb-query/src/hybrid.rs
+++ b/crates/rb-query/src/hybrid.rs
@@ -1,0 +1,385 @@
+//! Hybrid retrieval: dense (Qdrant ANN) + sparse (Postgres FTS) fused via RRF.
+//!
+//! Entry point: [`hybrid_search`]. Mirrors the signature of [`semantic_search`] but
+//! adds a [`PgPool`] and query-text for the sparse leg. Both legs are tenant-isolated:
+//! - Dense: `TenantVectorStore::search` injects a `must` `tenant_id` filter (ADR-007 §13.2).
+//! - Sparse: query runs against the per-tenant schema (`TenantCtx::qualify`) — physically
+//!   isolated; no extra filter required (ADR-014 §10).
+//!
+//! The pure fusion function `rrf_fuse` is private; unit tests within this module
+//! access it directly to verify the k=60 math without a live database or Qdrant instance.
+//!
+//! Rerank is intentionally **not** applied here — it is the caller's (control-api)
+//! responsibility, keeping `rb-query` free of a dependency on `rb-rerank` (ADR-014 §2).
+
+use std::collections::HashMap;
+
+use rb_schemas::TenantId;
+use rb_storage_qdrant::TenantVectorStore;
+use rb_tenant::TenantCtx;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    QueryError,
+    vector::search::{SearchOptions, SemanticHit, semantic_search},
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// RRF smoothing constant (ADR-014 §3.3). Fixed for v1; k=60 is the standard baseline.
+pub const RRF_K: f32 = 60.0;
+
+/// Minimum fetch depth per leg: `N_fetch = max(limit, MIN_FETCH)`.
+const MIN_FETCH: u32 = 50;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Options for [`hybrid_search`].
+pub struct HybridSearchOptions {
+    /// Maximum number of fused results to return (after fusion + truncation).
+    pub limit: u32,
+    /// When set, restricts both legs to a single repository.
+    pub repo_id: Option<Uuid>,
+}
+
+/// A fused result from the hybrid retrieval path.
+#[derive(Debug, Clone)]
+pub struct HybridHit {
+    /// Fully-qualified name of the matched code symbol.
+    pub fqn: String,
+    /// Repository UUID (as string, matching `SemanticHit` convention).
+    pub repo_id: String,
+    /// Relative path within the repo (from `code_symbols.source_path`).
+    pub source_path: Option<String>,
+    /// First line of the symbol (1-indexed, inclusive).
+    pub line_start: Option<i32>,
+    /// Last line of the symbol (1-indexed, inclusive).
+    pub line_end: Option<i32>,
+    /// RRF-fused score normalized to `[0, 1]`. Higher is more relevant.
+    pub score: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+type SparseRow = (String, String, Option<String>, Option<i32>, Option<i32>);
+
+/// Raw row returned by the sparse FTS query.
+#[derive(Debug, Clone)]
+struct SparseHit {
+    fqn: String,
+    repo_id: String,
+    source_path: Option<String>,
+    line_start: Option<i32>,
+    line_end: Option<i32>,
+}
+
+impl From<SparseRow> for SparseHit {
+    fn from((fqn, repo_id, source_path, line_start, line_end): SparseRow) -> Self {
+        Self {
+            fqn,
+            repo_id,
+            source_path,
+            line_start,
+            line_end,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sparse leg
+// ---------------------------------------------------------------------------
+
+async fn sparse_search(
+    pool: &PgPool,
+    ctx: &TenantCtx,
+    query_text: &str,
+    limit: u32,
+    repo_id: Option<Uuid>,
+) -> Result<Vec<SparseHit>, QueryError> {
+    // Schema is tenant-qualified — no additional tenant_id filter needed.
+    let table = ctx.qualify("code_symbols");
+    let rows: Vec<SparseRow> = match repo_id {
+        Some(rid) => {
+            sqlx::query_as(&format!(
+                "SELECT fqn, repo_id::text, source_path, line_start, line_end \
+                 FROM {table} \
+                 WHERE fts @@ plainto_tsquery('simple', $1) \
+                   AND repo_id = $2 \
+                 ORDER BY ts_rank_cd(fts, plainto_tsquery('simple', $1)) DESC \
+                 LIMIT $3",
+            ))
+            .bind(query_text)
+            .bind(rid)
+            .bind(i64::from(limit))
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as(&format!(
+                "SELECT fqn, repo_id::text, source_path, line_start, line_end \
+                 FROM {table} \
+                 WHERE fts @@ plainto_tsquery('simple', $1) \
+                 ORDER BY ts_rank_cd(fts, plainto_tsquery('simple', $1)) DESC \
+                 LIMIT $2",
+            ))
+            .bind(query_text)
+            .bind(i64::from(limit))
+            .fetch_all(pool)
+            .await?
+        }
+    };
+
+    Ok(rows.into_iter().map(SparseHit::from).collect())
+}
+
+// ---------------------------------------------------------------------------
+// RRF fusion
+// ---------------------------------------------------------------------------
+
+/// Fuse two ranked lists via Reciprocal Rank Fusion (RRF, k=60).
+///
+/// Formula per hit `d`: `RRF(d) = Σ_legs 1 / (k + rank_leg(d))` where rank is 1-indexed.
+/// Result is truncated to `limit` and returned in descending score order.
+///
+/// Returns `Vec<(fqn, repo_id, raw_rrf_score)>` — callers normalize the score.
+fn rrf_fuse(
+    dense: &[SemanticHit],
+    sparse: &[SparseHit],
+    k: f32,
+    limit: usize,
+) -> Vec<(String, String, f32)> {
+    let mut scores: HashMap<&str, f32> = HashMap::new();
+
+    for (rank, hit) in dense.iter().enumerate() {
+        // rank is at most MIN_FETCH (50) — cast is safe in practice.
+        #[allow(clippy::cast_precision_loss)]
+        let contrib = 1.0 / (k + (rank + 1) as f32);
+        *scores.entry(hit.fqn.as_str()).or_insert(0.0) += contrib;
+    }
+    for (rank, hit) in sparse.iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let contrib = 1.0 / (k + (rank + 1) as f32);
+        *scores.entry(hit.fqn.as_str()).or_insert(0.0) += contrib;
+    }
+
+    // Build fqn → repo_id lookup (dense wins on tie; both legs agree in practice).
+    let mut fqn_repo: HashMap<&str, &str> = HashMap::new();
+    for h in dense {
+        fqn_repo.entry(h.fqn.as_str()).or_insert(h.repo_id.as_str());
+    }
+    for h in sparse {
+        fqn_repo.entry(h.fqn.as_str()).or_insert(h.repo_id.as_str());
+    }
+
+    let mut ranked: Vec<(&str, f32)> = scores.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.truncate(limit);
+
+    ranked
+        .into_iter()
+        .map(|(fqn, rrf_score)| {
+            let repo_id = fqn_repo.get(fqn).copied().unwrap_or("").to_owned();
+            (fqn.to_owned(), repo_id, rrf_score)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Hybrid semantic + full-text search within a single tenant's code corpus.
+///
+/// Runs the dense leg (`semantic_search` via Qdrant) and the sparse leg (Postgres
+/// `ts_rank_cd`) to depth `N_fetch = max(limit, 50)`, fuses results
+/// via RRF (k=60), and returns the top `limit` hits in descending score order.
+///
+/// Both legs enforce tenant isolation independently (see module-level docs).
+///
+/// # Errors
+///
+/// Returns [`QueryError::Database`] on Postgres failure or [`QueryError::Qdrant`]
+/// on Qdrant failure.
+pub async fn hybrid_search(
+    pool: &PgPool,
+    store: &TenantVectorStore,
+    tenant_id: &TenantId,
+    vector: &[f32],
+    query_text: &str,
+    opts: HybridSearchOptions,
+) -> Result<Vec<HybridHit>, QueryError> {
+    let n_fetch = opts.limit.max(MIN_FETCH);
+    let ctx = TenantCtx::new(*tenant_id);
+
+    // Run both legs sequentially (tracer slice; S7 adds parallelism + budget guard).
+    let dense_hits = semantic_search(
+        store,
+        tenant_id,
+        vector,
+        SearchOptions {
+            limit: n_fetch,
+            repo_id: opts.repo_id,
+        },
+    )
+    .await?;
+    let sparse_hits = sparse_search(pool, &ctx, query_text, n_fetch, opts.repo_id).await?;
+
+    // Fuse via RRF, then normalize scores to [0, 1].
+    #[allow(clippy::cast_possible_truncation)]
+    let fused = rrf_fuse(&dense_hits, &sparse_hits, RRF_K, opts.limit as usize);
+    let max_score = fused.iter().map(|(_, _, s)| *s).fold(0.0f32, f32::max);
+
+    // Build metadata lookup from sparse hits (carries source_path, line_start/end).
+    let sparse_meta: HashMap<&str, &SparseHit> =
+        sparse_hits.iter().map(|h| (h.fqn.as_str(), h)).collect();
+
+    let results = fused
+        .into_iter()
+        .map(|(fqn, repo_id, raw_score)| {
+            let normalized = if max_score > 0.0 {
+                raw_score / max_score
+            } else {
+                0.0
+            };
+            let meta = sparse_meta.get(fqn.as_str()).copied();
+            HybridHit {
+                source_path: meta.and_then(|m| m.source_path.clone()),
+                line_start: meta.and_then(|m| m.line_start),
+                line_end: meta.and_then(|m| m.line_end),
+                fqn,
+                repo_id,
+                score: normalized,
+            }
+        })
+        .collect();
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dense(items: &[(&str, &str)]) -> Vec<SemanticHit> {
+        items
+            .iter()
+            .map(|(fqn, repo)| SemanticHit {
+                fqn: (*fqn).to_owned(),
+                repo_id: (*repo).to_owned(),
+                score: 0.9,
+            })
+            .collect()
+    }
+
+    fn sparse(items: &[(&str, &str)]) -> Vec<SparseHit> {
+        items
+            .iter()
+            .map(|(fqn, repo)| SparseHit {
+                fqn: (*fqn).to_owned(),
+                repo_id: (*repo).to_owned(),
+                source_path: Some("src/lib.rs".to_owned()),
+                line_start: Some(1),
+                line_end: Some(10),
+            })
+            .collect()
+    }
+
+    // AC2(a): only dense hits — sparse is empty.
+    #[test]
+    fn rrf_only_dense_hits() {
+        let d = dense(&[("a::Fn", "r1"), ("b::Fn", "r1"), ("c::Fn", "r1")]);
+        let s: Vec<SparseHit> = vec![];
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+
+        assert_eq!(fused.len(), 3);
+        assert_eq!(fused[0].0, "a::Fn");
+        assert_eq!(fused[1].0, "b::Fn");
+        assert_eq!(fused[2].0, "c::Fn");
+        assert!(fused.iter().all(|(_, _, s)| *s > 0.0));
+    }
+
+    // AC2(b): only sparse hits — dense is empty.
+    #[test]
+    fn rrf_only_sparse_hits() {
+        let d: Vec<SemanticHit> = vec![];
+        let s = sparse(&[("x::Struct", "r2"), ("y::Struct", "r2")]);
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+
+        assert_eq!(fused.len(), 2);
+        assert_eq!(fused[0].0, "x::Struct");
+        assert!(fused[0].2 > fused[1].2);
+    }
+
+    // AC2(c): overlapping ranks — hit in both legs scores higher.
+    #[test]
+    fn rrf_overlapping_ranks_scores_higher() {
+        let d = dense(&[("shared", "r1"), ("dense_only", "r1")]);
+        let s = sparse(&[("shared", "r1"), ("sparse_only", "r1")]);
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+
+        let score_shared = fused.iter().find(|(f, _, _)| f == "shared").unwrap().2;
+        let score_dense = fused.iter().find(|(f, _, _)| f == "dense_only").unwrap().2;
+        let score_sparse = fused.iter().find(|(f, _, _)| f == "sparse_only").unwrap().2;
+
+        assert!(score_shared > score_dense);
+        assert!(score_shared > score_sparse);
+    }
+
+    // AC2(d): k=60 math is correct.
+    #[test]
+    fn rrf_k60_math_correct() {
+        let d = dense(&[("only", "r1")]);
+        let s: Vec<SparseHit> = vec![];
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+
+        assert_eq!(fused.len(), 1);
+        let expected = 1.0_f32 / (60.0 + 1.0);
+        assert!(
+            (fused[0].2 - expected).abs() < 1e-6,
+            "expected {expected}, got {}",
+            fused[0].2
+        );
+    }
+
+    #[test]
+    fn rrf_truncates_to_limit() {
+        let items: Vec<(&str, &str)> = (0..20usize)
+            .map(|i| {
+                let fqn: &'static str = Box::leak(format!("fn_{i}::Fn").into_boxed_str());
+                (fqn, "r1")
+            })
+            .collect();
+        let d = dense(&items);
+        let s: Vec<SparseHit> = vec![];
+        let fused = rrf_fuse(&d, &s, RRF_K, 5);
+        assert_eq!(fused.len(), 5);
+    }
+
+    #[test]
+    fn rrf_empty_both_legs_returns_empty() {
+        let d: Vec<SemanticHit> = vec![];
+        let s: Vec<SparseHit> = vec![];
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn rrf_fuse_repo_id_from_dense_on_tie() {
+        let d = dense(&[("shared", "dense-repo")]);
+        let s = sparse(&[("shared", "sparse-repo")]);
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+        let (_, repo, _) = &fused[0];
+        assert_eq!(repo, "dense-repo");
+    }
+}

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -11,7 +11,7 @@
 
 mod error;
 mod graph;
-pub mod hybrid;
+mod hybrid;
 mod pg;
 mod semantic;
 mod vector;

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -7,9 +7,11 @@
 //! [`rb_storage_neo4j::TenantGraph`] for tenant isolation (ADR-007 §3.4).
 //! The `vector` module provides semantic search via [`rb_storage_qdrant::TenantVectorStore`]
 //! with mandatory per-tenant isolation (ADR-007 §13.2).
+//! The `hybrid` module fuses dense + sparse legs via RRF (ADR-014 §3).
 
 mod error;
 mod graph;
+pub mod hybrid;
 mod pg;
 mod semantic;
 mod vector;
@@ -21,6 +23,7 @@ pub use graph::traversal::{
     TraversalNode, TraversalOptions, TraversalResult, fetch_callees, fetch_callers,
 };
 pub use graph::usages::{UsageEntry, fetch_type_usages};
+pub use hybrid::{HybridHit, HybridSearchOptions, hybrid_search};
 pub use pg::items;
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};
 pub use semantic::{SemanticSearchError, search_by_vector};

--- a/crates/rb-schemas/Cargo.toml
+++ b/crates/rb-schemas/Cargo.toml
@@ -11,6 +11,7 @@ prost.workspace = true
 uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+utoipa.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rb-schemas/src/citation.rs
+++ b/crates/rb-schemas/src/citation.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// Line range (inclusive on both ends) within a source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct LineRange {
+    pub start: i32,
+    pub end: i32,
+}
+
+/// Which retrieval leg(s) produced this hit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Dense,
+    Sparse,
+    Hybrid,
+    Rerank,
+}
+
+/// Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool
+/// when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 §5, Wave 10 S2).
+///
+/// S4 (chat UI citation rendering) builds against this exact shape. Field additions
+/// within the same `version` value are additive; breaking changes must bump `version`.
+///
+/// `commit_sha` is always non-empty: Wave 10 sources the repo-level head SHA at
+/// ingest time when per-symbol SHAs are unavailable. Consumers should treat it as
+/// a best-effort "ingested at this commit" rather than a per-line provenance.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CitationV1 {
+    /// Schema version tag. Always `"v1"` for this type.
+    pub version: String,
+    /// Repository that contains this symbol.
+    pub repo_id: Uuid,
+    /// Relative path within the repository (from `code_symbols.source_path`).
+    pub file_path: String,
+    /// Source line range (from `code_symbols.line_start`/`line_end`).
+    pub line_range: LineRange,
+    /// Commit SHA at which this symbol was ingested. Non-empty; see type-level docs.
+    pub commit_sha: String,
+    /// Fused score normalized to `[0, 1]`.
+    pub score: f32,
+    /// Which retrieval path(s) produced this result.
+    pub source_kind: SourceKind,
+}
+
+impl CitationV1 {
+    pub const VERSION: &'static str = "v1";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn citation_v1_serializes_version_field() {
+        let c = CitationV1 {
+            version: CitationV1::VERSION.to_owned(),
+            repo_id: Uuid::nil(),
+            file_path: "src/lib.rs".to_owned(),
+            line_range: LineRange { start: 1, end: 10 },
+            commit_sha: "abc123".to_owned(),
+            score: 0.85,
+            source_kind: SourceKind::Hybrid,
+        };
+        let json = serde_json::to_value(&c).unwrap();
+        assert_eq!(json["version"], "v1");
+        assert_eq!(json["source_kind"], "hybrid");
+        assert_eq!(json["line_range"]["start"], 1);
+        assert_eq!(json["line_range"]["end"], 10);
+    }
+
+    #[test]
+    fn citation_v1_roundtrip() {
+        let c = CitationV1 {
+            version: CitationV1::VERSION.to_owned(),
+            repo_id: Uuid::new_v4(),
+            file_path: "crates/rb-query/src/lib.rs".to_owned(),
+            line_range: LineRange { start: 42, end: 87 },
+            commit_sha: "deadbeef12345678".to_owned(),
+            score: 0.73,
+            source_kind: SourceKind::Dense,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: CitationV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.file_path, c.file_path);
+        assert_eq!(back.line_range.start, c.line_range.start);
+        assert_eq!(back.commit_sha, c.commit_sha);
+        assert_eq!(back.source_kind, SourceKind::Dense);
+    }
+
+    #[test]
+    fn source_kind_all_variants_serialize() {
+        for (kind, expected) in [
+            (SourceKind::Dense, "dense"),
+            (SourceKind::Sparse, "sparse"),
+            (SourceKind::Hybrid, "hybrid"),
+            (SourceKind::Rerank, "rerank"),
+        ] {
+            let s = serde_json::to_value(kind).unwrap();
+            assert_eq!(s, expected);
+        }
+    }
+}

--- a/crates/rb-schemas/src/lib.rs
+++ b/crates/rb-schemas/src/lib.rs
@@ -1,5 +1,8 @@
 use uuid::Uuid;
 
+mod citation;
+pub use citation::{CitationV1, LineRange, SourceKind};
+
 mod stream_json;
 pub use stream_json::RuntimeEvent;
 

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1330,6 +1330,27 @@ export interface components {
             /** Format: uuid */
             readonly user_id?: string | null;
         };
+        /** @description Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 §5). */
+        readonly CitationV1: {
+            /** @description Schema version tag. Always `"v1"` for this type. */
+            readonly version: string;
+            /**
+             * Format: uuid
+             * @description Repository that contains this symbol.
+             */
+            readonly repo_id: string;
+            /** @description Relative path within the repository (from `code_symbols.source_path`). */
+            readonly file_path: string;
+            readonly line_range: components["schemas"]["LineRange"];
+            /** @description Commit SHA at which this symbol was ingested. Non-empty. */
+            readonly commit_sha: string;
+            /**
+             * Format: float
+             * @description Fused score normalized to `[0, 1]`.
+             */
+            readonly score: number;
+            readonly source_kind: components["schemas"]["SourceKind"];
+        };
         readonly ConnectRepoRequest: {
             /** @description Default branch override. If omitted, the value is fetched from GitHub. */
             readonly default_branch?: string | null;
@@ -1556,6 +1577,19 @@ export interface components {
              */
             readonly source_preview?: string | null;
         };
+        /** @description Line range (inclusive on both ends) within a source file. */
+        readonly LineRange: {
+            /**
+             * Format: int32
+             * @description First line (1-based, inclusive).
+             */
+            readonly start: number;
+            /**
+             * Format: int32
+             * @description Last line (1-based, inclusive).
+             */
+            readonly end: number;
+        };
         readonly ListApiKeysResponse: {
             readonly keys: readonly components["schemas"]["ApiKeyItem"][];
         };
@@ -1738,6 +1772,8 @@ export interface components {
         /** @description Response body for `POST /v1/search`. */
         readonly SearchResponse: {
             readonly results: readonly components["schemas"]["SearchResult"][];
+            /** @description Citation envelopes (CitationV1). Populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent (empty) otherwise to preserve flag-off byte-compatibility. */
+            readonly citations?: readonly components["schemas"]["CitationV1"][];
         };
         /** @description A single ranked result returned by `/v1/search`. */
         readonly SearchResult: {
@@ -1810,6 +1846,11 @@ export interface components {
             /** Format: uuid */
             readonly user_id: string;
         };
+        /**
+         * @description Which retrieval leg(s) produced this hit.
+         * @enum {string}
+         */
+        readonly SourceKind: "dense" | "sparse" | "hybrid" | "rerank";
         readonly StageRunItem: {
             readonly error_message?: string | null;
             /** Format: date-time */

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1011,6 +1011,9 @@ export interface paths {
          *     the Qdrant `rb_embeddings` collection filtered by `tenant_id`, and returns
          *     ranked results with their fully-qualified names and crate context.
          *
+         *     When `RB_HYBRID_SEARCH_ENABLED=true`, also runs Postgres FTS and fuses
+         *     results via RRF k=60, returning `CitationV1` envelopes in `citations`.
+         *
          *     Returns 503 when either Qdrant (`RB_QDRANT_URL`) or Ollama (`RB_OLLAMA_URL`)
          *     are not configured on this instance.
          */
@@ -1330,26 +1333,38 @@ export interface components {
             /** Format: uuid */
             readonly user_id?: string | null;
         };
-        /** @description Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 §5). */
+        /**
+         * @description Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool
+         *     when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 §5, Wave 10 S2).
+         *
+         *     S4 (chat UI citation rendering) builds against this exact shape. Field additions
+         *     within the same `version` value are additive; breaking changes must bump `version`.
+         *
+         *     `commit_sha` is always non-empty: Wave 10 sources the repo-level head SHA at
+         *     ingest time when per-symbol SHAs are unavailable. Consumers should treat it as
+         *     a best-effort "ingested at this commit" rather than a per-line provenance.
+         */
         readonly CitationV1: {
-            /** @description Schema version tag. Always `"v1"` for this type. */
-            readonly version: string;
+            /** @description Commit SHA at which this symbol was ingested. Non-empty; see type-level docs. */
+            readonly commit_sha: string;
+            /** @description Relative path within the repository (from `code_symbols.source_path`). */
+            readonly file_path: string;
+            /** @description Source line range (from `code_symbols.line_start`/`line_end`). */
+            readonly line_range: components["schemas"]["LineRange"];
             /**
              * Format: uuid
              * @description Repository that contains this symbol.
              */
             readonly repo_id: string;
-            /** @description Relative path within the repository (from `code_symbols.source_path`). */
-            readonly file_path: string;
-            readonly line_range: components["schemas"]["LineRange"];
-            /** @description Commit SHA at which this symbol was ingested. Non-empty. */
-            readonly commit_sha: string;
             /**
              * Format: float
              * @description Fused score normalized to `[0, 1]`.
              */
             readonly score: number;
+            /** @description Which retrieval path(s) produced this result. */
             readonly source_kind: components["schemas"]["SourceKind"];
+            /** @description Schema version tag. Always `"v1"` for this type. */
+            readonly version: string;
         };
         readonly ConnectRepoRequest: {
             /** @description Default branch override. If omitted, the value is fetched from GitHub. */
@@ -1579,16 +1594,10 @@ export interface components {
         };
         /** @description Line range (inclusive on both ends) within a source file. */
         readonly LineRange: {
-            /**
-             * Format: int32
-             * @description First line (1-based, inclusive).
-             */
-            readonly start: number;
-            /**
-             * Format: int32
-             * @description Last line (1-based, inclusive).
-             */
+            /** Format: int32 */
             readonly end: number;
+            /** Format: int32 */
+            readonly start: number;
         };
         readonly ListApiKeysResponse: {
             readonly keys: readonly components["schemas"]["ApiKeyItem"][];
@@ -1769,11 +1778,16 @@ export interface components {
             /** @description Natural-language query to embed and search. */
             readonly q: string;
         };
-        /** @description Response body for `POST /v1/search`. */
+        /**
+         * @description Response body for `POST /v1/search`.
+         *
+         *     `results` is always present (backward compat).
+         *     `citations` is populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent otherwise
+         *     (skipped in serialization when empty) so flag-off response is byte-identical to pre-S2.
+         */
         readonly SearchResponse: {
-            readonly results: readonly components["schemas"]["SearchResult"][];
-            /** @description Citation envelopes (CitationV1). Populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent (empty) otherwise to preserve flag-off byte-compatibility. */
             readonly citations?: readonly components["schemas"]["CitationV1"][];
+            readonly results: readonly components["schemas"]["SearchResult"][];
         };
         /** @description A single ranked result returned by `/v1/search`. */
         readonly SearchResult: {

--- a/migrations/tenant/007_code_symbols_fts.sql
+++ b/migrations/tenant/007_code_symbols_fts.sql
@@ -1,0 +1,16 @@
+-- Wave 10 S2: add FTS column + GIN index to code_symbols for hybrid retrieval.
+--
+-- GENERATED ALWAYS AS ... STORED means Postgres self-maintains the tsvector on
+-- insert/update — no application change required in projector-pg or embed-worker.
+-- 'simple' config avoids language stemming that hurts code identifiers.
+-- The sparse leg of hybrid_search uses ts_rank_cd + plainto_tsquery('simple', $q).
+--
+-- This migration is additive; the dense path is untouched.
+ALTER TABLE code_symbols
+  ADD COLUMN IF NOT EXISTS fts tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('simple',
+      coalesce(fqn, '') || ' ' || coalesce(source_text, ''))
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_code_symbols_fts ON code_symbols USING GIN (fts);

--- a/openapi.json
+++ b/openapi.json
@@ -19,7 +19,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "List admin audit-log rows (operator-only, ADR-012 \u00a7S1.2).",
+        "summary": "List admin audit-log rows (operator-only, ADR-012 §S1.2).",
         "description": "Returns up to `limit` rows (default 100, max 500) in descending\n`created_at` order.  Each row now includes the `ip` and `user_agent`\nfields that were captured at request time (RUSAA-1801).",
         "operationId": "list_audit_log",
         "parameters": [
@@ -99,7 +99,7 @@
           "health"
         ],
         "summary": "Liveness probe with per-store connectivity status.",
-        "description": "Returns 200 in all cases (even when stores are degraded) so load-balancers\ndo not kill the process \u2014 callers inspect `status` for fine-grained health.\nPublic / unauthenticated.",
+        "description": "Returns 200 in all cases (even when stores are degraded) so load-balancers\ndo not kill the process — callers inspect `status` for fine-grained health.\nPublic / unauthenticated.",
         "operationId": "health_check",
         "responses": {
           "200": {
@@ -120,7 +120,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Compile-time build provenance \u2014 SHA, timestamp, and dirty flag.",
+        "summary": "Compile-time build provenance — SHA, timestamp, and dirty flag.",
         "description": "Public / unauthenticated. Returns commit SHA only (board decision 2026-05-21).\nUsed by CI smoke gate and the dev-stack watcher to detect stale images.",
         "operationId": "build_info",
         "responses": {
@@ -166,7 +166,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Readiness probe \u2014 returns 200 when the service is ready to serve traffic.",
+        "summary": "Readiness probe — returns 200 when the service is ready to serve traffic.",
         "operationId": "ready_check",
         "responses": {
           "200": {
@@ -190,7 +190,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Build identity \u2014 SHA and timestamp baked in at image build time.",
+        "summary": "Build identity — SHA and timestamp baked in at image build time.",
         "description": "Public / unauthenticated. Returns `\"unknown\"` for fields not set during\nthe docker build (e.g. local `docker build` without `--build-arg`).",
         "operationId": "version",
         "responses": {
@@ -617,7 +617,7 @@
           "api-keys"
         ],
         "summary": "List all active (non-revoked) API keys for the current session's tenant.",
-        "description": "Plaintext keys are never returned \u2014 only metadata.\nRequires an active session.",
+        "description": "Plaintext keys are never returned — only metadata.\nRequires an active session.",
         "operationId": "list_api_keys",
         "responses": {
           "200": {
@@ -717,7 +717,7 @@
           {
             "name": "tenant_id",
             "in": "query",
-            "description": "Restrict to this tenant UUID.  For session callers this must match\n(or be absent) \u2014 the session tenant is used as the implicit default.",
+            "description": "Restrict to this tenant UUID.  For session callers this must match\n(or be absent) — the session tenant is used as the implicit default.",
             "required": false,
             "schema": {
               "type": [
@@ -768,7 +768,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of rows to return (1\u2013500; default 100).",
+            "description": "Maximum number of rows to return (1–500; default 100).",
             "required": false,
             "schema": {
               "type": [
@@ -805,7 +805,7 @@
           "auth"
         ],
         "summary": "Request a password-reset email.",
-        "description": "Always returns 200 OK regardless of whether the address is registered,\npreventing email enumeration. When found, a reset link with a 15-minute\nexpiry is emailed. When not found, a dummy argon2id hash is performed to\nkeep the response time within \u00b150ms of a real lookup.",
+        "description": "Always returns 200 OK regardless of whether the address is registered,\npreventing email enumeration. When found, a reset link with a 15-minute\nexpiry is emailed. When not found, a dummy argon2id hash is performed to\nkeep the response time within ±50ms of a real lookup.",
         "operationId": "forgot_password",
         "requestBody": {
           "content": {
@@ -871,7 +871,7 @@
           "auth"
         ],
         "summary": "Revoke the caller's current session and clear the `rb_session` cookie.",
-        "description": "Sets `revoked_at = now()` on the session row, writes a `logout` row to\n`control.auth_events` for audit, and returns `204 No Content` with a\n`Set-Cookie` header that overwrites `rb_session` with `Max-Age=0` so the\nbrowser drops it. Requires an authenticated session \u2014 anonymous and\nAPI-key callers receive `401 unauthorized`.",
+        "description": "Sets `revoked_at = now()` on the session row, writes a `logout` row to\n`control.auth_events` for audit, and returns `204 No Content` with a\n`Set-Cookie` header that overwrites `rb_session` with `Max-Age=0` so the\nbrowser drops it. Requires an authenticated session — anonymous and\nAPI-key callers receive `401 unauthorized`.",
         "operationId": "logout",
         "responses": {
           "204": {
@@ -889,7 +889,7 @@
           "auth"
         ],
         "summary": "Resend a verification email.",
-        "description": "Invalidates any existing unused verify tokens for the address and issues a\nfresh one with a 1-hour expiry. Always returns 204 to avoid email\nenumeration \u2014 callers cannot distinguish a known-unverified address from\nan unknown or already-verified one. Rate-gated via the login rate limiter.",
+        "description": "Invalidates any existing unused verify tokens for the address and issues a\nfresh one with a 1-hour expiry. Always returns 204 to avoid email\nenumeration — callers cannot distinguish a known-unverified address from\nan unknown or already-verified one. Rate-gated via the login rate limiter.",
         "operationId": "resend_verification",
         "requestBody": {
           "content": {
@@ -1489,7 +1489,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of runs to return (1\u2013100; default 50).",
+            "description": "Maximum number of runs to return (1–100; default 50).",
             "required": false,
             "schema": {
               "type": [
@@ -1568,7 +1568,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Return the authenticated user's profile, current tenant, and available\ntenants. As a side-effect, refreshes the session's `last_seen_at` and\nextends `expires_at` by `session_ttl_days` so the session is sliding\nrather than fixed-from-login. The refresh is fire-and-forget \u2014 failing\nto extend the session does not fail the request (see REQ-AU-06).",
+        "summary": "Return the authenticated user's profile, current tenant, and available\ntenants. As a side-effect, refreshes the session's `last_seen_at` and\nextends `expires_at` by `session_ttl_days` so the session is sliding\nrather than fixed-from-login. The refresh is fire-and-forget — failing\nto extend the session does not fail the request (see REQ-AU-06).",
         "operationId": "get_me",
         "responses": {
           "200": {
@@ -1821,7 +1821,7 @@
           "query"
         ],
         "summary": "Retrieve a code symbol by its fully-qualified name within a repository.",
-        "description": "`fqn_b64` must be the FQN encoded as URL-safe base64 without padding\n(`base64url` / RFC 4648 \u00a75, no `=` padding). Returns the item's metadata\nand, when the stored source is \u2264 4 KiB, an inline `source_preview`.\nLarger items carry only a `blob_ref` URI pointing to the full AST JSON.\n\nCross-tenant requests are rejected: the repository must belong to the\ncaller's tenant (AC4). Returns 404 both when the repo is absent and when\nthe `(repo_id, fqn)` tuple is not found (AC2).",
+        "description": "`fqn_b64` must be the FQN encoded as URL-safe base64 without padding\n(`base64url` / RFC 4648 §5, no `=` padding). Returns the item's metadata\nand, when the stored source is ≤ 4 KiB, an inline `source_preview`.\nLarger items carry only a `blob_ref` URI pointing to the full AST JSON.\n\nCross-tenant requests are rejected: the repository must belong to the\ncaller's tenant (AC4). Returns 404 both when the repo is absent and when\nthe `(repo_id, fqn)` tuple is not found (AC2).",
         "operationId": "get_item",
         "parameters": [
           {
@@ -1901,7 +1901,7 @@
           {
             "name": "depth",
             "in": "query",
-            "description": "BFS traversal depth (1\u201310, default 3).",
+            "description": "BFS traversal depth (1–10, default 3).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -1912,7 +1912,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum edges to return per page (1\u2013200, default 50).",
+            "description": "Maximum edges to return per page (1–200, default 50).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -1992,7 +1992,7 @@
           {
             "name": "depth",
             "in": "query",
-            "description": "BFS traversal depth (1\u201310, default 3).",
+            "description": "BFS traversal depth (1–10, default 3).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -2003,7 +2003,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum edges to return per page (1\u2013200, default 50).",
+            "description": "Maximum edges to return per page (1–200, default 50).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -2116,7 +2116,7 @@
           "query"
         ],
         "summary": "List all usages of the type identified by `fqn_b64` within a repository.",
-        "description": "Returns two categories of usage combined in a flat list:\n- **Textual** (`usage_kind = \"textual\"`)  \u2014 items that reference the type\n  by name (`USES_TYPE` edge).\n- **Monomorphized** (`usage_kind = \"monomorphized\"`) \u2014 `TypeInstance` nodes\n  derived from this type via a `MONOMORPHIZED_FROM` edge.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
+        "description": "Returns two categories of usage combined in a flat list:\n- **Textual** (`usage_kind = \"textual\"`)  — items that reference the type\n  by name (`USES_TYPE` edge).\n- **Monomorphized** (`usage_kind = \"monomorphized\"`) — `TypeInstance` nodes\n  derived from this type via a `MONOMORPHIZED_FROM` edge.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
         "operationId": "get_type_usages",
         "parameters": [
           {
@@ -2217,7 +2217,7 @@
           "search"
         ],
         "summary": "Semantic search across embedded code symbols within the caller's tenant.",
-        "description": "Embeds `q` via Ollama, performs approximate nearest-neighbour search in\nthe Qdrant `rb_embeddings` collection filtered by `tenant_id`, and returns\nranked results with their fully-qualified names and crate context.\n\nReturns 503 when either Qdrant (`RB_QDRANT_URL`) or Ollama (`RB_OLLAMA_URL`)\nare not configured on this instance.",
+        "description": "Embeds `q` via Ollama, performs approximate nearest-neighbour search in\nthe Qdrant `rb_embeddings` collection filtered by `tenant_id`, and returns\nranked results with their fully-qualified names and crate context.\n\nWhen `RB_HYBRID_SEARCH_ENABLED=true`, also runs Postgres FTS and fuses\nresults via RRF k=60, returning `CitationV1` envelopes in `citations`.\n\nReturns 503 when either Qdrant (`RB_QDRANT_URL`) or Ollama (`RB_OLLAMA_URL`)\nare not configured on this instance.",
         "operationId": "search",
         "requestBody": {
           "content": {
@@ -2261,7 +2261,7 @@
           "tenants"
         ],
         "summary": "Delete a tenant (owner-only, requires typed confirmation).",
-        "description": "Soft-deletes the tenant by setting `deleted_at` and transitioning its\nstatus to `deleting`, cancels all in-flight ingestion runs, then emits a\n`Tombstone` to `rb.tombstones.v1`. The tombstoner service performs the\nasync data-plane cleanup (`PostgreSQL` schema drop, `Neo4j` node removal,\n`Qdrant` point deletion).\n\n**Idempotent**: repeating the call on a tenant already in `deleting` or\n`deleted` state returns `204 No Content`.\n\n**Typed confirmation**: the `X-Confirm` header must match the tenant slug\nexactly (case-insensitive) to prevent accidental deletions.\n\nReturns `503` if the Kafka producer is not available \u2014 the request can be\nretried once the broker is reachable.",
+        "description": "Soft-deletes the tenant by setting `deleted_at` and transitioning its\nstatus to `deleting`, cancels all in-flight ingestion runs, then emits a\n`Tombstone` to `rb.tombstones.v1`. The tombstoner service performs the\nasync data-plane cleanup (`PostgreSQL` schema drop, `Neo4j` node removal,\n`Qdrant` point deletion).\n\n**Idempotent**: repeating the call on a tenant already in `deleting` or\n`deleted` state returns `204 No Content`.\n\n**Typed confirmation**: the `X-Confirm` header must match the tenant slug\nexactly (case-insensitive) to prevent accidental deletions.\n\nReturns `503` if the Kafka producer is not available — the request can be\nretried once the broker is reachable.",
         "operationId": "delete_tenant",
         "parameters": [
           {
@@ -2286,7 +2286,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Deletion queued \u2014 tombstone emitted",
+            "description": "Deletion queued — tombstone emitted",
             "content": {
               "application/json": {
                 "schema": {
@@ -2305,7 +2305,7 @@
             "description": "Not authenticated"
           },
           "403": {
-            "description": "Insufficient role \u2014 must be owner (insufficient_role)"
+            "description": "Insufficient role — must be owner (insufficient_role)"
           },
           "404": {
             "description": "Tenant not found"
@@ -2472,7 +2472,7 @@
           "tenants"
         ],
         "summary": "Change a member's role within a tenant.",
-        "description": "Requires: session with admin or owner role.\nCannot change the owner's role \u2014 use transfer-ownership for that.\nCannot set `owner` as the new role \u2014 use transfer-ownership.",
+        "description": "Requires: session with admin or owner role.\nCannot change the owner's role — use transfer-ownership for that.\nCannot set `owner` as the new role — use transfer-ownership.",
         "operationId": "update_member_role",
         "parameters": [
           {
@@ -2570,7 +2570,7 @@
             "description": "Not authenticated"
           },
           "403": {
-            "description": "Insufficient role \u2014 must be owner (insufficient_role)"
+            "description": "Insufficient role — must be owner (insufficient_role)"
           },
           "404": {
             "description": "Target user is not a member"
@@ -2625,7 +2625,7 @@
               "string",
               "null"
             ],
-            "description": "GitHub-facing App name \u2014 visible on the consent screen.",
+            "description": "GitHub-facing App name — visible on the consent screen.",
             "default": null
           }
         }
@@ -2639,7 +2639,7 @@
         "properties": {
           "redirect_url": {
             "type": "string",
-            "description": "`https://github.com/settings/apps/new?manifest=\u2026&state=\u2026` \u2014\nplatform admin should be redirected here."
+            "description": "`https://github.com/settings/apps/new?manifest=…&state=…` —\nplatform admin should be redirected here."
           },
           "state_token": {
             "type": "string",
@@ -2669,7 +2669,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Numeric GitHub App ID \u2014 present only when `configured == true`."
+            "description": "Numeric GitHub App ID — present only when `configured == true`."
           },
           "configured": {
             "type": "boolean",
@@ -2681,7 +2681,7 @@
               "null"
             ],
             "format": "date-time",
-            "description": "Install timestamp \u2014 present only for DB-sourced configurations."
+            "description": "Install timestamp — present only for DB-sourced configurations."
           },
           "installed_by": {
             "type": [
@@ -2689,14 +2689,14 @@
               "null"
             ],
             "format": "uuid",
-            "description": "Platform-admin user that installed the App \u2014 present only for\nDB-sourced configurations."
+            "description": "Platform-admin user that installed the App — present only for\nDB-sourced configurations."
           },
           "slug": {
             "type": [
               "string",
               "null"
             ],
-            "description": "GitHub App slug \u2014 present only for DB-sourced configurations."
+            "description": "GitHub App slug — present only for DB-sourced configurations."
           },
           "source": {
             "$ref": "#/components/schemas/AppSource",
@@ -3050,7 +3050,7 @@
       },
       "CitationV1": {
         "type": "object",
-        "description": "Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 \u00a75).",
+        "description": "Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool\nwhen `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 §5, Wave 10 S2).\n\nS4 (chat UI citation rendering) builds against this exact shape. Field additions\nwithin the same `version` value are additive; breaking changes must bump `version`.\n\n`commit_sha` is always non-empty: Wave 10 sources the repo-level head SHA at\ningest time when per-symbol SHAs are unavailable. Consumers should treat it as\na best-effort \"ingested at this commit\" rather than a per-line provenance.",
         "required": [
           "version",
           "repo_id",
@@ -3061,25 +3061,22 @@
           "source_kind"
         ],
         "properties": {
-          "version": {
+          "commit_sha": {
             "type": "string",
-            "description": "Schema version tag. Always `\"v1\"` for this type."
-          },
-          "repo_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Repository that contains this symbol."
+            "description": "Commit SHA at which this symbol was ingested. Non-empty; see type-level docs."
           },
           "file_path": {
             "type": "string",
             "description": "Relative path within the repository (from `code_symbols.source_path`)."
           },
           "line_range": {
-            "$ref": "#/components/schemas/LineRange"
+            "$ref": "#/components/schemas/LineRange",
+            "description": "Source line range (from `code_symbols.line_start`/`line_end`)."
           },
-          "commit_sha": {
+          "repo_id": {
             "type": "string",
-            "description": "Commit SHA at which this symbol was ingested. Non-empty."
+            "format": "uuid",
+            "description": "Repository that contains this symbol."
           },
           "score": {
             "type": "number",
@@ -3087,7 +3084,12 @@
             "description": "Fused score normalized to `[0, 1]`."
           },
           "source_kind": {
-            "$ref": "#/components/schemas/SourceKind"
+            "$ref": "#/components/schemas/SourceKind",
+            "description": "Which retrieval path(s) produced this result."
+          },
+          "version": {
+            "type": "string",
+            "description": "Schema version tag. Always `\"v1\"` for this type."
           }
         }
       },
@@ -3218,7 +3220,7 @@
           },
           "key": {
             "type": "string",
-            "description": "Plaintext key \u2014 shown exactly once. Store it securely; it cannot be retrieved later."
+            "description": "Plaintext key — shown exactly once. Store it securely; it cannot be retrieved later."
           },
           "name": {
             "type": "string"
@@ -3431,7 +3433,7 @@
           },
           "params": {
             "type": "object",
-            "description": "Named parameters bound into the query (`$key` \u2192 value).",
+            "description": "Named parameters bound into the query (`$key` → value).",
             "additionalProperties": {},
             "propertyNames": {
               "type": "string"
@@ -3665,7 +3667,7 @@
               "string",
               "null"
             ],
-            "description": "Inline source text \u2014 present when the item's source is \u2264 4 KiB.\nAbsent when `blob_ref` is populated (AC3)."
+            "description": "Inline source text — present when the item's source is ≤ 4 KiB.\nAbsent when `blob_ref` is populated (AC3)."
           }
         }
       },
@@ -3677,15 +3679,13 @@
           "end"
         ],
         "properties": {
-          "start": {
-            "type": "integer",
-            "format": "int32",
-            "description": "First line (1-based, inclusive)."
-          },
           "end": {
             "type": "integer",
-            "format": "int32",
-            "description": "Last line (1-based, inclusive)."
+            "format": "int32"
+          },
+          "start": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -3822,7 +3822,7 @@
         "properties": {
           "email_verification_required": {
             "type": "boolean",
-            "description": "`true` when `email_verified_at IS NULL` \u2014 caller should redirect to verification."
+            "description": "`true` when `email_verified_at IS NULL` — caller should redirect to verification."
           },
           "tenant_id": {
             "type": "string",
@@ -3920,7 +3920,7 @@
               },
               {
                 "$ref": "#/components/schemas/NodeSource",
-                "description": "Source location \u2014 absent for virtual/synthetic module nodes."
+                "description": "Source location — absent for virtual/synthetic module nodes."
               }
             ]
           }
@@ -4241,23 +4241,22 @@
       },
       "SearchResponse": {
         "type": "object",
-        "description": "Response body for `POST /v1/search`.",
+        "description": "Response body for `POST /v1/search`.\n\n`results` is always present (backward compat).\n`citations` is populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent otherwise\n(skipped in serialization when empty) so flag-off response is byte-identical to pre-S2.",
         "required": [
           "results"
         ],
         "properties": {
+          "citations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CitationV1"
+            }
+          },
           "results": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
-          },
-          "citations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CitationV1"
-            },
-            "description": "Citation envelopes (CitationV1). Populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent (empty) otherwise to preserve flag-off byte-compatibility."
           }
         }
       },
@@ -4462,7 +4461,7 @@
         "properties": {
           "email_verification_required": {
             "type": "boolean",
-            "description": "Always `true` on signup \u2014 email verification required before tenant access."
+            "description": "Always `true` on signup — email verification required before tenant access."
           },
           "user_id": {
             "type": "string",
@@ -4561,7 +4560,7 @@
           },
           "status": {
             "type": "string",
-            "description": "`healthy` (<30 s), `degraded` (30\u2013300 s), `stale` (>300 s or never)."
+            "description": "`healthy` (<30 s), `degraded` (30–300 s), `stale` (>300 s or never)."
           }
         }
       },
@@ -4850,7 +4849,7 @@
           },
           "usage_kind": {
             "type": "string",
-            "description": "`\"textual\"` \u2014 item uses the type by name in its source.\n`\"monomorphized\"` \u2014 `TypeInstance` instantiated from this type's `TypeDef`."
+            "description": "`\"textual\"` — item uses the type by name in its source.\n`\"monomorphized\"` — `TypeInstance` instantiated from this type's `TypeDef`."
           }
         }
       },
@@ -4999,7 +4998,7 @@
     },
     {
       "name": "chat",
-      "description": "Chat panel \u2014 session lifecycle and message stream (ADR-013)"
+      "description": "Chat panel — session lifecycle and message stream (ADR-013)"
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -19,7 +19,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "List admin audit-log rows (operator-only, ADR-012 §S1.2).",
+        "summary": "List admin audit-log rows (operator-only, ADR-012 \u00a7S1.2).",
         "description": "Returns up to `limit` rows (default 100, max 500) in descending\n`created_at` order.  Each row now includes the `ip` and `user_agent`\nfields that were captured at request time (RUSAA-1801).",
         "operationId": "list_audit_log",
         "parameters": [
@@ -99,7 +99,7 @@
           "health"
         ],
         "summary": "Liveness probe with per-store connectivity status.",
-        "description": "Returns 200 in all cases (even when stores are degraded) so load-balancers\ndo not kill the process — callers inspect `status` for fine-grained health.\nPublic / unauthenticated.",
+        "description": "Returns 200 in all cases (even when stores are degraded) so load-balancers\ndo not kill the process \u2014 callers inspect `status` for fine-grained health.\nPublic / unauthenticated.",
         "operationId": "health_check",
         "responses": {
           "200": {
@@ -120,7 +120,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Compile-time build provenance — SHA, timestamp, and dirty flag.",
+        "summary": "Compile-time build provenance \u2014 SHA, timestamp, and dirty flag.",
         "description": "Public / unauthenticated. Returns commit SHA only (board decision 2026-05-21).\nUsed by CI smoke gate and the dev-stack watcher to detect stale images.",
         "operationId": "build_info",
         "responses": {
@@ -166,7 +166,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Readiness probe — returns 200 when the service is ready to serve traffic.",
+        "summary": "Readiness probe \u2014 returns 200 when the service is ready to serve traffic.",
         "operationId": "ready_check",
         "responses": {
           "200": {
@@ -190,7 +190,7 @@
         "tags": [
           "health"
         ],
-        "summary": "Build identity — SHA and timestamp baked in at image build time.",
+        "summary": "Build identity \u2014 SHA and timestamp baked in at image build time.",
         "description": "Public / unauthenticated. Returns `\"unknown\"` for fields not set during\nthe docker build (e.g. local `docker build` without `--build-arg`).",
         "operationId": "version",
         "responses": {
@@ -617,7 +617,7 @@
           "api-keys"
         ],
         "summary": "List all active (non-revoked) API keys for the current session's tenant.",
-        "description": "Plaintext keys are never returned — only metadata.\nRequires an active session.",
+        "description": "Plaintext keys are never returned \u2014 only metadata.\nRequires an active session.",
         "operationId": "list_api_keys",
         "responses": {
           "200": {
@@ -717,7 +717,7 @@
           {
             "name": "tenant_id",
             "in": "query",
-            "description": "Restrict to this tenant UUID.  For session callers this must match\n(or be absent) — the session tenant is used as the implicit default.",
+            "description": "Restrict to this tenant UUID.  For session callers this must match\n(or be absent) \u2014 the session tenant is used as the implicit default.",
             "required": false,
             "schema": {
               "type": [
@@ -768,7 +768,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of rows to return (1–500; default 100).",
+            "description": "Maximum number of rows to return (1\u2013500; default 100).",
             "required": false,
             "schema": {
               "type": [
@@ -805,7 +805,7 @@
           "auth"
         ],
         "summary": "Request a password-reset email.",
-        "description": "Always returns 200 OK regardless of whether the address is registered,\npreventing email enumeration. When found, a reset link with a 15-minute\nexpiry is emailed. When not found, a dummy argon2id hash is performed to\nkeep the response time within ±50ms of a real lookup.",
+        "description": "Always returns 200 OK regardless of whether the address is registered,\npreventing email enumeration. When found, a reset link with a 15-minute\nexpiry is emailed. When not found, a dummy argon2id hash is performed to\nkeep the response time within \u00b150ms of a real lookup.",
         "operationId": "forgot_password",
         "requestBody": {
           "content": {
@@ -871,7 +871,7 @@
           "auth"
         ],
         "summary": "Revoke the caller's current session and clear the `rb_session` cookie.",
-        "description": "Sets `revoked_at = now()` on the session row, writes a `logout` row to\n`control.auth_events` for audit, and returns `204 No Content` with a\n`Set-Cookie` header that overwrites `rb_session` with `Max-Age=0` so the\nbrowser drops it. Requires an authenticated session — anonymous and\nAPI-key callers receive `401 unauthorized`.",
+        "description": "Sets `revoked_at = now()` on the session row, writes a `logout` row to\n`control.auth_events` for audit, and returns `204 No Content` with a\n`Set-Cookie` header that overwrites `rb_session` with `Max-Age=0` so the\nbrowser drops it. Requires an authenticated session \u2014 anonymous and\nAPI-key callers receive `401 unauthorized`.",
         "operationId": "logout",
         "responses": {
           "204": {
@@ -889,7 +889,7 @@
           "auth"
         ],
         "summary": "Resend a verification email.",
-        "description": "Invalidates any existing unused verify tokens for the address and issues a\nfresh one with a 1-hour expiry. Always returns 204 to avoid email\nenumeration — callers cannot distinguish a known-unverified address from\nan unknown or already-verified one. Rate-gated via the login rate limiter.",
+        "description": "Invalidates any existing unused verify tokens for the address and issues a\nfresh one with a 1-hour expiry. Always returns 204 to avoid email\nenumeration \u2014 callers cannot distinguish a known-unverified address from\nan unknown or already-verified one. Rate-gated via the login rate limiter.",
         "operationId": "resend_verification",
         "requestBody": {
           "content": {
@@ -1489,7 +1489,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of runs to return (1–100; default 50).",
+            "description": "Maximum number of runs to return (1\u2013100; default 50).",
             "required": false,
             "schema": {
               "type": [
@@ -1568,7 +1568,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Return the authenticated user's profile, current tenant, and available\ntenants. As a side-effect, refreshes the session's `last_seen_at` and\nextends `expires_at` by `session_ttl_days` so the session is sliding\nrather than fixed-from-login. The refresh is fire-and-forget — failing\nto extend the session does not fail the request (see REQ-AU-06).",
+        "summary": "Return the authenticated user's profile, current tenant, and available\ntenants. As a side-effect, refreshes the session's `last_seen_at` and\nextends `expires_at` by `session_ttl_days` so the session is sliding\nrather than fixed-from-login. The refresh is fire-and-forget \u2014 failing\nto extend the session does not fail the request (see REQ-AU-06).",
         "operationId": "get_me",
         "responses": {
           "200": {
@@ -1821,7 +1821,7 @@
           "query"
         ],
         "summary": "Retrieve a code symbol by its fully-qualified name within a repository.",
-        "description": "`fqn_b64` must be the FQN encoded as URL-safe base64 without padding\n(`base64url` / RFC 4648 §5, no `=` padding). Returns the item's metadata\nand, when the stored source is ≤ 4 KiB, an inline `source_preview`.\nLarger items carry only a `blob_ref` URI pointing to the full AST JSON.\n\nCross-tenant requests are rejected: the repository must belong to the\ncaller's tenant (AC4). Returns 404 both when the repo is absent and when\nthe `(repo_id, fqn)` tuple is not found (AC2).",
+        "description": "`fqn_b64` must be the FQN encoded as URL-safe base64 without padding\n(`base64url` / RFC 4648 \u00a75, no `=` padding). Returns the item's metadata\nand, when the stored source is \u2264 4 KiB, an inline `source_preview`.\nLarger items carry only a `blob_ref` URI pointing to the full AST JSON.\n\nCross-tenant requests are rejected: the repository must belong to the\ncaller's tenant (AC4). Returns 404 both when the repo is absent and when\nthe `(repo_id, fqn)` tuple is not found (AC2).",
         "operationId": "get_item",
         "parameters": [
           {
@@ -1901,7 +1901,7 @@
           {
             "name": "depth",
             "in": "query",
-            "description": "BFS traversal depth (1–10, default 3).",
+            "description": "BFS traversal depth (1\u201310, default 3).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -1912,7 +1912,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum edges to return per page (1–200, default 50).",
+            "description": "Maximum edges to return per page (1\u2013200, default 50).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -1992,7 +1992,7 @@
           {
             "name": "depth",
             "in": "query",
-            "description": "BFS traversal depth (1–10, default 3).",
+            "description": "BFS traversal depth (1\u201310, default 3).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -2003,7 +2003,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum edges to return per page (1–200, default 50).",
+            "description": "Maximum edges to return per page (1\u2013200, default 50).",
             "required": false,
             "schema": {
               "type": "integer",
@@ -2116,7 +2116,7 @@
           "query"
         ],
         "summary": "List all usages of the type identified by `fqn_b64` within a repository.",
-        "description": "Returns two categories of usage combined in a flat list:\n- **Textual** (`usage_kind = \"textual\"`)  — items that reference the type\n  by name (`USES_TYPE` edge).\n- **Monomorphized** (`usage_kind = \"monomorphized\"`) — `TypeInstance` nodes\n  derived from this type via a `MONOMORPHIZED_FROM` edge.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
+        "description": "Returns two categories of usage combined in a flat list:\n- **Textual** (`usage_kind = \"textual\"`)  \u2014 items that reference the type\n  by name (`USES_TYPE` edge).\n- **Monomorphized** (`usage_kind = \"monomorphized\"`) \u2014 `TypeInstance` nodes\n  derived from this type via a `MONOMORPHIZED_FROM` edge.\n\n`fqn_b64` must be URL-safe base64 (no padding) of the type's FQN.\nRequires the graph to be configured (`RB_NEO4J_URI`); returns 503 otherwise.",
         "operationId": "get_type_usages",
         "parameters": [
           {
@@ -2261,7 +2261,7 @@
           "tenants"
         ],
         "summary": "Delete a tenant (owner-only, requires typed confirmation).",
-        "description": "Soft-deletes the tenant by setting `deleted_at` and transitioning its\nstatus to `deleting`, cancels all in-flight ingestion runs, then emits a\n`Tombstone` to `rb.tombstones.v1`. The tombstoner service performs the\nasync data-plane cleanup (`PostgreSQL` schema drop, `Neo4j` node removal,\n`Qdrant` point deletion).\n\n**Idempotent**: repeating the call on a tenant already in `deleting` or\n`deleted` state returns `204 No Content`.\n\n**Typed confirmation**: the `X-Confirm` header must match the tenant slug\nexactly (case-insensitive) to prevent accidental deletions.\n\nReturns `503` if the Kafka producer is not available — the request can be\nretried once the broker is reachable.",
+        "description": "Soft-deletes the tenant by setting `deleted_at` and transitioning its\nstatus to `deleting`, cancels all in-flight ingestion runs, then emits a\n`Tombstone` to `rb.tombstones.v1`. The tombstoner service performs the\nasync data-plane cleanup (`PostgreSQL` schema drop, `Neo4j` node removal,\n`Qdrant` point deletion).\n\n**Idempotent**: repeating the call on a tenant already in `deleting` or\n`deleted` state returns `204 No Content`.\n\n**Typed confirmation**: the `X-Confirm` header must match the tenant slug\nexactly (case-insensitive) to prevent accidental deletions.\n\nReturns `503` if the Kafka producer is not available \u2014 the request can be\nretried once the broker is reachable.",
         "operationId": "delete_tenant",
         "parameters": [
           {
@@ -2286,7 +2286,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Deletion queued — tombstone emitted",
+            "description": "Deletion queued \u2014 tombstone emitted",
             "content": {
               "application/json": {
                 "schema": {
@@ -2305,7 +2305,7 @@
             "description": "Not authenticated"
           },
           "403": {
-            "description": "Insufficient role — must be owner (insufficient_role)"
+            "description": "Insufficient role \u2014 must be owner (insufficient_role)"
           },
           "404": {
             "description": "Tenant not found"
@@ -2472,7 +2472,7 @@
           "tenants"
         ],
         "summary": "Change a member's role within a tenant.",
-        "description": "Requires: session with admin or owner role.\nCannot change the owner's role — use transfer-ownership for that.\nCannot set `owner` as the new role — use transfer-ownership.",
+        "description": "Requires: session with admin or owner role.\nCannot change the owner's role \u2014 use transfer-ownership for that.\nCannot set `owner` as the new role \u2014 use transfer-ownership.",
         "operationId": "update_member_role",
         "parameters": [
           {
@@ -2570,7 +2570,7 @@
             "description": "Not authenticated"
           },
           "403": {
-            "description": "Insufficient role — must be owner (insufficient_role)"
+            "description": "Insufficient role \u2014 must be owner (insufficient_role)"
           },
           "404": {
             "description": "Target user is not a member"
@@ -2625,7 +2625,7 @@
               "string",
               "null"
             ],
-            "description": "GitHub-facing App name — visible on the consent screen.",
+            "description": "GitHub-facing App name \u2014 visible on the consent screen.",
             "default": null
           }
         }
@@ -2639,7 +2639,7 @@
         "properties": {
           "redirect_url": {
             "type": "string",
-            "description": "`https://github.com/settings/apps/new?manifest=…&state=…` —\nplatform admin should be redirected here."
+            "description": "`https://github.com/settings/apps/new?manifest=\u2026&state=\u2026` \u2014\nplatform admin should be redirected here."
           },
           "state_token": {
             "type": "string",
@@ -2669,7 +2669,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Numeric GitHub App ID — present only when `configured == true`."
+            "description": "Numeric GitHub App ID \u2014 present only when `configured == true`."
           },
           "configured": {
             "type": "boolean",
@@ -2681,7 +2681,7 @@
               "null"
             ],
             "format": "date-time",
-            "description": "Install timestamp — present only for DB-sourced configurations."
+            "description": "Install timestamp \u2014 present only for DB-sourced configurations."
           },
           "installed_by": {
             "type": [
@@ -2689,14 +2689,14 @@
               "null"
             ],
             "format": "uuid",
-            "description": "Platform-admin user that installed the App — present only for\nDB-sourced configurations."
+            "description": "Platform-admin user that installed the App \u2014 present only for\nDB-sourced configurations."
           },
           "slug": {
             "type": [
               "string",
               "null"
             ],
-            "description": "GitHub App slug — present only for DB-sourced configurations."
+            "description": "GitHub App slug \u2014 present only for DB-sourced configurations."
           },
           "source": {
             "$ref": "#/components/schemas/AppSource",
@@ -3048,6 +3048,49 @@
           }
         }
       },
+      "CitationV1": {
+        "type": "object",
+        "description": "Versioned citation envelope returned by `/v1/search` and `search_items` MCP tool when `RB_HYBRID_SEARCH_ENABLED=true` (ADR-014 \u00a75).",
+        "required": [
+          "version",
+          "repo_id",
+          "file_path",
+          "line_range",
+          "commit_sha",
+          "score",
+          "source_kind"
+        ],
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "Schema version tag. Always `\"v1\"` for this type."
+          },
+          "repo_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Repository that contains this symbol."
+          },
+          "file_path": {
+            "type": "string",
+            "description": "Relative path within the repository (from `code_symbols.source_path`)."
+          },
+          "line_range": {
+            "$ref": "#/components/schemas/LineRange"
+          },
+          "commit_sha": {
+            "type": "string",
+            "description": "Commit SHA at which this symbol was ingested. Non-empty."
+          },
+          "score": {
+            "type": "number",
+            "format": "float",
+            "description": "Fused score normalized to `[0, 1]`."
+          },
+          "source_kind": {
+            "$ref": "#/components/schemas/SourceKind"
+          }
+        }
+      },
       "ConnectRepoRequest": {
         "type": "object",
         "required": [
@@ -3175,7 +3218,7 @@
           },
           "key": {
             "type": "string",
-            "description": "Plaintext key — shown exactly once. Store it securely; it cannot be retrieved later."
+            "description": "Plaintext key \u2014 shown exactly once. Store it securely; it cannot be retrieved later."
           },
           "name": {
             "type": "string"
@@ -3388,7 +3431,7 @@
           },
           "params": {
             "type": "object",
-            "description": "Named parameters bound into the query (`$key` → value).",
+            "description": "Named parameters bound into the query (`$key` \u2192 value).",
             "additionalProperties": {},
             "propertyNames": {
               "type": "string"
@@ -3622,7 +3665,27 @@
               "string",
               "null"
             ],
-            "description": "Inline source text — present when the item's source is ≤ 4 KiB.\nAbsent when `blob_ref` is populated (AC3)."
+            "description": "Inline source text \u2014 present when the item's source is \u2264 4 KiB.\nAbsent when `blob_ref` is populated (AC3)."
+          }
+        }
+      },
+      "LineRange": {
+        "type": "object",
+        "description": "Line range (inclusive on both ends) within a source file.",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32",
+            "description": "First line (1-based, inclusive)."
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Last line (1-based, inclusive)."
           }
         }
       },
@@ -3759,7 +3822,7 @@
         "properties": {
           "email_verification_required": {
             "type": "boolean",
-            "description": "`true` when `email_verified_at IS NULL` — caller should redirect to verification."
+            "description": "`true` when `email_verified_at IS NULL` \u2014 caller should redirect to verification."
           },
           "tenant_id": {
             "type": "string",
@@ -3857,7 +3920,7 @@
               },
               {
                 "$ref": "#/components/schemas/NodeSource",
-                "description": "Source location — absent for virtual/synthetic module nodes."
+                "description": "Source location \u2014 absent for virtual/synthetic module nodes."
               }
             ]
           }
@@ -4188,6 +4251,13 @@
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
+          },
+          "citations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CitationV1"
+            },
+            "description": "Citation envelopes (CitationV1). Populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent (empty) otherwise to preserve flag-off byte-compatibility."
           }
         }
       },
@@ -4392,13 +4462,23 @@
         "properties": {
           "email_verification_required": {
             "type": "boolean",
-            "description": "Always `true` on signup — email verification required before tenant access."
+            "description": "Always `true` on signup \u2014 email verification required before tenant access."
           },
           "user_id": {
             "type": "string",
             "format": "uuid"
           }
         }
+      },
+      "SourceKind": {
+        "type": "string",
+        "description": "Which retrieval leg(s) produced this hit.",
+        "enum": [
+          "dense",
+          "sparse",
+          "hybrid",
+          "rerank"
+        ]
       },
       "StageRunItem": {
         "type": "object",
@@ -4481,7 +4561,7 @@
           },
           "status": {
             "type": "string",
-            "description": "`healthy` (<30 s), `degraded` (30–300 s), `stale` (>300 s or never)."
+            "description": "`healthy` (<30 s), `degraded` (30\u2013300 s), `stale` (>300 s or never)."
           }
         }
       },
@@ -4770,7 +4850,7 @@
           },
           "usage_kind": {
             "type": "string",
-            "description": "`\"textual\"` — item uses the type by name in its source.\n`\"monomorphized\"` — `TypeInstance` instantiated from this type's `TypeDef`."
+            "description": "`\"textual\"` \u2014 item uses the type by name in its source.\n`\"monomorphized\"` \u2014 `TypeInstance` instantiated from this type's `TypeDef`."
           }
         }
       },
@@ -4919,7 +4999,7 @@
     },
     {
       "name": "chat",
-      "description": "Chat panel — session lifecycle and message stream (ADR-013)"
+      "description": "Chat panel \u2014 session lifecycle and message stream (ADR-013)"
     }
   ]
 }

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -6,6 +6,7 @@ use base64::Engine as _;
 
 /// Service configuration loaded from environment variables.
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Config {
     pub listen_addr: String,
     pub database_url: String,
@@ -105,6 +106,12 @@ pub struct Config {
     /// Loaded via `rb-secrets::from_env("RB")` at the call site.
     /// This field stores the resolved value; it is never logged (`SecretValue`).
     pub llm_api_key: Option<String>,
+
+    // --- Hybrid search (ADR-014 §5, Wave 10 S2) ---
+    /// `RB_HYBRID_SEARCH_ENABLED` — enables hybrid (FTS + RRF) retrieval at
+    /// `POST /v1/search` and the `search_items` MCP tool. Default **off**.
+    /// Set to `true` only after migration 007 has been applied and S6 eval clears.
+    pub hybrid_search_enabled: bool,
 
     // --- Admin bootstrap (REQ-AD-01, ADR-012 §S1) ---
     /// `RB_ADMIN_TOKEN` — shared bearer secret that gates all `/api/admin/v1/*`
@@ -213,6 +220,8 @@ impl Config {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(900),
             llm_api_key: env::var("RB_LLM_API_KEY").ok().filter(|s| !s.is_empty()),
+            hybrid_search_enabled: env::var("RB_HYBRID_SEARCH_ENABLED")
+                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")),
         })
     }
 
@@ -372,6 +381,7 @@ impl Config {
             mcp_jwt_secret: Some("test-mcp-jwt-secret-for-unit-tests-only".to_owned()),
             mcp_jwt_ttl_secs: 900,
             llm_api_key: None,
+            hybrid_search_enabled: false,
         }
     }
 }

--- a/services/control-api/src/jobs/tests.rs
+++ b/services/control-api/src/jobs/tests.rs
@@ -201,6 +201,7 @@ fn make_state(pool: PgPool) -> AppState {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     AppState {
         pool,

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -5,13 +5,19 @@
 //! only; it has no dependency on `rb-query`.
 
 use rb_mcp::ToolCallResult;
-use rb_query::{DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, items, semantic_search};
-use rb_schemas::TenantId;
+use rb_query::hybrid::HybridSearchOptions;
+use rb_query::{
+    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search, items, semantic_search,
+};
+use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use rb_tenant::TenantCtx;
+use sqlx::Row as _;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::{embed::normalize_query, error::AppError, state::AppState};
 
+#[allow(clippy::too_many_lines)]
 pub(super) async fn dispatch_search_items(
     state: &AppState,
     tenant_id: Uuid,
@@ -69,27 +75,85 @@ pub(super) async fn dispatch_search_items(
     .await?;
 
     let tenant = TenantId::from(tenant_id);
-    let opts = SearchOptions {
-        limit,
-        repo_id: repo_id_filter,
-    };
-    let hits = semantic_search(qdrant, &tenant, &vector, opts).await?;
 
-    let results: Vec<serde_json::Value> = hits
-        .into_iter()
-        .map(|h| {
-            let crate_name = h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
-            serde_json::json!({
-                "fqn": h.fqn,
-                "crate_name": crate_name,
-                "repo_id": h.repo_id,
-                "score": h.score
+    if state.config.hybrid_search_enabled {
+        // --- Hybrid path (flag on) ---
+        let hits = hybrid_search(
+            &state.pool,
+            qdrant,
+            &tenant,
+            &vector,
+            query,
+            HybridSearchOptions {
+                limit,
+                repo_id: repo_id_filter,
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!("hybrid_search (mcp) failed: {e}");
+            AppError::ServiceUnavailable
+        })?;
+
+        // Collect distinct repo_ids for commit_sha lookup.
+        let repo_ids: Vec<Uuid> = {
+            let mut seen = std::collections::HashSet::new();
+            hits.iter()
+                .filter_map(|h| h.repo_id.parse::<Uuid>().ok())
+                .filter(|id| seen.insert(*id))
+                .collect()
+        };
+        let commit_shas = fetch_commit_shas(&state.pool, &repo_ids).await?;
+
+        let citations: Vec<CitationV1> = hits
+            .into_iter()
+            .map(|h| {
+                let repo_uuid = h.repo_id.parse::<Uuid>().unwrap_or(Uuid::nil());
+                let commit_sha = commit_shas
+                    .get(&repo_uuid)
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_owned());
+                CitationV1 {
+                    version: CitationV1::VERSION.to_owned(),
+                    repo_id: repo_uuid,
+                    file_path: h.source_path.unwrap_or_default(),
+                    line_range: LineRange {
+                        start: h.line_start.unwrap_or(0),
+                        end: h.line_end.unwrap_or(0),
+                    },
+                    commit_sha,
+                    score: h.score,
+                    source_kind: SourceKind::Hybrid,
+                }
             })
-        })
-        .collect();
+            .collect();
 
-    let text = serde_json::to_string_pretty(&results).unwrap_or_default();
-    Ok(ToolCallResult::success(text))
+        let text = serde_json::to_string_pretty(&citations).unwrap_or_default();
+        Ok(ToolCallResult::success(text))
+    } else {
+        // --- Dense-only path (flag off) — behavior identical to pre-S2 ---
+        let opts = SearchOptions {
+            limit,
+            repo_id: repo_id_filter,
+        };
+        let hits = semantic_search(qdrant, &tenant, &vector, opts).await?;
+
+        let results: Vec<serde_json::Value> = hits
+            .into_iter()
+            .map(|h| {
+                let crate_name = h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
+                serde_json::json!({
+                    "fqn": h.fqn,
+                    "crate_name": crate_name,
+                    "repo_id": h.repo_id,
+                    "score": h.score
+                })
+            })
+            .collect();
+
+        let text = serde_json::to_string_pretty(&results).unwrap_or_default();
+        Ok(ToolCallResult::success(text))
+    }
 }
 
 pub(super) async fn dispatch_get_item(
@@ -187,6 +251,36 @@ async fn embed_query(
                 .ok_or(AppError::ServiceUnavailable)
         })
         .collect()
+}
+
+/// Fetch the latest non-null `commit_sha` from `control.ingestion_runs` per repo.
+/// Repos with no run default to `"unknown"` per ADR-014 §5.
+async fn fetch_commit_shas(
+    pool: &sqlx::PgPool,
+    repo_ids: &[Uuid],
+) -> Result<HashMap<Uuid, String>, AppError> {
+    if repo_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = sqlx::query(
+        "SELECT DISTINCT ON (repo_id) repo_id, commit_sha \
+         FROM control.ingestion_runs \
+         WHERE repo_id = ANY($1) \
+           AND commit_sha IS NOT NULL \
+         ORDER BY repo_id, started_at DESC NULLS LAST",
+    )
+    .bind(repo_ids)
+    .fetch_all(pool)
+    .await?;
+
+    let mut map: HashMap<Uuid, String> = rows
+        .into_iter()
+        .map(|r| (r.get("repo_id"), r.get("commit_sha")))
+        .collect();
+    for rid in repo_ids {
+        map.entry(*rid).or_insert_with(|| "unknown".to_owned());
+    }
+    Ok(map)
 }
 
 #[cfg(test)]

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -5,9 +5,9 @@
 //! only; it has no dependency on `rb-query`.
 
 use rb_mcp::ToolCallResult;
-use rb_query::hybrid::HybridSearchOptions;
 use rb_query::{
-    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search, items, semantic_search,
+    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search,
+    items, semantic_search,
 };
 use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use rb_tenant::TenantCtx;

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -15,9 +15,9 @@
 //!      must belong to the caller's tenant (validated against Postgres).
 
 use axum::{Json, extract::State, response::IntoResponse};
-use rb_query::hybrid::HybridSearchOptions;
 use rb_query::{
-    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search, semantic_search,
+    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search,
+    semantic_search,
 };
 use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use serde::{Deserialize, Serialize};

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -1,7 +1,12 @@
 //! `POST /v1/search` — semantic code search (REQ-DP-01).
 //!
-//! Embeds the caller's query via Ollama, searches the `rb_embeddings` Qdrant
-//! collection within the caller's tenant scope, and returns ranked code symbols.
+//! When `RB_HYBRID_SEARCH_ENABLED=false` (default): embeds the query via Ollama,
+//! searches Qdrant with a `tenant_id` must-filter, and returns ranked code symbols.
+//! Response shape: `{"results":[...]}` — byte-identical to the pre-Wave-10 path.
+//!
+//! When `RB_HYBRID_SEARCH_ENABLED=true`: runs dense + sparse legs via
+//! `rb_query::hybrid_search`, fuses via RRF k=60, sources `commit_sha` from
+//! `control.ingestion_runs`, and populates `citations` (`CitationV1` envelope).
 //!
 //! Multi-tenancy is enforced at two layers:
 //!   1. [`TenantVectorStore::search`] injects a `must` `tenant_id` filter so
@@ -10,9 +15,14 @@
 //!      must belong to the caller's tenant (validated against Postgres).
 
 use axum::{Json, extract::State, response::IntoResponse};
-use rb_query::{DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, semantic_search};
-use rb_schemas::TenantId;
+use rb_query::hybrid::HybridSearchOptions;
+use rb_query::{
+    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search, semantic_search,
+};
+use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use serde::{Deserialize, Serialize};
+use sqlx::Row as _;
+use std::collections::HashMap;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -59,9 +69,15 @@ pub struct SearchResult {
 }
 
 /// Response body for `POST /v1/search`.
+///
+/// `results` is always present (backward compat).
+/// `citations` is populated only when `RB_HYBRID_SEARCH_ENABLED=true`; absent otherwise
+/// (skipped in serialization when empty) so flag-off response is byte-identical to pre-S2.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SearchResponse {
     pub results: Vec<SearchResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub citations: Vec<CitationV1>,
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +146,52 @@ async fn embed_query(
 }
 
 // ---------------------------------------------------------------------------
+// Commit-SHA sourcing (hybrid path only)
+// ---------------------------------------------------------------------------
+
+/// Fetch the latest non-null `commit_sha` from `control.ingestion_runs` for each
+/// distinct `repo_id` in `repo_ids`. Returns a map `repo_id → commit_sha`.
+///
+/// Repos with no succeeded run (or all runs have NULL `commit_sha`) are mapped to
+/// `"unknown"` per ADR-014 §5 ("`commit_sha` must not be `Option` or empty").
+async fn fetch_commit_shas(
+    pool: &sqlx::PgPool,
+    repo_ids: &[Uuid],
+) -> Result<HashMap<Uuid, String>, AppError> {
+    if repo_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Latest non-null commit_sha per repo (most recent started run first).
+    let rows = sqlx::query(
+        "SELECT DISTINCT ON (repo_id) repo_id, commit_sha \
+         FROM control.ingestion_runs \
+         WHERE repo_id = ANY($1) \
+           AND commit_sha IS NOT NULL \
+         ORDER BY repo_id, started_at DESC NULLS LAST",
+    )
+    .bind(repo_ids)
+    .fetch_all(pool)
+    .await?;
+
+    let mut map: HashMap<Uuid, String> = rows
+        .into_iter()
+        .map(|r| {
+            let repo_id: Uuid = r.get("repo_id");
+            let sha: String = r.get("commit_sha");
+            (repo_id, sha)
+        })
+        .collect();
+
+    // Fill "unknown" for repos with no ingestion run yet.
+    for rid in repo_ids {
+        map.entry(*rid).or_insert_with(|| "unknown".to_owned());
+    }
+
+    Ok(map)
+}
+
+// ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
@@ -138,6 +200,9 @@ async fn embed_query(
 /// Embeds `q` via Ollama, performs approximate nearest-neighbour search in
 /// the Qdrant `rb_embeddings` collection filtered by `tenant_id`, and returns
 /// ranked results with their fully-qualified names and crate context.
+///
+/// When `RB_HYBRID_SEARCH_ENABLED=true`, also runs Postgres FTS and fuses
+/// results via RRF k=60, returning `CitationV1` envelopes in `citations`.
 ///
 /// Returns 503 when either Qdrant (`RB_QDRANT_URL`) or Ollama (`RB_OLLAMA_URL`)
 /// are not configured on this instance.
@@ -154,6 +219,7 @@ async fn embed_query(
     ),
     tag = "search"
 )]
+#[allow(clippy::too_many_lines)]
 pub async fn search(
     State(state): State<AppState>,
     auth: AuthContext,
@@ -199,33 +265,113 @@ pub async fn search(
     let vector = embed_query(&http, ollama_url, &state.config.embedding_model, &req.q).await?;
 
     let tenant_id = TenantId::from(tenant_id_uuid);
-    let opts = SearchOptions {
-        limit,
-        repo_id: repo_id_filter,
-    };
-    let hits = semantic_search(qdrant, &tenant_id, &vector, opts).await?;
 
-    let results: Vec<SearchResult> = hits
-        .into_iter()
-        .map(|h| {
-            let crate_name = h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
-            SearchResult {
-                fqn: h.fqn,
-                crate_name,
-                repo_id: h.repo_id,
-                score: h.score,
-            }
-        })
-        .collect();
+    if state.config.hybrid_search_enabled {
+        // --- Hybrid path (flag on) ---
+        let hits = hybrid_search(
+            &state.pool,
+            qdrant,
+            &tenant_id,
+            &vector,
+            &req.q,
+            HybridSearchOptions {
+                limit,
+                repo_id: repo_id_filter,
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!("hybrid_search failed: {e}");
+            AppError::ServiceUnavailable
+        })?;
 
-    tracing::debug!(
-        tenant_id = %tenant_id_uuid,
-        query = %req.q,
-        result_count = results.len(),
-        "semantic search completed"
-    );
+        // Collect distinct repo_ids for commit_sha lookup.
+        let repo_ids: Vec<Uuid> = {
+            let mut seen = std::collections::HashSet::new();
+            hits.iter()
+                .filter_map(|h| h.repo_id.parse::<Uuid>().ok())
+                .filter(|id| seen.insert(*id))
+                .collect()
+        };
+        let commit_shas = fetch_commit_shas(&state.pool, &repo_ids).await?;
 
-    Ok(Json(SearchResponse { results }))
+        let results: Vec<SearchResult> = hits
+            .iter()
+            .map(|h| {
+                let crate_name = h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
+                SearchResult {
+                    fqn: h.fqn.clone(),
+                    crate_name,
+                    repo_id: h.repo_id.clone(),
+                    score: h.score,
+                }
+            })
+            .collect();
+
+        let citations: Vec<CitationV1> = hits
+            .into_iter()
+            .map(|h| {
+                let repo_uuid = h.repo_id.parse::<Uuid>().unwrap_or(Uuid::nil());
+                let commit_sha = commit_shas
+                    .get(&repo_uuid)
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_owned());
+                CitationV1 {
+                    version: CitationV1::VERSION.to_owned(),
+                    repo_id: repo_uuid,
+                    file_path: h.source_path.unwrap_or_default(),
+                    line_range: LineRange {
+                        start: h.line_start.unwrap_or(0),
+                        end: h.line_end.unwrap_or(0),
+                    },
+                    commit_sha,
+                    score: h.score,
+                    source_kind: SourceKind::Hybrid,
+                }
+            })
+            .collect();
+
+        tracing::debug!(
+            tenant_id = %tenant_id_uuid,
+            query = %req.q,
+            result_count = results.len(),
+            "hybrid search completed"
+        );
+
+        Ok(Json(SearchResponse { results, citations }))
+    } else {
+        // --- Dense-only path (flag off) — byte-identical to pre-S2 ---
+        let opts = SearchOptions {
+            limit,
+            repo_id: repo_id_filter,
+        };
+        let hits = semantic_search(qdrant, &tenant_id, &vector, opts).await?;
+
+        let results: Vec<SearchResult> = hits
+            .into_iter()
+            .map(|h| {
+                let crate_name = h.fqn.split("::").next().unwrap_or(&h.fqn).to_owned();
+                SearchResult {
+                    fqn: h.fqn,
+                    crate_name,
+                    repo_id: h.repo_id,
+                    score: h.score,
+                }
+            })
+            .collect();
+
+        tracing::debug!(
+            tenant_id = %tenant_id_uuid,
+            query = %req.q,
+            result_count = results.len(),
+            "semantic search completed"
+        );
+
+        Ok(Json(SearchResponse {
+            results,
+            citations: vec![],
+        }))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -335,5 +481,42 @@ mod tests {
 
         let over = 200_u32.clamp(1, MAX_SEARCH_LIMIT);
         assert_eq!(over, MAX_SEARCH_LIMIT);
+    }
+
+    // AC6: flag-off response serializes WITHOUT `citations` field — byte-identical to pre-S2.
+    #[test]
+    fn flag_off_response_omits_citations_field() {
+        let resp = SearchResponse {
+            results: vec![SearchResult {
+                fqn: "a::Fn".to_owned(),
+                crate_name: "a".to_owned(),
+                repo_id: "r1".to_owned(),
+                score: 0.9,
+            }],
+            citations: vec![],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("citations"));
+        assert!(json.as_object().unwrap().contains_key("results"));
+    }
+
+    // AC6: flag-on response includes `citations` field.
+    #[test]
+    fn flag_on_response_includes_citations_field() {
+        let resp = SearchResponse {
+            results: vec![],
+            citations: vec![CitationV1 {
+                version: CitationV1::VERSION.to_owned(),
+                repo_id: Uuid::nil(),
+                file_path: "src/lib.rs".to_owned(),
+                line_range: LineRange { start: 1, end: 10 },
+                commit_sha: "abc123".to_owned(),
+                score: 0.85,
+                source_kind: SourceKind::Hybrid,
+            }],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.as_object().unwrap().contains_key("citations"));
+        assert_eq!(json["citations"][0]["version"], "v1");
     }
 }

--- a/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
@@ -66,6 +66,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_audit_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_tests.rs
@@ -75,6 +75,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_tests.rs
@@ -68,6 +68,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     }
 }
 

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -80,6 +80,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_api_key_revocation_tests.rs
+++ b/services/control-api/tests/integration_api_key_revocation_tests.rs
@@ -90,6 +90,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_chat_tests.rs
+++ b/services/control-api/tests/integration_chat_tests.rs
@@ -91,6 +91,7 @@ async fn build_state(chat_panel_enabled: bool) -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret-chat".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_cookie_tests.rs
+++ b/services/control-api/tests/integration_cookie_tests.rs
@@ -66,6 +66,7 @@ async fn real_db_app() -> Option<axum::Router> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool,

--- a/services/control-api/tests/integration_email_transport_tests.rs
+++ b/services/control-api/tests/integration_email_transport_tests.rs
@@ -89,6 +89,7 @@ async fn state_with_transport(transport_name: &str) -> Option<(AppState, PgPool)
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_events_history_tests/helpers.rs
+++ b/services/control-api/tests/integration_events_history_tests/helpers.rs
@@ -71,6 +71,7 @@ pub async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ingest_chat_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_chat_tests.rs
@@ -90,6 +90,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ingest_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_tests.rs
@@ -88,6 +88,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ndjson_tests.rs
+++ b/services/control-api/tests/integration_events_ndjson_tests.rs
@@ -84,6 +84,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -124,6 +124,7 @@ fn build_test_config_with_api_base(
         mcp_jwt_secret: Some("test-mcp-jwt-secret-for-unit-tests-only".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     }
 }
 

--- a/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
+++ b/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
@@ -1,21 +1,7 @@
 //! AC5 tenant isolation regression tests for hybrid retrieval (ADR-014 §10).
-//!
-//! Requirement: two tenants seeded, query one, assert zero rows from the other
-//! on **both dense and sparse legs** of the hybrid path, at **both** call sites
-//! (`search.rs` — `POST /v1/search` and `dispatch.rs` — MCP `search_items`).
-//!
-//! **Sparse leg** — Postgres FTS isolation is structural: `TenantCtx::qualify`
-//! routes every query to `tenant_<hex>.code_symbols`, a schema that physically
-//! contains only the owner tenant's rows.  This file seeds a unique FQN into
-//! tenant B's schema only, then queries as tenant A and asserts zero results.
-//!
-//! **Dense leg** — Qdrant isolation is enforced by `TenantVectorStore::search`,
-//! which always injects `{ "key": "tenant_id", "match": { "value": … } }` into
-//! the Qdrant must-filter (ADR-007 §13.2).  This file stubs Qdrant with wiremock,
-//! then inspects the captured request body to assert the correct tenant UUID
-//! appears in the filter and the cross-tenant UUID does not.
-//!
-//! Both tests require `RB_DATABASE_URL` and skip gracefully when absent.
+//! Seeds two tenants, queries one, asserts zero rows from the other on both
+//! dense (Qdrant must-filter) and sparse (PG FTS schema routing) legs at both
+//! call sites (`POST /v1/search` and MCP `search_items`). Skips without `RB_DATABASE_URL`.
 
 use std::sync::Arc;
 
@@ -38,10 +24,6 @@ use uuid::Uuid;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const MCP_JWT_SECRET: &[u8] = b"test-hybrid-isolation-mcp-secret-long-enough"; // gitleaks:allow
 
 async fn connect_pool() -> Option<sqlx::PgPool> {
@@ -53,17 +35,13 @@ async fn connect_pool() -> Option<sqlx::PgPool> {
         .ok()
 }
 
-/// Derive a `tenant_<24hex>` schema name from a UUID.
 fn schema_name_for(tenant_id: Uuid) -> String {
     TenantCtx::new(TenantId::from(tenant_id))
         .schema_name()
         .to_owned()
 }
 
-/// Create a tenant schema with `code_symbols` (including `fts` GENERATED column).
-///
-/// Idempotent: `IF NOT EXISTS` guards on all DDL.  Only creates the table(s)
-/// that the sparse leg of `hybrid_search` queries.
+/// Create a per-tenant schema with `code_symbols` + `fts` GENERATED column (idempotent).
 async fn provision_tenant_schema(pool: &sqlx::PgPool, tenant_id: Uuid) {
     let schema = schema_name_for(tenant_id);
 
@@ -272,14 +250,9 @@ fn build_hybrid_state(pool: sqlx::PgPool, qdrant_url: &str, ollama_url: &str) ->
     }
 }
 
-/// A fake 3-dimensional embedding vector returned by the Ollama stub.
 const FAKE_VECTOR: [f32; 3] = [0.1, 0.2, 0.3];
 
-/// Mount Ollama and Qdrant stubs.
-///
-/// - Ollama `POST /api/embeddings` → `{"embedding": [0.1, 0.2, 0.3]}`
-/// - Qdrant `POST /collections/rb_embeddings/points/search` → `{"result": []}`
-///   (dense leg returns zero hits so only the sparse leg can produce results)
+/// Mount Ollama embedding stub and Qdrant stub (dense leg returns empty; sparse leg drives results).
 async fn mount_stubs(ollama: &MockServer, qdrant: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/api/embeddings"))
@@ -300,8 +273,7 @@ async fn mount_stubs(ollama: &MockServer, qdrant: &MockServer) {
         .await;
 }
 
-/// Assert that every Qdrant request received by `qdrant` contains `expected_tenant_id`
-/// in the must-filter and does NOT contain `cross_tenant_id`.
+/// Assert every Qdrant request carries `expected_tenant_id` in must-filter and not `cross_tenant_id`.
 async fn assert_qdrant_must_filter(
     qdrant: &MockServer,
     expected_tenant_id: Uuid,
@@ -345,20 +317,8 @@ async fn assert_qdrant_must_filter(
     }
 }
 
-// ---------------------------------------------------------------------------
-// AC5a — search.rs site: POST /v1/search
-// ---------------------------------------------------------------------------
-
-/// Proof: querying as tenant_A for a symbol that only exists in tenant_B's
-/// schema returns zero results at both legs of the hybrid path.
-///
-/// - **Sparse leg** (Postgres FTS): `TenantCtx::qualify` routes the FTS query
-///   to `tenant_A.code_symbols`, which has no rows; the tainted symbol only
-///   lives in `tenant_B.code_symbols`.
-/// - **Dense leg** (Qdrant): the wiremocked stub captures the request; this
-///   test asserts the `must` filter carries `tenant_A`'s UUID only.
-///
-/// Skips automatically when `RB_DATABASE_URL` is not set.
+/// AC5a — `POST /v1/search`: tainted symbol seeded in tenant_B returns zero results queried as tenant_A.
+/// Both sparse (PG FTS schema routing) and dense (Qdrant must-filter) legs verified.
 #[tokio::test]
 async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
     let Some(pool) = connect_pool().await else {
@@ -369,7 +329,6 @@ async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
     let tenant_b = Uuid::new_v4();
     let repo_b = Uuid::new_v4();
 
-    // Provision two isolated schemas; seed the tainted symbol ONLY in tenant_B.
     provision_tenant_schema(&pool, tenant_a).await;
     provision_tenant_schema(&pool, tenant_b).await;
     insert_symbol(&pool, tenant_b, repo_b, "tainted_b_only::ToxicFn").await;
@@ -419,11 +378,8 @@ async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
          tainted symbol lives in tenant_B's schema only"
     );
 
-    // Dense leg: Qdrant must-filter must name tenant_A, not tenant_B.
     assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
 
-    // Cleanup: drop tenant schemas; delete control rows (users/members/sessions are
-    // cascade-deleted via FK on tenant deletion where applicable, so drop tenant last).
     drop_tenant_schema(&pool, tenant_a).await;
     drop_tenant_schema(&pool, tenant_b).await;
     sqlx::query("DELETE FROM control.tenants WHERE id = $1")
@@ -433,18 +389,7 @@ async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
         .ok();
 }
 
-// ---------------------------------------------------------------------------
-// AC5b — dispatch.rs site: MCP search_items
-// ---------------------------------------------------------------------------
-
-/// Same two-tenant isolation proof exercised via the MCP `search_items` tool
-/// (dispatch.rs call site).  A short-lived MCP JWT is minted for tenant_A,
-/// an MCP session is initialized, and then `tools/call` is invoked.
-///
-/// - **Sparse leg**: tenant_A's schema is empty → zero citations in the result.
-/// - **Dense leg**: Qdrant must-filter carries tenant_A's UUID only.
-///
-/// Skips automatically when `RB_DATABASE_URL` is not set.
+/// AC5b — MCP `search_items` (dispatch.rs): same two-tenant isolation proof via MCP JWT + tools/call.
 #[tokio::test]
 async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
     let Some(pool) = connect_pool().await else {
@@ -468,7 +413,6 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
     let state = build_hybrid_state(pool.clone(), &qdrant_stub.uri(), &ollama_stub.uri());
     let app = build_public(state);
 
-    // Mint a short-lived MCP JWT for tenant_A.
     let jwt = mint_mcp_token(
         MCP_JWT_SECRET,
         900,
@@ -480,7 +424,6 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
     )
     .expect("mint MCP JWT");
 
-    // Step 1: initialize MCP session → receive Mcp-Session-Id.
     let init_resp = app
         .clone()
         .oneshot(
@@ -521,7 +464,6 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
         .unwrap()
         .to_owned();
 
-    // Step 2: tools/call search_items for a query that exists only in tenant_B.
     let call_resp = app
         .oneshot(
             Request::builder()
@@ -574,7 +516,6 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
          tainted symbol lives in tenant_B's schema only"
     );
 
-    // Dense leg: Qdrant must-filter must name tenant_A, not tenant_B.
     assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
 
     drop_tenant_schema(&pool, tenant_a).await;
@@ -586,19 +527,7 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
         .ok();
 }
 
-// ---------------------------------------------------------------------------
-// AC5c — direct crate-level proof: hybrid_search sparse isolation
-// ---------------------------------------------------------------------------
-
-/// Directly calls `rb_query::hybrid_search` (the function both search.rs and
-/// dispatch.rs delegate to) with a wiremocked Qdrant and a real Postgres pool
-/// containing two tenant schemas.
-///
-/// This test proves isolation at the crate API boundary, independently of the
-/// HTTP routing layer.  It is additive: the two HTTP-layer tests above cover the
-/// routing; this one covers the function contract.
-///
-/// Skips automatically when `RB_DATABASE_URL` is not set.
+/// AC5c — direct crate API proof: `hybrid_search` itself is isolated (complements HTTP-layer tests above).
 #[tokio::test]
 async fn ac5_direct_hybrid_search_sparse_leg_isolation() {
     let Some(pool) = connect_pool().await else {
@@ -647,7 +576,6 @@ async fn ac5_direct_hybrid_search_sparse_leg_isolation() {
          cross_tenant_b::ExclusiveFn only exists in tenant_B's schema"
     );
 
-    // Dense leg: Qdrant must-filter must carry tenant_A's UUID only.
     assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
 
     drop_tenant_schema(&pool, tenant_a).await;

--- a/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
+++ b/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
@@ -1,0 +1,655 @@
+//! AC5 tenant isolation regression tests for hybrid retrieval (ADR-014 §10).
+//!
+//! Requirement: two tenants seeded, query one, assert zero rows from the other
+//! on **both dense and sparse legs** of the hybrid path, at **both** call sites
+//! (`search.rs` — `POST /v1/search` and `dispatch.rs` — MCP `search_items`).
+//!
+//! **Sparse leg** — Postgres FTS isolation is structural: `TenantCtx::qualify`
+//! routes every query to `tenant_<hex>.code_symbols`, a schema that physically
+//! contains only the owner tenant's rows.  This file seeds a unique FQN into
+//! tenant B's schema only, then queries as tenant A and asserts zero results.
+//!
+//! **Dense leg** — Qdrant isolation is enforced by `TenantVectorStore::search`,
+//! which always injects `{ "key": "tenant_id", "match": { "value": … } }` into
+//! the Qdrant must-filter (ADR-007 §13.2).  This file stubs Qdrant with wiremock,
+//! then inspects the captured request body to assert the correct tenant UUID
+//! appears in the filter and the cross-tenant UUID does not.
+//!
+//! Both tests require `RB_DATABASE_URL` and skip gracefully when absent.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use control_api::{AppState, Config, build_public};
+use http_body_util::BodyExt as _;
+use rb_auth::{LoginRateLimiter, McpTokenClaims, PasswordHasher, mint_mcp_token, sha256_hex};
+use rb_email::from_transport;
+use rb_query::{HybridSearchOptions, hybrid_search};
+use rb_schemas::TenantId;
+use rb_sse::{EventBus, SseConfig};
+use rb_storage_qdrant::TenantVectorStore;
+use rb_tenant::TenantCtx;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt as _;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MCP_JWT_SECRET: &[u8] = b"test-hybrid-isolation-mcp-secret-long-enough"; // gitleaks:allow
+
+async fn connect_pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("RB_DATABASE_URL").ok()?;
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+/// Derive a `tenant_<24hex>` schema name from a UUID.
+fn schema_name_for(tenant_id: Uuid) -> String {
+    TenantCtx::new(TenantId::from(tenant_id))
+        .schema_name()
+        .to_owned()
+}
+
+/// Create a tenant schema with `code_symbols` (including `fts` GENERATED column).
+///
+/// Idempotent: `IF NOT EXISTS` guards on all DDL.  Only creates the table(s)
+/// that the sparse leg of `hybrid_search` queries.
+async fn provision_tenant_schema(pool: &sqlx::PgPool, tenant_id: Uuid) {
+    let schema = schema_name_for(tenant_id);
+
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+        .execute(pool)
+        .await
+        .expect("create tenant schema");
+
+    sqlx::query(&format!(
+        "CREATE TABLE IF NOT EXISTS {schema}.code_symbols (
+            id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+            repo_id     UUID        NOT NULL,
+            fqn         TEXT        NOT NULL,
+            kind        TEXT        NOT NULL DEFAULT 'function',
+            source_path TEXT,
+            line_start  INTEGER,
+            line_end    INTEGER,
+            source_text TEXT,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        )"
+    ))
+    .execute(pool)
+    .await
+    .expect("create code_symbols table");
+
+    // Apply migration 007: add fts GENERATED column if absent.
+    sqlx::query(&format!(
+        "ALTER TABLE {schema}.code_symbols
+             ADD COLUMN IF NOT EXISTS fts tsvector
+             GENERATED ALWAYS AS (
+                 to_tsvector('simple',
+                     coalesce(fqn, '') || ' ' || coalesce(source_text, ''))
+             ) STORED"
+    ))
+    .execute(pool)
+    .await
+    .expect("add fts column");
+}
+
+/// Drop the tenant schema created by `provision_tenant_schema`.
+async fn drop_tenant_schema(pool: &sqlx::PgPool, tenant_id: Uuid) {
+    let schema = schema_name_for(tenant_id);
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(pool)
+        .await
+        .ok();
+}
+
+/// Insert a single code symbol into a tenant's schema.
+async fn insert_symbol(pool: &sqlx::PgPool, tenant_id: Uuid, repo_id: Uuid, fqn: &str) {
+    let schema = schema_name_for(tenant_id);
+    sqlx::query(&format!(
+        "INSERT INTO {schema}.code_symbols (repo_id, fqn, kind, source_text)
+         VALUES ($1, $2, 'function', $2)
+         ON CONFLICT DO NOTHING"
+    ))
+    .bind(repo_id)
+    .bind(fqn)
+    .execute(pool)
+    .await
+    .expect("insert symbol");
+}
+
+/// Seed a row in `control.tenants` for the given UUID.
+async fn seed_control_tenant(pool: &sqlx::PgPool, tenant_id: Uuid) {
+    let schema = schema_name_for(tenant_id);
+    sqlx::query(
+        "INSERT INTO control.tenants (id, slug, name, schema_name, status)
+         VALUES ($1, $2, $3, $4, 'active')
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(format!(
+        "hybrid-iso-{}",
+        &tenant_id.simple().to_string()[..8]
+    ))
+    .bind("Hybrid Isolation Test")
+    .bind(&schema)
+    .execute(pool)
+    .await
+    .expect("seed control tenant");
+}
+
+/// Seed a user + session for a tenant; returns the plaintext session token.
+async fn seed_user_session(pool: &sqlx::PgPool, tenant_id: Uuid) -> String {
+    let user_id = Uuid::new_v4();
+    let session_token = format!("hybrid-iso-tok-{}", Uuid::new_v4().simple());
+    let token_hash = sha256_hex(&session_token);
+
+    sqlx::query(
+        "INSERT INTO control.users (id, email, password_hash, email_verified_at)
+         VALUES ($1, $2, '$argon2id$v=19$m=65536,t=1,p=1$placeholder', now())
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(user_id)
+    .bind(format!("hybrid-iso-{}@test.internal", user_id.simple()))
+    .execute(pool)
+    .await
+    .expect("seed user");
+
+    sqlx::query(
+        "INSERT INTO control.tenant_members (tenant_id, user_id, role)
+         VALUES ($1, $2, 'owner') ON CONFLICT DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed tenant_member");
+
+    sqlx::query(
+        "INSERT INTO control.sessions (id, user_id, tenant_id, token_hash, expires_at)
+         VALUES ($1, $2, $3, $4, now() + interval '30 days')
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(user_id)
+    .bind(tenant_id)
+    .bind(&token_hash)
+    .execute(pool)
+    .await
+    .expect("seed session");
+
+    session_token
+}
+
+/// Build an `AppState` with `hybrid_search_enabled: true`, a wiremocked Qdrant
+/// URL, and a wiremocked Ollama URL.
+fn build_hybrid_state(pool: sqlx::PgPool, qdrant_url: &str, ollama_url: &str) -> AppState {
+    let smtp = rb_email::SmtpConfig {
+        host: String::new(),
+        port: 587,
+        username: String::new(),
+        password: String::new(),
+        from_address: "test@example.com".to_owned(),
+    };
+    let email_sender = from_transport("noop", &smtp).expect("noop transport");
+    let hasher = PasswordHasher::from_config(64, 1, 1).expect("hasher");
+
+    let config = Config {
+        listen_addr: "127.0.0.1:0".to_owned(),
+        database_url: "unused".to_owned(),
+        cors_origins: vec![],
+        base_url: "http://localhost:8080".to_owned(),
+        session_ttl_days: 30,
+        argon2_memory_kb: 64,
+        argon2_time_cost: 1,
+        argon2_parallelism: 1,
+        email_transport: "noop".to_owned(),
+        service_name: "control-api-hybrid-isolation-test".to_owned(),
+        secure_cookies: false,
+        gh_app_id: None,
+        gh_app_private_key_b64: None,
+        gh_app_webhook_secret: None,
+        gh_app_enc_key_b64: None,
+        gh_api_base: rb_github::DEFAULT_GITHUB_API_BASE.to_owned(),
+        neo4j_uri: None,
+        neo4j_user: "neo4j".to_owned(),
+        neo4j_password: None,
+        kafka_bootstrap_servers: "localhost:9092".to_owned(),
+        dev_test_routes: false,
+        migrations_root: None,
+        qdrant_url: Some(qdrant_url.to_owned()),
+        ollama_url: Some(ollama_url.to_owned()),
+        embedding_model: "nomic-embed-text".to_owned(),
+        internal_secret: Some("test-hybrid-internal-secret".to_owned()),
+        internal_listen_addr: "127.0.0.1:0".to_owned(),
+        session_create_rate_limit: 100,
+        session_create_window_secs: 60,
+        tenant_session_cap: 100,
+        admin_token: None,
+        chat_panel_enabled: false,
+        tempo_base_url: "http://localhost:3000".to_owned(),
+        mcp_jwt_secret: Some(std::str::from_utf8(MCP_JWT_SECRET).unwrap().to_owned()),
+        mcp_jwt_ttl_secs: 900,
+        llm_api_key: None,
+        hybrid_search_enabled: true,
+    };
+
+    AppState {
+        pool,
+        email_sender: Arc::from(email_sender),
+        hasher: Arc::new(hasher),
+        login_rate_limiter: Arc::new(LoginRateLimiter::new()),
+        config: Arc::new(config),
+        gh_loader: Arc::new(rb_github::GhAppLoader::new(None)),
+        sse_bus: Arc::new(EventBus::new(SseConfig::default())),
+        ingest_producer: None,
+        tombstone_producer: None,
+        module_tree_cache: rb_query::new_module_tree_cache(),
+        graph: None,
+        qdrant: Some(Arc::new(TenantVectorStore::new(qdrant_url))),
+        http_client: reqwest::Client::new(),
+        neo4j_uri: None,
+        kafka_consistency: Arc::new(control_api::KafkaConsistencyState::new()),
+        mcp_sessions: control_api::McpSessionStore::new(),
+        agent_registry: control_api::AgentRegistry::new(),
+        agent_commands_producer: None,
+        internal_secret: "test-hybrid-internal-secret".to_owned(),
+        session_create_rate_limiter: Arc::new(control_api::SessionCreateRateLimiter::default()),
+        tenant_session_count: Arc::new(control_api::TenantSessionCount::new()),
+        mcp_jwt_secret: std::str::from_utf8(MCP_JWT_SECRET).unwrap().to_owned(),
+        mcp_jwt_ttl_secs: 900,
+        llm_api_key: String::new(),
+    }
+}
+
+/// A fake 3-dimensional embedding vector returned by the Ollama stub.
+const FAKE_VECTOR: [f32; 3] = [0.1, 0.2, 0.3];
+
+/// Mount Ollama and Qdrant stubs.
+///
+/// - Ollama `POST /api/embeddings` → `{"embedding": [0.1, 0.2, 0.3]}`
+/// - Qdrant `POST /collections/rb_embeddings/points/search` → `{"result": []}`
+///   (dense leg returns zero hits so only the sparse leg can produce results)
+async fn mount_stubs(ollama: &MockServer, qdrant: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/api/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "embedding": FAKE_VECTOR
+        })))
+        .mount(ollama)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/collections/rb_embeddings/points/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [],
+            "status": "ok",
+            "time": 0.001
+        })))
+        .mount(qdrant)
+        .await;
+}
+
+/// Assert that every Qdrant request received by `qdrant` contains `expected_tenant_id`
+/// in the must-filter and does NOT contain `cross_tenant_id`.
+async fn assert_qdrant_must_filter(
+    qdrant: &MockServer,
+    expected_tenant_id: Uuid,
+    cross_tenant_id: Uuid,
+) {
+    let reqs = qdrant.received_requests().await.unwrap_or_default();
+    assert!(
+        !reqs.is_empty(),
+        "AC5 dense leg: Qdrant must receive at least one request"
+    );
+
+    for req in &reqs {
+        let body: serde_json::Value =
+            serde_json::from_slice(&req.body).expect("Qdrant request must be valid JSON");
+
+        let must_conditions = body
+            .pointer("/filter/must")
+            .and_then(serde_json::Value::as_array)
+            .expect("AC5 dense leg: Qdrant request must have /filter/must array");
+
+        let tenant_cond = must_conditions
+            .iter()
+            .find(|c| c.get("key").and_then(|k| k.as_str()) == Some("tenant_id"))
+            .expect("AC5 dense leg: /filter/must must contain a tenant_id condition");
+
+        let filter_value = tenant_cond
+            .pointer("/match/value")
+            .and_then(serde_json::Value::as_str)
+            .expect("AC5 dense leg: tenant_id condition must have /match/value");
+
+        assert_eq!(
+            filter_value,
+            expected_tenant_id.to_string(),
+            "AC5 dense leg: Qdrant must-filter must name the querying tenant, got {filter_value}"
+        );
+        assert_ne!(
+            filter_value,
+            cross_tenant_id.to_string(),
+            "AC5 dense leg: Qdrant must-filter must NOT name the cross-tenant UUID"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC5a — search.rs site: POST /v1/search
+// ---------------------------------------------------------------------------
+
+/// Proof: querying as tenant_A for a symbol that only exists in tenant_B's
+/// schema returns zero results at both legs of the hybrid path.
+///
+/// - **Sparse leg** (Postgres FTS): `TenantCtx::qualify` routes the FTS query
+///   to `tenant_A.code_symbols`, which has no rows; the tainted symbol only
+///   lives in `tenant_B.code_symbols`.
+/// - **Dense leg** (Qdrant): the wiremocked stub captures the request; this
+///   test asserts the `must` filter carries `tenant_A`'s UUID only.
+///
+/// Skips automatically when `RB_DATABASE_URL` is not set.
+#[tokio::test]
+async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
+    let Some(pool) = connect_pool().await else {
+        return;
+    };
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let repo_b = Uuid::new_v4();
+
+    // Provision two isolated schemas; seed the tainted symbol ONLY in tenant_B.
+    provision_tenant_schema(&pool, tenant_a).await;
+    provision_tenant_schema(&pool, tenant_b).await;
+    insert_symbol(&pool, tenant_b, repo_b, "tainted_b_only::ToxicFn").await;
+
+    // Register tenant_A in control schema so the auth middleware accepts the session.
+    seed_control_tenant(&pool, tenant_a).await;
+    let session_token = seed_user_session(&pool, tenant_a).await;
+
+    let ollama_stub = MockServer::start().await;
+    let qdrant_stub = MockServer::start().await;
+    mount_stubs(&ollama_stub, &qdrant_stub).await;
+
+    let state = build_hybrid_state(pool.clone(), &qdrant_stub.uri(), &ollama_stub.uri());
+
+    let resp = build_public(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/search")
+                .header("content-type", "application/json")
+                .header("cookie", format!("rb_session={session_token}"))
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "q": "tainted_b_only ToxicFn"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "AC5 search site: /v1/search must return 200"
+    );
+
+    let raw = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+
+    // Sparse leg: tenant_A.code_symbols is empty, so results must be empty.
+    assert_eq!(
+        body["results"].as_array().map(Vec::len).unwrap_or(0),
+        0,
+        "AC5 sparse leg (search site): must return zero results — \
+         tainted symbol lives in tenant_B's schema only"
+    );
+
+    // Dense leg: Qdrant must-filter must name tenant_A, not tenant_B.
+    assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
+
+    // Cleanup: drop tenant schemas; delete control rows (users/members/sessions are
+    // cascade-deleted via FK on tenant deletion where applicable, so drop tenant last).
+    drop_tenant_schema(&pool, tenant_a).await;
+    drop_tenant_schema(&pool, tenant_b).await;
+    sqlx::query("DELETE FROM control.tenants WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+// ---------------------------------------------------------------------------
+// AC5b — dispatch.rs site: MCP search_items
+// ---------------------------------------------------------------------------
+
+/// Same two-tenant isolation proof exercised via the MCP `search_items` tool
+/// (dispatch.rs call site).  A short-lived MCP JWT is minted for tenant_A,
+/// an MCP session is initialized, and then `tools/call` is invoked.
+///
+/// - **Sparse leg**: tenant_A's schema is empty → zero citations in the result.
+/// - **Dense leg**: Qdrant must-filter carries tenant_A's UUID only.
+///
+/// Skips automatically when `RB_DATABASE_URL` is not set.
+#[tokio::test]
+async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
+    let Some(pool) = connect_pool().await else {
+        return;
+    };
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let repo_b = Uuid::new_v4();
+
+    provision_tenant_schema(&pool, tenant_a).await;
+    provision_tenant_schema(&pool, tenant_b).await;
+    insert_symbol(&pool, tenant_b, repo_b, "tainted_b_only::ToxicFn").await;
+
+    seed_control_tenant(&pool, tenant_a).await;
+
+    let ollama_stub = MockServer::start().await;
+    let qdrant_stub = MockServer::start().await;
+    mount_stubs(&ollama_stub, &qdrant_stub).await;
+
+    let state = build_hybrid_state(pool.clone(), &qdrant_stub.uri(), &ollama_stub.uri());
+    let app = build_public(state);
+
+    // Mint a short-lived MCP JWT for tenant_A.
+    let jwt = mint_mcp_token(
+        MCP_JWT_SECRET,
+        900,
+        McpTokenClaims {
+            sub: Uuid::new_v4(),
+            tenant_id: tenant_a,
+            user_id: Uuid::new_v4(),
+        },
+    )
+    .expect("mint MCP JWT");
+
+    // Step 1: initialize MCP session → receive Mcp-Session-Id.
+    let init_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {jwt}"))
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": { "name": "ac5-test", "version": "0.1" }
+                        }
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        init_resp.status(),
+        StatusCode::OK,
+        "AC5 dispatch site: MCP initialize must return 200"
+    );
+
+    let mcp_session_id = init_resp
+        .headers()
+        .get("Mcp-Session-Id")
+        .expect("AC5 dispatch site: initialize must return Mcp-Session-Id header")
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    // Step 2: tools/call search_items for a query that exists only in tenant_B.
+    let call_resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {jwt}"))
+                .header("Mcp-Session-Id", &mcp_session_id)
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "search_items",
+                            "arguments": {
+                                "query": "tainted_b_only ToxicFn",
+                                "limit": 10
+                            }
+                        }
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        call_resp.status(),
+        StatusCode::OK,
+        "AC5 dispatch site: MCP tools/call must return 200"
+    );
+
+    let raw = call_resp.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+
+    // Extract citations from the tool result text field.
+    let tool_text = body
+        .pointer("/result/content/0/text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("[]");
+    let citations: serde_json::Value =
+        serde_json::from_str(tool_text).unwrap_or(serde_json::json!([]));
+
+    assert_eq!(
+        citations.as_array().map(Vec::len).unwrap_or(0),
+        0,
+        "AC5 sparse leg (dispatch site): MCP search_items must return zero citations — \
+         tainted symbol lives in tenant_B's schema only"
+    );
+
+    // Dense leg: Qdrant must-filter must name tenant_A, not tenant_B.
+    assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
+
+    drop_tenant_schema(&pool, tenant_a).await;
+    drop_tenant_schema(&pool, tenant_b).await;
+    sqlx::query("DELETE FROM control.tenants WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+// ---------------------------------------------------------------------------
+// AC5c — direct crate-level proof: hybrid_search sparse isolation
+// ---------------------------------------------------------------------------
+
+/// Directly calls `rb_query::hybrid_search` (the function both search.rs and
+/// dispatch.rs delegate to) with a wiremocked Qdrant and a real Postgres pool
+/// containing two tenant schemas.
+///
+/// This test proves isolation at the crate API boundary, independently of the
+/// HTTP routing layer.  It is additive: the two HTTP-layer tests above cover the
+/// routing; this one covers the function contract.
+///
+/// Skips automatically when `RB_DATABASE_URL` is not set.
+#[tokio::test]
+async fn ac5_direct_hybrid_search_sparse_leg_isolation() {
+    let Some(pool) = connect_pool().await else {
+        return;
+    };
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let repo_b = Uuid::new_v4();
+
+    provision_tenant_schema(&pool, tenant_a).await;
+    provision_tenant_schema(&pool, tenant_b).await;
+    insert_symbol(&pool, tenant_b, repo_b, "cross_tenant_b::ExclusiveFn").await;
+
+    let qdrant_stub = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/collections/rb_embeddings/points/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [],
+            "status": "ok",
+            "time": 0.001
+        })))
+        .mount(&qdrant_stub)
+        .await;
+
+    let store = TenantVectorStore::new(&qdrant_stub.uri());
+    let tenant_a_id = TenantId::from(tenant_a);
+
+    let results: Vec<rb_query::HybridHit> = hybrid_search(
+        &pool,
+        &store,
+        &tenant_a_id,
+        &FAKE_VECTOR,
+        "cross_tenant_b ExclusiveFn",
+        HybridSearchOptions {
+            limit: 10,
+            repo_id: None,
+        },
+    )
+    .await
+    .expect("hybrid_search must not error");
+
+    assert!(
+        results.is_empty(),
+        "AC5 sparse leg (direct): hybrid_search for tenant_A must return zero hits — \
+         cross_tenant_b::ExclusiveFn only exists in tenant_B's schema"
+    );
+
+    // Dense leg: Qdrant must-filter must carry tenant_A's UUID only.
+    assert_qdrant_must_filter(&qdrant_stub, tenant_a, tenant_b).await;
+
+    drop_tenant_schema(&pool, tenant_a).await;
+    drop_tenant_schema(&pool, tenant_b).await;
+}

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -86,6 +86,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -67,6 +67,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret-for-unit-tests-only".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -80,6 +80,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_multitenant_scenarios.rs
+++ b/services/control-api/tests/integration_multitenant_scenarios.rs
@@ -96,6 +96,7 @@ async fn real_db_state() -> Option<(AppState, sqlx::PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_partition_pruning_tests.rs
+++ b/services/control-api/tests/integration_partition_pruning_tests.rs
@@ -91,6 +91,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_regression_defence_orphan.rs
+++ b/services/control-api/tests/integration_regression_defence_orphan.rs
@@ -126,6 +126,7 @@ fn build_state_with_gh(pool: PgPool, gh_loader: Arc<GhAppLoader>) -> AppState {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     AppState {
         pool,

--- a/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
+++ b/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
@@ -79,6 +79,7 @@ async fn real_db_state_chat_enabled() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-1884-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_resend_verification_tests.rs
+++ b/services/control-api/tests/integration_resend_verification_tests.rs
@@ -67,6 +67,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -362,6 +362,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_secret: Some("test-mcp-jwt-secret".to_owned()),
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
+        hybrid_search_enabled: false,
     };
     let state = AppState {
         pool: pool.clone(),


### PR DESCRIPTION
## Summary

- **Migration 007**: additive `fts` `GENERATED ALWAYS AS` tsvector column + GIN index on `code_symbols` (fqn + source_text; no `signature` column exists in schema)
- **`rb-schemas::CitationV1`**: versioned citation envelope (`version`, `repo_id`, `file_path`, `line_range`, `commit_sha`, `score`, `source_kind`) frozen for S4 compatibility
- **`rb-query::hybrid`**: `hybrid_search` + `sparse_search` + private `rrf_fuse` (k=60, unit-tested); no `rb-rerank` dep — ADR-014 §2 acyclic graph preserved
- **`control-api` feature flag**: `RB_HYBRID_SEARCH_ENABLED` (default off); flag-off path is byte-identical to pre-S2 (citations field omitted via `skip_serializing_if`)
- **`commit_sha` sourcing**: `DISTINCT ON (repo_id) ORDER BY started_at DESC` from `control.ingestion_runs`; defaults to `"unknown"` when no run

## GitHub Issue

Closes #805

## Checklist

- [x] `cargo-locked test --workspace` passes (all tests green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes (no errors, pre-existing duplicate warnings only)
- [x] No new external dependencies (AC7)
- [x] Crate graph invariant preserved: `rb-query` does not depend on `rb-rerank` (AC8)
- [x] Flag-off response byte-identical to pre-S2 (AC5 / AC6)
- [x] RRF k=60 math tested (AC2)
- [x] `CitationV1` contract frozen shape matches ADR-014 §5 (AC3)