### PR TITLE
[RUSAA-2126] chore(compose): wire Wave 10 retrieval flags into control-api env block

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -271,6 +271,11 @@ services:
       RB_TEMPO_BASE_URL: "${RB_TEMPO_BASE_URL:-http://localhost:3000}"
       RB_CHAT_PANEL_ENABLED: "${RB_CHAT_PANEL_ENABLED:-true}"
       RB_MCP_JWT_SECRET: "${RB_MCP_JWT_SECRET:-dev-mcp-jwt-secret-change-me-in-prod-32b}"
+      # Wave 10 retrieval flags (ADR-014). Default off for local dev; enabled via tailscale.env on mars.
+      RB_HYBRID_SEARCH_ENABLED: "${RB_HYBRID_SEARCH_ENABLED:-false}"
+      RB_RERANK_ENABLED: "${RB_RERANK_ENABLED:-false}"
+      RB_MULTI_QUERY_N: "${RB_MULTI_QUERY_N:-1}"
+      RB_LLM_TOKEN_CEILING_PER_TENANT: "${RB_LLM_TOKEN_CEILING_PER_TENANT:-0}"
     volumes:
       - ../migrations:/migrations:ro
     ports:

--- a/compose/tailscale.env
+++ b/compose/tailscale.env
@@ -79,3 +79,14 @@ RB_SSH_AUTHORIZED_KEYS="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCUdbE1pviGKfQVGvmq
 # WARNING: do NOT rotate this key without first re-encrypting existing rows.
 # Prod must use a separate key injected via the secret manager.
 RB_GH_APP_ENC_KEY=z3YrdZfhH18CV4fyJWqa0rPivsRR8qS7oqm8MusXLHM= # gitleaks:allow
+
+# --- Wave 10 retrieval flags (ADR-014) ---
+# Enable hybrid retrieval, reranking, multi-query expansion, and LLM token quota
+# for the mars UAT stack. These are the flags needed for RUSAA-2125 acceptance steps.
+RB_HYBRID_SEARCH_ENABLED=true
+RB_RERANK_ENABLED=true
+RB_MULTI_QUERY_N=3
+# Non-zero value enables LLM calls and the per-tenant quota ceiling (step 7 UAT).
+# 100 000 tokens is enough for normal UAT; set lower per-tenant via control.tenant_query_settings
+# to trigger the budget-exceeded counter for step 7.
+RB_LLM_TOKEN_CEILING_PER_TENANT=100000

--- a/compose/tailscale.yml
+++ b/compose/tailscale.yml
@@ -43,6 +43,10 @@ services:
 
   control-api:
     restart: unless-stopped
+    # Mount a host-side model cache so fastembed downloads BGE-reranker-base once
+    # and re-uses it across container recreations (ADR-014 §12 — self-hosted, no CDN).
+    volumes:
+      - /home/jarnura/models/rerank:/models/rerank
 
   caddy:
     restart: unless-stopped


### PR DESCRIPTION
## Summary

All four ADR-014 Wave 10 retrieval feature flags were absent from the \`control-api\`
environment block in \`compose/dev.yml\`. Docker Compose only passes env vars that are
**explicitly referenced** in a service's \`environment:\` section — setting them in
\`tailscale.env\` on mars had no effect on the running container.

**Changes:**
- \`compose/dev.yml\`: add four env-var passthrough entries with off/disabled defaults
- \`compose/tailscale.env\`: enable all four flags for mars UAT stack
- \`compose/tailscale.yml\`: add \`/home/jarnura/models/rerank:/models/rerank\` volume mount for ONNX model persistence

## GitHub Issue
Closes #822

## Migration type
N/A — compose/config only

## Checklist
- [x] \`compose/dev.yml\` defaults are conservative — local dev unchanged
- [x] Volume mount path \`/home/jarnura/models/rerank\` exists on mars host with model files
- [x] Compose-only change — no Rust compilation required for the flags to take effect