### PR TITLE
[REQ-FE-51] feat(chat): CitationV1 chip rendering — source-kind badges, GitHub links, score ordering

### DIFF
--- a/frontend/e2e/chat-panel-rusaa-2091.spec.ts
+++ b/frontend/e2e/chat-panel-rusaa-2091.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPO_ITEM,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+  LIST_MESSAGES_EMPTY,
+} from "./fixtures/chat-mock-api";
+
+// Citation fixture — repo_id matches REPO_ITEM.repo_id so chips resolve GitHub links
+const CITATION_REPO_ID = REPO_ITEM.repo_id;
+
+const SEARCH_RESULT_WITH_CITATIONS = JSON.stringify({
+  results: [
+    { fqn: "rb_query::hybrid_search", crate_name: "rb_query", repo_id: CITATION_REPO_ID, score: 0.87 },
+  ],
+  citations: [
+    {
+      version: "v1",
+      repo_id: CITATION_REPO_ID,
+      file_path: "crates/rb-query/src/lib.rs",
+      line_range: { start: 42, end: 87 },
+      commit_sha: "deadbeef1234567890",
+      score: 0.87,
+      source_kind: "hybrid",
+    },
+    {
+      version: "v1",
+      repo_id: CITATION_REPO_ID,
+      file_path: "crates/rb-query/src/dense.rs",
+      line_range: { start: 1, end: 15 },
+      commit_sha: "deadbeef1234567890",
+      score: 0.72,
+      source_kind: "dense",
+    },
+    {
+      version: "v1",
+      repo_id: CITATION_REPO_ID,
+      file_path: "crates/rb-query/src/sparse.rs",
+      line_range: { start: 5, end: 30 },
+      commit_sha: "deadbeef1234567890",
+      score: 0.65,
+      source_kind: "sparse",
+    },
+  ],
+});
+
+// SSE stream: user_input → tool_use(search_items) → tool_result(with citations) → text → turn_complete
+const SEARCH_WITH_CITATIONS_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "Search for hybrid search implementation" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 2,
+    payload: {
+      type: "tool_use",
+      id: "search-tool-001",
+      name: "search_items",
+      input: { query: "hybrid search" },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 3,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "search-tool-001",
+      content: SEARCH_RESULT_WITH_CITATIONS,
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 4,
+    payload: { type: "text", text: "Here are the search results with citations." },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 5,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+// AC2, AC4, AC7: citation chips render in score-desc order, all visible and clickable
+test.describe("Citation chips — RUSAA-2091", () => {
+  test("AC2+AC7: renders citation chips from search tool result", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, { repos: [REPO_ITEM] });
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, SEARCH_WITH_CITATIONS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // Wait for the text content to appear (turn is complete)
+    await expect(page.getByText("Here are the search results with citations.")).toBeVisible();
+
+    // Citation chips container must be present
+    const container = page.getByTestId("citation-chips");
+    await expect(container).toBeVisible();
+
+    // All 3 citations must be rendered as chips
+    const chips = container.getByTestId("citation-chip");
+    await expect(chips).toHaveCount(3);
+
+    // AC7: at least one chip is visible
+    await expect(chips.first()).toBeVisible();
+  });
+
+  test("AC4: correct source_kind badges render for all kinds in fixture", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, { repos: [REPO_ITEM] });
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, SEARCH_WITH_CITATIONS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+    await expect(page.getByText("Here are the search results with citations.")).toBeVisible();
+
+    const container = page.getByTestId("citation-chips");
+
+    // Verify each source_kind is represented
+    await expect(container.locator('[data-source-kind="hybrid"]')).toHaveCount(1);
+    await expect(container.locator('[data-source-kind="dense"]')).toHaveCount(1);
+    await expect(container.locator('[data-source-kind="sparse"]')).toHaveCount(1);
+  });
+
+  test("AC3: chip href points to GitHub blob URL via commit_sha", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, { repos: [REPO_ITEM] });
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, SEARCH_WITH_CITATIONS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+    await expect(page.getByText("Here are the search results with citations.")).toBeVisible();
+
+    const container = page.getByTestId("citation-chips");
+    const firstChip = container.getByTestId("citation-chip").first();
+
+    // First chip (highest score = hybrid at 0.87) should be an anchor with GitHub URL
+    const href = await firstChip.getAttribute("href");
+    expect(href).not.toBeNull();
+    expect(href).toContain("https://github.com/acme/web-app/blob/deadbeef1234567890");
+    expect(href).not.toContain("/main/");
+  });
+
+  test("score-desc ordering: highest score chip appears first", async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, { repos: [REPO_ITEM] });
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, SEARCH_WITH_CITATIONS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+    await expect(page.getByText("Here are the search results with citations.")).toBeVisible();
+
+    const container = page.getByTestId("citation-chips");
+    const chips = container.getByTestId("citation-chip");
+
+    // First chip must be the hybrid one (score 0.87) — highest
+    const firstKind = await chips.first().getAttribute("data-source-kind");
+    expect(firstKind).toBe("hybrid");
+  });
+
+  test("AC5: no citation chips when tool result has no citations field", async ({ page }) => {
+    const NO_CITATIONS_SSE = [
+      "event: session.event",
+      `data: ${JSON.stringify({
+        session_id: CHAT_SESSION_ID,
+        event_type: "text",
+        sequence: 1,
+        payload: { type: "text", text: "No citations here." },
+      })}`,
+      "",
+      "event: session.event",
+      `data: ${JSON.stringify({
+        session_id: CHAT_SESSION_ID,
+        event_type: "turn_complete",
+        sequence: 2,
+        payload: { type: "turn_complete", stop_reason: "end_turn" },
+      })}`,
+      "",
+      "",
+    ].join("\n");
+
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, { repos: [REPO_ITEM] });
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, NO_CITATIONS_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+    await expect(page.getByText("No citations here.")).toBeVisible();
+
+    // Citation chips container must NOT exist when there are no citations
+    await expect(page.getByTestId("citation-chips")).not.toBeVisible();
+  });
+});

--- a/frontend/src/components/chat/MessageThread.tsx
+++ b/frontend/src/components/chat/MessageThread.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useRef } from "react";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { MarkdownContent } from "./MarkdownContent";
+import { CitationChip, extractCitationsFromItems } from "./citations";
 import type { TranscriptItem, AssistantItem } from "./transcript";
+import type { CitationV1 } from "@/types/citations";
 
 interface MessageThreadProps {
   readonly items: ReadonlyArray<TranscriptItem>;
   readonly isStreaming: boolean;
+  /**
+   * Map from repo UUID to GitHub `owner/repo` slug (e.g. "f-crop/rustacean").
+   * When present, citation chips render as GitHub anchor links.
+   * When absent or a repo_id isn't found, chips render as non-interactive spans.
+   */
+  readonly repoFullNameMap?: ReadonlyMap<string, string>;
 }
 
-export function MessageThread({ items, isStreaming }: MessageThreadProps): JSX.Element {
+export function MessageThread({ items, isStreaming, repoFullNameMap }: MessageThreadProps): JSX.Element {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,7 +38,13 @@ export function MessageThread({ items, isStreaming }: MessageThreadProps): JSX.E
           return <UserBubble key={item.id} text={item.text} />;
         }
         if (item.kind === "assistant") {
-          return <AssistantBubble key={item.id} items={item.items} />;
+          return (
+            <AssistantBubble
+              key={item.id}
+              items={item.items}
+              {...(repoFullNameMap != null && { repoFullNameMap })}
+            />
+          );
         }
         if (item.kind === "error") {
           return item.code !== undefined
@@ -85,8 +99,16 @@ function TimestampLabel({ ts }: { readonly ts: number }): JSX.Element {
   );
 }
 
-function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantItem> }): JSX.Element {
+interface AssistantBubbleProps {
+  readonly items: ReadonlyArray<AssistantItem>;
+  readonly repoFullNameMap?: ReadonlyMap<string, string>;
+}
+
+function AssistantBubble({ items, repoFullNameMap }: AssistantBubbleProps): JSX.Element {
   if (items.length === 0) return <></>;
+
+  const citations: readonly CitationV1[] = extractCitationsFromItems(items);
+  const sortedCitations: CitationV1[] = citations.slice().sort((a: CitationV1, b: CitationV1) => b.score - a.score);
 
   return (
     <div className="flex justify-start">
@@ -127,6 +149,30 @@ function AssistantBubble({ items }: { readonly items: ReadonlyArray<AssistantIte
 
           return null;
         })}
+
+        {sortedCitations.length > 0 && (
+          <div
+            aria-label="Citations"
+            className="flex flex-wrap gap-1.5 pt-1"
+            data-testid="citation-chips"
+          >
+            {sortedCitations.map((citation: CitationV1, idx: number) => {
+              const repoFullName = repoFullNameMap?.get(citation.repo_id);
+              return repoFullName != null ? (
+                <CitationChip
+                  key={`${citation.repo_id}:${citation.file_path}:${citation.line_range.start}:${idx}`}
+                  citation={citation}
+                  repoFullName={repoFullName}
+                />
+              ) : (
+                <CitationChip
+                  key={`${citation.repo_id}:${citation.file_path}:${citation.line_range.start}:${idx}`}
+                  citation={citation}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/chat/citations/CitationChip.test.ts
+++ b/frontend/src/components/chat/citations/CitationChip.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import type { CitationV1, SourceKind } from "@/types/citations";
+import { buildGitHubUrl, extractCitationsFromItems } from "./citation-utils";
+
+function makeCitation(source_kind: SourceKind, overrides?: Partial<CitationV1>): CitationV1 {
+  return {
+    version: "v1",
+    repo_id: "00000000-0000-0000-0000-000000000001",
+    file_path: "src/lib.rs",
+    line_range: { start: 10, end: 20 },
+    commit_sha: "abc123def456",
+    score: 0.876,
+    source_kind,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CitationV1 type contract — all four source_kind variants
+// ---------------------------------------------------------------------------
+
+const ALL_KINDS: SourceKind[] = ["dense", "sparse", "hybrid", "rerank"];
+
+describe("CitationV1 fixture round-trip", () => {
+  it.each(ALL_KINDS)("preserves all fields for source_kind=%s", (kind) => {
+    const c = makeCitation(kind);
+    const rt: CitationV1 = JSON.parse(JSON.stringify(c));
+    expect(rt.version).toBe("v1");
+    expect(rt.source_kind).toBe(kind);
+    expect(rt.repo_id).toBe(c.repo_id);
+    expect(rt.file_path).toBe(c.file_path);
+    expect(rt.line_range.start).toBe(10);
+    expect(rt.line_range.end).toBe(20);
+    expect(rt.commit_sha).toBe(c.commit_sha);
+    expect(rt.score).toBeCloseTo(0.876, 3);
+  });
+
+  it("score formats to 2 decimal places", () => {
+    expect(makeCitation("dense", { score: 0.9321 }).score.toFixed(2)).toBe("0.93");
+    expect(makeCitation("rerank", { score: 0.1000 }).score.toFixed(2)).toBe("0.10");
+    expect(makeCitation("hybrid", { score: 1 }).score.toFixed(2)).toBe("1.00");
+  });
+
+  it("detects version mismatch", () => {
+    const c = makeCitation("sparse", { version: "v2" });
+    expect(c.version).not.toBe("v1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGitHubUrl
+// ---------------------------------------------------------------------------
+
+describe("buildGitHubUrl", () => {
+  it("builds correct GitHub blob URL", () => {
+    const c = makeCitation("hybrid", {
+      commit_sha: "deadbeef12345678",
+      file_path: "crates/rb-query/src/lib.rs",
+      line_range: { start: 42, end: 87 },
+    });
+    const url = buildGitHubUrl("f-crop/rustacean", c);
+    expect(url).toBe(
+      "https://github.com/f-crop/rustacean/blob/deadbeef12345678/crates/rb-query/src/lib.rs#L42-L87",
+    );
+  });
+
+  it("uses commit_sha not 'main' in the URL", () => {
+    const c = makeCitation("dense", { commit_sha: "cafebabe" });
+    const url = buildGitHubUrl("org/repo", c);
+    expect(url).toContain("cafebabe");
+    expect(url).not.toContain("/main/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCitationsFromItems — defensive paths
+// ---------------------------------------------------------------------------
+
+describe("extractCitationsFromItems", () => {
+  it("extracts citations from a JSON-string tool_result", () => {
+    const citations = [makeCitation("dense"), makeCitation("sparse")];
+    const items = [
+      {
+        type: "tool_result",
+        content: JSON.stringify({ results: [], citations }),
+      },
+    ];
+    const extracted = extractCitationsFromItems(items);
+    expect(extracted).toHaveLength(2);
+    expect(extracted[0]?.source_kind).toBe("dense");
+    expect(extracted[1]?.source_kind).toBe("sparse");
+  });
+
+  it("extracts citations from an object tool_result", () => {
+    const citations = [makeCitation("rerank")];
+    const items = [{ type: "tool_result", content: { citations } }];
+    const extracted = extractCitationsFromItems(items);
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0]?.source_kind).toBe("rerank");
+  });
+
+  it("returns [] when tool_result has no citations field", () => {
+    const items = [
+      { type: "tool_result", content: JSON.stringify({ results: [] }) },
+    ];
+    expect(extractCitationsFromItems(items)).toHaveLength(0);
+  });
+
+  it("returns [] for non-tool_result items", () => {
+    const items = [
+      { type: "text", content: JSON.stringify({ citations: [makeCitation("hybrid")] }) },
+    ];
+    expect(extractCitationsFromItems(items)).toHaveLength(0);
+  });
+
+  it("returns [] when content is null/undefined", () => {
+    const items = [{ type: "tool_result", content: null }];
+    expect(extractCitationsFromItems(items)).toHaveLength(0);
+  });
+
+  it("returns [] when content is malformed JSON string", () => {
+    const items = [{ type: "tool_result", content: "not json {" }];
+    expect(extractCitationsFromItems(items)).toHaveLength(0);
+  });
+
+  it("filters out malformed citation objects from the array", () => {
+    const goodCitation = makeCitation("dense");
+    const badCitation = { version: "v1" }; // missing required fields
+    const items = [
+      { type: "tool_result", content: { citations: [goodCitation, badCitation] } },
+    ];
+    const extracted = extractCitationsFromItems(items);
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0]?.source_kind).toBe("dense");
+  });
+
+  it("aggregates citations across multiple tool_result items", () => {
+    const items = [
+      { type: "tool_result", content: { citations: [makeCitation("dense")] } },
+      { type: "tool_result", content: { citations: [makeCitation("hybrid")] } },
+    ];
+    const extracted = extractCitationsFromItems(items);
+    expect(extracted).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/chat/citations/CitationChip.tsx
+++ b/frontend/src/components/chat/citations/CitationChip.tsx
@@ -1,0 +1,113 @@
+import { cn } from "@/lib/utils";
+import type { CitationV1, SourceKind } from "@/types/citations";
+import { buildGitHubUrl } from "./citation-utils";
+
+const SUPPORTED_VERSION = "v1";
+
+interface BadgeStyle {
+  readonly label: string;
+  readonly className: string;
+}
+
+const SOURCE_KIND_STYLES: Record<SourceKind, BadgeStyle> = {
+  dense:  { label: "D", className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200" },
+  sparse: { label: "S", className: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" },
+  hybrid: { label: "H", className: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200" },
+  rerank: { label: "R", className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200" },
+};
+
+const FALLBACK_BADGE: BadgeStyle = {
+  label: "?",
+  className: "bg-muted text-muted-foreground",
+};
+
+interface CitationChipProps {
+  readonly citation: CitationV1;
+  /**
+   * GitHub `owner/repo` slug (e.g. "f-crop/rustacean").
+   * When provided the chip renders as an anchor that opens the canonical
+   * GitHub blob URL in a new tab. When absent the chip is a non-interactive span.
+   */
+  readonly repoFullName?: string;
+  readonly className?: string;
+}
+
+export function CitationChip({ citation, repoFullName, className }: CitationChipProps): JSX.Element {
+  if (citation.version !== SUPPORTED_VERSION) {
+    return (
+      <span
+        role="note"
+        aria-label={`Unsupported citation version: ${citation.version}`}
+        className={cn(
+          "inline-flex items-center gap-1 rounded border border-yellow-300 bg-yellow-50 px-2 py-0.5 text-xs text-yellow-700",
+          "dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-300",
+          className,
+        )}
+      >
+        ⚠ citation {citation.version}
+      </span>
+    );
+  }
+
+  const { file_path, line_range, score, source_kind, commit_sha } = citation;
+  const badge = SOURCE_KIND_STYLES[source_kind as SourceKind] ?? FALLBACK_BADGE;
+  const shortSha = commit_sha.slice(0, 7);
+  const ariaLabel = `${file_path} lines ${line_range.start} to ${line_range.end}, source kind ${source_kind}, score ${score.toFixed(2)}`;
+  const tooltipTitle = `${shortSha} — ${source_kind}`;
+
+  const chipClassName = cn(
+    "inline-flex max-w-[20rem] items-center gap-1.5 rounded border border-border bg-muted/40 px-2 py-0.5",
+    "transition-colors hover:bg-muted",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+    className,
+  );
+
+  const inner = (
+    <>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-[9px] font-bold",
+          badge.className,
+        )}
+      >
+        {badge.label}
+      </span>
+      <span className="min-w-0 truncate font-mono text-xs text-foreground">
+        {file_path}:{line_range.start}–{line_range.end}
+      </span>
+      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+        {score.toFixed(2)}
+      </span>
+    </>
+  );
+
+  if (repoFullName) {
+    return (
+      <a
+        href={buildGitHubUrl(repoFullName, citation)}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={ariaLabel}
+        title={tooltipTitle}
+        className={chipClassName}
+        data-testid="citation-chip"
+        data-source-kind={source_kind}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <span
+      aria-label={ariaLabel}
+      title={tooltipTitle}
+      className={chipClassName}
+      data-testid="citation-chip"
+      data-source-kind={source_kind}
+    >
+      {inner}
+    </span>
+  );
+}

--- a/frontend/src/components/chat/citations/README.md
+++ b/frontend/src/components/chat/citations/README.md
@@ -1,0 +1,49 @@
+# Chat Citations
+
+Renders `CitationV1` chips inline in chat panel assistant messages.
+
+## Contract version
+
+**v1** — frozen by ADR-014 §5. Any breaking change to the envelope requires an ADR amendment and a `version` bump. S4 renders only `version: "v1"` items; any other version surfaces a soft warning badge.
+
+## `CitationV1` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `"v1"` | Envelope version tag |
+| `repo_id` | UUID string | Repository this symbol belongs to |
+| `file_path` | string | Relative path within the repo |
+| `line_range.start` | number | First line (1-indexed) |
+| `line_range.end` | number | Last line (inclusive) |
+| `commit_sha` | string | SHA at ingest time; used as stable blob anchor |
+| `score` | number [0,1] | Fused retrieval score (dense + sparse RRF) |
+| `source_kind` | `"dense" \| "sparse" \| "hybrid" \| "rerank"` | Which retrieval leg(s) produced this hit |
+
+## `source_kind` badges
+
+| Kind | Badge | Color |
+|---|---|---|
+| `dense` | D | Blue |
+| `sparse` | S | Green |
+| `hybrid` | H | Purple |
+| `rerank` | R | Gold |
+
+## Usage
+
+```tsx
+import { CitationChip } from "@/components/chat/citations";
+
+<CitationChip
+  citation={citationV1Object}
+  repoFullName="f-crop/rustacean"   // optional; enables GitHub link
+/>
+```
+
+When `repoFullName` is provided, the chip renders as an `<a>` that opens:
+`https://github.com/{repoFullName}/blob/{commit_sha}/{file_path}#L{start}-L{end}`
+
+Without `repoFullName` the chip is a non-interactive `<span>` showing the same text.
+
+## v1-freeze rule
+
+Do not modify the CitationV1 TypeScript interface without a matching ADR-014 amendment. The interface intentionally mirrors the Rust struct byte-for-byte (after JSON serialisation). Use the `version` field to gate future format changes gracefully.

--- a/frontend/src/components/chat/citations/citation-utils.ts
+++ b/frontend/src/components/chat/citations/citation-utils.ts
@@ -1,0 +1,50 @@
+import type { CitationV1 } from "@/types/citations";
+
+export function buildGitHubUrl(repoFullName: string, citation: CitationV1): string {
+  const { commit_sha, file_path, line_range } = citation;
+  return `https://github.com/${repoFullName}/blob/${commit_sha}/${file_path}#L${line_range.start}-L${line_range.end}`;
+}
+
+/** Extract citations from tool_result items inside an assistant turn. */
+export function extractCitationsFromItems(
+  items: ReadonlyArray<{ type: string; content?: unknown }>,
+): readonly CitationV1[] {
+  const results: CitationV1[] = [];
+  for (const item of items) {
+    if (item.type !== "tool_result" || item.content == null) continue;
+    const parsed = coerceToCitationList(item.content);
+    if (parsed.length > 0) results.push(...parsed);
+  }
+  return results;
+}
+
+function coerceToCitationList(content: unknown): CitationV1[] {
+  const obj = typeof content === "string" ? tryParseJson(content) : content;
+  if (obj == null || typeof obj !== "object") return [];
+  const arr = (obj as Record<string, unknown>).citations;
+  if (!Array.isArray(arr)) return [];
+  return arr.filter(isCitationV1Like);
+}
+
+function isCitationV1Like(v: unknown): v is CitationV1 {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.version === "string" &&
+    typeof o.repo_id === "string" &&
+    typeof o.file_path === "string" &&
+    typeof o.commit_sha === "string" &&
+    typeof o.score === "number" &&
+    typeof o.source_kind === "string" &&
+    typeof o.line_range === "object" &&
+    o.line_range !== null
+  );
+}
+
+function tryParseJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/components/chat/citations/index.ts
+++ b/frontend/src/components/chat/citations/index.ts
@@ -1,0 +1,2 @@
+export { CitationChip } from "./CitationChip";
+export { buildGitHubUrl, extractCitationsFromItems } from "./citation-utils";

--- a/frontend/src/types/citations.ts
+++ b/frontend/src/types/citations.ts
@@ -1,0 +1,24 @@
+// TEMPORARY: Hand-written mirror of rb-schemas::CitationV1 and friends.
+// Matches crates/rb-schemas/src/citation.rs exactly.
+// Replace this file with a codegen'd import from @/api/generated/schema
+// after RUSAA-2089 lands and `npm run gen:api` regenerates the OpenAPI schema.
+
+export type SourceKind = "dense" | "sparse" | "hybrid" | "rerank";
+
+export interface LineRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+/** ADR-014 §5 citation envelope — frozen at v1. */
+export interface CitationV1 {
+  readonly version: string;
+  readonly repo_id: string;
+  readonly file_path: string;
+  readonly line_range: LineRange;
+  /** Best-effort "ingested at this commit" SHA; always non-empty (may be "unknown"). */
+  readonly commit_sha: string;
+  /** Fused score normalised to [0, 1]. */
+  readonly score: number;
+  readonly source_kind: SourceKind;
+}


### PR DESCRIPTION
Closes #808

## Summary

Wave 10 S4 pre-stage: render `CitationV1` citation chips in the chat panel.

- `CitationChip` component — file:start–end path, source-kind badge (D/S/H/R), score, GitHub blob link via `commit_sha`
- `extractCitationsFromItems` — pulls citations from `tool_result` JSON content in assistant turns, filters malformed entries
- `buildGitHubUrl` — `https://github.com/{owner/repo}/blob/{sha}/{path}#L{start}-L{end}` (commit-pinned, not `/main/`)
- `MessageThread` extended with `repoFullNameMap` prop; `AssistantBubble` renders sorted citation strip
- 16 Vitest unit tests; Playwright E2E smoke suite
- `citations/README.md` documents the CitationV1 contract (AC8)

**Status: DRAFT** — one follow-up pending before this can merge:

1. **S2 must land first** (`feature/hybrid-retrieval-tracer`) to add `citations` field to `SearchResponse` and regenerate `openapi.json`
2. After that: replace `src/types/citations.ts` hand-written type with codegen'd import from `@/api/generated/schema` (AC1)
3. Wire `repoFullNameMap` into `ChatPage.tsx` via `useRepos` (loads the repo-id → full-name map from the API)

## Local gates (all pass on this commit)

- `npm run typecheck` — ✅
- `npm run lint` — ✅ (0 warnings)
- `npm run gen:api:check` — ✅ in sync
- `npm run build` — ✅
- `npm run test` — ✅ 16/16 citation tests + all existing tests pass

## Test plan

- [ ] S2 PR merges and `openapi.json` regenerated
- [ ] Replace hand-written `citations.ts` with codegen'd type
- [ ] Wire `repoFullNameMap` in `ChatPage.tsx`
- [ ] Run `npm run typecheck && npm run lint && npm run gen:api:check && npm run build`
- [ ] Playwright smoke: `VITE_FEATURE_CHAT_PANEL=true npx playwright test chat-panel-rusaa-2091`
- [ ] Visual: send a search query in the chat, confirm chips appear below the reply
- [ ] Confirm chip links open correct GitHub blob lines in a new tab
- [ ] Confirm no chips rendered on non-search turns