### PR TITLE
[RUSAA-2103] docs(runbooks): replace stale mars.internal with Tailscale IP and MagicDNS name

### DIFF
--- a/docs/runbooks/claude-login.md
+++ b/docs/runbooks/claude-login.md
@@ -31,7 +31,10 @@ docker compose -f compose/dev.yml restart claude-login
 
 ```bash
 ssh -p 12222 loginuser@<host>
-# On mars: loginuser@mars.internal
+# On mars (MagicDNS — works when your machine is on the tailnet):
+ssh -p 12222 loginuser@mars
+# On mars (Tailscale IP — always works from the tailnet):
+ssh -p 12222 loginuser@100.87.157.74
 ```
 
 Expected: you get a shell prompt. If you see `Permission denied (publickey)`, double-check that `RB_SSH_AUTHORIZED_KEYS` matches your private key.


### PR DESCRIPTION
## Summary

- Replace stale `mars.internal` hostname in `docs/runbooks/claude-login.md` step 2 with the two correct forms: bare MagicDNS name (`mars`) and Tailscale IP (`100.87.157.74`)
- Grepped the full `docs/` tree — no other `mars.internal` references exist

Triggered by RUSAA-2102 (operator hit `ssh: Could not resolve hostname mars.internal`).

## GitHub Issue

Closes #815

## Checklist

- [x] Docs-only diff — no compose, scripts, or env files touched
- [x] No `RUSAA-XX` outside the title bracket prefix
- [x] `mars.internal` fully scrubbed from `docs/`