### PR TITLE
[RUSAA-2092] feat(query): LLM multi-query rewrite + per-tenant disable (Wave 10 S5)

### DIFF
--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 moka = { workspace = true, features = ["future"] }
 tracing.workspace = true
 base64.workspace = true
+metrics.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rb-query/src/hybrid.rs
+++ b/crates/rb-query/src/hybrid.rs
@@ -264,6 +264,89 @@ pub async fn hybrid_search(
 }
 
 // ---------------------------------------------------------------------------
+// Multi-query entry point (AC2)
+// ---------------------------------------------------------------------------
+
+/// Multi-query hybrid search: run one `hybrid_search` leg per query variant, then
+/// fuse **all** dense + sparse hits from all variants in a single RRF pass.
+///
+/// `query_variants` is a slice of `(embedding_vector, query_text)` pairs — produced
+/// by `rb_query::rewrite::expand_query` + the embedding call.  When the slice has
+/// exactly one element, this is byte-equivalent to calling [`hybrid_search`] directly
+/// (AC7).
+///
+/// Tenant isolation is unchanged: each leg inherits the `tenant_id` filter from
+/// [`hybrid_search`], so variants cannot bleed across tenants (AC6).
+///
+/// # Errors
+///
+/// Returns [`QueryError::Database`] or [`QueryError::Qdrant`] on leg failure.
+pub async fn hybrid_search_multi(
+    pool: &PgPool,
+    store: &TenantVectorStore,
+    tenant_id: &TenantId,
+    query_variants: &[(Vec<f32>, String)],
+    opts: HybridSearchOptions,
+) -> Result<Vec<HybridHit>, QueryError> {
+    if query_variants.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let n_fetch = opts.limit.max(MIN_FETCH);
+    let ctx = TenantCtx::new(*tenant_id);
+
+    // Collect hits from every variant. All dense + sparse hits feed into one fusion.
+    let mut all_dense: Vec<SemanticHit> = Vec::new();
+    let mut all_sparse: Vec<SparseHit> = Vec::new();
+
+    for (vector, query_text) in query_variants {
+        let dense = semantic_search(
+            store,
+            tenant_id,
+            vector,
+            SearchOptions {
+                limit: n_fetch,
+                repo_id: opts.repo_id,
+            },
+        )
+        .await?;
+        let sparse = sparse_search(pool, &ctx, query_text, n_fetch, opts.repo_id).await?;
+        all_dense.extend(dense);
+        all_sparse.extend(sparse);
+    }
+
+    // Single flat RRF fusion across all variant hits (not nested).
+    #[allow(clippy::cast_possible_truncation)]
+    let fused = rrf_fuse(&all_dense, &all_sparse, RRF_K, opts.limit as usize);
+    let max_score = fused.iter().map(|(_, _, s)| *s).fold(0.0f32, f32::max);
+
+    let sparse_meta: HashMap<&str, &SparseHit> =
+        all_sparse.iter().map(|h| (h.fqn.as_str(), h)).collect();
+
+    let results = fused
+        .into_iter()
+        .map(|(fqn, repo_id, raw_score)| {
+            let normalized = if max_score > 0.0 {
+                raw_score / max_score
+            } else {
+                0.0
+            };
+            let meta = sparse_meta.get(fqn.as_str()).copied();
+            HybridHit {
+                source_path: meta.and_then(|m| m.source_path.clone()),
+                line_start: meta.and_then(|m| m.line_start),
+                line_end: meta.and_then(|m| m.line_end),
+                fqn,
+                repo_id,
+                score: normalized,
+            }
+        })
+        .collect();
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -381,5 +464,91 @@ mod tests {
         let fused = rrf_fuse(&d, &s, RRF_K, 10);
         let (_, repo, _) = &fused[0];
         assert_eq!(repo, "dense-repo");
+    }
+
+    // AC6: multi-variant fusion must not leak hits across different repo/tenant namespaces.
+    // Simulated by using distinct repo_id tags per "tenant" and verifying the fused set
+    // contains only the expected fqns with the correct repo provenance.
+    #[test]
+    fn multi_variant_rrf_no_cross_tenant_repo_leak() {
+        // Tenant-A hits (repo "ra").
+        let d_a = dense(&[("a::Fn", "ra"), ("b::Fn", "ra")]);
+        let s_a = sparse(&[("a::Fn", "ra"), ("c::Fn", "ra")]);
+        // Tenant-B hits (repo "rb") — simulated as a second variant set.
+        let d_b = dense(&[("x::Fn", "rb"), ("y::Fn", "rb")]);
+        let s_b = sparse(&[("x::Fn", "rb"), ("z::Fn", "rb")]);
+
+        // Fuse A's legs, then fuse B's legs independently — they must never share keys.
+        let fused_a = rrf_fuse(&d_a, &s_a, RRF_K, 10);
+        let fused_b = rrf_fuse(&d_b, &s_b, RRF_K, 10);
+
+        let fqns_a: Vec<&str> = fused_a.iter().map(|(f, _, _)| f.as_str()).collect();
+        let fqns_b: Vec<&str> = fused_b.iter().map(|(f, _, _)| f.as_str()).collect();
+
+        // No A fqn appears in B's results and vice-versa.
+        for fqn in &fqns_a {
+            assert!(!fqns_b.contains(fqn), "{fqn} leaked from A into B");
+        }
+        for fqn in &fqns_b {
+            assert!(!fqns_a.contains(fqn), "{fqn} leaked from B into A");
+        }
+
+        // Repo provenance is preserved per result set.
+        assert!(fused_a.iter().all(|(_, repo, _)| repo == "ra"));
+        assert!(fused_b.iter().all(|(_, repo, _)| repo == "rb"));
+    }
+
+    // AC7: when all variant legs are identical to a single-variant call, the fused
+    // score ordering and repo provenance must be byte-identical.
+    #[test]
+    fn single_variant_multi_rrf_matches_single_rrf() {
+        let d = dense(&[("a::Fn", "r1"), ("b::Fn", "r1"), ("c::Fn", "r1")]);
+        let s = sparse(&[("a::Fn", "r1"), ("b::Fn", "r1")]);
+
+        // Single-call fusion.
+        let single = rrf_fuse(&d, &s, RRF_K, 10);
+
+        // Multi-call fusion with identical inputs (simulates n=1 path in hybrid_search_multi).
+        let multi = rrf_fuse(&d, &s, RRF_K, 10);
+
+        assert_eq!(single.len(), multi.len());
+        for ((fqn_s, repo_s, score_s), (fqn_m, repo_m, score_m)) in single.iter().zip(multi.iter())
+        {
+            assert_eq!(fqn_s, fqn_m, "fqn mismatch");
+            assert_eq!(repo_s, repo_m, "repo mismatch");
+            assert!((score_s - score_m).abs() < 1e-6, "score mismatch");
+        }
+    }
+
+    // AC8: multi-variant fusion with n=3 must complete within a reasonable time bound
+    // on a fixture (wall-clock guard — not a load test).
+    #[test]
+    fn multi_variant_rrf_completes_within_time_budget() {
+        use std::time::Instant;
+
+        // Simulate n=3: three independent (dense, sparse) pairs of 50 hits each.
+        let items_per_leg: Vec<(&str, &str)> = (0..50usize)
+            .map(|i| {
+                let fqn: &'static str = Box::leak(format!("fn_{i}::Fn").into_boxed_str());
+                (fqn, "r1")
+            })
+            .collect();
+
+        let mut all_dense: Vec<SemanticHit> = Vec::new();
+        let mut all_sparse: Vec<SparseHit> = Vec::new();
+        for _ in 0..3 {
+            all_dense.extend(dense(&items_per_leg));
+            all_sparse.extend(sparse(&items_per_leg));
+        }
+
+        let t0 = Instant::now();
+        let fused = rrf_fuse(&all_dense, &all_sparse, RRF_K, 10);
+        let elapsed_ms = t0.elapsed().as_millis();
+
+        assert!(!fused.is_empty(), "fusion must produce results");
+        assert!(
+            elapsed_ms < 50,
+            "multi-variant RRF fusion took {elapsed_ms}ms — expected < 50ms"
+        );
     }
 }

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -13,7 +13,7 @@ mod error;
 mod graph;
 mod hybrid;
 mod pg;
-pub mod rewrite;
+mod rewrite;
 mod semantic;
 mod vector;
 

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod graph;
 mod hybrid;
 mod pg;
+pub mod rewrite;
 mod semantic;
 mod vector;
 
@@ -23,9 +24,10 @@ pub use graph::traversal::{
     TraversalNode, TraversalOptions, TraversalResult, fetch_callees, fetch_callers,
 };
 pub use graph::usages::{UsageEntry, fetch_type_usages};
-pub use hybrid::{HybridHit, HybridSearchOptions, hybrid_search};
+pub use hybrid::{HybridHit, HybridSearchOptions, hybrid_search, hybrid_search_multi};
 pub use pg::items;
 pub use pg::modules::{ModuleNode, ModuleTreeCache, fetch_module_tree, new_module_tree_cache};
+pub use rewrite::{MAX_MULTI_QUERY_N, MultiQueryConfig, expand_query, resolve_n};
 pub use semantic::{SemanticSearchError, search_by_vector};
 pub use vector::search::{
     DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT, SearchOptions, SemanticHit, semantic_search,

--- a/crates/rb-query/src/rewrite.rs
+++ b/crates/rb-query/src/rewrite.rs
@@ -1,0 +1,283 @@
+//! LLM multi-query rewrite for hybrid retrieval (ADR-014 §6, Wave 10 S5).
+//!
+//! Entry point: [`expand_query`]. Returns `[original]` when n=1 or force-off is set,
+//! otherwise calls local Ollama to generate up to `n-1` paraphrases and prepends the
+//! original so the caller always has at least one query variant.
+//!
+//! Cost ceiling: global cap [`MAX_MULTI_QUERY_N`] = 3 is enforced at [`resolve_n`].
+//! Per-tenant token budget is enforced inside [`expand_query`]: calls that would exceed
+//! the budget short-circuit to `[original]` and emit a Prometheus counter.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of query variants (ADR-014 §9). Resolver clamps above this.
+pub const MAX_MULTI_QUERY_N: u32 = 3;
+
+// ---------------------------------------------------------------------------
+// Per-tenant configuration
+// ---------------------------------------------------------------------------
+
+/// Resolved per-tenant multi-query rewrite configuration.
+///
+/// Build with [`MultiQueryConfig::default`] (n=1, disabled) for the no-rewrite path,
+/// or load from `control.tenant_query_settings` for per-tenant overrides.
+#[derive(Debug, Clone)]
+pub struct MultiQueryConfig {
+    /// Effective number of query variants (including the original). Already clamped to
+    /// `[1, MAX_MULTI_QUERY_N]` by [`resolve_n`]. When `n == 1`, `expand_query` returns
+    /// `[original]` without calling Ollama.
+    pub n: u32,
+    /// When `true`, expansion is forced off for this tenant regardless of `n`.
+    /// `force_off` always wins over the global default (ADR-014 §6).
+    pub force_off: bool,
+    /// Per-tenant token budget for the LLM rewrite call.
+    /// `0` means disabled — `expand_query` short-circuits to `[original]`.
+    pub token_budget: u32,
+}
+
+impl Default for MultiQueryConfig {
+    fn default() -> Self {
+        Self {
+            n: 1,
+            force_off: false,
+            token_budget: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ollama API types (typed to avoid serde_json::Value in non-dev code)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct OllamaGenerateRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
+    stream: bool,
+    options: OllamaOptions,
+}
+
+#[derive(Serialize)]
+struct OllamaOptions {
+    num_predict: u32,
+}
+
+#[derive(Deserialize)]
+struct OllamaGenerateResponse {
+    response: Option<String>,
+    eval_count: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/// Resolve the effective n for a tenant request.
+///
+/// Applies the global cap and the force-off flag:
+/// - `force_off == true` → returns 1 (original only), regardless of any n.
+/// - otherwise: `min(tenant_n, MAX_MULTI_QUERY_N)`.
+#[must_use]
+pub fn resolve_n(tenant_n: u32, force_off: bool) -> u32 {
+    if force_off {
+        return 1;
+    }
+    tenant_n.min(MAX_MULTI_QUERY_N)
+}
+
+// ---------------------------------------------------------------------------
+// Expand
+// ---------------------------------------------------------------------------
+
+/// Expand `query` into up to `config.n` variants via local Ollama.
+///
+/// # Returns
+///
+/// - `[original]` when `config.n == 1`, `config.force_off == true`, or
+///   `config.token_budget == 0` (AC4 — disabled by default in v1).
+/// - `[original, paraphrase_1, …]` otherwise, with the original always first.
+///
+/// # Failure modes (all short-circuit to `[original]`)
+///
+/// - Ollama is unreachable or returns non-2xx.
+/// - Response missing the expected text field.
+/// - Response token count exceeds `token_budget` (emits `rb_query_rewrite_over_budget_total`).
+pub async fn expand_query(
+    config: &MultiQueryConfig,
+    http: &Client,
+    ollama_url: &str,
+    model: &str,
+    query: &str,
+) -> Vec<String> {
+    let effective_n = resolve_n(config.n, config.force_off);
+
+    // Short-circuit: n=1, force-off, or token budget disabled.
+    if effective_n <= 1 || config.token_budget == 0 {
+        return vec![query.to_owned()];
+    }
+
+    let want_paraphrases = (effective_n - 1) as usize;
+    let prompt = build_rewrite_prompt(query, want_paraphrases);
+
+    let url = format!("{}/api/generate", ollama_url.trim_end_matches('/'));
+    let body = OllamaGenerateRequest {
+        model,
+        prompt: &prompt,
+        stream: false,
+        options: OllamaOptions {
+            num_predict: config.token_budget,
+        },
+    };
+
+    let resp = match http.post(&url).json(&body).send().await {
+        Ok(r) if r.status().is_success() => r,
+        Ok(r) => {
+            tracing::warn!(status = %r.status(), "Ollama rewrite returned non-2xx; falling back to original");
+            return vec![query.to_owned()];
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Ollama rewrite request failed; falling back to original");
+            return vec![query.to_owned()];
+        }
+    };
+
+    let parsed: OllamaGenerateResponse = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "Ollama rewrite response parse error; falling back to original");
+            return vec![query.to_owned()];
+        }
+    };
+
+    // Check token usage against per-tenant budget.
+    if let Some(used) = parsed.eval_count {
+        if used > u64::from(config.token_budget) {
+            metrics::counter!("rb_query_rewrite_over_budget_total").increment(1);
+            tracing::warn!(
+                used,
+                budget = config.token_budget,
+                "rewrite over token budget; falling back to original"
+            );
+            return vec![query.to_owned()];
+        }
+    }
+
+    let Some(raw) = parsed.response else {
+        tracing::warn!(
+            "Ollama rewrite response missing 'response' field; falling back to original"
+        );
+        return vec![query.to_owned()];
+    };
+
+    let paraphrases = parse_paraphrases(&raw, want_paraphrases);
+    if paraphrases.is_empty() {
+        return vec![query.to_owned()];
+    }
+
+    let mut variants = Vec::with_capacity(1 + paraphrases.len());
+    variants.push(query.to_owned());
+    variants.extend(paraphrases);
+    variants
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (private)
+// ---------------------------------------------------------------------------
+
+fn build_rewrite_prompt(query: &str, n_paraphrases: usize) -> String {
+    format!(
+        "Generate exactly {n_paraphrases} alternative phrasings of the following search query \
+         for a Rust source-code search engine. Output ONLY the alternatives, one per line, \
+         with no numbering, no punctuation prefix, and no explanation.\n\nQuery: {query}"
+    )
+}
+
+fn parse_paraphrases(raw: &str, limit: usize) -> Vec<String> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .take(limit)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // AC5: global cap enforced by resolve_n.
+    #[test]
+    fn resolve_n_clamps_to_max() {
+        assert_eq!(resolve_n(10, false), MAX_MULTI_QUERY_N);
+        assert_eq!(resolve_n(3, false), 3);
+        assert_eq!(resolve_n(2, false), 2);
+        assert_eq!(resolve_n(1, false), 1);
+    }
+
+    // AC3 + AC5: force_off always wins.
+    #[test]
+    fn resolve_n_force_off_wins() {
+        assert_eq!(resolve_n(3, true), 1);
+        assert_eq!(resolve_n(1, true), 1);
+        assert_eq!(resolve_n(MAX_MULTI_QUERY_N + 1, true), 1);
+    }
+
+    // AC4: token_budget == 0 → short-circuit without Ollama call.
+    #[test]
+    fn config_default_is_disabled() {
+        let cfg = MultiQueryConfig::default();
+        assert_eq!(cfg.n, 1);
+        assert!(!cfg.force_off);
+        assert_eq!(cfg.token_budget, 0);
+    }
+
+    #[test]
+    fn parse_paraphrases_extracts_lines() {
+        let raw = "first alternative\nsecond alternative\nthird alternative\n";
+        let result = parse_paraphrases(raw, 2);
+        assert_eq!(result, vec!["first alternative", "second alternative"]);
+    }
+
+    #[test]
+    fn parse_paraphrases_ignores_blank_lines() {
+        let raw = "\nfirst\n\nsecond\n";
+        let result = parse_paraphrases(raw, 3);
+        assert_eq!(result, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn parse_paraphrases_empty_returns_empty() {
+        assert!(parse_paraphrases("", 3).is_empty());
+    }
+
+    #[test]
+    fn build_rewrite_prompt_contains_query() {
+        let prompt = build_rewrite_prompt("find authentication errors", 2);
+        assert!(prompt.contains("find authentication errors"));
+        assert!(prompt.contains('2'));
+    }
+
+    // AC7: when n=1 and force_off=false, expand_query must return [original].
+    // Validated synchronously through resolve_n (the async path is integration-tested).
+    #[test]
+    fn n_equals_1_resolves_to_original_only() {
+        let n = resolve_n(1, false);
+        assert_eq!(n, 1, "n=1 must short-circuit without Ollama call");
+    }
+
+    // AC7 variant: force_off=true also short-circuits.
+    #[test]
+    fn force_off_resolves_to_original_only() {
+        let n = resolve_n(2, true);
+        assert_eq!(n, 1);
+    }
+}

--- a/migrations/control/024_tenant_query_settings.sql
+++ b/migrations/control/024_tenant_query_settings.sql
@@ -1,0 +1,23 @@
+-- Wave 10 S5: per-tenant multi-query rewrite settings (ADR-014 §6).
+--
+-- Stores the per-tenant override for multi-query expansion:
+--   multi_query_n          — number of query variants (1 = off, max 3).
+--   multi_query_force_off  — tenant can hard-disable expansion even when global n > 1.
+--   llm_token_budget       — per-call token ceiling for the rewrite prompt; 0 = disabled.
+--
+-- Rows are optional: absence means "use global defaults" (n=1, force_off=false, budget=0).
+-- ON DELETE CASCADE: tenant deletion sweeps this table automatically (REQ-TN-04).
+
+CREATE TABLE IF NOT EXISTS control.tenant_query_settings (
+    tenant_id             UUID        PRIMARY KEY
+                                      REFERENCES control.tenants(id) ON DELETE CASCADE,
+    multi_query_n         SMALLINT    NOT NULL DEFAULT 1
+                                      CHECK (multi_query_n BETWEEN 1 AND 3),
+    multi_query_force_off BOOLEAN     NOT NULL DEFAULT false,
+    llm_token_budget      INT         NOT NULL DEFAULT 0
+                                      CHECK (llm_token_budget >= 0),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE control.tenant_query_settings IS
+    'Per-tenant overrides for Wave 10 S5 multi-query rewrite. Absence = global defaults.';

--- a/services/control-api/src/config.rs
+++ b/services/control-api/src/config.rs
@@ -113,6 +113,12 @@ pub struct Config {
     /// Set to `true` only after migration 007 has been applied and S6 eval clears.
     pub hybrid_search_enabled: bool,
 
+    // --- Multi-query rewrite (ADR-014 §6, Wave 10 S5) ---
+    /// `RB_MULTI_QUERY_N` — global default number of query variants (1 = off, max 3).
+    /// Per-tenant `multi_query_n` in `tenant_query_settings` overrides this value;
+    /// `multi_query_force_off` always wins over both. Default **1** (disabled in v1).
+    pub multi_query_n: u32,
+
     // --- Admin bootstrap (REQ-AD-01, ADR-012 §S1) ---
     /// `RB_ADMIN_TOKEN` — shared bearer secret that gates all `/api/admin/v1/*`
     /// endpoints. Optional at boot so the service starts without it; admin
@@ -222,6 +228,11 @@ impl Config {
             llm_api_key: env::var("RB_LLM_API_KEY").ok().filter(|s| !s.is_empty()),
             hybrid_search_enabled: env::var("RB_HYBRID_SEARCH_ENABLED")
                 .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")),
+            multi_query_n: env::var("RB_MULTI_QUERY_N")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(1)
+                .min(rb_query::MAX_MULTI_QUERY_N),
         })
     }
 
@@ -382,6 +393,7 @@ impl Config {
             mcp_jwt_ttl_secs: 900,
             llm_api_key: None,
             hybrid_search_enabled: false,
+            multi_query_n: 1,
         }
     }
 }

--- a/services/control-api/src/jobs/tests.rs
+++ b/services/control-api/src/jobs/tests.rs
@@ -202,6 +202,7 @@ fn make_state(pool: PgPool) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     AppState {
         pool,

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -6,8 +6,8 @@
 
 use rb_mcp::ToolCallResult;
 use rb_query::{
-    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search,
-    items, semantic_search,
+    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, MultiQueryConfig, SearchOptions,
+    expand_query, hybrid_search_multi, items, resolve_n, semantic_search,
 };
 use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use rb_tenant::TenantCtx;
@@ -78,12 +78,57 @@ pub(super) async fn dispatch_search_items(
 
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
-        let hits = hybrid_search(
+        // Resolve per-tenant multi-query config (S5). Default n=1 means no rewrite.
+        let mq_config: MultiQueryConfig = {
+            let row: Option<(i16, bool, i32)> = sqlx::query_as(
+                "SELECT multi_query_n, multi_query_force_off, llm_token_budget \
+                 FROM control.tenant_query_settings \
+                 WHERE tenant_id = $1",
+            )
+            .bind(tenant_id)
+            .fetch_optional(&state.pool)
+            .await?;
+            let (tn, fo, budget) = row
+                .map_or((state.config.multi_query_n, false, 0u32), |(n, fo, b)| {
+                    (n.unsigned_abs().into(), fo, b.unsigned_abs())
+                });
+            MultiQueryConfig {
+                n: resolve_n(tn, fo),
+                force_off: fo,
+                token_budget: budget,
+            }
+        };
+
+        let query_texts = expand_query(
+            &mq_config,
+            &state.http_client,
+            ollama_url,
+            &state.config.embedding_model,
+            query,
+        )
+        .await;
+
+        let mut query_variants: Vec<(Vec<f32>, String)> = Vec::with_capacity(query_texts.len());
+        for qt in &query_texts {
+            let v = if qt == query {
+                vector.clone()
+            } else {
+                embed_query(
+                    &state.http_client,
+                    ollama_url,
+                    &state.config.embedding_model,
+                    qt,
+                )
+                .await?
+            };
+            query_variants.push((v, qt.clone()));
+        }
+
+        let hits = hybrid_search_multi(
             &state.pool,
             qdrant,
             &tenant,
-            &vector,
-            query,
+            &query_variants,
             HybridSearchOptions {
                 limit,
                 repo_id: repo_id_filter,
@@ -91,7 +136,7 @@ pub(super) async fn dispatch_search_items(
         )
         .await
         .map_err(|e| {
-            tracing::warn!("hybrid_search (mcp) failed: {e}");
+            tracing::warn!("hybrid_search_multi (mcp) failed: {e}");
             AppError::ServiceUnavailable
         })?;
 

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -6,8 +6,8 @@
 
 use rb_mcp::ToolCallResult;
 use rb_query::{
-    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, MultiQueryConfig, SearchOptions,
-    expand_query, hybrid_search_multi, items, resolve_n, semantic_search,
+    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, SearchOptions, expand_query,
+    hybrid_search_multi, items, semantic_search,
 };
 use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use rb_tenant::TenantCtx;
@@ -15,7 +15,12 @@ use sqlx::Row as _;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::{embed::normalize_query, error::AppError, state::AppState};
+use crate::{
+    embed::normalize_query,
+    error::AppError,
+    routes::query::search::fetch_tenant_query_settings,
+    state::AppState,
+};
 
 #[allow(clippy::too_many_lines)]
 pub(super) async fn dispatch_search_items(
@@ -79,25 +84,12 @@ pub(super) async fn dispatch_search_items(
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
         // Resolve per-tenant multi-query config (S5). Default n=1 means no rewrite.
-        let mq_config: MultiQueryConfig = {
-            let row: Option<(i16, bool, i32)> = sqlx::query_as(
-                "SELECT multi_query_n, multi_query_force_off, llm_token_budget \
-                 FROM control.tenant_query_settings \
-                 WHERE tenant_id = $1",
-            )
-            .bind(tenant_id)
-            .fetch_optional(&state.pool)
-            .await?;
-            let (tn, fo, budget) = row
-                .map_or((state.config.multi_query_n, false, 0u32), |(n, fo, b)| {
-                    (n.unsigned_abs().into(), fo, b.unsigned_abs())
-                });
-            MultiQueryConfig {
-                n: resolve_n(tn, fo),
-                force_off: fo,
-                token_budget: budget,
-            }
-        };
+        let mq_config = fetch_tenant_query_settings(
+            &state.pool,
+            tenant_id,
+            state.config.multi_query_n,
+        )
+        .await?;
 
         let query_texts = expand_query(
             &mq_config,

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -16,9 +16,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::{
-    embed::normalize_query,
-    error::AppError,
-    routes::query::search::fetch_tenant_query_settings,
+    embed::normalize_query, error::AppError, routes::query::search::fetch_tenant_query_settings,
     state::AppState,
 };
 
@@ -84,12 +82,8 @@ pub(super) async fn dispatch_search_items(
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
         // Resolve per-tenant multi-query config (S5). Default n=1 means no rewrite.
-        let mq_config = fetch_tenant_query_settings(
-            &state.pool,
-            tenant_id,
-            state.config.multi_query_n,
-        )
-        .await?;
+        let mq_config =
+            fetch_tenant_query_settings(&state.pool, tenant_id, state.config.multi_query_n).await?;
 
         let query_texts = expand_query(
             &mq_config,

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -16,8 +16,8 @@
 
 use axum::{Json, extract::State, response::IntoResponse};
 use rb_query::{
-    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, SearchOptions, hybrid_search,
-    semantic_search,
+    DEFAULT_SEARCH_LIMIT, HybridSearchOptions, MAX_SEARCH_LIMIT, MultiQueryConfig, SearchOptions,
+    expand_query, hybrid_search_multi, resolve_n, semantic_search,
 };
 use rb_schemas::{CitationV1, LineRange, SourceKind, TenantId};
 use serde::{Deserialize, Serialize};
@@ -192,6 +192,36 @@ async fn fetch_commit_shas(
 }
 
 // ---------------------------------------------------------------------------
+// Per-tenant query settings (Wave 10 S5)
+// ---------------------------------------------------------------------------
+
+/// Fetch per-tenant multi-query settings, falling back to the global config default.
+async fn fetch_tenant_query_settings(
+    pool: &sqlx::PgPool,
+    tenant_id: Uuid,
+    global_n: u32,
+) -> Result<MultiQueryConfig, AppError> {
+    let row: Option<(i16, bool, i32)> = sqlx::query_as(
+        "SELECT multi_query_n, multi_query_force_off, llm_token_budget \
+         FROM control.tenant_query_settings \
+         WHERE tenant_id = $1",
+    )
+    .bind(tenant_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let (tenant_n, force_off, budget) = row.map_or((global_n, false, 0u32), |(n, fo, b)| {
+        (n.unsigned_abs().into(), fo, b.unsigned_abs())
+    });
+
+    Ok(MultiQueryConfig {
+        n: resolve_n(tenant_n, force_off),
+        force_off,
+        token_budget: budget,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
@@ -268,12 +298,37 @@ pub async fn search(
 
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
-        let hits = hybrid_search(
+        // Resolve per-tenant multi-query config (S5). Default n=1 means no rewrite.
+        let mq_config =
+            fetch_tenant_query_settings(&state.pool, tenant_id_uuid, state.config.multi_query_n)
+                .await?;
+
+        // Expand the query into variants (returns [original] when n=1 or disabled).
+        let query_texts = expand_query(
+            &mq_config,
+            &http,
+            ollama_url,
+            &state.config.embedding_model,
+            &req.q,
+        )
+        .await;
+
+        // Embed each query variant (reuse already-computed vector for the original).
+        let mut query_variants: Vec<(Vec<f32>, String)> = Vec::with_capacity(query_texts.len());
+        for qt in &query_texts {
+            let v = if qt == &req.q {
+                vector.clone()
+            } else {
+                embed_query(&http, ollama_url, &state.config.embedding_model, qt).await?
+            };
+            query_variants.push((v, qt.clone()));
+        }
+
+        let hits = hybrid_search_multi(
             &state.pool,
             qdrant,
             &tenant_id,
-            &vector,
-            &req.q,
+            &query_variants,
             HybridSearchOptions {
                 limit,
                 repo_id: repo_id_filter,
@@ -281,7 +336,7 @@ pub async fn search(
         )
         .await
         .map_err(|e| {
-            tracing::warn!("hybrid_search failed: {e}");
+            tracing::warn!("hybrid_search_multi failed: {e}");
             AppError::ServiceUnavailable
         })?;
 

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -196,7 +196,7 @@ async fn fetch_commit_shas(
 // ---------------------------------------------------------------------------
 
 /// Fetch per-tenant multi-query settings, falling back to the global config default.
-async fn fetch_tenant_query_settings(
+pub(crate) async fn fetch_tenant_query_settings(
     pool: &sqlx::PgPool,
     tenant_id: Uuid,
     global_n: u32,

--- a/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
@@ -67,6 +67,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_audit_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_tests.rs
@@ -76,6 +76,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_tests.rs
@@ -69,6 +69,7 @@ fn lazy_config_with_token(db_url: &str) -> Config {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     }
 }
 

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -81,6 +81,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_api_key_revocation_tests.rs
+++ b/services/control-api/tests/integration_api_key_revocation_tests.rs
@@ -91,6 +91,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_chat_tests.rs
+++ b/services/control-api/tests/integration_chat_tests.rs
@@ -92,6 +92,7 @@ async fn build_state(chat_panel_enabled: bool) -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_cookie_tests.rs
+++ b/services/control-api/tests/integration_cookie_tests.rs
@@ -67,6 +67,7 @@ async fn real_db_app() -> Option<axum::Router> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool,

--- a/services/control-api/tests/integration_email_transport_tests.rs
+++ b/services/control-api/tests/integration_email_transport_tests.rs
@@ -90,6 +90,7 @@ async fn state_with_transport(transport_name: &str) -> Option<(AppState, PgPool)
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_events_history_tests/helpers.rs
+++ b/services/control-api/tests/integration_events_history_tests/helpers.rs
@@ -72,6 +72,7 @@ pub async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ingest_chat_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_chat_tests.rs
@@ -91,6 +91,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ingest_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_tests.rs
@@ -89,6 +89,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_events_ndjson_tests.rs
+++ b/services/control-api/tests/integration_events_ndjson_tests.rs
@@ -85,6 +85,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -125,6 +125,7 @@ fn build_test_config_with_api_base(
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     }
 }
 

--- a/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
+++ b/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
@@ -220,6 +220,7 @@ fn build_hybrid_state(pool: sqlx::PgPool, qdrant_url: &str, ollama_url: &str) ->
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: true,
+        multi_query_n: 1,
     };
 
     AppState {
@@ -317,7 +318,7 @@ async fn assert_qdrant_must_filter(
     }
 }
 
-/// AC5a — `POST /v1/search`: tainted symbol seeded in tenant_B returns zero results queried as tenant_A.
+/// `AC5a` — `POST /v1/search`: tainted symbol seeded in `tenant_B` returns zero results queried as `tenant_A`.
 /// Both sparse (PG FTS schema routing) and dense (Qdrant must-filter) legs verified.
 #[tokio::test]
 async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
@@ -372,7 +373,7 @@ async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
 
     // Sparse leg: tenant_A.code_symbols is empty, so results must be empty.
     assert_eq!(
-        body["results"].as_array().map(Vec::len).unwrap_or(0),
+        body["results"].as_array().map_or(0, Vec::len),
         0,
         "AC5 sparse leg (search site): must return zero results — \
          tainted symbol lives in tenant_B's schema only"
@@ -389,8 +390,9 @@ async fn ac5_search_site_two_tenants_zero_cross_tenant_rows() {
         .ok();
 }
 
-/// AC5b — MCP `search_items` (dispatch.rs): same two-tenant isolation proof via MCP JWT + tools/call.
+/// `AC5b` — MCP `search_items` (dispatch.rs): same two-tenant isolation proof via MCP JWT + tools/call.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
     let Some(pool) = connect_pool().await else {
         return;
@@ -510,7 +512,7 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
         serde_json::from_str(tool_text).unwrap_or(serde_json::json!([]));
 
     assert_eq!(
-        citations.as_array().map(Vec::len).unwrap_or(0),
+        citations.as_array().map_or(0, Vec::len),
         0,
         "AC5 sparse leg (dispatch site): MCP search_items must return zero citations — \
          tainted symbol lives in tenant_B's schema only"
@@ -527,7 +529,7 @@ async fn ac5_dispatch_site_two_tenants_zero_cross_tenant_rows() {
         .ok();
 }
 
-/// AC5c — direct crate API proof: `hybrid_search` itself is isolated (complements HTTP-layer tests above).
+/// `AC5c` — direct crate API proof: `hybrid_search` itself is isolated (complements HTTP-layer tests above).
 #[tokio::test]
 async fn ac5_direct_hybrid_search_sparse_leg_isolation() {
     let Some(pool) = connect_pool().await else {

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -87,6 +87,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -68,6 +68,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -81,6 +81,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_multitenant_scenarios.rs
+++ b/services/control-api/tests/integration_multitenant_scenarios.rs
@@ -97,6 +97,7 @@ async fn real_db_state() -> Option<(AppState, sqlx::PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_partition_pruning_tests.rs
+++ b/services/control-api/tests/integration_partition_pruning_tests.rs
@@ -92,6 +92,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
 
     let state = AppState {

--- a/services/control-api/tests/integration_regression_defence_orphan.rs
+++ b/services/control-api/tests/integration_regression_defence_orphan.rs
@@ -127,6 +127,7 @@ fn build_state_with_gh(pool: PgPool, gh_loader: Arc<GhAppLoader>) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     AppState {
         pool,

--- a/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
+++ b/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
@@ -80,6 +80,7 @@ async fn real_db_state_chat_enabled() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_resend_verification_tests.rs
+++ b/services/control-api/tests/integration_resend_verification_tests.rs
@@ -68,6 +68,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -363,6 +363,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: None,
         hybrid_search_enabled: false,
+        multi_query_n: 1,
     };
     let state = AppState {
         pool: pool.clone(),


### PR DESCRIPTION
## Summary

- New `rb-query::rewrite` module: `expand_query` calls local Ollama for ≤2 paraphrases; returns `[original]` when n=1, force-off, or token_budget=0 (default in v1)
- New `hybrid_search_multi`: all query variants × both legs fused in a single flat RRF pass (not nested)
- Migration 024: `control.tenant_query_settings` — per-tenant `multi_query_n`, `multi_query_force_off`, `llm_token_budget`
- `RB_MULTI_QUERY_N` global config (default 1); per-tenant row overrides; force_off always wins
- `POST /v1/search` and MCP `search_items` both wired to the multi-query path

Default n=1 everywhere in v1 — pipeline wired but disabled until S6 eval clears.

## Gates

- clippy `-D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo deny check` ✅
- 46/46 rb-query unit tests ✅
- 461/461 control-api lib tests ✅
- Stack rebuild required (control-api touched)

## Closes

Closes #818