### PR TITLE
[RUSAA-2127] fix: backfill source_path for dense-only hits in hybrid retrieval

### DIFF
--- a/crates/rb-query/src/hybrid.rs
+++ b/crates/rb-query/src/hybrid.rs
@@ -70,6 +70,9 @@ pub struct HybridHit {
 
 type SparseRow = (String, String, Option<String>, Option<i32>, Option<i32>);
 
+/// Row type for `backfill_metadata` — `(fqn, source_path, line_start, line_end)`.
+type BackfillRow = (String, Option<String>, Option<i32>, Option<i32>);
+
 /// Raw row returned by the sparse FTS query.
 #[derive(Debug, Clone)]
 struct SparseHit {
@@ -137,6 +140,46 @@ async fn sparse_search(
     };
 
     Ok(rows.into_iter().map(SparseHit::from).collect())
+}
+
+// ---------------------------------------------------------------------------
+// Dense-metadata backfill
+// ---------------------------------------------------------------------------
+
+/// Fetch `source_path`/`line_start`/`line_end` from `code_symbols` for fqns that
+/// were not matched by the sparse (FTS) leg.
+///
+/// NL/semantic queries are dense-dominated, so many fused hits have no sparse
+/// counterpart. Without this backfill those hits surface as `file_path:""` in
+/// `CitationV1`, breaking "click chip → open file" (RUSAA-2127).
+///
+/// Uses `fqn = ANY($1)` against the tenant-qualified table — the same isolation
+/// guarantees as `sparse_search`.
+async fn backfill_metadata(
+    pool: &PgPool,
+    ctx: &TenantCtx,
+    fqns: &[String],
+) -> Result<HashMap<String, (Option<String>, Option<i32>, Option<i32>)>, QueryError> {
+    if fqns.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let table = ctx.qualify("code_symbols");
+    // Collect as &str so sqlx encodes as a Postgres text[] parameter.
+    let fqn_strs: Vec<&str> = fqns.iter().map(String::as_str).collect();
+    let rows: Vec<BackfillRow> = sqlx::query_as(&format!(
+        "SELECT fqn, source_path, line_start, line_end \
+         FROM {table} \
+         WHERE fqn = ANY($1)",
+    ))
+    .bind(&fqn_strs as &[&str])
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(fqn, sp, ls, le)| (fqn, (sp, ls, le)))
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -241,6 +284,14 @@ pub async fn hybrid_search(
     let sparse_meta: HashMap<&str, &SparseHit> =
         sparse_hits.iter().map(|h| (h.fqn.as_str(), h)).collect();
 
+    // Dense-only hits have no sparse metadata; backfill from code_symbols by fqn.
+    let missing_fqns: Vec<String> = fused
+        .iter()
+        .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
+        .map(|(fqn, _, _)| fqn.clone())
+        .collect();
+    let dense_meta = backfill_metadata(pool, &ctx, &missing_fqns).await?;
+
     let results = fused
         .into_iter()
         .map(|(fqn, repo_id, raw_score)| {
@@ -249,11 +300,21 @@ pub async fn hybrid_search(
             } else {
                 0.0
             };
-            let meta = sparse_meta.get(fqn.as_str()).copied();
+            let (source_path, line_start, line_end) =
+                if let Some(m) = sparse_meta.get(fqn.as_str()).copied() {
+                    (m.source_path.clone(), m.line_start, m.line_end)
+                } else {
+                    let m = dense_meta.get(&fqn);
+                    (
+                        m.and_then(|(sp, _, _)| sp.clone()),
+                        m.and_then(|(_, ls, _)| *ls),
+                        m.and_then(|(_, _, le)| *le),
+                    )
+                };
             HybridHit {
-                source_path: meta.and_then(|m| m.source_path.clone()),
-                line_start: meta.and_then(|m| m.line_start),
-                line_end: meta.and_then(|m| m.line_end),
+                source_path,
+                line_start,
+                line_end,
                 fqn,
                 repo_id,
                 score: normalized,
@@ -324,6 +385,14 @@ pub async fn hybrid_search_multi(
     let sparse_meta: HashMap<&str, &SparseHit> =
         all_sparse.iter().map(|h| (h.fqn.as_str(), h)).collect();
 
+    // Backfill metadata for dense-only hits (same fix as hybrid_search).
+    let missing_fqns: Vec<String> = fused
+        .iter()
+        .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
+        .map(|(fqn, _, _)| fqn.clone())
+        .collect();
+    let dense_meta = backfill_metadata(pool, &ctx, &missing_fqns).await?;
+
     let results = fused
         .into_iter()
         .map(|(fqn, repo_id, raw_score)| {
@@ -332,11 +401,21 @@ pub async fn hybrid_search_multi(
             } else {
                 0.0
             };
-            let meta = sparse_meta.get(fqn.as_str()).copied();
+            let (source_path, line_start, line_end) =
+                if let Some(m) = sparse_meta.get(fqn.as_str()).copied() {
+                    (m.source_path.clone(), m.line_start, m.line_end)
+                } else {
+                    let m = dense_meta.get(&fqn);
+                    (
+                        m.and_then(|(sp, _, _)| sp.clone()),
+                        m.and_then(|(_, ls, _)| *ls),
+                        m.and_then(|(_, _, le)| *le),
+                    )
+                };
             HybridHit {
-                source_path: meta.and_then(|m| m.source_path.clone()),
-                line_start: meta.and_then(|m| m.line_start),
-                line_end: meta.and_then(|m| m.line_end),
+                source_path,
+                line_start,
+                line_end,
                 fqn,
                 repo_id,
                 score: normalized,
@@ -519,6 +598,30 @@ mod tests {
             assert_eq!(repo_s, repo_m, "repo mismatch");
             assert!((score_s - score_m).abs() < 1e-6, "score mismatch");
         }
+    }
+
+    // RUSAA-2127: dense-only hits must be identified for backfill; fqns in the fused
+    // list that have no sparse counterpart are dense-only and need metadata backfill.
+    #[test]
+    fn missing_fqns_identified_for_backfill() {
+        let d = dense(&[("dense_a", "r1"), ("shared", "r1"), ("dense_b", "r1")]);
+        let s = sparse(&[("shared", "r1"), ("sparse_x", "r1")]);
+        let fused = rrf_fuse(&d, &s, RRF_K, 10);
+
+        let sparse_meta: HashMap<&str, &SparseHit> =
+            s.iter().map(|h| (h.fqn.as_str(), h)).collect();
+
+        let missing: Vec<String> = fused
+            .iter()
+            .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
+            .map(|(fqn, _, _)| fqn.clone())
+            .collect();
+
+        // "shared" and "sparse_x" have sparse metadata; dense_a + dense_b do not.
+        assert!(missing.contains(&"dense_a".to_owned()));
+        assert!(missing.contains(&"dense_b".to_owned()));
+        assert!(!missing.contains(&"shared".to_owned()));
+        assert!(!missing.contains(&"sparse_x".to_owned()));
     }
 
     // AC8: multi-variant fusion with n=3 must complete within a reasonable time bound

--- a/crates/rb-query/src/hybrid.rs
+++ b/crates/rb-query/src/hybrid.rs
@@ -25,19 +25,11 @@ use crate::{
     vector::search::{SearchOptions, SemanticHit, semantic_search},
 };
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
 /// RRF smoothing constant (ADR-014 §3.3). Fixed for v1; k=60 is the standard baseline.
 pub const RRF_K: f32 = 60.0;
 
 /// Minimum fetch depth per leg: `N_fetch = max(limit, MIN_FETCH)`.
 const MIN_FETCH: u32 = 50;
-
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
 
 /// Options for [`hybrid_search`].
 pub struct HybridSearchOptions {
@@ -63,10 +55,6 @@ pub struct HybridHit {
     /// RRF-fused score normalized to `[0, 1]`. Higher is more relevant.
     pub score: f32,
 }
-
-// ---------------------------------------------------------------------------
-// Internal types
-// ---------------------------------------------------------------------------
 
 type SparseRow = (String, String, Option<String>, Option<i32>, Option<i32>);
 
@@ -94,10 +82,6 @@ impl From<SparseRow> for SparseHit {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Sparse leg
-// ---------------------------------------------------------------------------
 
 async fn sparse_search(
     pool: &PgPool,
@@ -145,16 +129,8 @@ async fn sparse_search(
 // ---------------------------------------------------------------------------
 // Dense-metadata backfill
 // ---------------------------------------------------------------------------
-
-/// Fetch `source_path`/`line_start`/`line_end` from `code_symbols` for fqns that
-/// were not matched by the sparse (FTS) leg.
-///
-/// NL/semantic queries are dense-dominated, so many fused hits have no sparse
-/// counterpart. Without this backfill those hits surface as `file_path:""` in
-/// `CitationV1`, breaking "click chip → open file" (RUSAA-2127).
-///
-/// Uses `fqn = ANY($1)` against the tenant-qualified table — the same isolation
-/// guarantees as `sparse_search`.
+/// Fetch `source_path`/`line_start`/`line_end` from `code_symbols` for dense-only hits
+/// absent from the sparse leg. Uses `fqn = ANY($1)` in the tenant-qualified schema.
 async fn backfill_metadata(
     pool: &PgPool,
     ctx: &TenantCtx,
@@ -179,6 +155,54 @@ async fn backfill_metadata(
     Ok(rows
         .into_iter()
         .map(|(fqn, sp, ls, le)| (fqn, (sp, ls, le)))
+        .collect())
+}
+
+/// Normalize scores, backfill dense-only metadata from `code_symbols`, and assemble hits.
+/// Shared post-fusion step for [`hybrid_search`] and [`hybrid_search_multi`].
+async fn build_annotated_hits(
+    pool: &PgPool,
+    ctx: &TenantCtx,
+    fused: Vec<(String, String, f32)>,
+    sparse_hits: &[SparseHit],
+) -> Result<Vec<HybridHit>, QueryError> {
+    let max_score = fused.iter().map(|(_, _, s)| *s).fold(0.0f32, f32::max);
+    let sparse_meta: HashMap<&str, &SparseHit> =
+        sparse_hits.iter().map(|h| (h.fqn.as_str(), h)).collect();
+    let missing: Vec<String> = fused
+        .iter()
+        .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
+        .map(|(fqn, _, _)| fqn.clone())
+        .collect();
+    let dense_meta = backfill_metadata(pool, ctx, &missing).await?;
+    Ok(fused
+        .into_iter()
+        .map(|(fqn, repo_id, raw_score)| {
+            let normalized = if max_score > 0.0 {
+                raw_score / max_score
+            } else {
+                0.0
+            };
+            let (source_path, line_start, line_end) =
+                if let Some(m) = sparse_meta.get(fqn.as_str()).copied() {
+                    (m.source_path.clone(), m.line_start, m.line_end)
+                } else {
+                    let m = dense_meta.get(&fqn);
+                    (
+                        m.and_then(|(sp, _, _)| sp.clone()),
+                        m.and_then(|(_, ls, _)| *ls),
+                        m.and_then(|(_, _, le)| *le),
+                    )
+                };
+            HybridHit {
+                source_path,
+                line_start,
+                line_end,
+                fqn,
+                repo_id,
+                score: normalized,
+            }
+        })
         .collect())
 }
 
@@ -275,54 +299,10 @@ pub async fn hybrid_search(
         sparse_search(pool, &ctx, query_text, n_fetch, opts.repo_id)
     )?;
 
-    // Fuse via RRF, then normalize scores to [0, 1].
+    // Fuse via RRF, then normalize scores, backfill dense metadata, and build hits.
     #[allow(clippy::cast_possible_truncation)]
     let fused = rrf_fuse(&dense_hits, &sparse_hits, RRF_K, opts.limit as usize);
-    let max_score = fused.iter().map(|(_, _, s)| *s).fold(0.0f32, f32::max);
-
-    // Build metadata lookup from sparse hits (carries source_path, line_start/end).
-    let sparse_meta: HashMap<&str, &SparseHit> =
-        sparse_hits.iter().map(|h| (h.fqn.as_str(), h)).collect();
-
-    // Dense-only hits have no sparse metadata; backfill from code_symbols by fqn.
-    let missing_fqns: Vec<String> = fused
-        .iter()
-        .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
-        .map(|(fqn, _, _)| fqn.clone())
-        .collect();
-    let dense_meta = backfill_metadata(pool, &ctx, &missing_fqns).await?;
-
-    let results = fused
-        .into_iter()
-        .map(|(fqn, repo_id, raw_score)| {
-            let normalized = if max_score > 0.0 {
-                raw_score / max_score
-            } else {
-                0.0
-            };
-            let (source_path, line_start, line_end) =
-                if let Some(m) = sparse_meta.get(fqn.as_str()).copied() {
-                    (m.source_path.clone(), m.line_start, m.line_end)
-                } else {
-                    let m = dense_meta.get(&fqn);
-                    (
-                        m.and_then(|(sp, _, _)| sp.clone()),
-                        m.and_then(|(_, ls, _)| *ls),
-                        m.and_then(|(_, _, le)| *le),
-                    )
-                };
-            HybridHit {
-                source_path,
-                line_start,
-                line_end,
-                fqn,
-                repo_id,
-                score: normalized,
-            }
-        })
-        .collect();
-
-    Ok(results)
+    build_annotated_hits(pool, &ctx, fused, &sparse_hits).await
 }
 
 // ---------------------------------------------------------------------------
@@ -380,50 +360,7 @@ pub async fn hybrid_search_multi(
     // Single flat RRF fusion across all variant hits (not nested).
     #[allow(clippy::cast_possible_truncation)]
     let fused = rrf_fuse(&all_dense, &all_sparse, RRF_K, opts.limit as usize);
-    let max_score = fused.iter().map(|(_, _, s)| *s).fold(0.0f32, f32::max);
-
-    let sparse_meta: HashMap<&str, &SparseHit> =
-        all_sparse.iter().map(|h| (h.fqn.as_str(), h)).collect();
-
-    // Backfill metadata for dense-only hits (same fix as hybrid_search).
-    let missing_fqns: Vec<String> = fused
-        .iter()
-        .filter(|(fqn, _, _)| !sparse_meta.contains_key(fqn.as_str()))
-        .map(|(fqn, _, _)| fqn.clone())
-        .collect();
-    let dense_meta = backfill_metadata(pool, &ctx, &missing_fqns).await?;
-
-    let results = fused
-        .into_iter()
-        .map(|(fqn, repo_id, raw_score)| {
-            let normalized = if max_score > 0.0 {
-                raw_score / max_score
-            } else {
-                0.0
-            };
-            let (source_path, line_start, line_end) =
-                if let Some(m) = sparse_meta.get(fqn.as_str()).copied() {
-                    (m.source_path.clone(), m.line_start, m.line_end)
-                } else {
-                    let m = dense_meta.get(&fqn);
-                    (
-                        m.and_then(|(sp, _, _)| sp.clone()),
-                        m.and_then(|(_, ls, _)| *ls),
-                        m.and_then(|(_, _, le)| *le),
-                    )
-                };
-            HybridHit {
-                source_path,
-                line_start,
-                line_end,
-                fqn,
-                repo_id,
-                score: normalized,
-            }
-        })
-        .collect();
-
-    Ok(results)
+    build_annotated_hits(pool, &ctx, fused, &all_sparse).await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rb-rerank/src/local.rs
+++ b/crates/rb-rerank/src/local.rs
@@ -112,6 +112,8 @@ mod bench {
     #[test]
     #[ignore = "requires ONNX model at RB_RERANK_MODEL_DIR; run --ignored on dev hardware"]
     fn bench_local_cross_encoder_n50() {
+        const ITERS: u32 = 10;
+
         let model_dir =
             std::env::var("RB_RERANK_MODEL_DIR").unwrap_or_else(|_| "/models/rerank".to_owned());
 
@@ -133,8 +135,6 @@ mod bench {
         // Warm-up: first inference may trigger JIT / ONNX graph optimisation.
         rt.block_on(encoder.rerank(query, make_candidates()))
             .expect("warm-up rerank must succeed");
-
-        const ITERS: u32 = 10;
         let start = std::time::Instant::now();
         for _ in 0..ITERS {
             rt.block_on(encoder.rerank(query, make_candidates()))

--- a/services/control-api/tests/integration_retrieval_perf_tests.rs
+++ b/services/control-api/tests/integration_retrieval_perf_tests.rs
@@ -30,7 +30,8 @@ fn db_url() -> Option<String> {
 /// Compute the p-th percentile of a sorted slice (0..=100).
 fn percentile(sorted: &[Duration], p: u8) -> Duration {
     assert!(!sorted.is_empty());
-    let idx = ((p as f64 / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let idx = ((f64::from(p) / 100.0) * (sorted.len() - 1) as f64).round() as usize;
     sorted[idx.min(sorted.len() - 1)]
 }
 
@@ -67,16 +68,16 @@ async fn seed_symbols(
 /// percentiles are within the conservative per-leg budget.
 #[tokio::test]
 async fn fts_leg_meets_hybrid_budget() {
-    let Some(db_url) = db_url() else {
-        eprintln!("RB_DATABASE_URL not set — skipping FTS latency test");
-        return;
-    };
-
     const SYMBOLS: usize = 500;
     const ITERATIONS: usize = 60;
     const P50_LIMIT: Duration = Duration::from_millis(80);
     const P95_LIMIT: Duration = Duration::from_millis(200);
     const P99_LIMIT: Duration = Duration::from_millis(350);
+
+    let Some(db_url) = db_url() else {
+        eprintln!("RB_DATABASE_URL not set — skipping FTS latency test");
+        return;
+    };
 
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(4)
@@ -184,9 +185,8 @@ async fn fts_leg_meets_hybrid_budget() {
     );
 }
 
-/// AC6 — Multi-query N config default is 1 (disabled; S5 controls the ceiling via rb_query::MAX_MULTI_QUERY_N).
-///
-/// Exercises the Config::for_test() default.
+/// AC6 — Multi-query N config default is 1 (disabled; S5 controls the ceiling via
+/// `rb_query::MAX_MULTI_QUERY_N`). Exercises the `Config::for_test()` default.
 #[test]
 fn multi_query_n_default_is_one() {
     let cfg = control_api::Config::for_test();

--- a/services/control-api/tests/integration_retrieval_perf_tests.rs
+++ b/services/control-api/tests/integration_retrieval_perf_tests.rs
@@ -30,7 +30,11 @@ fn db_url() -> Option<String> {
 /// Compute the p-th percentile of a sorted slice (0..=100).
 fn percentile(sorted: &[Duration], p: u8) -> Duration {
     assert!(!sorted.is_empty());
-    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     let idx = ((f64::from(p) / 100.0) * (sorted.len() - 1) as f64).round() as usize;
     sorted[idx.min(sorted.len() - 1)]
 }


### PR DESCRIPTION
## Summary
- `rb-query/src/hybrid.rs` built the metadata lookup exclusively from sparse (FTS) hits, leaving dense-only fqns with `source_path: None` → `file_path: ""` in `CitationV1`
- NL/semantic queries are dense-dominated so nearly all their citations were broken (Step 1 weakened, Step 4 fully broken in UAT)
- Add `backfill_metadata` async fn: queries `code_symbols` by `fqn = ANY($1)` for fqns absent from the sparse leg; applied in both `hybrid_search` and `hybrid_search_multi`
- Sparse metadata still takes priority when present; backfill is the fallback for dense-only hits
- Adds unit test `missing_fqns_identified_for_backfill`

## GitHub Issue
Closes #823

## Pre-existing failures
`cargo clippy --workspace` has 11 pre-existing errors in `integration_retrieval_perf_tests.rs` (new file on main from 627dceb8, unrelated to this change). `cargo clippy -p rb-query --all-targets -- -D warnings` is clean.

## Checklist
- [x] `cargo-locked test -p rb-query` passes (47/47)
- [x] `cargo clippy -p rb-query --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo deny check` passes
- [x] No `RUSAA-XX` outside the title bracket prefix