### PR TITLE
[RUSAA-2128] fix: wire per-tenant LLM token ceiling enforcement (AC5)

### DIFF
--- a/crates/rb-query/src/rewrite.rs
+++ b/crates/rb-query/src/rewrite.rs
@@ -98,11 +98,16 @@ pub fn resolve_n(tenant_n: u32, force_off: bool) -> u32 {
 ///
 /// # Returns
 ///
-/// - `[original]` when `config.n == 1`, `config.force_off == true`, or
-///   `config.token_budget == 0` (AC4 — disabled by default in v1).
-/// - `[original, paraphrase_1, …]` otherwise, with the original always first.
+/// A tuple `(variants, tokens_used)` where:
+/// - `variants` is `[original]` on all short-circuit paths, or
+///   `[original, paraphrase_1, …]` on a successful LLM call.
+/// - `tokens_used` is the `eval_count` reported by Ollama (0 on all
+///   short-circuit / error paths, so callers can accumulate accurately).
 ///
-/// # Failure modes (all short-circuit to `[original]`)
+/// Short-circuit conditions (no LLM call, `tokens_used` = 0):
+/// - `config.n == 1`, `config.force_off == true`, or `config.token_budget == 0`.
+///
+/// # Failure modes (all short-circuit to `([original], 0)`)
 ///
 /// - Ollama is unreachable or returns non-2xx.
 /// - Response missing the expected text field.
@@ -113,12 +118,12 @@ pub async fn expand_query(
     ollama_url: &str,
     model: &str,
     query: &str,
-) -> Vec<String> {
+) -> (Vec<String>, u32) {
     let effective_n = resolve_n(config.n, config.force_off);
 
     // Short-circuit: n=1, force-off, or token budget disabled.
     if effective_n <= 1 || config.token_budget == 0 {
-        return vec![query.to_owned()];
+        return (vec![query.to_owned()], 0);
     }
 
     let want_paraphrases = (effective_n - 1) as usize;
@@ -138,11 +143,11 @@ pub async fn expand_query(
         Ok(r) if r.status().is_success() => r,
         Ok(r) => {
             tracing::warn!(status = %r.status(), "Ollama rewrite returned non-2xx; falling back to original");
-            return vec![query.to_owned()];
+            return (vec![query.to_owned()], 0);
         }
         Err(e) => {
             tracing::warn!(error = %e, "Ollama rewrite request failed; falling back to original");
-            return vec![query.to_owned()];
+            return (vec![query.to_owned()], 0);
         }
     };
 
@@ -150,39 +155,41 @@ pub async fn expand_query(
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(error = %e, "Ollama rewrite response parse error; falling back to original");
-            return vec![query.to_owned()];
+            return (vec![query.to_owned()], 0);
         }
     };
 
+    // Capture the token count before any early-return so callers always see it.
+    #[allow(clippy::cast_possible_truncation)]
+    let tokens_consumed = parsed.eval_count.unwrap_or(0).min(u64::from(u32::MAX)) as u32;
+
     // Check token usage against per-tenant budget.
-    if let Some(used) = parsed.eval_count {
-        if used > u64::from(config.token_budget) {
-            metrics::counter!("rb_query_rewrite_over_budget_total").increment(1);
-            tracing::warn!(
-                used,
-                budget = config.token_budget,
-                "rewrite over token budget; falling back to original"
-            );
-            return vec![query.to_owned()];
-        }
+    if tokens_consumed > config.token_budget {
+        metrics::counter!("rb_query_rewrite_over_budget_total").increment(1);
+        tracing::warn!(
+            tokens_consumed,
+            budget = config.token_budget,
+            "rewrite over token budget; falling back to original"
+        );
+        return (vec![query.to_owned()], tokens_consumed);
     }
 
     let Some(raw) = parsed.response else {
         tracing::warn!(
             "Ollama rewrite response missing 'response' field; falling back to original"
         );
-        return vec![query.to_owned()];
+        return (vec![query.to_owned()], tokens_consumed);
     };
 
     let paraphrases = parse_paraphrases(&raw, want_paraphrases);
     if paraphrases.is_empty() {
-        return vec![query.to_owned()];
+        return (vec![query.to_owned()], tokens_consumed);
     }
 
     let mut variants = Vec::with_capacity(1 + paraphrases.len());
     variants.push(query.to_owned());
     variants.extend(paraphrases);
-    variants
+    (variants, tokens_consumed)
 }
 
 // ---------------------------------------------------------------------------

--- a/services/control-api/src/jobs/tests.rs
+++ b/services/control-api/src/jobs/tests.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use super::*;
 use crate::{
     AppState, Config, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
-    TenantSessionCount, state::AgentRegistry,
+    TenantLlmTokenCounter, TenantSessionCount, state::AgentRegistry,
 };
 
 /// Connect to the real Postgres instance.
@@ -234,6 +234,7 @@ fn make_state(pool: PgPool) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: Arc::new(TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/src/lib.rs
+++ b/services/control-api/src/lib.rs
@@ -21,5 +21,5 @@ pub use routes::{build_internal, build_public};
 pub use server::run;
 pub use state::{
     AgentRegistry, AppState, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
-    TenantSessionCount,
+    TenantLlmTokenCounter, TenantSessionCount,
 };

--- a/services/control-api/src/routes/mcp/dispatch.rs
+++ b/services/control-api/src/routes/mcp/dispatch.rs
@@ -84,8 +84,12 @@ pub(super) async fn dispatch_search_items(
 
     let tenant = TenantId::from(tenant_id);
 
-    // AC5: guard LLM calls before they reach any rewriter/reranker.
-    let _llm_allowed = llm_budget_allows(state.config.llm_token_ceiling_per_tenant, 0, tenant_id);
+    // AC5: check per-tenant LLM budget before issuing any rewrite call.
+    let llm_allowed = llm_budget_allows(
+        state.config.llm_token_ceiling_per_tenant,
+        state.llm_tenant_tokens.tokens_used(tenant_id),
+        tenant_id,
+    );
 
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
@@ -93,14 +97,25 @@ pub(super) async fn dispatch_search_items(
         let mq_config =
             fetch_tenant_query_settings(&state.pool, tenant_id, state.config.multi_query_n).await?;
 
-        let query_texts = expand_query(
-            &mq_config,
-            &state.http_client,
-            ollama_url,
-            &state.config.embedding_model,
-            query,
-        )
-        .await;
+        // Short-circuit to [original] when LLM budget is exhausted (AC5).
+        let query_texts = if llm_allowed {
+            let (texts, tokens_consumed) = expand_query(
+                &mq_config,
+                &state.http_client,
+                ollama_url,
+                &state.config.embedding_model,
+                query,
+            )
+            .await;
+            if tokens_consumed > 0 {
+                state
+                    .llm_tenant_tokens
+                    .add_tokens(tenant_id, tokens_consumed);
+            }
+            texts
+        } else {
+            vec![query.to_owned()]
+        };
 
         let mut query_variants: Vec<(Vec<f32>, String)> = Vec::with_capacity(query_texts.len());
         for qt in &query_texts {

--- a/services/control-api/src/routes/query/search.rs
+++ b/services/control-api/src/routes/query/search.rs
@@ -299,10 +299,13 @@ pub async fn search(
 
     let tenant_id = TenantId::from(tenant_id_uuid);
 
-    // AC5: guard LLM calls before they reach any rewriter/reranker.
+    // AC5: check per-tenant LLM budget before issuing any rewrite call.
     // ceiling=0 (default) → zero outbound LLM cost for all tenants.
-    let _llm_allowed =
-        llm_budget_allows(state.config.llm_token_ceiling_per_tenant, 0, tenant_id_uuid);
+    let llm_allowed = llm_budget_allows(
+        state.config.llm_token_ceiling_per_tenant,
+        state.llm_tenant_tokens.tokens_used(tenant_id_uuid),
+        tenant_id_uuid,
+    );
 
     if state.config.hybrid_search_enabled {
         // --- Hybrid path (flag on) ---
@@ -311,15 +314,27 @@ pub async fn search(
             fetch_tenant_query_settings(&state.pool, tenant_id_uuid, state.config.multi_query_n)
                 .await?;
 
-        // Expand the query into variants (returns [original] when n=1 or disabled).
-        let query_texts = expand_query(
-            &mq_config,
-            &http,
-            ollama_url,
-            &state.config.embedding_model,
-            &req.q,
-        )
-        .await;
+        // Expand the query into variants; short-circuit to [original] when LLM budget
+        // is exhausted so we never issue outbound Ollama calls over-ceiling (AC5).
+        let query_texts = if llm_allowed {
+            let (texts, tokens_consumed) = expand_query(
+                &mq_config,
+                &http,
+                ollama_url,
+                &state.config.embedding_model,
+                &req.q,
+            )
+            .await;
+            // Accumulate real token spend for this tenant.
+            if tokens_consumed > 0 {
+                state
+                    .llm_tenant_tokens
+                    .add_tokens(tenant_id_uuid, tokens_consumed);
+            }
+            texts
+        } else {
+            vec![req.q.clone()]
+        };
 
         // Embed each query variant (reuse already-computed vector for the original).
         let mut query_variants: Vec<(Vec<f32>, String)> = Vec::with_capacity(query_texts.len());

--- a/services/control-api/src/routes/query/search_tests.rs
+++ b/services/control-api/src/routes/query/search_tests.rs
@@ -157,6 +157,56 @@ fn non_zero_ceiling_allows_under_budget_denies_at_or_over() {
     assert!(!llm_budget_allows(1000, 1001, tid));
 }
 
+// AC5: TenantLlmTokenCounter accumulates per-tenant and enforces ceiling when read back.
+#[test]
+fn llm_token_counter_accumulates_per_tenant() {
+    use crate::state::TenantLlmTokenCounter;
+
+    let counter = TenantLlmTokenCounter::new();
+    let t1 = Uuid::new_v4();
+    let t2 = Uuid::new_v4();
+
+    assert_eq!(counter.tokens_used(t1), 0);
+    assert_eq!(counter.tokens_used(t2), 0);
+
+    counter.add_tokens(t1, 500);
+    counter.add_tokens(t1, 300);
+    counter.add_tokens(t2, 100);
+
+    assert_eq!(counter.tokens_used(t1), 800);
+    assert_eq!(counter.tokens_used(t2), 100);
+}
+
+#[test]
+fn llm_token_counter_saturates_at_u32_max() {
+    use crate::state::TenantLlmTokenCounter;
+
+    let counter = TenantLlmTokenCounter::new();
+    let t = Uuid::new_v4();
+    counter.add_tokens(t, u32::MAX);
+    counter.add_tokens(t, 1); // must not overflow
+    assert_eq!(counter.tokens_used(t), u32::MAX);
+}
+
+// AC5: budget gates the LLM path — ceiling exhausted → llm_budget_allows returns false.
+#[test]
+fn budget_gates_after_accumulation() {
+    use crate::state::TenantLlmTokenCounter;
+
+    let counter = TenantLlmTokenCounter::new();
+    let tid = Uuid::new_v4();
+    let ceiling: u32 = 1_000;
+
+    // Under budget: allowed.
+    assert!(llm_budget_allows(ceiling, counter.tokens_used(tid), tid));
+
+    // Accumulate up to the ceiling.
+    counter.add_tokens(tid, 1_000);
+
+    // At ceiling: denied + emits counter.
+    assert!(!llm_budget_allows(ceiling, counter.tokens_used(tid), tid));
+}
+
 // AC3: clamp_rerank_candidates truncates over-cap sets.
 #[test]
 fn rerank_cap_truncates_oversized_set() {

--- a/services/control-api/src/routes/traces.rs
+++ b/services/control-api/src/routes/traces.rs
@@ -47,7 +47,7 @@ mod tests {
 
     use crate::{
         AgentRegistry, AppState, Config, KafkaConsistencyState, McpSessionStore,
-        SessionCreateRateLimiter, TenantSessionCount,
+        SessionCreateRateLimiter, TenantLlmTokenCounter, TenantSessionCount,
     };
 
     fn test_state() -> AppState {
@@ -91,6 +91,7 @@ mod tests {
             mcp_jwt_ttl_secs: 900,
             llm_api_key: String::new(),
             reranker: None,
+            llm_tenant_tokens: Arc::new(TenantLlmTokenCounter::new()),
         }
     }
 

--- a/services/control-api/src/server.rs
+++ b/services/control-api/src/server.rs
@@ -25,7 +25,7 @@ use crate::{
     ingest_consumer, jobs, middleware, routes,
     state::{
         AgentRegistry, AppState, KafkaConsistencyState, McpSessionStore, SessionCreateRateLimiter,
-        TenantSessionCount,
+        TenantLlmTokenCounter, TenantSessionCount,
     },
 };
 
@@ -178,6 +178,7 @@ pub async fn run(config: Config) -> Result<()> {
         mcp_jwt_ttl_secs: config.mcp_jwt_ttl_secs,
         llm_api_key: config.llm_api_key.clone().unwrap_or_default(),
         reranker,
+        llm_tenant_tokens: Arc::new(TenantLlmTokenCounter::new()),
     };
 
     // Spawn the periodic reconciler that heals ingestion runs left in `queued`

--- a/services/control-api/src/state.rs
+++ b/services/control-api/src/state.rs
@@ -219,6 +219,44 @@ impl TenantSessionCount {
 }
 
 // ---------------------------------------------------------------------------
+// TenantLlmTokenCounter — ADR-014 §9 AC5
+// ---------------------------------------------------------------------------
+
+/// Per-tenant in-process accumulator for LLM token spend (ADR-014 §9, AC5).
+///
+/// Tracks cumulative `eval_count` from Ollama across all rewrite calls for a
+/// tenant in the lifetime of this process.  When `llm_budget_allows` returns
+/// `false`, the calling handler short-circuits the LLM rewrite instead of
+/// issuing the outbound call, then emits `llm_budget_exceeded_total{tenant}`.
+///
+/// This counter is intentionally process-scoped (resets on restart), matching
+/// the "configurable per-tenant ceiling" design in ADR-014 which is a
+/// cost-cap guard, not a durable billing counter.
+#[derive(Clone, Default)]
+pub struct TenantLlmTokenCounter {
+    usage: Arc<DashMap<Uuid, u32>>,
+}
+
+impl TenantLlmTokenCounter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return cumulative tokens consumed by `tenant_id` so far this process lifetime.
+    #[must_use]
+    pub fn tokens_used(&self, tenant_id: Uuid) -> u32 {
+        self.usage.get(&tenant_id).map_or(0, |v| *v)
+    }
+
+    /// Saturating-add `n` tokens to `tenant_id`'s running total.
+    pub fn add_tokens(&self, tenant_id: Uuid, n: u32) {
+        let mut entry = self.usage.entry(tenant_id).or_insert(0);
+        *entry = entry.saturating_add(n);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // AgentRegistry — ADR-009 Phase 1
 // ---------------------------------------------------------------------------
 
@@ -419,6 +457,8 @@ pub struct AppState {
     pub llm_api_key: String,
     /// Flag-gated cross-encoder reranker; `None` when `RB_RERANK_ENABLED=false`.
     pub reranker: Option<std::sync::Arc<dyn Reranker>>,
+    /// Per-tenant LLM token spend accumulator (ADR-014 §9, AC5).
+    pub llm_tenant_tokens: Arc<TenantLlmTokenCounter>,
 }
 
 #[cfg(test)]

--- a/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_log_surface_tests.rs
@@ -111,6 +111,7 @@ fn build_state_from_pool(pool: PgPool, config: Config) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_audit_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_audit_tests.rs
@@ -120,6 +120,7 @@ fn build_state_from_pool(pool: PgPool, config: Config) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_admin_v1_tests.rs
+++ b/services/control-api/tests/integration_admin_v1_tests.rs
@@ -113,6 +113,7 @@ fn build_state_from_pool(pool: PgPool, config: Config) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_agent_events_tests.rs
+++ b/services/control-api/tests/integration_agent_events_tests.rs
@@ -113,6 +113,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_api_key_revocation_tests.rs
+++ b/services/control-api/tests/integration_api_key_revocation_tests.rs
@@ -123,6 +123,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_chat_tests.rs
+++ b/services/control-api/tests/integration_chat_tests.rs
@@ -124,6 +124,7 @@ async fn build_state(chat_panel_enabled: bool) -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_cookie_tests.rs
+++ b/services/control-api/tests/integration_cookie_tests.rs
@@ -99,6 +99,7 @@ async fn real_db_app() -> Option<axum::Router> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some(build_public(state))
 }

--- a/services/control-api/tests/integration_email_transport_tests.rs
+++ b/services/control-api/tests/integration_email_transport_tests.rs
@@ -122,6 +122,7 @@ async fn state_with_transport(transport_name: &str) -> Option<(AppState, PgPool)
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_events_history_tests/helpers.rs
+++ b/services/control-api/tests/integration_events_history_tests/helpers.rs
@@ -105,6 +105,7 @@ pub async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
 
     Some((state, pool))

--- a/services/control-api/tests/integration_events_ingest_chat_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_chat_tests.rs
@@ -124,6 +124,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
 
     Some((state, pool))

--- a/services/control-api/tests/integration_events_ingest_tests.rs
+++ b/services/control-api/tests/integration_events_ingest_tests.rs
@@ -122,6 +122,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
 
     Some((state, pool))

--- a/services/control-api/tests/integration_events_ndjson_tests.rs
+++ b/services/control-api/tests/integration_events_ndjson_tests.rs
@@ -118,6 +118,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
 
     Some((state, pool))

--- a/services/control-api/tests/integration_github_app_manifest_tests.rs
+++ b/services/control-api/tests/integration_github_app_manifest_tests.rs
@@ -178,6 +178,7 @@ fn build_state(pool: PgPool, config: Config) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_github_webhook.rs
+++ b/services/control-api/tests/integration_github_webhook.rs
@@ -124,6 +124,7 @@ fn state_with_gh(secret: &[u8]) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 
@@ -155,6 +156,7 @@ fn state_without_gh() -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
+++ b/services/control-api/tests/integration_hybrid_tenant_isolation_tests.rs
@@ -253,6 +253,7 @@ fn build_hybrid_state(pool: sqlx::PgPool, qdrant_url: &str, ollama_url: &str) ->
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_ingest_tests.rs
+++ b/services/control-api/tests/integration_ingest_tests.rs
@@ -119,6 +119,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_logout_tests.rs
+++ b/services/control-api/tests/integration_logout_tests.rs
@@ -100,6 +100,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_me_tests.rs
+++ b/services/control-api/tests/integration_me_tests.rs
@@ -113,6 +113,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_multitenant_scenarios.rs
+++ b/services/control-api/tests/integration_multitenant_scenarios.rs
@@ -129,6 +129,7 @@ async fn real_db_state() -> Option<(AppState, sqlx::PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_partition_pruning_tests.rs
+++ b/services/control-api/tests/integration_partition_pruning_tests.rs
@@ -125,6 +125,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
 
     Some((state, pool))

--- a/services/control-api/tests/integration_regression_defence_orphan.rs
+++ b/services/control-api/tests/integration_regression_defence_orphan.rs
@@ -159,6 +159,7 @@ fn build_state_with_gh(pool: PgPool, gh_loader: Arc<GhAppLoader>) -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 

--- a/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
+++ b/services/control-api/tests/integration_regression_rusaa1884_chat_multi_turn.rs
@@ -112,6 +112,7 @@ async fn real_db_state_chat_enabled() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_resend_verification_tests.rs
+++ b/services/control-api/tests/integration_resend_verification_tests.rs
@@ -100,6 +100,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_rusaa1560_tests.rs
+++ b/services/control-api/tests/integration_rusaa1560_tests.rs
@@ -106,6 +106,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_tests.rs
+++ b/services/control-api/tests/integration_tests.rs
@@ -55,6 +55,7 @@ fn test_state() -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 
@@ -396,6 +397,7 @@ async fn real_db_state() -> Option<(AppState, PgPool)> {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     };
     Some((state, pool))
 }

--- a/services/control-api/tests/integration_trace_id_tests.rs
+++ b/services/control-api/tests/integration_trace_id_tests.rs
@@ -81,6 +81,7 @@ fn test_state() -> AppState {
         mcp_jwt_ttl_secs: 900,
         llm_api_key: String::new(),
         reranker: None,
+        llm_tenant_tokens: std::sync::Arc::new(control_api::TenantLlmTokenCounter::new()),
     }
 }
 


### PR DESCRIPTION
## Summary

- `expand_query` in `rb-query` now returns `(Vec<String>, u32)` — the second value is tokens consumed from Ollama `eval_count`; all short-circuit paths return `0`.
- New `TenantLlmTokenCounter` added to `AppState`: per-process `DashMap<Uuid, u32>` accumulator with `tokens_used(tenant)` + `add_tokens(tenant, n)` API.
- Both `search.rs` and `dispatch.rs` now (a) check `llm_budget_allows` with real accumulated spend before calling `expand_query`, (b) skip the LLM call when budget exhausted, (c) accumulate real token spend after each successful rewrite.
- `llm_budget_exceeded_total{tenant}` counter is already in `cost_ceilings.rs` — fires on every short-circuit at the ceiling.
- 3 new unit tests covering accumulator isolation, saturation guard (`saturating_add`), and end-to-end budget gate.

## Root cause

The original implementation at `search.rs:304` and `dispatch.rs:88` had:
```rust
let _llm_allowed = llm_budget_allows(state.config.llm_token_ceiling_per_tenant, 0, tenant_id);
```
Both problems at once: return value discarded, `tokens_used` hardcoded to 0.

## GitHub Issue
Closes #827

## Checklist
- [x] `cargo-locked test -p control-api -p rb-query --lib` — 467 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo-locked clippy -p control-api --lib --bins -- -D warnings` — clean
- [x] `cargo deny check` — clean
- [x] No `RUSAA-XX` outside this title bracket