### PR TITLE
[RUSAA-2129] fix(migrations): tenant migration 008 backfill fts column for v7-slot collision

### DIFF
--- a/migrations/tenant/008_code_symbols_fts_backfill.sql
+++ b/migrations/tenant/008_code_symbols_fts_backfill.sql
@@ -1,0 +1,19 @@
+-- Wave 10: safety-net backfill for the fts column introduced in 007_code_symbols_fts.
+--
+-- Tenant schemas created before 007_code_symbols_fts was added had a prior
+-- migration recorded under version 7 ("agent sessions", since deleted).  The
+-- idempotency check in migrate-tenant.sh skips any migration whose version is
+-- already in schema_migrations, so those schemas never received the fts column.
+--
+-- This migration re-applies the identical DDL under a fresh version number so
+-- the runner picks it up for every schema that was skipped.  Both statements
+-- are idempotent (IF NOT EXISTS) so schemas that already have the column and
+-- index are unaffected.
+ALTER TABLE code_symbols
+  ADD COLUMN IF NOT EXISTS fts tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('simple',
+      coalesce(fqn, '') || ' ' || coalesce(source_text, ''))
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_code_symbols_fts ON code_symbols USING GIN (fts);


### PR DESCRIPTION
## Summary

- Old deleted migration v7 ("agent sessions") consumed version slot 7 in 27 tenant schemas before `007_code_symbols_fts.sql` existed
- `migrate-tenant.sh` version-only idempotency check skipped the new 007 for those schemas
- Hybrid search sparse leg failed with `column "fts" does not exist` → 503 for all affected tenants

Fix: add `008_code_symbols_fts_backfill.sql` with identical idempotent DDL (`ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`) under version 8 so the runner picks it up for any schema missing the column.

## Operational backfill (dev — applied this fix)

Applied the DDL directly to all 27 affected schemas on the dev stack. Verified:
- 0 schemas now missing the `fts` column
- FTS query returns results on Smoke UAT (`tenant_2f36..`), Neda (`tenant_5b7e..`), `tenant_097b..`
- Hybrid search unblocked for UAT re-run

## GitHub Issue
Closes #825

## Checklist
- [x] Migration is additive (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`)
- [x] No Rust/binary changes — migrations-only PR, no cargo gates needed
- [x] Dev backfill verified before PR (0 schemas missing fts)
- [x] No `RUSAA-XX` outside the title bracket prefix