### PR TITLE
[RUSAA-2091] feat(chat): CitationV1 citation chips (S4 — Wave 10)

### DIFF
--- a/frontend/e2e/chat-panel-citations-rusaa-2091.spec.ts
+++ b/frontend/e2e/chat-panel-citations-rusaa-2091.spec.ts
@@ -1,0 +1,199 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAuthenticatedSession,
+  mockReposList,
+  REPOS_RESPONSE,
+  REPO_ITEM,
+} from "./fixtures/mock-api";
+import {
+  mockChatSessionsListAndCreate,
+  mockSendChatMessage,
+  mockChatStream,
+  mockListChatMessages,
+  CHAT_SESSION_ID,
+  LIST_SESSIONS_ONE,
+  LIST_MESSAGES_EMPTY,
+} from "./fixtures/chat-mock-api";
+
+// CitationV1 payload matching the rb-schemas shape shipped by RUSAA-2089.
+const CITATION_V1 = {
+  version: "v1",
+  repo_id: REPO_ITEM.repo_id,
+  file_path: "src/query/hybrid.rs",
+  line_range: { start: 42, end: 58 },
+  commit_sha: "deadbeefcafe1234",
+  score: 0.87,
+  source_kind: "hybrid",
+};
+
+// The backend serialises citations as serde_json::to_string_pretty — a JSON string.
+const CITATION_RESULT_JSON = JSON.stringify([CITATION_V1], null, 2);
+
+const CITATION_SSE = [
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "user_input",
+    sequence: 1,
+    payload: { type: "user_input", text: "find hybrid search code" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_use",
+    sequence: 2,
+    payload: {
+      type: "tool_use",
+      id: "tu-search-001",
+      name: "mcp__rust_brain__search_items",
+      input: { query: "hybrid search", limit: 5 },
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 3,
+    payload: { type: "turn_complete", stop_reason: "tool_use" },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "tool_result",
+    sequence: 4,
+    payload: {
+      type: "tool_result",
+      tool_use_id: "tu-search-001",
+      content: CITATION_RESULT_JSON,
+      is_error: false,
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "text",
+    sequence: 5,
+    payload: {
+      type: "text",
+      text: "I found the hybrid search implementation.",
+    },
+  })}`,
+  "",
+  "event: session.event",
+  `data: ${JSON.stringify({
+    session_id: CHAT_SESSION_ID,
+    event_type: "turn_complete",
+    sequence: 6,
+    payload: { type: "turn_complete", stop_reason: "end_turn" },
+  })}`,
+  "",
+  "",
+].join("\n");
+
+// Regression guard for RUSAA-2091 (S4): CitationV1 chips rendered in chat tool results.
+test.describe("Chat panel — CitationV1 citation chips [RUSAA-2091]", () => {
+  test("AC2+AC3+AC4: search_items result renders clickable citation chips with badge and GitHub link", async ({
+    page,
+  }) => {
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, CITATION_SSE);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    // ToolCallBlock for search_items is visible
+    const toolBlock = page.getByTestId("tool-call-block");
+    await expect(toolBlock).toBeVisible();
+    await expect(toolBlock).toContainText("mcp__rust_brain__search_items");
+
+    // Expand the tool block to reveal the citation chips
+    await toolBlock.getByRole("button").click();
+
+    // At least one citation chip is present
+    const chip = page.getByTestId("citation-chip").first();
+    await expect(chip).toBeVisible();
+
+    // Chip contains file path and line range (AC2)
+    await expect(chip).toContainText("src/query/hybrid.rs");
+    await expect(chip).toContainText("42");
+
+    // Chip has a valid GitHub link (AC3) — commit SHA in href, not "main"
+    const href = await chip.getAttribute("href");
+    expect(href).not.toBeNull();
+    expect(href).toContain("github.com");
+    expect(href).toContain("deadbeefcafe1234");
+    expect(href).not.toContain("/main/");
+
+    // source_kind badge is present (AC4) with "hybrid" label
+    const badge = page.getByTestId("source-kind-badge-hybrid");
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText("hybrid");
+
+    // Chip opens in new tab (target=_blank)
+    const target = await chip.getAttribute("target");
+    expect(target).toBe("_blank");
+  });
+
+  test("AC5: version mismatch renders soft warning, not a JS error", async ({ page }) => {
+    const unknownVersionResult = JSON.stringify([
+      { ...CITATION_V1, version: "v99" },
+    ], null, 2);
+
+    const unknownVersionSse = CITATION_SSE.replace(
+      CITATION_RESULT_JSON,
+      unknownVersionResult,
+    );
+
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, unknownVersionSse);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    const toolBlock = page.getByTestId("tool-call-block");
+    await expect(toolBlock).toBeVisible();
+    await toolBlock.getByRole("button").click();
+
+    // No chips rendered (unknown version)
+    await expect(page.getByTestId("citation-chip")).not.toBeVisible();
+
+    // Soft warning is shown instead
+    await expect(page.getByTestId("citation-version-warning")).toBeVisible();
+
+    // No uncaught JS errors — if there were any, Playwright would have thrown above
+  });
+
+  test("AC2 empty: empty citation array renders graceful empty state", async ({ page }) => {
+    const emptyCitationsSse = CITATION_SSE.replace(
+      CITATION_RESULT_JSON,
+      "[]",
+    );
+
+    await mockAuthenticatedSession(page);
+    await mockReposList(page, REPOS_RESPONSE);
+    await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
+    await mockChatStream(page, CHAT_SESSION_ID, emptyCitationsSse);
+    await mockSendChatMessage(page);
+    await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
+
+    await page.goto(`/chat?sessionId=${CHAT_SESSION_ID}`);
+
+    const toolBlock = page.getByTestId("tool-call-block");
+    await expect(toolBlock).toBeVisible();
+    await toolBlock.getByRole("button").click();
+
+    // No chips, no JS errors — graceful empty state
+    await expect(page.getByTestId("citation-chip")).not.toBeVisible();
+    await expect(page.getByTestId("citation-empty")).toBeVisible();
+  });
+});

--- a/frontend/e2e/chat-panel-citations.spec.ts
+++ b/frontend/e2e/chat-panel-citations.spec.ts
@@ -15,7 +15,6 @@ import {
   LIST_MESSAGES_EMPTY,
 } from "./fixtures/chat-mock-api";
 
-// CitationV1 payload matching the rb-schemas shape shipped by RUSAA-2089.
 const CITATION_V1 = {
   version: "v1",
   repo_id: REPO_ITEM.repo_id,
@@ -26,83 +25,82 @@ const CITATION_V1 = {
   source_kind: "hybrid",
 };
 
-// The backend serialises citations as serde_json::to_string_pretty — a JSON string.
-const CITATION_RESULT_JSON = JSON.stringify([CITATION_V1], null, 2);
+function buildCitationSse(citations: unknown[]): string {
+  const contentValue = JSON.stringify(citations, null, 2);
+  return [
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "user_input",
+      sequence: 1,
+      payload: { type: "user_input", text: "find hybrid search code" },
+    })}`,
+    "",
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "tool_use",
+      sequence: 2,
+      payload: {
+        type: "tool_use",
+        id: "tu-search-001",
+        name: "mcp__rust_brain__search_items",
+        input: { query: "hybrid search", limit: 5 },
+      },
+    })}`,
+    "",
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "turn_complete",
+      sequence: 3,
+      payload: { type: "turn_complete", stop_reason: "tool_use" },
+    })}`,
+    "",
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "tool_result",
+      sequence: 4,
+      payload: {
+        type: "tool_result",
+        tool_use_id: "tu-search-001",
+        content: contentValue,
+        is_error: false,
+      },
+    })}`,
+    "",
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "text",
+      sequence: 5,
+      payload: {
+        type: "text",
+        text: "I found the hybrid search implementation.",
+      },
+    })}`,
+    "",
+    "event: session.event",
+    `data: ${JSON.stringify({
+      session_id: CHAT_SESSION_ID,
+      event_type: "turn_complete",
+      sequence: 6,
+      payload: { type: "turn_complete", stop_reason: "end_turn" },
+    })}`,
+    "",
+    "",
+  ].join("\n");
+}
 
-const CITATION_SSE = [
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "user_input",
-    sequence: 1,
-    payload: { type: "user_input", text: "find hybrid search code" },
-  })}`,
-  "",
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "tool_use",
-    sequence: 2,
-    payload: {
-      type: "tool_use",
-      id: "tu-search-001",
-      name: "mcp__rust_brain__search_items",
-      input: { query: "hybrid search", limit: 5 },
-    },
-  })}`,
-  "",
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "turn_complete",
-    sequence: 3,
-    payload: { type: "turn_complete", stop_reason: "tool_use" },
-  })}`,
-  "",
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "tool_result",
-    sequence: 4,
-    payload: {
-      type: "tool_result",
-      tool_use_id: "tu-search-001",
-      content: CITATION_RESULT_JSON,
-      is_error: false,
-    },
-  })}`,
-  "",
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "text",
-    sequence: 5,
-    payload: {
-      type: "text",
-      text: "I found the hybrid search implementation.",
-    },
-  })}`,
-  "",
-  "event: session.event",
-  `data: ${JSON.stringify({
-    session_id: CHAT_SESSION_ID,
-    event_type: "turn_complete",
-    sequence: 6,
-    payload: { type: "turn_complete", stop_reason: "end_turn" },
-  })}`,
-  "",
-  "",
-].join("\n");
-
-// Regression guard for RUSAA-2091 (S4): CitationV1 chips rendered in chat tool results.
-test.describe("Chat panel — CitationV1 citation chips [RUSAA-2091]", () => {
+test.describe("Chat panel — CitationV1 citation chips", () => {
   test("AC2+AC3+AC4: search_items result renders clickable citation chips with badge and GitHub link", async ({
     page,
   }) => {
     await mockAuthenticatedSession(page);
     await mockReposList(page, REPOS_RESPONSE);
     await mockChatSessionsListAndCreate(page, LIST_SESSIONS_ONE);
-    await mockChatStream(page, CHAT_SESSION_ID, CITATION_SSE);
+    await mockChatStream(page, CHAT_SESSION_ID, buildCitationSse([CITATION_V1]));
     await mockSendChatMessage(page);
     await mockListChatMessages(page, CHAT_SESSION_ID, LIST_MESSAGES_EMPTY);
 
@@ -142,14 +140,9 @@ test.describe("Chat panel — CitationV1 citation chips [RUSAA-2091]", () => {
   });
 
   test("AC5: version mismatch renders soft warning, not a JS error", async ({ page }) => {
-    const unknownVersionResult = JSON.stringify([
+    const unknownVersionSse = buildCitationSse([
       { ...CITATION_V1, version: "v99" },
-    ], null, 2);
-
-    const unknownVersionSse = CITATION_SSE.replace(
-      CITATION_RESULT_JSON,
-      unknownVersionResult,
-    );
+    ]);
 
     await mockAuthenticatedSession(page);
     await mockReposList(page, REPOS_RESPONSE);
@@ -169,15 +162,10 @@ test.describe("Chat panel — CitationV1 citation chips [RUSAA-2091]", () => {
 
     // Soft warning is shown instead
     await expect(page.getByTestId("citation-version-warning")).toBeVisible();
-
-    // No uncaught JS errors — if there were any, Playwright would have thrown above
   });
 
   test("AC2 empty: empty citation array renders graceful empty state", async ({ page }) => {
-    const emptyCitationsSse = CITATION_SSE.replace(
-      CITATION_RESULT_JSON,
-      "[]",
-    );
+    const emptyCitationsSse = buildCitationSse([]);
 
     await mockAuthenticatedSession(page);
     await mockReposList(page, REPOS_RESPONSE);

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -5,6 +5,7 @@ import { getToolRenderer, getArgPreview, deepDecodeJsonStrings } from "./tool-ca
 import { JsonResultRenderer } from "./tool-renderers/JsonResultRenderer";
 import { BashResultRenderer } from "./tool-renderers/BashResultRenderer";
 import { ReadResultRenderer } from "./tool-renderers/ReadResultRenderer";
+import { CitationChipsRenderer } from "./tool-renderers/CitationChipsRenderer";
 
 function InputBlock({ input }: { readonly input: unknown }): JSX.Element {
   const text = JSON.stringify(deepDecodeJsonStrings(input), null, 2);
@@ -143,6 +144,8 @@ export function ToolCallBlock({
                   <ReadResultRenderer result={result} input={input} />
                 ) : rendererType === "bash" ? (
                   <BashResultRenderer result={result} />
+                ) : rendererType === "citation" ? (
+                  <CitationChipsRenderer result={result} />
                 ) : (
                   <JsonResultRenderer result={result} />
                 )}

--- a/frontend/src/components/chat/citation-utils.test.ts
+++ b/frontend/src/components/chat/citation-utils.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseCitationResult,
+  buildGitHubUrl,
+  sourceKindBadgeClass,
+  type CitationV1,
+} from "./citation-utils";
+
+const BASE: CitationV1 = {
+  version: "v1",
+  repo_id: "repo-uuid-1",
+  file_path: "src/lib.rs",
+  line_range: { start: 10, end: 25 },
+  commit_sha: "abc123def456",
+  score: 0.94,
+  source_kind: "hybrid",
+};
+
+const makeRaw = (overrides: Partial<Record<string, unknown>> = {}): unknown =>
+  JSON.stringify([{ ...BASE, ...overrides }]);
+
+// ── parseCitationResult ────────────────────────────────────────────────────
+
+describe("parseCitationResult — input variety", () => {
+  it("returns empty array for null", () => {
+    expect(parseCitationResult(null)).toEqual([]);
+  });
+
+  it("returns empty array for undefined", () => {
+    expect(parseCitationResult(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for non-array JSON string", () => {
+    expect(parseCitationResult('{"foo":"bar"}')).toEqual([]);
+  });
+
+  it("returns empty array for invalid JSON string", () => {
+    expect(parseCitationResult("[not json")).toEqual([]);
+  });
+
+  it("returns empty array for empty array JSON string", () => {
+    expect(parseCitationResult("[]")).toEqual([]);
+  });
+
+  it("returns empty array for empty array value", () => {
+    expect(parseCitationResult([])).toEqual([]);
+  });
+
+  it("returns empty array for a plain object (not array)", () => {
+    expect(parseCitationResult({ version: "v1" })).toEqual([]);
+  });
+
+  it("parses a valid CitationV1 JSON string", () => {
+    const result = parseCitationResult(makeRaw());
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "v1", citation: { ...BASE } });
+  });
+
+  it("parses a valid CitationV1 array value (pre-decoded)", () => {
+    const result = parseCitationResult([{ ...BASE }]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "v1" });
+  });
+
+  it("skips items that are not plain objects", () => {
+    const raw = JSON.stringify([null, 42, "string", { ...BASE }]);
+    const result = parseCitationResult(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "v1" });
+  });
+
+  it("skips items with missing file_path", () => {
+    const raw = JSON.stringify([{ ...BASE, file_path: undefined }]);
+    expect(parseCitationResult(raw)).toEqual([]);
+  });
+
+  it("skips items with missing repo_id", () => {
+    const raw = JSON.stringify([{ ...BASE, repo_id: undefined }]);
+    expect(parseCitationResult(raw)).toEqual([]);
+  });
+
+  it("defaults missing commit_sha to 'unknown'", () => {
+    const result = parseCitationResult(JSON.stringify([{ ...BASE, commit_sha: "" }]));
+    expect(result[0]).toMatchObject({ type: "v1", citation: { commit_sha: "unknown" } });
+  });
+
+  it("defaults missing score to 0", () => {
+    const result = parseCitationResult(JSON.stringify([{ ...BASE, score: undefined }]));
+    expect(result[0]).toMatchObject({ type: "v1", citation: { score: 0 } });
+  });
+
+  it("defaults missing line_range to {start:0, end:0}", () => {
+    const result = parseCitationResult(JSON.stringify([{ ...BASE, line_range: undefined }]));
+    expect(result[0]).toMatchObject({ type: "v1", citation: { line_range: { start: 0, end: 0 } } });
+  });
+
+  it("defaults unrecognized source_kind to 'dense'", () => {
+    const result = parseCitationResult(JSON.stringify([{ ...BASE, source_kind: "custom" }]));
+    expect(result[0]).toMatchObject({ type: "v1", citation: { source_kind: "dense" } });
+  });
+});
+
+// ── source_kind variants ───────────────────────────────────────────────────
+
+describe("parseCitationResult — all four source_kind variants", () => {
+  for (const kind of ["dense", "sparse", "hybrid", "rerank"] as const) {
+    it(`preserves source_kind "${kind}"`, () => {
+      const result = parseCitationResult(makeRaw({ source_kind: kind }));
+      expect(result[0]).toMatchObject({ type: "v1", citation: { source_kind: kind } });
+    });
+  }
+});
+
+// ── version guard ──────────────────────────────────────────────────────────
+
+describe("parseCitationResult — version guard (AC5)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("emits console.warn for unknown version", () => {
+    parseCitationResult(makeRaw({ version: "v2" }));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("v2"),
+    );
+  });
+
+  it("returns unknown_version item instead of dropping silently", () => {
+    const result = parseCitationResult(makeRaw({ version: "v99" }));
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "unknown_version", version: "v99" });
+  });
+
+  it("handles mix of v1 and unknown-version citations", () => {
+    const raw = JSON.stringify([
+      { ...BASE, version: "v2" },
+      { ...BASE },
+    ]);
+    const result = parseCitationResult(raw);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ type: "unknown_version" });
+    expect(result[1]).toMatchObject({ type: "v1" });
+  });
+});
+
+// ── buildGitHubUrl ─────────────────────────────────────────────────────────
+
+describe("buildGitHubUrl", () => {
+  it("builds a correct GitHub blob URL with line anchor", () => {
+    const url = buildGitHubUrl(BASE, "acme/web-app");
+    expect(url).toBe(
+      "https://github.com/acme/web-app/blob/abc123def456/src/lib.rs#L10-L25",
+    );
+  });
+
+  it("handles zero-based line range", () => {
+    const citation: CitationV1 = { ...BASE, line_range: { start: 0, end: 0 } };
+    const url = buildGitHubUrl(citation, "acme/web-app");
+    expect(url).toContain("#L0-L0");
+  });
+
+  it("encodes the full_name as-is (owner/repo)", () => {
+    const url = buildGitHubUrl(BASE, "my-org/my-repo");
+    expect(url).toContain("https://github.com/my-org/my-repo/blob/");
+  });
+});
+
+// ── sourceKindBadgeClass ───────────────────────────────────────────────────
+
+describe("sourceKindBadgeClass — badge colors", () => {
+  it("dense → blue classes", () => {
+    const cls = sourceKindBadgeClass("dense");
+    expect(cls).toContain("blue");
+  });
+
+  it("sparse → green classes", () => {
+    const cls = sourceKindBadgeClass("sparse");
+    expect(cls).toContain("green");
+  });
+
+  it("hybrid → purple classes", () => {
+    const cls = sourceKindBadgeClass("hybrid");
+    expect(cls).toContain("purple");
+  });
+
+  it("rerank → amber classes", () => {
+    const cls = sourceKindBadgeClass("rerank");
+    expect(cls).toContain("amber");
+  });
+});

--- a/frontend/src/components/chat/citation-utils.ts
+++ b/frontend/src/components/chat/citation-utils.ts
@@ -1,0 +1,95 @@
+import type { components } from "@/api/generated/schema";
+
+export type CitationV1 = components["schemas"]["CitationV1"];
+export type SourceKind = components["schemas"]["SourceKind"];
+export type LineRange = components["schemas"]["LineRange"];
+
+const VALID_SOURCE_KINDS: ReadonlySet<string> = new Set(["dense", "sparse", "hybrid", "rerank"]);
+
+function isValidSourceKind(s: unknown): s is SourceKind {
+  return typeof s === "string" && VALID_SOURCE_KINDS.has(s);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+export type ParsedCitationItem =
+  | { type: "v1"; citation: CitationV1 }
+  | { type: "unknown_version"; version: string };
+
+export function parseCitationResult(raw: unknown): ParsedCitationItem[] {
+  let arr: unknown[];
+
+  if (raw === null || raw === undefined) return [];
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed.startsWith("[")) return [];
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (!Array.isArray(parsed)) return [];
+      arr = parsed;
+    } catch {
+      return [];
+    }
+  } else if (Array.isArray(raw)) {
+    arr = raw;
+  } else {
+    return [];
+  }
+
+  const results: ParsedCitationItem[] = [];
+
+  for (const item of arr) {
+    if (!isPlainObject(item)) continue;
+
+    const { version, repo_id, file_path, line_range, commit_sha, score, source_kind } = item;
+
+    if (version !== "v1") {
+      // AC5: emit console.warn for unknown versions instead of throwing
+      console.warn(
+        `[CitationChipsRenderer] Skipping citation with unknown version: "${String(version)}"`,
+      );
+      results.push({ type: "unknown_version", version: String(version) });
+      continue;
+    }
+
+    if (typeof file_path !== "string" || typeof repo_id !== "string") continue;
+
+    const lr = isPlainObject(line_range) ? line_range : {};
+    const start = typeof lr["start"] === "number" ? lr["start"] : 0;
+    const end = typeof lr["end"] === "number" ? lr["end"] : 0;
+
+    results.push({
+      type: "v1",
+      citation: {
+        version: "v1",
+        repo_id,
+        file_path,
+        line_range: { start, end },
+        commit_sha: typeof commit_sha === "string" && commit_sha.length > 0 ? commit_sha : "unknown",
+        score: typeof score === "number" ? score : 0,
+        source_kind: isValidSourceKind(source_kind) ? source_kind : "dense",
+      },
+    });
+  }
+
+  return results;
+}
+
+export function buildGitHubUrl(citation: CitationV1, fullName: string): string {
+  const { commit_sha, file_path, line_range } = citation;
+  return `https://github.com/${fullName}/blob/${commit_sha}/${file_path}#L${line_range.start}-L${line_range.end}`;
+}
+
+const SOURCE_KIND_BADGE: Record<SourceKind, string> = {
+  dense: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  sparse: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  hybrid: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+  rerank: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+};
+
+export function sourceKindBadgeClass(kind: SourceKind): string {
+  return SOURCE_KIND_BADGE[kind] ?? SOURCE_KIND_BADGE.dense;
+}

--- a/frontend/src/components/chat/tool-call-utils.ts
+++ b/frontend/src/components/chat/tool-call-utils.ts
@@ -7,11 +7,12 @@ export function selectPrismStyle(resolvedTheme: "light" | "dark"): typeof oneDar
   return resolvedTheme === "dark" ? oneDark : oneLight;
 }
 
-export type ToolRendererType = "read" | "bash" | "json";
+export type ToolRendererType = "read" | "bash" | "citation" | "json";
 
 export function getToolRenderer(toolName: string): ToolRendererType {
   if (toolName === "Read") return "read";
   if (toolName === "Bash") return "bash";
+  if (toolName === "mcp__rust_brain__search_items") return "citation";
   return "json";
 }
 
@@ -30,6 +31,9 @@ export function getArgPreview(name: string, input: unknown): string {
     }
     if (name === "Agent" && typeof (obj["prompt"] ?? obj["description"]) === "string") {
       return (obj["prompt"] ?? obj["description"]) as string;
+    }
+    if (name === "mcp__rust_brain__search_items" && typeof obj["query"] === "string") {
+      return obj["query"] as string;
     }
   }
   const raw = JSON.stringify(input);

--- a/frontend/src/components/chat/tool-renderers/CitationChipsRenderer.tsx
+++ b/frontend/src/components/chat/tool-renderers/CitationChipsRenderer.tsx
@@ -1,0 +1,149 @@
+import { useMe } from "@/api/hooks/useMe";
+import { useRepos } from "@/api";
+import { cn } from "@/lib/utils";
+import {
+  parseCitationResult,
+  buildGitHubUrl,
+  sourceKindBadgeClass,
+  type CitationV1,
+  type SourceKind,
+} from "../citation-utils";
+
+interface CitationChipsRendererProps {
+  readonly result: unknown;
+}
+
+export function CitationChipsRenderer({ result }: CitationChipsRendererProps): JSX.Element {
+  const me = useMe();
+  const repos = useRepos(me.data?.current_tenant.id ?? "");
+
+  const items = parseCitationResult(result);
+
+  if (items.length === 0) {
+    return (
+      <p className="text-xs italic text-muted-foreground" data-testid="citation-empty">
+        No citations available.
+      </p>
+    );
+  }
+
+  const repoMap = new Map<string, string>(
+    (repos.data?.repos ?? []).map((r) => [r.repo_id, r.full_name]),
+  );
+
+  // Group valid citations by repo_id; preserve insertion order
+  const groups = new Map<string, CitationV1[]>();
+  const unknownVersions: string[] = [];
+
+  for (const item of items) {
+    if (item.type === "unknown_version") {
+      unknownVersions.push(item.version);
+      continue;
+    }
+    const { repo_id } = item.citation;
+    const bucket = groups.get(repo_id) ?? [];
+    bucket.push(item.citation);
+    groups.set(repo_id, bucket);
+  }
+
+  const multiRepo = groups.size > 1;
+
+  return (
+    <div className="space-y-2" data-testid="citation-chips-renderer">
+      {[...groups.entries()].map(([repoId, cits]) => {
+        const fullName = repoMap.get(repoId);
+        return (
+          <div key={repoId}>
+            {multiRepo && fullName !== undefined && (
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                {fullName}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-1.5">
+              {cits.map((c, i) => (
+                <CitationChip key={i} citation={c} fullName={fullName} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      {unknownVersions.length > 0 && (
+        <div
+          className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-300"
+          role="alert"
+          data-testid="citation-version-warning"
+        >
+          {unknownVersions.length === 1
+            ? `1 citation used an unknown format (version "${unknownVersions[0]}") and cannot be displayed.`
+            : `${unknownVersions.length} citations used an unknown format and cannot be displayed.`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CitationChipProps {
+  readonly citation: CitationV1;
+  readonly fullName: string | undefined;
+}
+
+function CitationChip({ citation, fullName }: CitationChipProps): JSX.Element {
+  const { file_path, line_range, score, source_kind } = citation;
+  const url = fullName !== undefined ? buildGitHubUrl(citation, fullName) : null;
+  const rangeLabel = `${line_range.start}-${line_range.end}`;
+  const chipLabel = `${file_path}:${rangeLabel}`;
+  const ariaLabel = `${chipLabel} — ${source_kind} (score ${score.toFixed(2)})`;
+
+  const chipClass =
+    "inline-flex max-w-xs items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-xs transition-colors hover:bg-accent";
+
+  const inner = (
+    <>
+      <span
+        className="max-w-[160px] truncate font-mono text-foreground/90"
+        title={chipLabel}
+      >
+        {chipLabel}
+      </span>
+      <SourceKindBadge kind={source_kind} />
+      <span className="shrink-0 tabular-nums text-muted-foreground">
+        {score.toFixed(2)}
+      </span>
+    </>
+  );
+
+  if (url !== null) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={chipClass}
+        aria-label={ariaLabel}
+        data-testid="citation-chip"
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <span className={chipClass} aria-label={ariaLabel} data-testid="citation-chip">
+      {inner}
+    </span>
+  );
+}
+
+function SourceKindBadge({ kind }: { readonly kind: SourceKind }): JSX.Element {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1 py-0.5 text-[10px] font-medium",
+        sourceKindBadgeClass(kind),
+      )}
+      data-testid={`source-kind-badge-${kind}`}
+    >
+      {kind}
+    </span>
+  );
+}


### PR DESCRIPTION
"## Summary\n\n- Renders `CitationV1` citations from `mcp__rust_brain__search_items` tool results as clickable chip UI in the chat panel.\n- **AC1** `CitationV1` TypeScript type is codegen'd from `rb-schemas` via the existing `openapi-typescript` pipeline (`schema.ts:1347`) \u2014 no hand-rolled duplicate.\n- **AC2** Each citation chip shows `file_path:line_range`, `source_kind` badge, and score (2 dp).\n- **AC3** Chip is an `<a target=\"_blank\">` linking to `github.com/{full_name}/blob/{commit_sha}/{file_path}#L{start}-L{end}` \u2014 commit-SHA-pinned, not `main`.\n- **AC4** `source_kind` badge colours: `dense`=blue, `sparse`=green, `hybrid`=purple, `rerank`=amber.\n- **AC5** `version !== \"v1\"` \u2192 `console.warn` + amber warning banner instead of throwing.\n- **AC6** 30 Vitest unit tests (`citation-utils.test.ts`): all 4 `source_kind` variants, missing-field defensive paths, version guard, URL builder, badge classes.\n- **AC7** 3 Playwright E2E tests (`chat-panel-citations-rusaa-2091.spec.ts`): chip visible + clickable + version-warning + empty-state.\n- **AC8** `flex-wrap`, `max-w-xs truncate` ellipsis on long paths, full dark-mode Tailwind classes.\n\nFE-only; no backend changes. Fingerprint EXEMPT per issue constraints.\n\n## Files changed\n\n| File | Change |\n|---|---|\n| `frontend/src/components/chat/citation-utils.ts` | New \u2014 pure parser, URL builder, badge classes |\n| `frontend/src/components/chat/tool-renderers/CitationChipsRenderer.tsx` | New \u2014 React component |\n| `frontend/src/components/chat/tool-call-utils.ts` | Add `\"citation\"` renderer type + search_items dispatch |\n| `frontend/src/components/chat/ToolCallBlock.tsx` | Route search_items to CitationChipsRenderer |\n| `frontend/src/components/chat/citation-utils.test.ts` | New \u2014 30 Vitest tests |\n| `frontend/e2e/chat-panel-citations-rusaa-2091.spec.ts` | New \u2014 3 Playwright E2E tests |\n\n## Test plan\n\n- [x] `npx vitest run src/components/chat/citation-utils.test.ts` \u2192 30/30 PASS\n- [x] Full Vitest suite: 5 pre-existing suites still pass (3 pre-existing failures unrelated to this PR: missing `react-syntax-highlighter` ESM resolution in node test env)\n- [x] `tsc --noEmit --skipLibCheck` \u2192 no errors in changed files\n- [ ] Playwright chat-smoke suite with `RB_HYBRID_SEARCH_ENABLED=true` (requires running stack)\n- [ ] Visual check: dark mode chip rendering, narrow-viewport wrap\n\nCloses #808\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\n"