### PR TITLE
[REQ-FE-52] fix: skip empty file_path citations to prevent broken chips

### DIFF
--- a/frontend/src/components/chat/citation-utils.test.ts
+++ b/frontend/src/components/chat/citation-utils.test.ts
@@ -74,6 +74,16 @@ describe("parseCitationResult — input variety", () => {
     expect(parseCitationResult(raw)).toEqual([]);
   });
 
+  it("skips items with empty-string file_path", () => {
+    const raw = JSON.stringify([{ ...BASE, file_path: "" }]);
+    expect(parseCitationResult(raw)).toEqual([]);
+  });
+
+  it("skips items with whitespace-only file_path", () => {
+    const raw = JSON.stringify([{ ...BASE, file_path: "   " }]);
+    expect(parseCitationResult(raw)).toEqual([]);
+  });
+
   it("skips items with missing repo_id", () => {
     const raw = JSON.stringify([{ ...BASE, repo_id: undefined }]);
     expect(parseCitationResult(raw)).toEqual([]);

--- a/frontend/src/components/chat/citation-utils.ts
+++ b/frontend/src/components/chat/citation-utils.ts
@@ -55,7 +55,7 @@ export function parseCitationResult(raw: unknown): ParsedCitationItem[] {
       continue;
     }
 
-    if (typeof file_path !== "string" || typeof repo_id !== "string") continue;
+    if (typeof file_path !== "string" || file_path.trim() === "" || typeof repo_id !== "string") continue;
 
     const lr = isPlainObject(line_range) ? line_range : {};
     const start = typeof lr["start"] === "number" ? lr["start"] : 0;


### PR DESCRIPTION
## Summary

- In `citation-utils.ts:58`, extend the `file_path` guard to reject empty or whitespace-only strings (previously only `typeof !== "string"` was checked — `""` passed through)
- Add two test cases covering `file_path: ""` and `file_path: "   "` (32 → 32 tests pass)

## Root cause

Orphan Qdrant embeddings whose `fqn` has no row in `code_symbols` produce `file_path: ""`. The frontend rendered these as broken `:0-0` chips with dead workspace/GitHub links. Live: `"where is the FTS rank function defined?"` → 3/5 chips broken.

## Test plan

- [x] `npx vitest run src/components/chat/citation-utils.test.ts` — 32/32 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings
- [ ] QA: re-run S4 of RUSAA-2125 UAT (`"where is the FTS rank function defined?"` query) — verify all valid chips open, orphan chips are absent rather than broken

Closes #829